### PR TITLE
fix: 修复首页 近期文章 未正确获取完全的问题

### DIFF
--- a/sanity/queries.ts
+++ b/sanity/queries.ts
@@ -27,7 +27,7 @@ export const getLatestBlogPostsQuery = ({
 }: GetBlogPostsOptions) =>
   groq`
   *[_type == "post" && !(_id in path("drafts.**")) && publishedAt <= "${getDate().toISOString()}"
-  && defined(slug.current)][0...${limit}] | order(publishedAt desc) {
+  && defined(slug.current)] | order(publishedAt desc)[0...${limit}] {
     _id,
     title,
     "slug": slug.current,


### PR DESCRIPTION
在查询文章列表时，应该先查询已经排序后的结果再对结果进行切片获取，避免出现无法获取到最新文章的问题。