### PR TITLE
fix: fix the issue where pop-up messages are being covered by the avatar

### DIFF
--- a/app/(main)/Activity.tsx
+++ b/app/(main)/Activity.tsx
@@ -79,6 +79,7 @@ export function Activity() {
             <Tooltip.Portal forceMount>
               <Tooltip.Content asChild>
                 <motion.div
+                    className="mt-1"
                   initial={{ opacity: 0, scale: 0.96 }}
                   animate={{ opacity: 1, scale: 1 }}
                   exit={{ opacity: 0, scale: 0.95 }}


### PR DESCRIPTION
头像右侧的当前使用 app 弹出框有可能会被头像遮挡一点点，可以通过增加一点距离来避免。
before: ![CleanShot 2023-10-26 at 17.54.30@2x.png](https://s2.loli.net/2023/10/26/2rKdicln8IMSAC5.png)
after: ![CleanShot 2023-10-26 at 17.54.52@2x.png](https://s2.loli.net/2023/10/26/yqFcO4pHfMUdPJY.png)