### PR TITLE
fix: 修复刚部署时数据为空页面崩溃的bug

### DIFF
--- a/app/(main)/blog/BlogPostPage.tsx
+++ b/app/(main)/blog/BlogPostPage.tsx
@@ -113,7 +113,7 @@ export function BlogPostPage({
                 </time>
                 <span className="inline-flex items-center space-x-1.5">
                   <ScriptIcon />
-                  <span>{post.categories.join(', ')}</span>
+                  <span>{post.categories?.join(', ')}</span>
                 </span>
               </motion.div>
               <motion.h1

--- a/app/(main)/blog/BlogPosts.tsx
+++ b/app/(main)/blog/BlogPosts.tsx
@@ -6,7 +6,7 @@ import { getLatestBlogPosts } from '~/sanity/queries'
 import { BlogPostCard } from './BlogPostCard'
 
 export async function BlogPosts({ limit = 5 }) {
-  const posts = await getLatestBlogPosts({ limit, forDisplay: true })
+  const posts = await getLatestBlogPosts({ limit, forDisplay: true }) || []
   const postIdKeys = posts.map(({ _id }) => kvKeys.postViews(_id))
 
   let views: number[] = []

--- a/app/(main)/projects/Projects.tsx
+++ b/app/(main)/projects/Projects.tsx
@@ -2,7 +2,7 @@ import { ProjectCard } from '~/app/(main)/projects/ProjectCard'
 import { getSettings } from '~/sanity/queries'
 
 export async function Projects() {
-  const { projects } = await getSettings()
+  const projects = (await getSettings()).projects || []
 
   return (
     <ul

--- a/sanity/queries.ts
+++ b/sanity/queries.ts
@@ -48,7 +48,7 @@ export const getLatestBlogPostsQuery = ({
     }
   }`
 export const getLatestBlogPosts = (options: GetBlogPostsOptions) =>
-  clientFetch<Post[]>(getLatestBlogPostsQuery(options))
+  clientFetch<Post[] | null>(getLatestBlogPostsQuery(options))
 
 export const getBlogPostQuery = groq`
   *[_type == "post" && slug.current == $slug && !(_id in path("drafts.**"))][0] {
@@ -109,4 +109,4 @@ export const getSettingsQuery = () =>
     }
 }`
 export const getSettings = () =>
-  clientFetch<{ projects: Project[] }>(getSettingsQuery())
+  clientFetch<{ projects: Project[] | null }>(getSettingsQuery())

--- a/sanity/schemas/post.ts
+++ b/sanity/schemas/post.ts
@@ -23,7 +23,7 @@ export const Post = z.object({
   }),
   publishedAt: z.string(),
   description: z.string(),
-  categories: z.array(z.string()),
+  categories: z.array(z.string()).optional(),
   body: z.any(),
   readingTime: z.number(),
   mood: z.enum(['happy', 'sad', 'neutral']),


### PR DESCRIPTION
posts，projects, categories任意一项无数据页面会崩溃