### PR TITLE
fix: 修复 postIdKeys 为空时在生产环境下部署带来的问题

### DIFF
--- a/app/(main)/blog/BlogPosts.tsx
+++ b/app/(main)/blog/BlogPosts.tsx
@@ -13,7 +13,9 @@ export async function BlogPosts({ limit = 5 }) {
   if (env.VERCEL_ENV === 'development') {
     views = posts.map(() => Math.floor(Math.random() * 1000))
   } else {
-    views = await redis.mget<number[]>(...postIdKeys)
+    if (postIdKeys.length > 0) {
+      views = await redis.mget<number[]>(...postIdKeys)
+    }
   }
 
   return (


### PR DESCRIPTION
当 post 为空时，在生产环境下部署，postIdKeys 为空，在获取文章阅读数量时，会导致 redis.mget() 参数不符合预期，从而引发错误
close #37 