### PR TITLE
fix: fix label won't be shown when no theme preference

### DIFF
--- a/app/(main)/ThemeSwitcher.tsx
+++ b/app/(main)/ThemeSwitcher.tsx
@@ -60,7 +60,7 @@ export function ThemeSwitcher() {
                   animate={{ opacity: 1, scale: 1 }}
                   exit={{ opacity: 0, scale: 0.95 }}
                 >
-                  {themes.find((t) => t.value === theme)?.label}
+                  {themes.find((t) => t.value === theme)?.label || "系统模式“}
                 </motion.div>
               </Tooltip.Content>
             </Tooltip.Portal>


### PR DESCRIPTION
Bug: When users access the website at the first time. hovering over the theme button won't show a valid tooltip label.
Fix: give ii a valid label.