### PR TITLE
feat: add AMA owner auth and availability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,11 +3,16 @@ DATABASE_URL=
 
 # Resend (newsletter sending + magic-link admin auth, ADR-0004)
 RESEND_API_KEY=
+RESEND_FROM_EMAIL="Cali Castle <hi@cali.so>"
 
 # Magic-link admin auth (ADR-0004)
 ADMIN_EMAIL=
 SESSION_SECRET=
+AMA_ENCRYPTION_KEY=
+SITE_URL=https://cali.so
 
 # Upstash (rate limiting the magic-link request endpoint)
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
+AUTH_RATE_LIMIT_MAX_REQUESTS=5
+AUTH_RATE_LIMIT_WINDOW_SECONDS=900

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ SESSION_SECRET=
 AMA_ENCRYPTION_KEY=
 SITE_URL=https://cali.so
 
+# Google Calendar OAuth (owner availability + meeting invitations)
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
 # Upstash (rate limiting the magic-link request endpoint)
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -6,4 +6,5 @@ and `docs/adr/` (context-scoped decisions). System-wide ADRs live in `docs/adr/`
 
 ## Contexts
 
-_None yet — the v2 rewrite starts from a clean slate._
+- [AMA Booking](./lib/ama/CONTEXT.md) — sells and manages Cali's paid
+  one-to-one AMA sessions

--- a/app/admin/(protected)/AdminDashboard.tsx
+++ b/app/admin/(protected)/AdminDashboard.tsx
@@ -1,0 +1,462 @@
+'use client'
+
+import { useEffect, useRef, useState, type FormEvent } from 'react'
+
+import { T } from '~/lib/i18n'
+import { localize, useLocale } from '~/lib/locale-client'
+
+import {
+  AvailabilityWindowForm,
+  type AvailabilityWindowViewModel,
+} from './AvailabilityWindowForm'
+
+export type { AvailabilityWindowViewModel } from './AvailabilityWindowForm'
+
+export type GoogleCalendarIdentityViewModel = {
+  calendarId: string
+  summary: string | null
+  email: string | null
+}
+
+export type GoogleConnectionStatus =
+  | 'disconnected'
+  | 'connected'
+  | 'expired'
+  | 'revoked'
+  | 'denied-scope'
+  | 'unavailable'
+
+export type GoogleConnectionViewModel = {
+  status: GoogleConnectionStatus
+  identity: GoogleCalendarIdentityViewModel | null
+}
+
+export type PreviewSlotViewModel = {
+  startsAt: string
+  endsAt: string
+}
+
+export type AdminQueryNotices = {
+  availability?: 'saved' | 'invalid' | 'failed'
+  calendar?: GoogleConnectionStatus
+}
+
+export type AdminDashboardProps = {
+  windows: readonly AvailabilityWindowViewModel[]
+  googleConnection: GoogleConnectionViewModel
+  previewSlots: readonly PreviewSlotViewModel[]
+  notices?: AdminQueryNotices
+}
+
+const ownerTimeZone = 'Asia/Taipei'
+const previewLimit = 12
+const previewDateOptions: Intl.DateTimeFormatOptions = {
+  timeZone: ownerTimeZone,
+  weekday: 'short',
+  month: 'short',
+  day: 'numeric',
+}
+const previewTimeOptions: Intl.DateTimeFormatOptions = {
+  timeZone: ownerTimeZone,
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+}
+const previewDateFormatters = {
+  zh: new Intl.DateTimeFormat('zh-TW', previewDateOptions),
+  en: new Intl.DateTimeFormat('en-US', previewDateOptions),
+}
+const previewTimeFormatters = {
+  zh: new Intl.DateTimeFormat('zh-TW', previewTimeOptions),
+  en: new Intl.DateTimeFormat('en-US', previewTimeOptions),
+}
+
+function QueryNotices({
+  notices,
+  restoreFocus = false,
+}: {
+  notices: AdminQueryNotices | undefined
+  restoreFocus?: boolean
+}) {
+  const noticeRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (restoreFocus) noticeRef.current?.focus()
+  }, [restoreFocus])
+
+  if (!notices?.availability && !notices?.calendar) return null
+
+  const availabilityCopy = {
+    saved: { zh: '可预约时段已保存。', en: 'Availability Windows saved.' },
+    invalid: {
+      zh: '这个时段无效。请确认星期和起止时间。',
+      en: 'That window is invalid. Check its day and start and end times.',
+    },
+    failed: {
+      zh: '暂时无法保存时段，请重试。',
+      en: 'The Availability Window could not be saved. Try again.',
+    },
+  } as const
+  const calendarCopy = {
+    disconnected: { zh: 'Google 日历已断开。', en: 'Google Calendar disconnected.' },
+    connected: { zh: 'Google 日历已连接。', en: 'Google Calendar connected.' },
+    expired: {
+      zh: 'Google 连接流程已过期，请重新连接。',
+      en: 'The Google connection attempt expired. Connect again.',
+    },
+    revoked: {
+      zh: 'Google 授权已撤销，请重新连接。',
+      en: 'Google access was revoked. Connect again.',
+    },
+    'denied-scope': {
+      zh: '没有授予所需的日历权限，请重新连接并允许两项权限。',
+      en: 'The required Calendar permissions were not granted. Connect again and allow both.',
+    },
+    unavailable: {
+      zh: '暂时无法联系 Google，请稍后重试。',
+      en: 'Google is unavailable right now. Try again shortly.',
+    },
+  } as const
+
+  const availability = notices.availability
+    ? availabilityCopy[notices.availability]
+    : null
+  const calendar = notices.calendar ? calendarCopy[notices.calendar] : null
+  const isAlert =
+    notices.availability === 'invalid' ||
+    notices.availability === 'failed' ||
+    (notices.calendar !== undefined &&
+      notices.calendar !== 'connected' &&
+      notices.calendar !== 'disconnected')
+
+  return (
+    <div
+      ref={noticeRef}
+      id={availability ? 'availability-notice' : 'calendar-notice'}
+      role={isAlert ? 'alert' : 'status'}
+      tabIndex={restoreFocus ? -1 : undefined}
+      className="mt-4 rounded-md bg-surface-1 px-4 py-3 text-sm leading-6"
+    >
+      {availability && <T zh={availability.zh} en={availability.en} />}
+      {availability && calendar && ' '}
+      {calendar && <T zh={calendar.zh} en={calendar.en} />}
+    </div>
+  )
+}
+
+function GoogleCalendarSection({
+  connection,
+  notice,
+  restoreNoticeFocus,
+}: {
+  connection: GoogleConnectionViewModel
+  notice?: GoogleConnectionStatus
+  restoreNoticeFocus: boolean
+}) {
+  const locale = useLocale()
+  const [pending, setPending] = useState<'connect' | 'disconnect' | null>(null)
+
+  function disconnect(event: FormEvent<HTMLFormElement>) {
+    if (
+      !globalThis.confirm(
+        localize(
+          locale,
+          '断开 Google 日历？可预约时段会保留，但在重新连接前无法检查日历冲突。',
+          'Disconnect Google Calendar? Availability Windows stay saved, but calendar conflicts cannot be checked until you reconnect.',
+        ),
+      )
+    ) {
+      event.preventDefault()
+      return
+    }
+    setPending('disconnect')
+  }
+
+  const stateCopy = {
+    disconnected: {
+      zh: '尚未连接。连接后会用 Google 日历排除已有安排。',
+      en: 'Not connected. Connect to exclude existing events from availability.',
+    },
+    connected: {
+      zh: '连接正常。日历中的忙碌时间会从预览中排除。',
+      en: 'Connected and healthy. Busy Calendar time is excluded from the preview.',
+    },
+    expired: {
+      zh: '连接流程已经过期，没有保存任何新凭据。请重新连接。',
+      en: 'The connection attempt expired and no new credential was saved. Connect again.',
+    },
+    revoked: {
+      zh: 'Google 已撤销访问权限。重新连接即可恢复忙碌时间检查。',
+      en: 'Google revoked access. Reconnect to restore busy-time checks.',
+    },
+    'denied-scope': {
+      zh: 'Google 没有授予事件与忙闲查询权限。请重新连接并允许两项权限。',
+      en: 'Google did not grant event and free/busy access. Reconnect and allow both permissions.',
+    },
+    unavailable: {
+      zh: '暂时无法检查 Google 日历。已保存的可预约时段不会丢失。',
+      en: 'Google Calendar cannot be checked right now. Saved Availability Windows are safe.',
+    },
+  } as const
+  const copy = stateCopy[connection.status]
+  const connectLabel =
+    connection.status === 'disconnected'
+      ? { zh: '连接 Google 日历', en: 'Connect Google Calendar' }
+      : { zh: '重新连接', en: 'Reconnect' }
+
+  return (
+    <section
+      className="border-t border-dashed border-border pt-6"
+      aria-labelledby="google-heading"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="max-w-md">
+          <h2 id="google-heading" className="text-sm font-medium">
+            <T zh="Google 日历" en="Google Calendar" />
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            <T zh={copy.zh} en={copy.en} />
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {connection.status !== 'connected' && (
+            <form
+              action="/api/admin/ama/google/connect"
+              method="post"
+              onSubmit={() => setPending('connect')}
+            >
+              <button
+                type="submit"
+                disabled={pending !== null}
+                className="min-h-11 min-w-[10rem] touch-manipulation rounded-md bg-foreground px-4 text-sm font-medium text-background outline-none transition-transform duration-100 ease-[ease] active:scale-[0.97] disabled:pointer-events-none disabled:opacity-60 focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-reduce:transform-none motion-reduce:transition-none"
+              >
+                {pending === 'connect' ? (
+                  <T zh="正在连接…" en="Connecting…" />
+                ) : (
+                  <T zh={connectLabel.zh} en={connectLabel.en} />
+                )}
+              </button>
+            </form>
+          )}
+          {connection.status !== 'disconnected' && (
+            <form
+              action="/api/admin/ama/google/disconnect"
+              method="post"
+              onSubmit={disconnect}
+            >
+              <button
+                type="submit"
+                disabled={pending !== null}
+                className="min-h-11 min-w-[7.5rem] touch-manipulation rounded-md px-3 text-sm text-muted-foreground outline-none transition-transform duration-100 ease-[ease] active:scale-[0.97] disabled:pointer-events-none disabled:opacity-60 focus-visible:ring-1 focus-visible:ring-foreground motion-reduce:transform-none motion-reduce:transition-none"
+              >
+                {pending === 'disconnect' ? (
+                  <T zh="正在断开…" en="Disconnecting…" />
+                ) : (
+                  <T zh="断开" en="Disconnect" />
+                )}
+              </button>
+            </form>
+          )}
+        </div>
+      </div>
+
+      <QueryNotices
+        notices={notice ? { calendar: notice } : undefined}
+        restoreFocus={restoreNoticeFocus}
+      />
+
+      {connection.identity && (
+        <dl className="mt-4 grid gap-x-6 gap-y-2 text-sm sm:grid-cols-[7rem_minmax(0,1fr)]">
+          <dt className="text-muted-foreground">
+            <T zh="日历" en="Calendar" />
+          </dt>
+          <dd className="min-w-0 break-words">
+            {connection.identity.summary || connection.identity.email || connection.identity.calendarId}
+          </dd>
+          {connection.identity.email && (
+            <>
+              <dt className="text-muted-foreground">
+                <T zh="账号" en="Account" />
+              </dt>
+              <dd className="min-w-0 break-words">{connection.identity.email}</dd>
+            </>
+          )}
+        </dl>
+      )}
+    </section>
+  )
+}
+
+function SlotPreview({ slots }: { slots: readonly PreviewSlotViewModel[] }) {
+  const visibleSlots = slots.slice(0, previewLimit)
+
+  return (
+    <section
+      className="border-t border-dashed border-border pt-6"
+      aria-labelledby="preview-heading"
+    >
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h2 id="preview-heading" className="text-sm font-medium">
+          <T zh="开放时间预览" en="Open-time preview" />
+        </h2>
+        <span className="text-sm text-muted-foreground tabular-nums">
+          Asia/Taipei · UTC+8
+        </span>
+      </div>
+
+      {visibleSlots.length === 0 ? (
+        <p className="mt-3 text-sm leading-6 text-muted-foreground">
+          <T
+            zh="未来 30 天没有开放时间。添加可预约时段，或检查 Google 日历连接。"
+            en="No open times in the next 30 days. Add an Availability Window or check Google Calendar."
+          />
+        </p>
+      ) : (
+        <>
+          <ol className="mt-3 divide-y divide-border/70">
+            {visibleSlots.map((slot) => {
+              const startsAt = new Date(slot.startsAt)
+              const endsAt = new Date(slot.endsAt)
+              return (
+                <li
+                  key={slot.startsAt}
+                  className="flex min-h-11 items-center justify-between gap-4 py-2 text-sm"
+                >
+                  <time dateTime={slot.startsAt}>
+                    <T
+                      zh={previewDateFormatters.zh.format(startsAt)}
+                      en={previewDateFormatters.en.format(startsAt)}
+                    />
+                  </time>
+                  <span className="text-muted-foreground tabular-nums">
+                    <T
+                      zh={`${previewTimeFormatters.zh.format(startsAt)}–${previewTimeFormatters.zh.format(endsAt)}`}
+                      en={`${previewTimeFormatters.en.format(startsAt)}–${previewTimeFormatters.en.format(endsAt)}`}
+                    />
+                  </span>
+                </li>
+              )
+            })}
+          </ol>
+          {slots.length > visibleSlots.length && (
+            <p className="mt-3 text-sm text-muted-foreground tabular-nums">
+              <T
+                zh={`显示接下来的 ${visibleSlots.length} 个，共 ${slots.length} 个。`}
+                en={`Showing the next ${visibleSlots.length} of ${slots.length}.`}
+              />
+            </p>
+          )}
+        </>
+      )}
+    </section>
+  )
+}
+
+export function AdminDashboard({
+  windows,
+  googleConnection,
+  previewSlots,
+  notices,
+}: AdminDashboardProps) {
+  return (
+    <div className="mx-auto w-full max-w-[37.5rem] px-6">
+      <header className="flex min-h-11 items-center justify-between gap-6">
+        <div>
+          <p className="text-sm text-muted-foreground">AMA / ADMIN</p>
+          <h1 className="mt-1 text-sm font-semibold">
+            <T zh="管理" en="Admin" />
+          </h1>
+        </div>
+        <form action="/api/admin/auth/logout" method="post">
+          <button
+            type="submit"
+            className="min-h-11 touch-manipulation px-2 text-sm text-muted-foreground outline-none transition-transform duration-100 ease-[ease] active:scale-[0.97] focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground motion-reduce:transform-none motion-reduce:transition-none"
+          >
+            <T zh="退出" en="Sign out" />
+          </button>
+        </form>
+      </header>
+
+      <section
+        className="mt-10 border-t border-dashed border-border pt-6"
+        aria-labelledby="policy-heading"
+      >
+        <h2 id="policy-heading" className="text-sm font-medium">
+          <T zh="规则" en="Policy" />
+        </h2>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">
+          <T
+            zh="每次 60 分钟 · 至少提前 24 小时 · 开放未来 30 天 · 前后各留 15 分钟"
+            en="60 minutes · 24-hour notice · 30-day horizon · 15-minute buffers"
+          />
+        </p>
+      </section>
+
+      <section
+        className="mt-8 border-t border-dashed border-border pt-6"
+        aria-labelledby="availability-heading"
+      >
+        <div className="max-w-md">
+          <h2 id="availability-heading" className="text-sm font-medium">
+            <T zh="每周可预约时段" en="Weekly Availability Windows" />
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            <T
+              zh="所有时间都按 Asia/Taipei 解释。可以在同一天添加多个时段。"
+              en="All times are interpreted in Asia/Taipei. You can add multiple windows on one day."
+            />
+          </p>
+        </div>
+
+        <QueryNotices
+          notices={
+            notices?.availability
+              ? { availability: notices.availability }
+              : undefined
+          }
+          restoreFocus={notices?.availability !== undefined}
+        />
+
+        {windows.length > 0 && (
+          <div className="mt-5 grid gap-5">
+            {windows.map((window) => (
+              <AvailabilityWindowForm
+                key={window.id}
+                window={window}
+                describedBy={
+                  notices?.availability && notices.availability !== 'saved'
+                    ? 'availability-notice'
+                    : undefined
+                }
+              />
+            ))}
+          </div>
+        )}
+
+        <div className="mt-6 border-t border-dotted border-border pt-5">
+          <p className="mb-3 text-sm text-muted-foreground">
+            <T zh="添加时段" en="Add a window" />
+          </p>
+          <AvailabilityWindowForm
+            describedBy={
+              notices?.availability && notices.availability !== 'saved'
+                ? 'availability-notice'
+                : undefined
+            }
+          />
+        </div>
+      </section>
+
+      <div className="mt-8 grid gap-8">
+        <GoogleCalendarSection
+          connection={googleConnection}
+          notice={notices?.calendar}
+          restoreNoticeFocus={
+            notices?.calendar !== undefined && notices.availability === undefined
+          }
+        />
+        <SlotPreview slots={previewSlots} />
+      </div>
+    </div>
+  )
+}

--- a/app/admin/(protected)/AvailabilityWindowForm.tsx
+++ b/app/admin/(protected)/AvailabilityWindowForm.tsx
@@ -1,0 +1,196 @@
+'use client'
+
+import { useId, useState, type FormEvent } from 'react'
+
+import { T } from '~/lib/i18n'
+import { localize, useLocale } from '~/lib/locale-client'
+
+export type AvailabilityWindowViewModel = {
+  id: number
+  isoWeekday: number
+  startMinute: number
+  endMinute: number
+}
+
+type AvailabilityWindowFormProps = {
+  window?: AvailabilityWindowViewModel
+  describedBy?: string
+}
+
+const weekdays = [
+  { value: 1, zh: '星期一', en: 'Monday' },
+  { value: 2, zh: '星期二', en: 'Tuesday' },
+  { value: 3, zh: '星期三', en: 'Wednesday' },
+  { value: 4, zh: '星期四', en: 'Thursday' },
+  { value: 5, zh: '星期五', en: 'Friday' },
+  { value: 6, zh: '星期六', en: 'Saturday' },
+  { value: 7, zh: '星期日', en: 'Sunday' },
+] as const
+
+function formatMinute(minute: number) {
+  if (minute === 24 * 60) return '24:00'
+  const hour = Math.floor(minute / 60)
+  return `${hour.toString().padStart(2, '0')}:${(minute % 60).toString().padStart(2, '0')}`
+}
+
+function timeOptions(firstMinute: number, lastMinute: number) {
+  const options: number[] = []
+  for (let minute = firstMinute; minute <= lastMinute; minute += 30) options.push(minute)
+  return options
+}
+
+const startOptions = timeOptions(0, 23 * 60 + 30)
+const endOptions = timeOptions(30, 24 * 60)
+
+export function AvailabilityWindowForm({
+  window,
+  describedBy,
+}: AvailabilityWindowFormProps) {
+  const locale = useLocale()
+  const weekdayId = useId()
+  const [weekday, setWeekday] = useState(window?.isoWeekday ?? 1)
+  const [pending, setPending] = useState<'save' | 'delete' | null>(null)
+  const isExisting = window !== undefined
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    const submitter = (event.nativeEvent as SubmitEvent).submitter as
+      | HTMLButtonElement
+      | null
+    if (
+      submitter?.value === 'delete' &&
+      !globalThis.confirm(
+        localize(
+          locale,
+          '删除这个可预约时段？其他时段和日历连接不会受影响。',
+          'Delete this Availability Window? Other windows and the calendar connection stay intact.',
+        ),
+      )
+    ) {
+      event.preventDefault()
+      return
+    }
+    setPending(submitter?.value === 'delete' ? 'delete' : 'save')
+  }
+
+  return (
+    <form
+      action="/api/admin/ama/availability"
+      method="post"
+      aria-describedby={describedBy}
+      className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_auto] sm:items-end"
+      onSubmit={handleSubmit}
+    >
+      {window && <input type="hidden" name="id" value={window.id} />}
+
+      <div className="grid gap-1.5 text-sm">
+        <input
+          type="hidden"
+          name="weekdayOriginal"
+          value={window?.isoWeekday ?? 1}
+        />
+        {(['zh', 'en'] as const).map((language) => {
+          const selectId = `${weekdayId}-weekday-${language}`
+          return (
+            <label
+              key={language}
+              htmlFor={selectId}
+              data-zh-block={language === 'zh' ? true : undefined}
+              data-en-block={language === 'en' ? true : undefined}
+              className="grid gap-1.5"
+            >
+              <span className="text-muted-foreground">
+                {language === 'zh' ? '星期' : 'Day'}
+              </span>
+              <select
+                id={selectId}
+                name={language === 'zh' ? 'weekdayZh' : 'weekdayEn'}
+                value={weekday}
+                disabled={pending !== null}
+                onChange={(event) => setWeekday(Number(event.target.value))}
+                className="min-h-11 w-full touch-manipulation rounded-md bg-background px-3 text-base shadow-[0_0_0_1px_var(--border)] outline-none focus-visible:shadow-[0_0_0_1px_var(--foreground)]"
+              >
+                {weekdays.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option[language]}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )
+        })}
+      </div>
+
+      <label className="grid gap-1.5 text-sm">
+        <span className="text-muted-foreground">
+          <T zh="开始" en="Start" />
+        </span>
+        <select
+          name="start"
+          defaultValue={formatMinute(window?.startMinute ?? 9 * 60)}
+          disabled={pending !== null}
+          aria-label={localize(locale, '开始时间', 'Start time')}
+          className="min-h-11 touch-manipulation rounded-md bg-background px-3 text-base tabular-nums shadow-[0_0_0_1px_var(--border)] outline-none focus-visible:shadow-[0_0_0_1px_var(--foreground)]"
+        >
+          {startOptions.map((minute) => (
+            <option key={minute} value={formatMinute(minute)}>
+              {formatMinute(minute)}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="grid gap-1.5 text-sm">
+        <span className="text-muted-foreground">
+          <T zh="结束" en="End" />
+        </span>
+        <select
+          name="end"
+          defaultValue={formatMinute(window?.endMinute ?? 12 * 60)}
+          disabled={pending !== null}
+          aria-label={localize(locale, '结束时间', 'End time')}
+          className="min-h-11 touch-manipulation rounded-md bg-background px-3 text-base tabular-nums shadow-[0_0_0_1px_var(--border)] outline-none focus-visible:shadow-[0_0_0_1px_var(--foreground)]"
+        >
+          {endOptions.map((minute) => (
+            <option key={minute} value={formatMinute(minute)}>
+              {formatMinute(minute)}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <div className="flex min-h-11 items-center gap-2 sm:justify-end">
+        <button
+          type="submit"
+          name="intent"
+          value={isExisting ? 'update' : 'create'}
+          disabled={pending !== null}
+          className="min-h-11 min-w-[5.5rem] touch-manipulation rounded-md bg-foreground px-4 text-sm font-medium text-background outline-none transition-transform duration-100 ease-[ease] active:scale-[0.97] disabled:pointer-events-none disabled:opacity-60 focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-reduce:transform-none motion-reduce:transition-none"
+        >
+          {pending === 'save' ? (
+            <T zh="正在保存…" en="Saving…" />
+          ) : isExisting ? (
+            <T zh="保存" en="Save" />
+          ) : (
+            <T zh="添加" en="Add" />
+          )}
+        </button>
+        {isExisting && (
+          <button
+            type="submit"
+            name="intent"
+            value="delete"
+            formNoValidate
+            disabled={pending !== null}
+            className="min-h-11 min-w-[6rem] touch-manipulation rounded-md px-3 text-sm text-muted-foreground outline-none transition-transform duration-100 ease-[ease] active:scale-[0.97] disabled:pointer-events-none disabled:opacity-60 focus-visible:ring-1 focus-visible:ring-foreground motion-reduce:transform-none motion-reduce:transition-none"
+          >
+            {pending === 'delete' ? (
+              <T zh="正在删除…" en="Deleting…" />
+            ) : (
+              <T zh="删除" en="Delete" />
+            )}
+          </button>
+        )}
+      </div>
+    </form>
+  )
+}

--- a/app/admin/(protected)/layout.tsx
+++ b/app/admin/(protected)/layout.tsx
@@ -1,0 +1,8 @@
+import { redirect } from 'next/navigation'
+
+import { isOwnerAuthenticated } from '~/lib/ama/auth/server'
+
+export default async function ProtectedAdminLayout({ children }: { children: React.ReactNode }) {
+  if (!(await isOwnerAuthenticated())) redirect('/admin/login')
+  return children
+}

--- a/app/admin/(protected)/page.tsx
+++ b/app/admin/(protected)/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next'
+
+import { T } from '~/lib/i18n'
+
+export const metadata: Metadata = {
+  title: 'AMA Admin',
+  robots: { index: false, follow: false },
+}
+
+export default function AdminPage() {
+  return (
+    <div className="mx-auto w-full max-w-[37.5rem] px-6">
+      <header className="flex min-h-11 items-center justify-between gap-6">
+        <div>
+          <p className="text-sm text-muted-foreground">AMA / ADMIN</p>
+          <h1 className="mt-1 text-sm font-semibold">
+            <T zh="管理" en="Admin" />
+          </h1>
+        </div>
+        <form action="/api/admin/auth/logout" method="post">
+          <button
+            type="submit"
+            className="relative min-h-11 touch-manipulation px-2 text-sm text-muted-foreground outline-none transition-colors duration-150 ease-[ease] [@media(hover:hover)_and_(pointer:fine)]:hover:text-foreground focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground motion-reduce:transition-none"
+          >
+            <T zh="退出" en="Sign out" />
+          </button>
+        </form>
+      </header>
+      <div className="mt-12 border-t border-dashed border-border pt-6 text-sm text-muted-foreground">
+        <T zh="AMA 管理工具将在这里出现。" en="AMA management tools will appear here." />
+      </div>
+    </div>
+  )
+}

--- a/app/admin/(protected)/page.tsx
+++ b/app/admin/(protected)/page.tsx
@@ -1,34 +1,108 @@
 import type { Metadata } from 'next'
 
-import { T } from '~/lib/i18n'
+import { getAmaAdminServices } from '~/lib/ama/admin/server'
+
+import {
+  AdminDashboard,
+  type AdminQueryNotices,
+  type GoogleConnectionStatus,
+} from './AdminDashboard'
 
 export const metadata: Metadata = {
   title: 'AMA Admin',
   robots: { index: false, follow: false },
 }
 
-export default function AdminPage() {
+const availabilityNotices = new Set(['saved', 'invalid', 'failed'] as const)
+const calendarNotices = new Set([
+  'disconnected',
+  'connected',
+  'expired',
+  'revoked',
+  'denied-scope',
+  'unavailable',
+] as const)
+
+function first(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value
+}
+
+function queryNotices(input: {
+  availability?: string | string[]
+  calendar?: string | string[]
+}): AdminQueryNotices {
+  const availability = first(input.availability)
+  const calendar = first(input.calendar)
+  return {
+    availability: availabilityNotices.has(
+      availability as AdminQueryNotices['availability'] & string,
+    )
+      ? (availability as AdminQueryNotices['availability'])
+      : undefined,
+    calendar: calendarNotices.has(calendar as GoogleConnectionStatus)
+      ? (calendar as GoogleConnectionStatus)
+      : undefined,
+  }
+}
+
+function connectionStatus(status: string | undefined): GoogleConnectionStatus {
+  if (status === 'connected' || status === 'expired' || status === 'revoked') {
+    return status
+  }
+  if (status === 'denied_scope') return 'denied-scope'
+  if (status === 'error') return 'unavailable'
+  return 'disconnected'
+}
+
+export default async function AdminPage({
+  searchParams,
+}: {
+  searchParams: Promise<{
+    availability?: string | string[]
+    calendar?: string | string[]
+  }>
+}) {
+  const { availability, google } = getAmaAdminServices()
+  const windowsPromise = availability.list()
+  const connectionPromise = google.getConnection()
+  const previewPromise = availability.preview()
+  const [windows, connection, preview, params] = await Promise.all([
+    windowsPromise,
+    connectionPromise,
+    previewPromise,
+    searchParams,
+  ])
+
+  const persistedStatus = connectionStatus(connection?.status)
+  const status =
+    persistedStatus === 'connected' && preview.status !== 'connected'
+      ? preview.status
+      : persistedStatus
+
   return (
-    <div className="mx-auto w-full max-w-[37.5rem] px-6">
-      <header className="flex min-h-11 items-center justify-between gap-6">
-        <div>
-          <p className="text-sm text-muted-foreground">AMA / ADMIN</p>
-          <h1 className="mt-1 text-sm font-semibold">
-            <T zh="管理" en="Admin" />
-          </h1>
-        </div>
-        <form action="/api/admin/auth/logout" method="post">
-          <button
-            type="submit"
-            className="relative min-h-11 touch-manipulation px-2 text-sm text-muted-foreground outline-none transition-colors duration-150 ease-[ease] [@media(hover:hover)_and_(pointer:fine)]:hover:text-foreground focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground motion-reduce:transition-none"
-          >
-            <T zh="退出" en="Sign out" />
-          </button>
-        </form>
-      </header>
-      <div className="mt-12 border-t border-dashed border-border pt-6 text-sm text-muted-foreground">
-        <T zh="AMA 管理工具将在这里出现。" en="AMA management tools will appear here." />
-      </div>
-    </div>
+    <AdminDashboard
+      windows={windows.map(({ id, isoWeekday, startMinute, endMinute }) => ({
+        id,
+        isoWeekday,
+        startMinute,
+        endMinute,
+      }))}
+      googleConnection={{
+        status,
+        identity:
+          connection?.calendarId && connection.status !== 'disconnected'
+            ? {
+                calendarId: connection.calendarId,
+                summary: connection.calendarSummary,
+                email: connection.calendarEmail,
+              }
+            : null,
+      }}
+      previewSlots={preview.slots.map((slot) => ({
+        startsAt: slot.startsAt.toISOString(),
+        endsAt: slot.endsAt.toISOString(),
+      }))}
+      notices={queryNotices(params)}
+    />
   )
 }

--- a/app/admin/login/LoginForm.tsx
+++ b/app/admin/login/LoginForm.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useState } from 'react'
+
+import { T } from '~/lib/i18n'
+
+export function LoginForm() {
+  const [pending, setPending] = useState(false)
+
+  return (
+    <form
+      action="/api/admin/auth/request"
+      method="post"
+      className="mt-6"
+      onSubmit={() => setPending(true)}
+    >
+      <label htmlFor="admin-email" className="block text-sm font-medium">
+        <T zh="邮箱" en="Email" />
+      </label>
+      <input
+        id="admin-email"
+        name="email"
+        type="email"
+        inputMode="email"
+        autoComplete="email"
+        required
+        disabled={pending}
+        className="mt-2 min-h-11 w-full rounded-md bg-background px-3 text-base shadow-[0_0_0_1px_var(--border)] outline-none transition-[box-shadow] duration-150 ease-[ease] disabled:opacity-60 focus-visible:shadow-[0_0_0_1px_var(--foreground)] motion-reduce:transition-none"
+      />
+      <button
+        type="submit"
+        disabled={pending}
+        aria-disabled={pending}
+        className="mt-3 min-h-11 w-full touch-manipulation rounded-md bg-foreground px-4 text-sm font-medium text-background outline-none transition-[background-color,transform] duration-100 ease-[ease] active:scale-[0.97] disabled:pointer-events-none disabled:opacity-60 focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-reduce:transform-none motion-reduce:transition-none"
+      >
+        {pending ? (
+          <T zh="正在发送…" en="Sending…" />
+        ) : (
+          <T zh="发送登录链接" en="Send sign-in link" />
+        )}
+      </button>
+    </form>
+  )
+}

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,0 +1,59 @@
+import type { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+
+import { T } from '~/lib/i18n'
+import { isOwnerAuthenticated } from '~/lib/ama/auth/server'
+
+import { LoginForm } from './LoginForm'
+
+export const metadata: Metadata = {
+  title: 'AMA Admin',
+  robots: { index: false, follow: false },
+}
+
+export default async function AdminLoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ sent?: string; error?: string }>
+}) {
+  if (await isOwnerAuthenticated()) redirect('/admin')
+  const state = await searchParams
+  const sent = state.sent === '1'
+  const invalidLink = state.error === 'invalid-link'
+
+  return (
+    <div className="mx-auto w-full max-w-[37.5rem] px-6">
+      <section className="mx-auto max-w-sm" aria-labelledby="admin-login-heading">
+        <p className="text-sm text-muted-foreground">AMA / ADMIN</p>
+        <h1 id="admin-login-heading" className="mt-3 text-sm font-semibold">
+          <T zh="管理员登录" en="Admin sign in" />
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-muted-foreground">
+          <T
+            zh="输入管理员邮箱，我们会发送一条 15 分钟内有效的一次性登录链接。"
+            en="Enter the owner email and we’ll send a single-use link valid for 15 minutes."
+          />
+        </p>
+
+        {sent && (
+          <p role="status" className="mt-5 rounded-md bg-surface-1 px-4 py-3 text-sm leading-6">
+            <T
+              zh="如果这个邮箱可以登录，链接已经发出。请检查收件箱。"
+              en="If that address can sign in, the link is on its way. Check the inbox."
+            />
+          </p>
+        )}
+        {invalidLink && (
+          <p role="alert" className="mt-5 rounded-md bg-surface-1 px-4 py-3 text-sm leading-6">
+            <T
+              zh="这个登录链接无效、已使用或已经过期。请重新申请。"
+              en="That sign-in link is invalid, already used, or expired. Request a new one."
+            />
+          </p>
+        )}
+
+        <LoginForm />
+      </section>
+    </div>
+  )
+}

--- a/app/api/admin/ama/availability/route.ts
+++ b/app/api/admin/ama/availability/route.ts
@@ -1,0 +1,14 @@
+import { createAvailabilityMutationHandler } from '~/lib/ama/admin/http'
+import {
+  getAmaAdminServices,
+  ownerRequestAuthenticator,
+} from '~/lib/ama/admin/server'
+
+export async function POST(request: Request) {
+  const { availability, baseUrl } = getAmaAdminServices()
+  return createAvailabilityMutationHandler({
+    authenticator: ownerRequestAuthenticator,
+    service: availability,
+    baseUrl,
+  })(request)
+}

--- a/app/api/admin/ama/google/callback/route.ts
+++ b/app/api/admin/ama/google/callback/route.ts
@@ -1,0 +1,14 @@
+import { createGoogleCallbackHandler } from '~/lib/ama/admin/http'
+import {
+  getAmaAdminServices,
+  ownerRequestAuthenticator,
+} from '~/lib/ama/admin/server'
+
+export async function GET(request: Request) {
+  const { google, baseUrl } = getAmaAdminServices()
+  return createGoogleCallbackHandler({
+    authenticator: ownerRequestAuthenticator,
+    service: google,
+    baseUrl,
+  })(request)
+}

--- a/app/api/admin/ama/google/connect/route.ts
+++ b/app/api/admin/ama/google/connect/route.ts
@@ -1,0 +1,14 @@
+import { createGoogleConnectHandler } from '~/lib/ama/admin/http'
+import {
+  getAmaAdminServices,
+  ownerRequestAuthenticator,
+} from '~/lib/ama/admin/server'
+
+export async function POST(request: Request) {
+  const { google, baseUrl } = getAmaAdminServices()
+  return createGoogleConnectHandler({
+    authenticator: ownerRequestAuthenticator,
+    service: google,
+    baseUrl,
+  })(request)
+}

--- a/app/api/admin/ama/google/disconnect/route.ts
+++ b/app/api/admin/ama/google/disconnect/route.ts
@@ -1,0 +1,14 @@
+import { createGoogleDisconnectHandler } from '~/lib/ama/admin/http'
+import {
+  getAmaAdminServices,
+  ownerRequestAuthenticator,
+} from '~/lib/ama/admin/server'
+
+export async function POST(request: Request) {
+  const { google, baseUrl } = getAmaAdminServices()
+  return createGoogleDisconnectHandler({
+    authenticator: ownerRequestAuthenticator,
+    service: google,
+    baseUrl,
+  })(request)
+}

--- a/app/api/admin/auth/logout/route.ts
+++ b/app/api/admin/auth/logout/route.ts
@@ -1,0 +1,6 @@
+import { createLogoutHandler } from '~/lib/ama/auth/http'
+import { getOwnerAuth } from '~/lib/ama/auth/server'
+
+export async function POST(request: Request) {
+  return createLogoutHandler(getOwnerAuth())(request)
+}

--- a/app/api/admin/auth/request/route.ts
+++ b/app/api/admin/auth/request/route.ts
@@ -1,0 +1,8 @@
+import { after } from 'next/server'
+
+import { createMagicLinkRequestHandler } from '~/lib/ama/auth/http'
+import { getOwnerAuth } from '~/lib/ama/auth/server'
+
+export async function POST(request: Request) {
+  return createMagicLinkRequestHandler(getOwnerAuth(), (task) => after(task))(request)
+}

--- a/app/api/admin/auth/verify/route.ts
+++ b/app/api/admin/auth/verify/route.ts
@@ -1,0 +1,6 @@
+import { createMagicLinkVerifyHandler } from '~/lib/ama/auth/http'
+import { getOwnerAuth } from '~/lib/ama/auth/server'
+
+export async function GET(request: Request) {
+  return createMagicLinkVerifyHandler(getOwnerAuth())(request)
+}

--- a/db/index.ts
+++ b/db/index.ts
@@ -1,0 +1,18 @@
+import 'server-only'
+
+import { neon } from '@neondatabase/serverless'
+import { drizzle } from 'drizzle-orm/neon-http'
+
+import { getServerEnv } from '~/lib/ama/server-env'
+
+let database: ReturnType<typeof createDatabase> | undefined
+
+function createDatabase() {
+  const sql = neon(getServerEnv().DATABASE_URL)
+  return drizzle({ client: sql })
+}
+
+export function getDatabase() {
+  database ??= createDatabase()
+  return database
+}

--- a/db/migrations/0001_ama_owner_auth.sql
+++ b/db/migrations/0001_ama_owner_auth.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS "ama_auth_tokens" (
+	"token_hash" varchar(64) PRIMARY KEY NOT NULL,
+	"owner_email" varchar(320) NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"consumed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ama_auth_tokens_expires_at_idx" ON "ama_auth_tokens" USING btree ("expires_at");
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "ama_admin_sessions" (
+	"token_hash" varchar(64) PRIMARY KEY NOT NULL,
+	"owner_email" varchar(320) NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"revoked_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ama_admin_sessions_expires_at_idx" ON "ama_admin_sessions" USING btree ("expires_at");

--- a/db/migrations/0002_ama_availability.sql
+++ b/db/migrations/0002_ama_availability.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "ama_availability_windows" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"iso_weekday" integer NOT NULL,
+	"start_minute" integer NOT NULL,
+	"end_minute" integer NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "ama_availability_windows_iso_weekday_check" CHECK ("ama_availability_windows"."iso_weekday" BETWEEN 1 AND 7),
+	CONSTRAINT "ama_availability_windows_start_minute_check" CHECK ("ama_availability_windows"."start_minute" BETWEEN 0 AND 1439),
+	CONSTRAINT "ama_availability_windows_end_minute_check" CHECK ("ama_availability_windows"."end_minute" BETWEEN 1 AND 1440),
+	CONSTRAINT "ama_availability_windows_same_day_check" CHECK ("ama_availability_windows"."start_minute" < "ama_availability_windows"."end_minute")
+);
+--> statement-breakpoint
+CREATE INDEX "ama_availability_windows_order_idx" ON "ama_availability_windows" USING btree ("iso_weekday","start_minute","end_minute");

--- a/db/migrations/0003_ama_google_calendar.sql
+++ b/db/migrations/0003_ama_google_calendar.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "ama_google_calendar_connections" (
+	"id" integer PRIMARY KEY DEFAULT 1 NOT NULL,
+	"status" varchar(32) NOT NULL,
+	"calendar_id" varchar(320),
+	"calendar_email" varchar(320),
+	"calendar_summary" text,
+	"granted_scopes" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"refresh_token_envelope" jsonb,
+	"access_token_expires_at" timestamp with time zone,
+	"last_error_code" varchar(64),
+	"connected_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "ama_google_calendar_connections_singleton_check" CHECK ("ama_google_calendar_connections"."id" = 1),
+	CONSTRAINT "ama_google_calendar_connections_status_check" CHECK ("ama_google_calendar_connections"."status" IN ('disconnected', 'connected', 'expired', 'revoked', 'denied_scope', 'error'))
+);

--- a/db/migrations/0004_ama_google_oauth.sql
+++ b/db/migrations/0004_ama_google_oauth.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "ama_google_oauth_attempts" (
+	"state_hash" varchar(64) PRIMARY KEY NOT NULL,
+	"owner_email" varchar(320) NOT NULL,
+	"pkce_verifier_envelope" jsonb NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"consumed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "ama_google_oauth_attempts_expires_at_idx" ON "ama_google_oauth_attempts" USING btree ("expires_at");

--- a/db/migrations/meta/0001_snapshot.json
+++ b/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,240 @@
+{
+  "id": "474d5c21-b432-4cfc-9250-890965a21ede",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ama_admin_sessions": {
+      "name": "ama_admin_sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_admin_sessions_expires_at_idx": {
+          "name": "ama_admin_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ama_auth_tokens": {
+      "name": "ama_auth_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_auth_tokens_expires_at_idx": {
+          "name": "ama_auth_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletters": {
+      "name": "newsletters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscribers": {
+      "name": "subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/0002_snapshot.json
+++ b/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,336 @@
+{
+  "id": "108c4779-e22e-4e96-9b19-b003f69f5671",
+  "prevId": "474d5c21-b432-4cfc-9250-890965a21ede",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ama_admin_sessions": {
+      "name": "ama_admin_sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_admin_sessions_expires_at_idx": {
+          "name": "ama_admin_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ama_auth_tokens": {
+      "name": "ama_auth_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_auth_tokens_expires_at_idx": {
+          "name": "ama_auth_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ama_availability_windows": {
+      "name": "ama_availability_windows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "iso_weekday": {
+          "name": "iso_weekday",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_minute": {
+          "name": "start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_minute": {
+          "name": "end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_availability_windows_order_idx": {
+          "name": "ama_availability_windows_order_idx",
+          "columns": [
+            {
+              "expression": "iso_weekday",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_minute",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_minute",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_availability_windows_iso_weekday_check": {
+          "name": "ama_availability_windows_iso_weekday_check",
+          "value": "\"ama_availability_windows\".\"iso_weekday\" BETWEEN 1 AND 7"
+        },
+        "ama_availability_windows_start_minute_check": {
+          "name": "ama_availability_windows_start_minute_check",
+          "value": "\"ama_availability_windows\".\"start_minute\" BETWEEN 0 AND 1439"
+        },
+        "ama_availability_windows_end_minute_check": {
+          "name": "ama_availability_windows_end_minute_check",
+          "value": "\"ama_availability_windows\".\"end_minute\" BETWEEN 1 AND 1440"
+        },
+        "ama_availability_windows_same_day_check": {
+          "name": "ama_availability_windows_same_day_check",
+          "value": "\"ama_availability_windows\".\"start_minute\" < \"ama_availability_windows\".\"end_minute\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.newsletters": {
+      "name": "newsletters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscribers": {
+      "name": "subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/0003_snapshot.json
+++ b/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,434 @@
+{
+  "id": "fec2675e-27bc-4958-aba2-4e492667011d",
+  "prevId": "108c4779-e22e-4e96-9b19-b003f69f5671",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ama_admin_sessions": {
+      "name": "ama_admin_sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_admin_sessions_expires_at_idx": {
+          "name": "ama_admin_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ama_auth_tokens": {
+      "name": "ama_auth_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_auth_tokens_expires_at_idx": {
+          "name": "ama_auth_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ama_availability_windows": {
+      "name": "ama_availability_windows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "iso_weekday": {
+          "name": "iso_weekday",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_minute": {
+          "name": "start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_minute": {
+          "name": "end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_availability_windows_order_idx": {
+          "name": "ama_availability_windows_order_idx",
+          "columns": [
+            {
+              "expression": "iso_weekday",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_minute",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_minute",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_availability_windows_iso_weekday_check": {
+          "name": "ama_availability_windows_iso_weekday_check",
+          "value": "\"ama_availability_windows\".\"iso_weekday\" BETWEEN 1 AND 7"
+        },
+        "ama_availability_windows_start_minute_check": {
+          "name": "ama_availability_windows_start_minute_check",
+          "value": "\"ama_availability_windows\".\"start_minute\" BETWEEN 0 AND 1439"
+        },
+        "ama_availability_windows_end_minute_check": {
+          "name": "ama_availability_windows_end_minute_check",
+          "value": "\"ama_availability_windows\".\"end_minute\" BETWEEN 1 AND 1440"
+        },
+        "ama_availability_windows_same_day_check": {
+          "name": "ama_availability_windows_same_day_check",
+          "value": "\"ama_availability_windows\".\"start_minute\" < \"ama_availability_windows\".\"end_minute\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_google_calendar_connections": {
+      "name": "ama_google_calendar_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_email": {
+          "name": "calendar_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_summary": {
+          "name": "calendar_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_scopes": {
+          "name": "granted_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "refresh_token_envelope": {
+          "name": "refresh_token_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_google_calendar_connections_singleton_check": {
+          "name": "ama_google_calendar_connections_singleton_check",
+          "value": "\"ama_google_calendar_connections\".\"id\" = 1"
+        },
+        "ama_google_calendar_connections_status_check": {
+          "name": "ama_google_calendar_connections_status_check",
+          "value": "\"ama_google_calendar_connections\".\"status\" IN ('disconnected', 'connected', 'expired', 'revoked', 'denied_scope', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.newsletters": {
+      "name": "newsletters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscribers": {
+      "name": "subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/0004_snapshot.json
+++ b/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,500 @@
+{
+  "id": "263ae2a4-1993-42b2-9786-4c7643759ec5",
+  "prevId": "fec2675e-27bc-4958-aba2-4e492667011d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ama_admin_sessions": {
+      "name": "ama_admin_sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_admin_sessions_expires_at_idx": {
+          "name": "ama_admin_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ama_auth_tokens": {
+      "name": "ama_auth_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_auth_tokens_expires_at_idx": {
+          "name": "ama_auth_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ama_availability_windows": {
+      "name": "ama_availability_windows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "iso_weekday": {
+          "name": "iso_weekday",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_minute": {
+          "name": "start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_minute": {
+          "name": "end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_availability_windows_order_idx": {
+          "name": "ama_availability_windows_order_idx",
+          "columns": [
+            {
+              "expression": "iso_weekday",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_minute",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_minute",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_availability_windows_iso_weekday_check": {
+          "name": "ama_availability_windows_iso_weekday_check",
+          "value": "\"ama_availability_windows\".\"iso_weekday\" BETWEEN 1 AND 7"
+        },
+        "ama_availability_windows_start_minute_check": {
+          "name": "ama_availability_windows_start_minute_check",
+          "value": "\"ama_availability_windows\".\"start_minute\" BETWEEN 0 AND 1439"
+        },
+        "ama_availability_windows_end_minute_check": {
+          "name": "ama_availability_windows_end_minute_check",
+          "value": "\"ama_availability_windows\".\"end_minute\" BETWEEN 1 AND 1440"
+        },
+        "ama_availability_windows_same_day_check": {
+          "name": "ama_availability_windows_same_day_check",
+          "value": "\"ama_availability_windows\".\"start_minute\" < \"ama_availability_windows\".\"end_minute\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_google_calendar_connections": {
+      "name": "ama_google_calendar_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_email": {
+          "name": "calendar_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_summary": {
+          "name": "calendar_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_scopes": {
+          "name": "granted_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "refresh_token_envelope": {
+          "name": "refresh_token_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_google_calendar_connections_singleton_check": {
+          "name": "ama_google_calendar_connections_singleton_check",
+          "value": "\"ama_google_calendar_connections\".\"id\" = 1"
+        },
+        "ama_google_calendar_connections_status_check": {
+          "name": "ama_google_calendar_connections_status_check",
+          "value": "\"ama_google_calendar_connections\".\"status\" IN ('disconnected', 'connected', 'expired', 'revoked', 'denied_scope', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_google_oauth_attempts": {
+      "name": "ama_google_oauth_attempts",
+      "schema": "",
+      "columns": {
+        "state_hash": {
+          "name": "state_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pkce_verifier_envelope": {
+          "name": "pkce_verifier_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_google_oauth_attempts_expires_at_idx": {
+          "name": "ama_google_oauth_attempts_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletters": {
+      "name": "newsletters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscribers": {
+      "name": "subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1783992000000,
+      "tag": "0001_ama_owner_auth",
+      "breakpoints": true
+    }
+  ]
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -8,6 +8,27 @@
       "when": 1783992000000,
       "tag": "0001_ama_owner_auth",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1784011897171,
+      "tag": "0002_ama_availability",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1784011975962,
+      "tag": "0003_ama_google_calendar",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1784012013999,
+      "tag": "0004_ama_google_oauth",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,0 +1,45 @@
+import { index, pgTable, serial, text, timestamp, varchar } from 'drizzle-orm/pg-core'
+
+// These two tables predate v2 and stay mapped exactly as production stores
+// them. AMA migrations must never recreate, rename, or drop either table.
+export const subscribers = pgTable('subscribers', {
+  id: serial('id').primaryKey(),
+  email: varchar('email', { length: 120 }),
+  token: varchar('token', { length: 50 }),
+  subscribedAt: timestamp('subscribed_at'),
+  unsubscribedAt: timestamp('unsubscribed_at'),
+  updatedAt: timestamp('updated_at').defaultNow(),
+})
+
+export const newsletters = pgTable('newsletters', {
+  id: serial('id').primaryKey(),
+  subject: varchar('subject', { length: 200 }),
+  body: text('body'),
+  sentAt: timestamp('sent_at'),
+  createdAt: timestamp('created_at').defaultNow(),
+  updatedAt: timestamp('updated_at').defaultNow(),
+})
+
+export const amaAuthTokens = pgTable(
+  'ama_auth_tokens',
+  {
+    tokenHash: varchar('token_hash', { length: 64 }).primaryKey(),
+    ownerEmail: varchar('owner_email', { length: 320 }).notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    consumedAt: timestamp('consumed_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [index('ama_auth_tokens_expires_at_idx').on(table.expiresAt)],
+)
+
+export const amaAdminSessions = pgTable(
+  'ama_admin_sessions',
+  {
+    tokenHash: varchar('token_hash', { length: 64 }).primaryKey(),
+    ownerEmail: varchar('owner_email', { length: 320 }).notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    revokedAt: timestamp('revoked_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [index('ama_admin_sessions_expires_at_idx').on(table.expiresAt)],
+)

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,4 +1,17 @@
-import { index, pgTable, serial, text, timestamp, varchar } from 'drizzle-orm/pg-core'
+import { sql } from 'drizzle-orm'
+import {
+  check,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  varchar,
+} from 'drizzle-orm/pg-core'
+
+import type { EncryptedSecretEnvelope } from '~/lib/ama/secrets'
 
 // These two tables predate v2 and stay mapped exactly as production stores
 // them. AMA migrations must never recreate, rename, or drop either table.
@@ -42,4 +55,69 @@ export const amaAdminSessions = pgTable(
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
   },
   (table) => [index('ama_admin_sessions_expires_at_idx').on(table.expiresAt)],
+)
+
+export const amaAvailabilityWindows = pgTable(
+  'ama_availability_windows',
+  {
+    id: serial('id').primaryKey(),
+    isoWeekday: integer('iso_weekday').notNull(),
+    startMinute: integer('start_minute').notNull(),
+    endMinute: integer('end_minute').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    check('ama_availability_windows_iso_weekday_check', sql`${table.isoWeekday} BETWEEN 1 AND 7`),
+    check('ama_availability_windows_start_minute_check', sql`${table.startMinute} BETWEEN 0 AND 1439`),
+    check('ama_availability_windows_end_minute_check', sql`${table.endMinute} BETWEEN 1 AND 1440`),
+    check('ama_availability_windows_same_day_check', sql`${table.startMinute} < ${table.endMinute}`),
+    index('ama_availability_windows_order_idx').on(
+      table.isoWeekday,
+      table.startMinute,
+      table.endMinute,
+    ),
+  ],
+)
+
+export const amaGoogleCalendarConnections = pgTable(
+  'ama_google_calendar_connections',
+  {
+    id: integer('id').primaryKey().default(1),
+    status: varchar('status', { length: 32 })
+      .$type<'disconnected' | 'connected' | 'expired' | 'revoked' | 'denied_scope' | 'error'>()
+      .notNull(),
+    calendarId: varchar('calendar_id', { length: 320 }),
+    calendarEmail: varchar('calendar_email', { length: 320 }),
+    calendarSummary: text('calendar_summary'),
+    grantedScopes: jsonb('granted_scopes').$type<string[]>().default(sql`'[]'::jsonb`).notNull(),
+    refreshTokenEnvelope: jsonb('refresh_token_envelope').$type<EncryptedSecretEnvelope>(),
+    accessTokenExpiresAt: timestamp('access_token_expires_at', { withTimezone: true }),
+    lastErrorCode: varchar('last_error_code', { length: 64 }),
+    connectedAt: timestamp('connected_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    check('ama_google_calendar_connections_singleton_check', sql`${table.id} = 1`),
+    check(
+      'ama_google_calendar_connections_status_check',
+      sql`${table.status} IN ('disconnected', 'connected', 'expired', 'revoked', 'denied_scope', 'error')`,
+    ),
+  ],
+)
+
+export const amaGoogleOAuthAttempts = pgTable(
+  'ama_google_oauth_attempts',
+  {
+    stateHash: varchar('state_hash', { length: 64 }).primaryKey(),
+    ownerEmail: varchar('owner_email', { length: 320 }).notNull(),
+    pkceVerifierEnvelope: jsonb('pkce_verifier_envelope')
+      .$type<EncryptedSecretEnvelope>()
+      .notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    consumedAt: timestamp('consumed_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [index('ama_google_oauth_attempts_expires_at_idx').on(table.expiresAt)],
 )

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+  dialect: 'postgresql',
+  schema: './db/schema.ts',
+  out: './db/migrations',
+  dbCredentials: { url: process.env.DATABASE_URL ?? '' },
+})

--- a/lib/ama/CONTEXT.md
+++ b/lib/ama/CONTEXT.md
@@ -1,0 +1,49 @@
+# AMA Booking
+
+AMA Booking covers the paid one-to-one sessions Cali offers through the site,
+from choosing a time through the session's completion.
+
+## Language
+
+**AMA Session**:
+A paid 60-minute one-to-one conversation with Cali about one or more topics
+chosen by the guest.
+_Avoid_: Consultation package, coaching call, appointment
+
+**Guest**:
+The person booking and attending an AMA Session.
+_Avoid_: Customer, client, attendee
+
+**Booking Brief**:
+The guest's short explanation of what would make the AMA Session valuable,
+with optional supporting links.
+_Avoid_: Application, intake questionnaire, notes
+
+**Availability Window**:
+A recurring period when Cali is generally open to AMA Sessions; actual open
+times also account for calendar conflicts and booking rules.
+_Avoid_: Slot, office hours
+
+**Slot Hold**:
+A 15-minute temporary claim on an available start time while a guest completes
+payment.
+_Avoid_: Booking, reservation
+
+**Booking**:
+A paid claim on one AMA Session start time, including its guest, Booking Brief,
+meeting choice, and lifecycle.
+_Avoid_: Appointment, order, transaction
+
+**Finalizing Booking**:
+A paid Booking whose meeting or calendar details are still being created and
+will be delivered after automatic or manual recovery.
+_Avoid_: Failed booking, pending payment
+
+**Alternate Time Request**:
+An unpaid request from a guest who cannot use any available start time.
+_Avoid_: Waitlist, custom booking
+
+**Manage Link**:
+A private capability link that lets a guest view, reschedule, or cancel one
+Booking without creating an account.
+_Avoid_: Account link, login link

--- a/lib/ama/admin/dashboard.test.tsx
+++ b/lib/ama/admin/dashboard.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { AdminDashboard } from '../../../app/admin/(protected)/AdminDashboard'
+import { AvailabilityWindowForm } from '../../../app/admin/(protected)/AvailabilityWindowForm'
+import { LOCALE_CHANGE_EVENT } from '../../locale-client'
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  delete document.documentElement.dataset.locale
+})
+
+function renderDashboard(
+  status: Parameters<typeof AdminDashboard>[0]['googleConnection']['status'],
+) {
+  return renderToStaticMarkup(
+    <AdminDashboard
+      windows={[
+        { id: 1, isoWeekday: 1, startMinute: 540, endMinute: 720 },
+      ]}
+      googleConnection={{
+        status,
+        identity:
+          status === 'disconnected'
+            ? null
+            : {
+                calendarId: 'owner@example.com',
+                summary: 'Cali Castle',
+                email: 'owner@example.com',
+              },
+      }}
+      previewSlots={[
+        {
+          startsAt: '2026-07-15T01:00:00.000Z',
+          endsAt: '2026-07-15T02:00:00.000Z',
+        },
+      ]}
+      notices={{ availability: 'invalid', calendar: status }}
+    />,
+  )
+}
+
+describe('AMA admin dashboard UI contract', () => {
+  it('keeps bilingual scheduling content and accessible form recovery in static HTML', () => {
+    const html = renderDashboard('expired')
+
+    expect(html).toMatch(/<label[^>]+for="[^"]+-weekday-zh"[^>]+data-zh-block="true"/)
+    expect(html).toMatch(/<label[^>]+for="[^"]+-weekday-en"[^>]+data-en-block="true"/)
+    expect(html).toContain('<option value="1" selected="">星期一</option>')
+    expect(html).toContain('<option value="1" selected="">Monday</option>')
+    expect(html).toContain('data-zh="true"')
+    expect(html).toContain('data-en="true"')
+    expect(html).toContain('Wed, Jul 15')
+    expect(html).toContain('aria-describedby="availability-notice"')
+    expect(html).toContain('id="availability-notice"')
+    expect(html).toContain('min-h-11')
+    expect(html).toContain('motion-reduce:transition-none')
+  })
+
+  it('offers recovery and local disconnect for an unhealthy Calendar connection', () => {
+    const html = renderDashboard('revoked')
+
+    expect(html).toContain('action="/api/admin/ama/google/connect"')
+    expect(html).toContain('action="/api/admin/ama/google/disconnect"')
+    expect(html).toContain('owner@example.com')
+  })
+
+  it('does not offer disconnect before a Calendar has connected', () => {
+    const html = renderDashboard('disconnected')
+
+    expect(html).toContain('action="/api/admin/ama/google/connect"')
+    expect(html).not.toContain('action="/api/admin/ama/google/disconnect"')
+  })
+
+  it('preserves an edited weekday when the locale changes mid-form', () => {
+    const { container } = render(<AvailabilityWindowForm />)
+    const zhSelect = container.querySelector<HTMLSelectElement>('label[data-zh-block] select')!
+    const enSelect = container.querySelector<HTMLSelectElement>('label[data-en-block] select')!
+
+    fireEvent.change(zhSelect, { target: { value: '5' } })
+    expect(zhSelect.value).toBe('5')
+    expect(enSelect.value).toBe('5')
+
+    act(() => {
+      document.documentElement.dataset.locale = 'en'
+      window.dispatchEvent(new Event(LOCALE_CHANGE_EVENT))
+    })
+
+    expect(enSelect.value).toBe('5')
+    expect(enSelect.options[4]?.text).toBe('Friday')
+    expect(zhSelect.options[4]?.text).toBe('星期五')
+    const formData = new FormData(container.querySelector('form')!)
+    expect(formData.get('weekdayZh')).toBe('5')
+    expect(formData.get('weekdayEn')).toBe('5')
+    expect(formData.get('weekdayOriginal')).toBe('1')
+  })
+
+  it('supports keyboard-style submission with a stable pending state', () => {
+    const { container } = render(<AvailabilityWindowForm />)
+    const form = container.querySelector('form')!
+    form.addEventListener('submit', (event) => event.preventDefault())
+
+    fireEvent.submit(form)
+
+    const save = container.querySelector<HTMLButtonElement>('button[value="create"]')!
+    expect(save.disabled).toBe(true)
+    expect(save.textContent).toContain('Saving')
+    for (const select of container.querySelectorAll('select')) {
+      expect(select.disabled).toBe(true)
+    }
+  })
+
+  it('restores focus to mutation feedback after a redirect render', () => {
+    render(
+      <AdminDashboard
+        windows={[]}
+        googleConnection={{ status: 'disconnected', identity: null }}
+        previewSlots={[]}
+        notices={{ availability: 'saved' }}
+      />,
+    )
+
+    expect(document.activeElement?.id).toBe('availability-notice')
+    expect(document.activeElement?.getAttribute('tabindex')).toBe('-1')
+  })
+
+  it('keeps delete idle when confirmation is cancelled and labels the accepted action', () => {
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const { container } = render(
+      <AvailabilityWindowForm
+        window={{ id: 1, isoWeekday: 1, startMinute: 540, endMinute: 720 }}
+      />,
+    )
+    const form = container.querySelector('form')!
+    form.addEventListener('submit', (event) => event.preventDefault())
+    const remove = container.querySelector<HTMLButtonElement>('button[value="delete"]')!
+
+    fireEvent.click(remove)
+    expect(confirm).toHaveBeenCalledOnce()
+    expect(remove.disabled).toBe(false)
+
+    confirm.mockReturnValue(true)
+    fireEvent.click(remove)
+    expect(remove.disabled).toBe(true)
+    expect(remove.textContent).toContain('Deleting')
+  })
+})

--- a/lib/ama/admin/http.test.ts
+++ b/lib/ama/admin/http.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createAvailabilityMutationHandler,
+  createGoogleCallbackHandler,
+  createGoogleConnectHandler,
+  createGoogleDisconnectHandler,
+  type AdminGoogleService,
+  type AvailabilityMutationService,
+  type OwnerRequestAuthenticator,
+} from './http'
+
+function formRequest(path: string, values: Record<string, string>, authenticated = true) {
+  const body = new FormData()
+  for (const [key, value] of Object.entries(values)) body.set(key, value)
+  return new Request(`https://attacker.example${path}`, {
+    method: 'POST',
+    headers: authenticated ? { cookie: 'owner=valid' } : undefined,
+    body,
+  })
+}
+
+function fixture() {
+  const mutations: unknown[] = []
+  const authenticator: OwnerRequestAuthenticator = {
+    async authenticate(request) {
+      return request.headers.get('cookie') === 'owner=valid'
+    },
+  }
+  const availability: AvailabilityMutationService = {
+    async create(input) {
+      mutations.push(['create', input])
+    },
+    async update(id, input) {
+      mutations.push(['update', id, input])
+    },
+    async delete(id) {
+      mutations.push(['delete', id])
+    },
+  }
+  const googleEvents: unknown[] = []
+  const google: AdminGoogleService = {
+    async begin() {
+      googleEvents.push(['begin'])
+      return new URL('https://accounts.google.com/o/oauth2/v2/auth?state=private')
+    },
+    async complete(input) {
+      googleEvents.push(['complete', input])
+      return 'connected'
+    },
+    async disconnect() {
+      googleEvents.push(['disconnect'])
+    },
+  }
+  return { authenticator, availability, google, mutations, googleEvents }
+}
+
+describe('AMA admin HTTP contract', () => {
+  it('redirects unauthenticated mutations to the canonical login page', async () => {
+    const f = fixture()
+    const handler = createAvailabilityMutationHandler({
+      authenticator: f.authenticator,
+      service: f.availability,
+      baseUrl: new URL('https://cali.so'),
+    })
+
+    const response = await handler(
+      formRequest(
+        '/api/admin/ama/availability',
+        { intent: 'create', weekday: '1', start: '09:00', end: '12:00' },
+        false,
+      ),
+    )
+
+    expect(response.status).toBe(303)
+    expect(response.headers.get('location')).toBe('https://cali.so/admin/login')
+    expect(f.mutations).toEqual([])
+  })
+
+  it('creates, updates, and deletes same-day Availability Windows', async () => {
+    const f = fixture()
+    const handler = createAvailabilityMutationHandler({
+      authenticator: f.authenticator,
+      service: f.availability,
+      baseUrl: new URL('https://cali.so'),
+    })
+
+    const createResponse = await handler(
+      formRequest('/api/admin/ama/availability', {
+        intent: 'create',
+        weekday: '1',
+        start: '09:30',
+        end: '12:00',
+      }),
+    )
+    const updateResponse = await handler(
+      formRequest('/api/admin/ama/availability', {
+        intent: 'update',
+        id: '7',
+        weekday: '5',
+        start: '13:00',
+        end: '17:30',
+      }),
+    )
+    const deleteResponse = await handler(
+      formRequest('/api/admin/ama/availability', { intent: 'delete', id: '7' }),
+    )
+
+    expect(f.mutations).toEqual([
+      ['create', { isoWeekday: 1, startMinute: 570, endMinute: 720 }],
+      ['update', 7, { isoWeekday: 5, startMinute: 780, endMinute: 1050 }],
+      ['delete', 7],
+    ])
+    for (const response of [createResponse, updateResponse, deleteResponse]) {
+      expect(response.status).toBe(303)
+      expect(response.headers.get('location')).toBe(
+        'https://cali.so/admin?availability=saved',
+      )
+    }
+  })
+
+  it('rejects malformed and overnight Availability Windows without mutation', async () => {
+    const f = fixture()
+    const handler = createAvailabilityMutationHandler({
+      authenticator: f.authenticator,
+      service: f.availability,
+      baseUrl: new URL('https://cali.so'),
+    })
+
+    const response = await handler(
+      formRequest('/api/admin/ama/availability', {
+        intent: 'create',
+        weekday: '8',
+        start: '18:00',
+        end: '09:00',
+      }),
+    )
+
+    expect(response.headers.get('location')).toBe(
+      'https://cali.so/admin?availability=invalid',
+    )
+    expect(f.mutations).toEqual([])
+  })
+
+  it('accepts the locale-specific weekday changed before hydration', async () => {
+    const f = fixture()
+    const handler = createAvailabilityMutationHandler({
+      authenticator: f.authenticator,
+      service: f.availability,
+      baseUrl: new URL('https://cali.so'),
+    })
+
+    const response = await handler(
+      formRequest('/api/admin/ama/availability', {
+        intent: 'create',
+        weekdayZh: '1',
+        weekdayEn: '5',
+        weekdayOriginal: '1',
+        start: '09:00',
+        end: '12:00',
+      }),
+    )
+
+    expect(f.mutations).toEqual([
+      ['create', { isoWeekday: 5, startMinute: 540, endMinute: 720 }],
+    ])
+    expect(response.headers.get('location')).toBe(
+      'https://cali.so/admin?availability=saved',
+    )
+  })
+
+  it('starts Google OAuth at the provider URL only for the owner', async () => {
+    const f = fixture()
+    const handler = createGoogleConnectHandler({
+      authenticator: f.authenticator,
+      service: f.google,
+      baseUrl: new URL('https://cali.so'),
+    })
+
+    const response = await handler(
+      new Request('https://attacker.example/api/admin/ama/google/connect', {
+        headers: { cookie: 'owner=valid' },
+      }),
+    )
+
+    expect(response.status).toBe(303)
+    expect(response.headers.get('location')).toMatch(/^https:\/\/accounts\.google\.com\//)
+    expect(f.googleEvents).toEqual([['begin']])
+  })
+
+  it('passes the OAuth callback values through one authenticated boundary', async () => {
+    const f = fixture()
+    const handler = createGoogleCallbackHandler({
+      authenticator: f.authenticator,
+      service: f.google,
+      baseUrl: new URL('https://cali.so'),
+    })
+    const request = new Request(
+      'https://cali.so/api/admin/ama/google/callback?state=s&code=c',
+      { headers: { cookie: 'owner=valid' } },
+    )
+
+    const response = await handler(request)
+
+    expect(f.googleEvents).toEqual([
+      ['complete', { state: 's', code: 'c', error: null }],
+    ])
+    expect(response.headers.get('location')).toBe('https://cali.so/admin?calendar=connected')
+  })
+
+  it('disconnects Calendar without touching Availability Windows', async () => {
+    const f = fixture()
+    const handler = createGoogleDisconnectHandler({
+      authenticator: f.authenticator,
+      service: f.google,
+      baseUrl: new URL('https://cali.so'),
+    })
+
+    const response = await handler(
+      formRequest('/api/admin/ama/google/disconnect', {}),
+    )
+
+    expect(f.googleEvents).toEqual([['disconnect']])
+    expect(f.mutations).toEqual([])
+    expect(response.headers.get('location')).toBe(
+      'https://cali.so/admin?calendar=disconnected',
+    )
+  })
+})

--- a/lib/ama/admin/http.ts
+++ b/lib/ama/admin/http.ts
@@ -1,0 +1,209 @@
+export interface OwnerRequestAuthenticator {
+  authenticate(request: Request): Promise<boolean>
+}
+
+export type AvailabilityWindowInput = {
+  isoWeekday: number
+  startMinute: number
+  endMinute: number
+}
+
+export interface AvailabilityMutationService {
+  create(input: AvailabilityWindowInput): Promise<unknown>
+  update(id: number, input: AvailabilityWindowInput): Promise<unknown>
+  delete(id: number): Promise<unknown>
+}
+
+export type GoogleCallbackResult =
+  | 'connected'
+  | 'denied-scope'
+  | 'expired'
+  | 'revoked'
+  | 'unavailable'
+
+export interface AdminGoogleService {
+  begin(): Promise<URL>
+  complete(input: {
+    state: string | null
+    code: string | null
+    error: string | null
+  }): Promise<GoogleCallbackResult>
+  disconnect(): Promise<void>
+}
+
+type HandlerDependencies<T> = {
+  authenticator: OwnerRequestAuthenticator
+  service: T
+  baseUrl: URL
+}
+
+function redirect(baseUrl: URL, pathOrUrl: string | URL) {
+  const location = pathOrUrl instanceof URL ? pathOrUrl : new URL(pathOrUrl, baseUrl)
+  return new Response(null, {
+    status: 303,
+    headers: {
+      location: location.toString(),
+      'cache-control': 'no-store',
+      'referrer-policy': 'no-referrer',
+    },
+  })
+}
+
+async function requireOwner(
+  authenticator: OwnerRequestAuthenticator,
+  request: Request,
+  baseUrl: URL,
+) {
+  if (await authenticator.authenticate(request)) return null
+  return redirect(baseUrl, '/admin/login')
+}
+
+function formString(formData: FormData, name: string) {
+  const value = formData.get(name)
+  return typeof value === 'string' ? value : ''
+}
+
+function parsePositiveInteger(value: string) {
+  if (!/^\d+$/.test(value)) return null
+  const parsed = Number(value)
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+function parseMinute(value: string, allowEndOfDay = false) {
+  if (allowEndOfDay && value === '24:00') return 24 * 60
+  const match = /^(\d{2}):(\d{2})$/.exec(value)
+  if (!match) return null
+  const hour = Number(match[1])
+  const minute = Number(match[2])
+  if (hour > 23 || minute > 59) return null
+  return hour * 60 + minute
+}
+
+function parseWeekday(formData: FormData) {
+  const direct = formString(formData, 'weekday')
+  if (direct) {
+    const parsed = parsePositiveInteger(direct)
+    return parsed !== null && parsed <= 7 ? parsed : null
+  }
+
+  const zh = parsePositiveInteger(formString(formData, 'weekdayZh'))
+  const en = parsePositiveInteger(formString(formData, 'weekdayEn'))
+  const original = parsePositiveInteger(formString(formData, 'weekdayOriginal'))
+  if (
+    zh === null ||
+    zh > 7 ||
+    en === null ||
+    en > 7 ||
+    original === null ||
+    original > 7
+  ) {
+    return null
+  }
+  if (zh === en) return zh
+  if (zh === original) return en
+  if (en === original) return zh
+  return null
+}
+
+function availabilityWindowFrom(formData: FormData): AvailabilityWindowInput | null {
+  const weekday = parseWeekday(formData)
+  const startMinute = parseMinute(formString(formData, 'start'))
+  const endMinute = parseMinute(formString(formData, 'end'), true)
+  if (
+    weekday === null ||
+    startMinute === null ||
+    endMinute === null ||
+    startMinute >= endMinute
+  ) {
+    return null
+  }
+  return { isoWeekday: weekday, startMinute, endMinute }
+}
+
+export function createAvailabilityMutationHandler({
+  authenticator,
+  service,
+  baseUrl,
+}: HandlerDependencies<AvailabilityMutationService>) {
+  return async function POST(request: Request) {
+    const unauthorized = await requireOwner(authenticator, request, baseUrl)
+    if (unauthorized) return unauthorized
+
+    try {
+      const formData = await request.formData()
+      const intent = formString(formData, 'intent')
+      const id = parsePositiveInteger(formString(formData, 'id'))
+
+      if (intent === 'delete' && id !== null) {
+        await service.delete(id)
+      } else {
+        const input = availabilityWindowFrom(formData)
+        if (!input || (intent === 'update' && id === null)) {
+          return redirect(baseUrl, '/admin?availability=invalid')
+        }
+        if (intent === 'create') await service.create(input)
+        else if (intent === 'update') await service.update(id!, input)
+        else return redirect(baseUrl, '/admin?availability=invalid')
+      }
+
+      return redirect(baseUrl, '/admin?availability=saved')
+    } catch {
+      return redirect(baseUrl, '/admin?availability=failed')
+    }
+  }
+}
+
+export function createGoogleConnectHandler({
+  authenticator,
+  service,
+  baseUrl,
+}: HandlerDependencies<AdminGoogleService>) {
+  return async function GET(request: Request) {
+    const unauthorized = await requireOwner(authenticator, request, baseUrl)
+    if (unauthorized) return unauthorized
+    try {
+      return redirect(baseUrl, await service.begin())
+    } catch {
+      return redirect(baseUrl, '/admin?calendar=unavailable')
+    }
+  }
+}
+
+export function createGoogleCallbackHandler({
+  authenticator,
+  service,
+  baseUrl,
+}: HandlerDependencies<AdminGoogleService>) {
+  return async function GET(request: Request) {
+    const unauthorized = await requireOwner(authenticator, request, baseUrl)
+    if (unauthorized) return unauthorized
+    const params = new URL(request.url).searchParams
+    try {
+      const result = await service.complete({
+        state: params.get('state'),
+        code: params.get('code'),
+        error: params.get('error'),
+      })
+      return redirect(baseUrl, `/admin?calendar=${result}`)
+    } catch {
+      return redirect(baseUrl, '/admin?calendar=unavailable')
+    }
+  }
+}
+
+export function createGoogleDisconnectHandler({
+  authenticator,
+  service,
+  baseUrl,
+}: HandlerDependencies<AdminGoogleService>) {
+  return async function POST(request: Request) {
+    const unauthorized = await requireOwner(authenticator, request, baseUrl)
+    if (unauthorized) return unauthorized
+    try {
+      await service.disconnect()
+      return redirect(baseUrl, '/admin?calendar=disconnected')
+    } catch {
+      return redirect(baseUrl, '/admin?calendar=unavailable')
+    }
+  }
+}

--- a/lib/ama/admin/server.ts
+++ b/lib/ama/admin/server.ts
@@ -1,0 +1,59 @@
+import 'server-only'
+
+import { availabilityRepository } from '../availability/repository'
+import { createAvailabilityService } from '../availability/service'
+import { authenticateOwnerRequest } from '../auth/http'
+import { getOwnerAuth } from '../auth/server'
+import { createGoogleCalendarClient } from '../google/client'
+import { googleRepository } from '../google/repository'
+import { createGoogleCalendarService } from '../google/service'
+import { getServerEnv } from '../server-env'
+import { createSecretBox } from '../secrets'
+
+export const AMA_OWNER_TIME_ZONE = 'Asia/Taipei'
+const GOOGLE_REQUEST_TIMEOUT_MS = 8_000
+
+let services: ReturnType<typeof createServices> | undefined
+
+function fetchWithTimeout(input: string | URL | Request, init: RequestInit = {}) {
+  const timeout = AbortSignal.timeout(GOOGLE_REQUEST_TIMEOUT_MS)
+  const signal = init.signal ? AbortSignal.any([init.signal, timeout]) : timeout
+  return fetch(input, { ...init, signal })
+}
+
+function createServices() {
+  const environment = getServerEnv()
+  const clock = { now: () => new Date() }
+  const google = createGoogleCalendarService({
+    ownerEmail: environment.ADMIN_EMAIL,
+    baseUrl: environment.SITE_URL,
+    repository: googleRepository,
+    provider: createGoogleCalendarClient({
+      clientId: environment.GOOGLE_CLIENT_ID,
+      clientSecret: environment.GOOGLE_CLIENT_SECRET,
+      fetch: fetchWithTimeout,
+      clock,
+    }),
+    secretBox: createSecretBox(environment.AMA_ENCRYPTION_KEY),
+    clock,
+  })
+  const availability = createAvailabilityService({
+    repository: availabilityRepository,
+    calendar: google,
+    ownerTimeZone: AMA_OWNER_TIME_ZONE,
+    clock,
+  })
+
+  return { google, availability, baseUrl: environment.SITE_URL }
+}
+
+export function getAmaAdminServices() {
+  services ??= createServices()
+  return services
+}
+
+export const ownerRequestAuthenticator = {
+  authenticate(request: Request) {
+    return authenticateOwnerRequest(getOwnerAuth(), request)
+  },
+}

--- a/lib/ama/auth/auth.test.ts
+++ b/lib/ama/auth/auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  authenticateOwnerRequest,
   createLogoutHandler,
   createMagicLinkRequestHandler,
   createMagicLinkVerifyHandler,
@@ -276,5 +277,34 @@ describe('owner authentication HTTP contract', () => {
     expect(logoutResponse.headers.get('location')).toBe('https://cali.so/admin/login')
     expect(logoutResponse.headers.get('set-cookie')).toContain('Max-Age=0')
     expect(await fixture.auth.authenticate(sessionCookie)).toBe(false)
+  })
+
+  it('authenticates protected API requests from the signed owner cookie', async () => {
+    const fixture = createFixture()
+    await requestMagicLink(
+      createMagicLinkRequestHandler(fixture.auth),
+      'owner@example.com',
+    )
+    const response = await createMagicLinkVerifyHandler(fixture.auth)(
+      new Request(fixture.sentLinks[0]),
+    )
+    const session = cookieValue(response)
+
+    await expect(
+      authenticateOwnerRequest(
+        fixture.auth,
+        new Request('https://cali.so/api/admin/ama/availability', {
+          headers: { cookie: `${AUTH_SESSION_COOKIE}=${session}` },
+        }),
+      ),
+    ).resolves.toBe(true)
+    await expect(
+      authenticateOwnerRequest(
+        fixture.auth,
+        new Request('https://cali.so/api/admin/ama/availability', {
+          headers: { cookie: `${AUTH_SESSION_COOKIE}=forged` },
+        }),
+      ),
+    ).resolves.toBe(false)
   })
 })

--- a/lib/ama/auth/auth.test.ts
+++ b/lib/ama/auth/auth.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createLogoutHandler,
+  createMagicLinkRequestHandler,
+  createMagicLinkVerifyHandler,
+} from './http'
+import {
+  AUTH_SESSION_COOKIE,
+  createOwnerAuth,
+  type AuthRepository,
+  type AuthSessionRecord,
+  type LoginTokenRecord,
+} from './service'
+
+function createFixture() {
+  let now = new Date('2026-07-14T04:00:00.000Z')
+  const tokens = new Map<string, LoginTokenRecord>()
+  const sessions = new Map<string, AuthSessionRecord>()
+  const sentLinks: string[] = []
+  let rateLimitAllowsRequest = true
+
+  const repository: AuthRepository = {
+    async createLoginToken(record) {
+      tokens.set(record.tokenHash, record)
+    },
+    async consumeLoginToken(tokenHash, ownerEmail, consumedAt) {
+      const token = tokens.get(tokenHash)
+      if (
+        !token ||
+        token.email !== ownerEmail ||
+        token.consumedAt ||
+        token.expiresAt <= consumedAt
+      ) {
+        return false
+      }
+      token.consumedAt = consumedAt
+      return true
+    },
+    async createSession(record) {
+      sessions.set(record.tokenHash, record)
+    },
+    async findActiveSession(tokenHash, ownerEmail, checkedAt) {
+      const session = sessions.get(tokenHash)
+      if (
+        !session ||
+        session.email !== ownerEmail ||
+        session.revokedAt ||
+        session.expiresAt <= checkedAt
+      ) {
+        return null
+      }
+      return session
+    },
+    async revokeSession(tokenHash, revokedAt) {
+      const session = sessions.get(tokenHash)
+      if (session && !session.revokedAt) session.revokedAt = revokedAt
+    },
+  }
+
+  function authFor(ownerEmail: string) {
+    return createOwnerAuth({
+      ownerEmail,
+      sessionSecret: 'a'.repeat(64),
+      baseUrl: new URL('https://cali.so'),
+      repository,
+      clock: { now: () => now },
+      rateLimiter: {
+        async limit() {
+          return { success: rateLimitAllowsRequest }
+        },
+      },
+      mailer: {
+        async sendMagicLink({ url }) {
+          sentLinks.push(url.toString())
+        },
+      },
+    })
+  }
+
+  const auth = authFor('owner@example.com')
+
+  return {
+    auth,
+    authFor,
+    sentLinks,
+    setNow(value: string) {
+      now = new Date(value)
+    },
+    denyRateLimit() {
+      rateLimitAllowsRequest = false
+    },
+  }
+}
+
+function requestMagicLink(handler: (request: Request) => Promise<Response>, email: string) {
+  const body = new FormData()
+  body.set('email', email)
+  return handler(
+    new Request('https://attacker.example/api/admin/auth/request', {
+      method: 'POST',
+      headers: { 'x-forwarded-for': '203.0.113.5' },
+      body,
+    }),
+  )
+}
+
+function cookieValue(response: Response) {
+  const match = response.headers.get('set-cookie')?.match(
+    new RegExp(`${AUTH_SESSION_COOKIE}=([^;]+)`),
+  )
+  return match?.[1]
+}
+
+describe('owner authentication HTTP contract', () => {
+  it('does not reveal whether an email is allowlisted', async () => {
+    const fixture = createFixture()
+    const handler = createMagicLinkRequestHandler(fixture.auth)
+
+    const denied = await requestMagicLink(handler, 'guest@example.com')
+    const allowed = await requestMagicLink(handler, 'OWNER@example.com')
+
+    expect(denied.status).toBe(303)
+    expect(allowed.status).toBe(303)
+    expect(denied.headers.get('location')).toBe('https://cali.so/admin/login?sent=1')
+    expect(allowed.headers.get('location')).toBe(denied.headers.get('location'))
+    expect(fixture.sentLinks).toHaveLength(1)
+  })
+
+  it('returns the same response before deferred delivery work runs', async () => {
+    const fixture = createFixture()
+    const tasks: Array<() => Promise<void>> = []
+    const handler = createMagicLinkRequestHandler(fixture.auth, (task) => {
+      tasks.push(task)
+    })
+
+    const denied = await requestMagicLink(handler, 'guest@example.com')
+    const allowed = await requestMagicLink(handler, 'owner@example.com')
+
+    expect(denied.headers.get('location')).toBe(allowed.headers.get('location'))
+    expect(fixture.sentLinks).toHaveLength(0)
+    await Promise.all(tasks.map((task) => task()))
+    expect(fixture.sentLinks).toHaveLength(1)
+  })
+
+  it('does not issue a magic link after the request limit is reached', async () => {
+    const fixture = createFixture()
+    fixture.denyRateLimit()
+
+    const response = await requestMagicLink(
+      createMagicLinkRequestHandler(fixture.auth),
+      'owner@example.com',
+    )
+
+    expect(response.status).toBe(303)
+    expect(response.headers.get('location')).toBe('https://cali.so/admin/login?sent=1')
+    expect(fixture.sentLinks).toHaveLength(0)
+  })
+
+  it('rejects an expired magic link', async () => {
+    const fixture = createFixture()
+    await requestMagicLink(
+      createMagicLinkRequestHandler(fixture.auth),
+      'owner@example.com',
+    )
+    const link = fixture.sentLinks[0]
+    fixture.setNow('2026-07-14T04:15:00.001Z')
+
+    const response = await createMagicLinkVerifyHandler(fixture.auth)(new Request(link))
+
+    expect(response.status).toBe(303)
+    expect(response.headers.get('location')).toBe(
+      'https://cali.so/admin/login?error=invalid-link',
+    )
+    expect(response.headers.get('set-cookie')).toBeNull()
+  })
+
+  it('consumes a magic link exactly once under concurrent requests', async () => {
+    const fixture = createFixture()
+    await requestMagicLink(
+      createMagicLinkRequestHandler(fixture.auth),
+      'owner@example.com',
+    )
+    const verify = createMagicLinkVerifyHandler(fixture.auth)
+
+    const responses = await Promise.all([
+      verify(new Request(fixture.sentLinks[0])),
+      verify(new Request(fixture.sentLinks[0])),
+    ])
+
+    expect(responses.filter((response) => cookieValue(response))).toHaveLength(1)
+    expect(responses.map((response) => response.headers.get('location')).sort()).toEqual([
+      'https://cali.so/admin',
+      'https://cali.so/admin/login?error=invalid-link',
+    ])
+  })
+
+  it('rejects links and sessions issued to a previous allowlisted owner', async () => {
+    const fixture = createFixture()
+    await requestMagicLink(
+      createMagicLinkRequestHandler(fixture.auth),
+      'owner@example.com',
+    )
+    const oldLink = fixture.sentLinks[0]
+    const newOwner = fixture.authFor('new-owner@example.com')
+
+    const oldLinkResponse = await createMagicLinkVerifyHandler(newOwner)(
+      new Request(oldLink),
+    )
+    expect(cookieValue(oldLinkResponse)).toBeUndefined()
+
+    await requestMagicLink(
+      createMagicLinkRequestHandler(fixture.auth),
+      'owner@example.com',
+    )
+    const oldSessionResponse = await createMagicLinkVerifyHandler(fixture.auth)(
+      new Request(fixture.sentLinks[1]),
+    )
+    expect(await newOwner.authenticate(cookieValue(oldSessionResponse))).toBe(false)
+  })
+
+  it('sets a signed 30-day secure session cookie', async () => {
+    const fixture = createFixture()
+    await requestMagicLink(
+      createMagicLinkRequestHandler(fixture.auth),
+      'owner@example.com',
+    )
+
+    const response = await createMagicLinkVerifyHandler(fixture.auth)(
+      new Request(fixture.sentLinks[0]),
+    )
+    const setCookie = response.headers.get('set-cookie') ?? ''
+
+    expect(cookieValue(response)?.split('.')).toHaveLength(2)
+    expect(setCookie).toContain('Max-Age=2592000')
+    expect(setCookie).toContain('Path=/')
+    expect(setCookie).toContain('HttpOnly')
+    expect(setCookie).toContain('Secure')
+    expect(setCookie).toContain('SameSite=Lax')
+  })
+
+  it('expires sessions after 30 days', async () => {
+    const fixture = createFixture()
+    await requestMagicLink(
+      createMagicLinkRequestHandler(fixture.auth),
+      'owner@example.com',
+    )
+    const response = await createMagicLinkVerifyHandler(fixture.auth)(
+      new Request(fixture.sentLinks[0]),
+    )
+    const sessionCookie = cookieValue(response)
+    fixture.setNow('2026-08-13T04:00:00.001Z')
+
+    expect(await fixture.auth.authenticate(sessionCookie)).toBe(false)
+  })
+
+  it('revokes the current session on logout and clears its cookie', async () => {
+    const fixture = createFixture()
+    await requestMagicLink(
+      createMagicLinkRequestHandler(fixture.auth),
+      'owner@example.com',
+    )
+    const loginResponse = await createMagicLinkVerifyHandler(fixture.auth)(
+      new Request(fixture.sentLinks[0]),
+    )
+    const sessionCookie = cookieValue(loginResponse)
+
+    const logoutResponse = await createLogoutHandler(fixture.auth)(
+      new Request('https://attacker.example/api/admin/auth/logout', {
+        method: 'POST',
+        headers: { cookie: `${AUTH_SESSION_COOKIE}=${sessionCookie}` },
+      }),
+    )
+
+    expect(logoutResponse.status).toBe(303)
+    expect(logoutResponse.headers.get('location')).toBe('https://cali.so/admin/login')
+    expect(logoutResponse.headers.get('set-cookie')).toContain('Max-Age=0')
+    expect(await fixture.auth.authenticate(sessionCookie)).toBe(false)
+  })
+})

--- a/lib/ama/auth/http.ts
+++ b/lib/ama/auth/http.ts
@@ -43,6 +43,10 @@ function readCookie(request: Request, name: string) {
   return undefined
 }
 
+export function authenticateOwnerRequest(auth: OwnerAuth, request: Request) {
+  return auth.authenticate(readCookie(request, AUTH_SESSION_COOKIE))
+}
+
 export function createMagicLinkRequestHandler(
   auth: OwnerAuth,
   defer: Defer = (task) => task(),

--- a/lib/ama/auth/http.ts
+++ b/lib/ama/auth/http.ts
@@ -1,0 +1,86 @@
+import {
+  AUTH_SESSION_COOKIE,
+  SESSION_LIFETIME_SECONDS,
+  type OwnerAuth,
+} from './service'
+
+type Defer = (task: () => Promise<void>) => void | Promise<void>
+
+function redirect(location: URL, setCookie?: string) {
+  const headers = new Headers({
+    location: location.toString(),
+    'cache-control': 'no-store',
+    'referrer-policy': 'no-referrer',
+  })
+  if (setCookie) headers.set('set-cookie', setCookie)
+  return new Response(null, { status: 303, headers })
+}
+
+function sessionCookie(value: string, maxAge = SESSION_LIFETIME_SECONDS) {
+  return [
+    `${AUTH_SESSION_COOKIE}=${value}`,
+    `Max-Age=${maxAge}`,
+    'Path=/',
+    'HttpOnly',
+    'Secure',
+    'SameSite=Lax',
+  ].join('; ')
+}
+
+function requestKey(request: Request) {
+  const forwarded = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+  return forwarded || request.headers.get('x-real-ip') || 'unknown'
+}
+
+function readCookie(request: Request, name: string) {
+  const cookie = request.headers.get('cookie')
+  if (!cookie) return undefined
+  for (const item of cookie.split(';')) {
+    const separator = item.indexOf('=')
+    if (separator === -1) continue
+    if (item.slice(0, separator).trim() === name) return item.slice(separator + 1).trim()
+  }
+  return undefined
+}
+
+export function createMagicLinkRequestHandler(
+  auth: OwnerAuth,
+  defer: Defer = (task) => task(),
+) {
+  return async function POST(request: Request) {
+    let email = ''
+    try {
+      const formData = await request.formData()
+      const value = formData.get('email')
+      email = typeof value === 'string' ? value : ''
+    } catch {
+      // Keep malformed input on the same non-enumerating response path.
+    }
+
+    await defer(async () => {
+      try {
+        await auth.requestMagicLink(email, requestKey(request))
+      } catch {
+        console.error('AMA magic-link request failed')
+      }
+    })
+
+    return redirect(auth.url('/admin/login?sent=1'))
+  }
+}
+
+export function createMagicLinkVerifyHandler(auth: OwnerAuth) {
+  return async function GET(request: Request) {
+    const token = new URL(request.url).searchParams.get('token')
+    const session = await auth.verifyMagicToken(token)
+    if (!session) return redirect(auth.url('/admin/login?error=invalid-link'))
+    return redirect(auth.url('/admin'), sessionCookie(session))
+  }
+}
+
+export function createLogoutHandler(auth: OwnerAuth) {
+  return async function POST(request: Request) {
+    await auth.logout(readCookie(request, AUTH_SESSION_COOKIE))
+    return redirect(auth.url('/admin/login'), sessionCookie('', 0))
+  }
+}

--- a/lib/ama/auth/repository.test.ts
+++ b/lib/ama/auth/repository.test.ts
@@ -1,0 +1,61 @@
+import { readFile } from 'node:fs/promises'
+
+import { PGlite } from '@electric-sql/pglite'
+import { drizzle } from 'drizzle-orm/pglite'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import { createAuthRepository, type AuthDatabase } from './repository'
+
+const migrationUrl = new URL('../../../db/migrations/0001_ama_owner_auth.sql', import.meta.url)
+
+describe('owner authentication repository', () => {
+  let client: PGlite
+  let repository: ReturnType<typeof createAuthRepository>
+
+  beforeEach(async () => {
+    client = new PGlite()
+    const migration = await readFile(migrationUrl, 'utf8')
+    await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
+    const database = drizzle(client)
+    repository = createAuthRepository(() => database as unknown as AuthDatabase)
+  })
+
+  afterEach(async () => {
+    await client.close()
+  })
+
+  it('allows exactly one concurrent consume for the current owner', async () => {
+    const now = new Date('2026-07-14T04:00:00.000Z')
+    await repository.createLoginToken({
+      tokenHash: 'a'.repeat(64),
+      email: 'owner@example.com',
+      expiresAt: new Date('2026-07-14T04:15:00.000Z'),
+      consumedAt: null,
+      createdAt: now,
+    })
+
+    const results = await Promise.all([
+      repository.consumeLoginToken('a'.repeat(64), 'owner@example.com', now),
+      repository.consumeLoginToken('a'.repeat(64), 'owner@example.com', now),
+    ])
+
+    expect(results.sort()).toEqual([false, true])
+  })
+
+  it('does not consume a token issued to a previous owner', async () => {
+    const now = new Date('2026-07-14T04:00:00.000Z')
+    await repository.createLoginToken({
+      tokenHash: 'b'.repeat(64),
+      email: 'old-owner@example.com',
+      expiresAt: new Date('2026-07-14T04:15:00.000Z'),
+      consumedAt: null,
+      createdAt: now,
+    })
+
+    await expect(
+      repository.consumeLoginToken('b'.repeat(64), 'new-owner@example.com', now),
+    ).resolves.toBe(false)
+  })
+})

--- a/lib/ama/auth/repository.ts
+++ b/lib/ama/auth/repository.ts
@@ -1,0 +1,87 @@
+import 'server-only'
+
+import { and, eq, gt, isNull } from 'drizzle-orm'
+
+import { getDatabase } from '~/db'
+import { amaAdminSessions, amaAuthTokens } from '~/db/schema'
+
+import type { AuthRepository } from './service'
+
+export type AuthDatabase = ReturnType<typeof getDatabase>
+
+export function createAuthRepository(database: () => AuthDatabase): AuthRepository {
+  return {
+    async createLoginToken(record) {
+      await database().insert(amaAuthTokens).values({
+        tokenHash: record.tokenHash,
+        ownerEmail: record.email,
+        expiresAt: record.expiresAt,
+        consumedAt: record.consumedAt,
+        createdAt: record.createdAt,
+      })
+    },
+
+    async consumeLoginToken(tokenHash, ownerEmail, consumedAt) {
+      const consumed = await database()
+        .update(amaAuthTokens)
+        .set({ consumedAt })
+        .where(
+          and(
+            eq(amaAuthTokens.tokenHash, tokenHash),
+            eq(amaAuthTokens.ownerEmail, ownerEmail),
+            isNull(amaAuthTokens.consumedAt),
+            gt(amaAuthTokens.expiresAt, consumedAt),
+          ),
+        )
+        .returning({ tokenHash: amaAuthTokens.tokenHash })
+      return consumed.length === 1
+    },
+
+    async createSession(record) {
+      await database().insert(amaAdminSessions).values({
+        tokenHash: record.tokenHash,
+        ownerEmail: record.email,
+        expiresAt: record.expiresAt,
+        revokedAt: record.revokedAt,
+        createdAt: record.createdAt,
+      })
+    },
+
+    async findActiveSession(tokenHash, ownerEmail, checkedAt) {
+      const [session] = await database()
+        .select()
+        .from(amaAdminSessions)
+        .where(
+          and(
+            eq(amaAdminSessions.tokenHash, tokenHash),
+            eq(amaAdminSessions.ownerEmail, ownerEmail),
+            isNull(amaAdminSessions.revokedAt),
+            gt(amaAdminSessions.expiresAt, checkedAt),
+          ),
+        )
+        .limit(1)
+      if (!session) return null
+      return {
+        tokenHash: session.tokenHash,
+        email: session.ownerEmail,
+        expiresAt: session.expiresAt,
+        revokedAt: session.revokedAt,
+        createdAt: session.createdAt,
+      }
+    },
+
+    async revokeSession(tokenHash, revokedAt) {
+      await database()
+        .update(amaAdminSessions)
+        .set({ revokedAt })
+        .where(
+          and(
+            eq(amaAdminSessions.tokenHash, tokenHash),
+            isNull(amaAdminSessions.revokedAt),
+          ),
+        )
+    },
+  }
+}
+
+export const authRepository = createAuthRepository(getDatabase)

--- a/lib/ama/auth/server.ts
+++ b/lib/ama/auth/server.ts
@@ -1,0 +1,77 @@
+import 'server-only'
+
+import { createHmac } from 'node:crypto'
+
+import { Ratelimit } from '@upstash/ratelimit'
+import { Redis } from '@upstash/redis'
+import { cookies } from 'next/headers'
+import { Resend } from 'resend'
+
+import { getServerEnv } from '~/lib/ama/server-env'
+
+import { authRepository } from './repository'
+import { AUTH_SESSION_COOKIE, createOwnerAuth } from './service'
+
+let ownerAuth: ReturnType<typeof createOwnerAuth> | undefined
+
+export function getOwnerAuth() {
+  if (ownerAuth) return ownerAuth
+
+  const environment = getServerEnv()
+  const resend = new Resend(environment.RESEND_API_KEY)
+  const redis = new Redis({
+    url: environment.UPSTASH_REDIS_REST_URL,
+    token: environment.UPSTASH_REDIS_REST_TOKEN,
+  })
+  const limiter = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(
+      environment.AUTH_RATE_LIMIT_MAX_REQUESTS,
+      `${environment.AUTH_RATE_LIMIT_WINDOW_SECONDS} s`,
+    ),
+    prefix: 'cali:ama:owner-auth',
+  })
+  const limiterKey = createHmac(
+    'sha256',
+    Buffer.from(environment.AMA_ENCRYPTION_KEY, 'base64'),
+  )
+    .update('ama-auth-rate-limit')
+    .digest()
+
+  ownerAuth = createOwnerAuth({
+    ownerEmail: environment.ADMIN_EMAIL,
+    sessionSecret: environment.SESSION_SECRET,
+    baseUrl: environment.SITE_URL,
+    repository: authRepository,
+    rateLimiter: {
+      limit(key) {
+        const privateKey = createHmac('sha256', limiterKey).update(key).digest('hex')
+        return limiter.limit(privateKey)
+      },
+    },
+    mailer: {
+      async sendMagicLink({ to, url }) {
+        const result = await resend.emails.send({
+          from: environment.RESEND_FROM_EMAIL,
+          to,
+          subject: 'Sign in to AMA admin',
+          text: [
+            'Use this private link to sign in to AMA admin:',
+            '',
+            url.toString(),
+            '',
+            'The link expires in 15 minutes and works once.',
+          ].join('\n'),
+        })
+        if (result.error) throw new Error('Magic-link delivery failed')
+      },
+    },
+  })
+
+  return ownerAuth
+}
+
+export async function isOwnerAuthenticated() {
+  const cookieStore = await cookies()
+  return getOwnerAuth().authenticate(cookieStore.get(AUTH_SESSION_COOKIE)?.value)
+}

--- a/lib/ama/auth/service.ts
+++ b/lib/ama/auth/service.ts
@@ -1,0 +1,153 @@
+import { createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
+
+export const AUTH_SESSION_COOKIE = '__Host-cali_ama_admin_session'
+export const MAGIC_LINK_LIFETIME_MS = 15 * 60 * 1000
+export const SESSION_LIFETIME_SECONDS = 30 * 24 * 60 * 60
+
+export type LoginTokenRecord = {
+  tokenHash: string
+  email: string
+  expiresAt: Date
+  consumedAt: Date | null
+  createdAt: Date
+}
+
+export type AuthSessionRecord = {
+  tokenHash: string
+  email: string
+  expiresAt: Date
+  revokedAt: Date | null
+  createdAt: Date
+}
+
+export interface AuthRepository {
+  createLoginToken(record: LoginTokenRecord): Promise<void>
+  consumeLoginToken(tokenHash: string, ownerEmail: string, consumedAt: Date): Promise<boolean>
+  createSession(record: AuthSessionRecord): Promise<void>
+  findActiveSession(
+    tokenHash: string,
+    ownerEmail: string,
+    checkedAt: Date,
+  ): Promise<AuthSessionRecord | null>
+  revokeSession(tokenHash: string, revokedAt: Date): Promise<void>
+}
+
+export interface AuthMailer {
+  sendMagicLink(input: { to: string; url: URL; expiresAt: Date }): Promise<void>
+}
+
+export interface AuthRateLimiter {
+  limit(key: string): Promise<{ success: boolean }>
+}
+
+type OwnerAuthDependencies = {
+  ownerEmail: string
+  sessionSecret: string
+  baseUrl: URL
+  repository: AuthRepository
+  mailer: AuthMailer
+  rateLimiter: AuthRateLimiter
+  clock?: { now(): Date }
+  randomToken?: () => string
+}
+
+function hash(value: string) {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function normalizeEmail(value: string) {
+  return value.trim().toLowerCase()
+}
+
+function sign(token: string, secret: string) {
+  return createHmac('sha256', secret).update(token).digest('base64url')
+}
+
+function signaturesMatch(actual: string, expected: string) {
+  const actualBytes = Buffer.from(actual)
+  const expectedBytes = Buffer.from(expected)
+  return actualBytes.length === expectedBytes.length && timingSafeEqual(actualBytes, expectedBytes)
+}
+
+function sessionTokenFromCookie(cookieValue: string | undefined, secret: string) {
+  if (!cookieValue) return null
+  const parts = cookieValue.split('.')
+  if (parts.length !== 2) return null
+  const [token, signature] = parts
+  if (!token || !signature || !signaturesMatch(signature, sign(token, secret))) return null
+  return token
+}
+
+export function createOwnerAuth(dependencies: OwnerAuthDependencies) {
+  const {
+    repository,
+    mailer,
+    rateLimiter,
+    baseUrl,
+    sessionSecret,
+    clock = { now: () => new Date() },
+    randomToken = () => randomBytes(32).toString('base64url'),
+  } = dependencies
+  const ownerEmail = normalizeEmail(dependencies.ownerEmail)
+
+  return {
+    url(path: string) {
+      return new URL(path, baseUrl)
+    },
+
+    async requestMagicLink(email: string, requestKey: string) {
+      const limit = await rateLimiter.limit(requestKey)
+      if (!limit.success || normalizeEmail(email) !== ownerEmail) return
+
+      const now = clock.now()
+      const expiresAt = new Date(now.getTime() + MAGIC_LINK_LIFETIME_MS)
+      const token = randomToken()
+      await repository.createLoginToken({
+        tokenHash: hash(token),
+        email: ownerEmail,
+        expiresAt,
+        consumedAt: null,
+        createdAt: now,
+      })
+
+      const url = new URL('/api/admin/auth/verify', baseUrl)
+      url.searchParams.set('token', token)
+      await mailer.sendMagicLink({ to: ownerEmail, url, expiresAt })
+    },
+
+    async verifyMagicToken(token: string | null) {
+      if (!token) return null
+      const now = clock.now()
+      const consumed = await repository.consumeLoginToken(hash(token), ownerEmail, now)
+      if (!consumed) return null
+
+      const sessionToken = randomToken()
+      const expiresAt = new Date(now.getTime() + SESSION_LIFETIME_SECONDS * 1000)
+      await repository.createSession({
+        tokenHash: hash(sessionToken),
+        email: ownerEmail,
+        expiresAt,
+        revokedAt: null,
+        createdAt: now,
+      })
+
+      return `${sessionToken}.${sign(sessionToken, sessionSecret)}`
+    },
+
+    async authenticate(cookieValue: string | undefined) {
+      const sessionToken = sessionTokenFromCookie(cookieValue, sessionSecret)
+      if (!sessionToken) return false
+      return Boolean(
+        await repository.findActiveSession(hash(sessionToken), ownerEmail, clock.now()),
+      )
+    },
+
+    async logout(cookieValue: string | undefined) {
+      const sessionToken = sessionTokenFromCookie(cookieValue, sessionSecret)
+      if (!sessionToken) return
+      await repository.revokeSession(hash(sessionToken), clock.now())
+    },
+  }
+}
+
+export type OwnerAuth = ReturnType<typeof createOwnerAuth>

--- a/lib/ama/availability/engine.test.ts
+++ b/lib/ama/availability/engine.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeAvailableSlots, type AvailabilityInput } from './engine'
+import { AMA_BOOKING_POLICY } from './policy'
+
+const at = (value: string) => new Date(value)
+
+function starts(input: AvailabilityInput) {
+  return computeAvailableSlots(input).map((slot) => slot.startsAt.toISOString())
+}
+
+function baseInput(overrides: Partial<AvailabilityInput> = {}): AvailabilityInput {
+  return {
+    now: at('2026-07-13T00:00:00.000Z'),
+    ownerTimeZone: 'UTC',
+    windows: [{ isoWeekday: 2, startMinute: 9 * 60, endMinute: 12 * 60 }],
+    googleBusy: [],
+    slotHolds: [],
+    bookings: [],
+    ...overrides,
+  }
+}
+
+describe('AMA availability policy', () => {
+  it('keeps the fixed booking rules in one policy value', () => {
+    expect(AMA_BOOKING_POLICY).toEqual({
+      sessionMinutes: 60,
+      minimumNoticeMinutes: 24 * 60,
+      horizonDays: 30,
+      bufferBeforeMinutes: 15,
+      bufferAfterMinutes: 15,
+      startCadenceMinutes: 30,
+    })
+  })
+})
+
+describe('computeAvailableSlots', () => {
+  it('requires the session, but not its buffers, to fit inside each window', () => {
+    const result = starts(baseInput())
+
+    expect(result.slice(0, 5)).toEqual([
+      '2026-07-14T09:00:00.000Z',
+      '2026-07-14T09:30:00.000Z',
+      '2026-07-14T10:00:00.000Z',
+      '2026-07-14T10:30:00.000Z',
+      '2026-07-14T11:00:00.000Z',
+    ])
+    expect(result).not.toContain('2026-07-14T11:30:00.000Z')
+  })
+
+  it('includes the notice boundary and excludes the rolling horizon boundary', () => {
+    const result = starts(
+      baseInput({
+        now: at('2026-07-13T09:00:00.000Z'),
+        windows: [
+          { isoWeekday: 2, startMinute: 9 * 60, endMinute: 10 * 60 },
+          { isoWeekday: 3, startMinute: 9 * 60, endMinute: 10 * 60 },
+        ],
+      }),
+    )
+
+    expect(result).toContain('2026-07-14T09:00:00.000Z')
+    expect(result).not.toContain('2026-08-12T09:00:00.000Z')
+  })
+
+  it('applies buffers to busy time while preserving half-open touching edges', () => {
+    const result = starts(
+      baseInput({
+        googleBusy: [
+          {
+            startsAt: at('2026-07-14T10:15:00.000Z'),
+            endsAt: at('2026-07-14T10:45:00.000Z'),
+          },
+        ],
+      }),
+    )
+
+    expect(result.filter((start) => start.startsWith('2026-07-14'))).toEqual([
+      '2026-07-14T09:00:00.000Z',
+      '2026-07-14T11:00:00.000Z',
+    ])
+  })
+
+  it('ignores expired holds and blocks active holds and Bookings', () => {
+    const result = starts(
+      baseInput({
+        windows: [{ isoWeekday: 2, startMinute: 9 * 60, endMinute: 13 * 60 }],
+        slotHolds: [
+          {
+            startsAt: at('2026-07-14T09:00:00.000Z'),
+            endsAt: at('2026-07-14T10:00:00.000Z'),
+            expiresAt: at('2026-07-13T00:00:00.000Z'),
+          },
+          {
+            startsAt: at('2026-07-14T12:00:00.000Z'),
+            endsAt: at('2026-07-14T13:00:00.000Z'),
+            expiresAt: at('2026-07-13T00:00:00.001Z'),
+          },
+        ],
+        bookings: [
+          {
+            startsAt: at('2026-07-14T10:30:00.000Z'),
+            endsAt: at('2026-07-14T11:30:00.000Z'),
+          },
+        ],
+      }),
+    )
+
+    expect(result).toContain('2026-07-14T09:00:00.000Z')
+    expect(result).not.toContain('2026-07-14T10:00:00.000Z')
+    expect(result).not.toContain('2026-07-14T11:30:00.000Z')
+  })
+
+  it('interprets recurring windows in the owner time zone across a UTC date boundary', () => {
+    const result = starts(
+      baseInput({
+        ownerTimeZone: 'Asia/Taipei',
+        windows: [{ isoWeekday: 2, startMinute: 7 * 60, endMinute: 9 * 60 }],
+      }),
+    )
+
+    expect(result[0]).toBe('2026-07-14T00:00:00.000Z')
+  })
+
+  it('skips nonexistent starts in a daylight-saving gap', () => {
+    const result = starts(
+      baseInput({
+        now: at('2026-03-06T00:00:00.000Z'),
+        ownerTimeZone: 'America/New_York',
+        windows: [{ isoWeekday: 7, startMinute: 60, endMinute: 4 * 60 }],
+      }),
+    ).filter((start) => start.startsWith('2026-03-08'))
+
+    expect(result).toEqual([
+      '2026-03-08T06:00:00.000Z',
+      '2026-03-08T06:30:00.000Z',
+      '2026-03-08T07:00:00.000Z',
+    ])
+  })
+
+  it('offers both real instants for repeated starts in a daylight-saving fold', () => {
+    const result = starts(
+      baseInput({
+        now: at('2026-10-30T00:00:00.000Z'),
+        ownerTimeZone: 'America/New_York',
+        windows: [{ isoWeekday: 7, startMinute: 30, endMinute: 3 * 60 }],
+      }),
+    ).filter((start) => start.startsWith('2026-11-01'))
+
+    expect(result).toEqual([
+      '2026-11-01T04:30:00.000Z',
+      '2026-11-01T05:00:00.000Z',
+      '2026-11-01T05:30:00.000Z',
+      '2026-11-01T06:00:00.000Z',
+      '2026-11-01T06:30:00.000Z',
+      '2026-11-01T07:00:00.000Z',
+    ])
+  })
+
+  it('merges multiple windows into a sorted deterministic set without duplicates', () => {
+    const first = baseInput({
+      windows: [
+        { isoWeekday: 2, startMinute: 10 * 60, endMinute: 12 * 60 },
+        { isoWeekday: 2, startMinute: 9 * 60, endMinute: 11 * 60 },
+      ],
+      googleBusy: [
+        {
+          startsAt: at('2026-07-21T09:45:00.000Z'),
+          endsAt: at('2026-07-21T10:15:00.000Z'),
+        },
+        {
+          startsAt: at('2026-07-14T09:45:00.000Z'),
+          endsAt: at('2026-07-14T10:15:00.000Z'),
+        },
+      ],
+    })
+    const second = {
+      ...first,
+      windows: [...first.windows].reverse(),
+      googleBusy: [...first.googleBusy].reverse(),
+    }
+
+    const firstResult = starts(first)
+    const secondResult = starts(second)
+
+    expect(firstResult).toEqual(secondResult)
+    expect(firstResult).toEqual([...new Set(firstResult)].sort())
+  })
+})

--- a/lib/ama/availability/engine.ts
+++ b/lib/ama/availability/engine.ts
@@ -1,0 +1,199 @@
+import { Temporal } from '@js-temporal/polyfill'
+
+import { AMA_BOOKING_POLICY } from './policy'
+
+export type AvailabilityWindow = {
+  /** ISO weekday: Monday is 1 and Sunday is 7. */
+  isoWeekday: number
+  /** Inclusive local wall-clock minute from midnight. */
+  startMinute: number
+  /** Exclusive local wall-clock minute from midnight; 1440 means midnight. */
+  endMinute: number
+}
+
+export type TimeInterval = {
+  startsAt: Date
+  endsAt: Date
+}
+
+export type SlotHold = TimeInterval & {
+  expiresAt: Date
+}
+
+export type AvailabilityInput = {
+  now: Date
+  ownerTimeZone: string
+  windows: readonly AvailabilityWindow[]
+  googleBusy: readonly TimeInterval[]
+  slotHolds: readonly SlotHold[]
+  bookings: readonly TimeInterval[]
+}
+
+export type AvailableSlot = TimeInterval
+
+const millisecondsPerMinute = 60_000
+
+function instant(date: Date) {
+  if (Number.isNaN(date.getTime())) throw new RangeError('Availability dates must be valid')
+  return Temporal.Instant.fromEpochMilliseconds(date.getTime())
+}
+
+function plainDateTimeAt(date: Temporal.PlainDate, minute: number) {
+  if (!Number.isInteger(minute) || minute < 0 || minute > 24 * 60) {
+    throw new RangeError(
+      'Availability window minutes must be integers from 0 through 1440',
+    )
+  }
+  if (minute === 24 * 60) return date.add({ days: 1 }).toPlainDateTime('00:00')
+  return date.toPlainDateTime({
+    hour: Math.floor(minute / 60),
+    minute: minute % 60,
+  })
+}
+
+function possibleStartInstants(plain: Temporal.PlainDateTime, timeZone: string) {
+  const earlier = plain.toZonedDateTime(timeZone, { disambiguation: 'earlier' })
+  const later = plain.toZonedDateTime(timeZone, { disambiguation: 'later' })
+  const candidates = [earlier, later].filter((value) =>
+    value.toPlainDateTime().equals(plain),
+  )
+
+  const unique = new Map<string, Temporal.Instant>()
+  for (const candidate of candidates) {
+    const candidateInstant = candidate.toInstant()
+    unique.set(candidateInstant.toString(), candidateInstant)
+  }
+  return [...unique.values()].sort(Temporal.Instant.compare)
+}
+
+function windowBoundary(
+  plain: Temporal.PlainDateTime,
+  timeZone: string,
+  edge: 'start' | 'end',
+) {
+  const earlier = plain.toZonedDateTime(timeZone, { disambiguation: 'earlier' })
+  const later = plain.toZonedDateTime(timeZone, { disambiguation: 'later' })
+  const earlierMatches = earlier.toPlainDateTime().equals(plain)
+  const laterMatches = later.toPlainDateTime().equals(plain)
+
+  if (earlierMatches && laterMatches) {
+    return edge === 'start' ? earlier.toInstant() : later.toInstant()
+  }
+
+  // A boundary inside a spring-forward gap has no real instant. The start
+  // advances beyond the gap while the end stops before it.
+  return edge === 'start' ? later.toInstant() : earlier.toInstant()
+}
+
+function assertWindow(window: AvailabilityWindow) {
+  if (
+    !Number.isInteger(window.isoWeekday) ||
+    window.isoWeekday < 1 ||
+    window.isoWeekday > 7
+  ) {
+    throw new RangeError(
+      'Availability window weekday must be an ISO weekday from 1 through 7',
+    )
+  }
+  plainDateTimeAt(Temporal.PlainDate.from('2000-01-03'), window.startMinute)
+  plainDateTimeAt(Temporal.PlainDate.from('2000-01-03'), window.endMinute)
+  if (window.startMinute >= window.endMinute) {
+    throw new RangeError('Availability window start must be before its end')
+  }
+}
+
+function intervalMilliseconds(interval: TimeInterval) {
+  const startsAt = interval.startsAt.getTime()
+  const endsAt = interval.endsAt.getTime()
+  if (!Number.isFinite(startsAt) || !Number.isFinite(endsAt) || startsAt >= endsAt) {
+    throw new RangeError('Blocking intervals must have valid ascending dates')
+  }
+  return { startsAt, endsAt }
+}
+
+function overlapsHalfOpen(
+  candidateStart: number,
+  candidateEnd: number,
+  blocker: { startsAt: number; endsAt: number },
+) {
+  return candidateStart < blocker.endsAt && blocker.startsAt < candidateEnd
+}
+
+export function computeAvailableSlots(input: AvailabilityInput): AvailableSlot[] {
+  const now = instant(input.now)
+  // Resolving the instant in the supplied zone validates the IANA identifier.
+  const ownerNow = now.toZonedDateTimeISO(input.ownerTimeZone)
+  const minimumStart = now.add({ minutes: AMA_BOOKING_POLICY.minimumNoticeMinutes })
+  const horizon = now.add({ hours: AMA_BOOKING_POLICY.horizonDays * 24 })
+  const lastOwnerDate = horizon.toZonedDateTimeISO(input.ownerTimeZone).toPlainDate()
+
+  for (const window of input.windows) assertWindow(window)
+
+  const activeHolds = input.slotHolds
+    .filter((hold) => hold.expiresAt.getTime() > input.now.getTime())
+    .map(intervalMilliseconds)
+  const blockers = [
+    ...input.googleBusy.map(intervalMilliseconds),
+    ...activeHolds,
+    ...input.bookings.map(intervalMilliseconds),
+  ]
+
+  const slots = new Map<number, AvailableSlot>()
+  let ownerDate = ownerNow.toPlainDate()
+  while (Temporal.PlainDate.compare(ownerDate, lastOwnerDate) <= 0) {
+    for (const window of input.windows) {
+      if (window.isoWeekday !== ownerDate.dayOfWeek) continue
+
+      const windowStart = windowBoundary(
+        plainDateTimeAt(ownerDate, window.startMinute),
+        input.ownerTimeZone,
+        'start',
+      )
+      const windowEnd = windowBoundary(
+        plainDateTimeAt(ownerDate, window.endMinute),
+        input.ownerTimeZone,
+        'end',
+      )
+      if (Temporal.Instant.compare(windowStart, windowEnd) >= 0) continue
+
+      for (
+        let candidateMinute = window.startMinute;
+        candidateMinute < window.endMinute;
+        candidateMinute += AMA_BOOKING_POLICY.startCadenceMinutes
+      ) {
+        const localCandidate = plainDateTimeAt(ownerDate, candidateMinute)
+        for (const startsAt of possibleStartInstants(localCandidate, input.ownerTimeZone)) {
+          const endsAt = startsAt.add({ minutes: AMA_BOOKING_POLICY.sessionMinutes })
+          if (Temporal.Instant.compare(startsAt, windowStart) < 0) continue
+          if (Temporal.Instant.compare(endsAt, windowEnd) > 0) continue
+          if (Temporal.Instant.compare(startsAt, minimumStart) < 0) continue
+          if (Temporal.Instant.compare(startsAt, horizon) >= 0) continue
+
+          const startsAtMs = startsAt.epochMilliseconds
+          const endsAtMs = endsAt.epochMilliseconds
+          const bufferedStart =
+            startsAtMs - AMA_BOOKING_POLICY.bufferBeforeMinutes * millisecondsPerMinute
+          const bufferedEnd =
+            endsAtMs + AMA_BOOKING_POLICY.bufferAfterMinutes * millisecondsPerMinute
+          if (
+            blockers.some((blocker) =>
+              overlapsHalfOpen(bufferedStart, bufferedEnd, blocker),
+            )
+          ) {
+            continue
+          }
+
+          slots.set(startsAtMs, {
+            startsAt: new Date(startsAtMs),
+            endsAt: new Date(endsAtMs),
+          })
+        }
+      }
+    }
+    ownerDate = ownerDate.add({ days: 1 })
+  }
+
+  return [...slots.values()].sort(
+    (left, right) => left.startsAt.getTime() - right.startsAt.getTime(),
+  )
+}

--- a/lib/ama/availability/policy.ts
+++ b/lib/ama/availability/policy.ts
@@ -1,0 +1,9 @@
+export const AMA_BOOKING_POLICY = Object.freeze({
+  sessionMinutes: 60,
+  minimumNoticeMinutes: 24 * 60,
+  horizonDays: 30,
+  bufferBeforeMinutes: 15,
+  bufferAfterMinutes: 15,
+  // Offer starts on the half hour while keeping 60-minute sessions flexible.
+  startCadenceMinutes: 30,
+})

--- a/lib/ama/availability/repository.test.ts
+++ b/lib/ama/availability/repository.test.ts
@@ -1,0 +1,113 @@
+import { readFile } from 'node:fs/promises'
+
+import { PGlite } from '@electric-sql/pglite'
+import { drizzle } from 'drizzle-orm/pglite'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import {
+  createAvailabilityRepository,
+  type AvailabilityDatabase,
+} from './repository'
+
+const migrations = [
+  new URL('../../../db/migrations/0001_ama_owner_auth.sql', import.meta.url),
+  new URL('../../../db/migrations/0002_ama_availability.sql', import.meta.url),
+]
+
+describe('Availability Window repository', () => {
+  let client: PGlite
+  let repository: ReturnType<typeof createAvailabilityRepository>
+
+  beforeEach(async () => {
+    client = new PGlite()
+    for (const migrationUrl of migrations) {
+      const migration = await readFile(migrationUrl, 'utf8')
+      await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
+    }
+    const database = drizzle(client)
+    repository = createAvailabilityRepository(() => database as unknown as AvailabilityDatabase)
+  })
+
+  afterEach(async () => {
+    await client.close()
+  })
+
+  it('stores multiple same-day Availability Windows in deterministic order', async () => {
+    await repository.create({ isoWeekday: 3, startMinute: 780, endMinute: 1020 })
+    await repository.create({ isoWeekday: 1, startMinute: 540, endMinute: 720 })
+    await repository.create({ isoWeekday: 1, startMinute: 780, endMinute: 900 })
+
+    const windows = await repository.list()
+
+    expect(windows.map(({ isoWeekday, startMinute, endMinute }) => ({
+      isoWeekday,
+      startMinute,
+      endMinute,
+    }))).toEqual([
+      { isoWeekday: 1, startMinute: 540, endMinute: 720 },
+      { isoWeekday: 1, startMinute: 780, endMinute: 900 },
+      { isoWeekday: 3, startMinute: 780, endMinute: 1020 },
+    ])
+  })
+
+  it('edits an existing Availability Window', async () => {
+    const created = await repository.create({ isoWeekday: 2, startMinute: 540, endMinute: 720 })
+
+    const updated = await repository.update(created.id, {
+      isoWeekday: 4,
+      startMinute: 780,
+      endMinute: 960,
+    })
+
+    expect(updated).toMatchObject({
+      id: created.id,
+      isoWeekday: 4,
+      startMinute: 780,
+      endMinute: 960,
+    })
+  })
+
+  it('deletes an Availability Window by id', async () => {
+    const kept = await repository.create({ isoWeekday: 2, startMinute: 540, endMinute: 720 })
+    const removed = await repository.create({
+      isoWeekday: 4,
+      startMinute: 780,
+      endMinute: 960,
+    })
+
+    await expect(repository.delete(removed.id)).resolves.toBe(true)
+    await expect(repository.delete(removed.id)).resolves.toBe(false)
+    await expect(repository.list()).resolves.toMatchObject([{ id: kept.id }])
+  })
+
+  it.each([
+    { isoWeekday: 0, startMinute: 540, endMinute: 720 },
+    { isoWeekday: 8, startMinute: 540, endMinute: 720 },
+  ])('rejects an invalid ISO weekday: $isoWeekday', async (input) => {
+    await expect(repository.create(input)).rejects.toThrow()
+  })
+
+  it.each([
+    { isoWeekday: 1, startMinute: -1, endMinute: 720 },
+    { isoWeekday: 1, startMinute: 1440, endMinute: 1441 },
+    { isoWeekday: 1, startMinute: 0, endMinute: 0 },
+    { isoWeekday: 1, startMinute: 1439, endMinute: 1441 },
+  ])(
+    'rejects invalid minute bounds: $startMinute-$endMinute',
+    async (input) => {
+      await expect(repository.create(input)).rejects.toThrow()
+    },
+  )
+
+  it.each([
+    { isoWeekday: 1, startMinute: 720, endMinute: 720 },
+    { isoWeekday: 1, startMinute: 900, endMinute: 540 },
+  ])(
+    'rejects an equal or overnight Availability Window: $startMinute-$endMinute',
+    async (input) => {
+      await expect(repository.create(input)).rejects.toThrow()
+    },
+  )
+})

--- a/lib/ama/availability/repository.ts
+++ b/lib/ama/availability/repository.ts
@@ -1,0 +1,57 @@
+import 'server-only'
+
+import { asc, eq, sql } from 'drizzle-orm'
+
+import { getDatabase } from '~/db'
+import { amaAvailabilityWindows } from '~/db/schema'
+
+export type AvailabilityDatabase = ReturnType<typeof getDatabase>
+
+export type AvailabilityWindowInput = {
+  isoWeekday: number
+  startMinute: number
+  endMinute: number
+}
+
+export function createAvailabilityRepository(database: () => AvailabilityDatabase) {
+  return {
+    async create(input: AvailabilityWindowInput) {
+      const [created] = await database()
+        .insert(amaAvailabilityWindows)
+        .values(input)
+        .returning()
+      return created
+    },
+
+    async update(id: number, input: AvailabilityWindowInput) {
+      const [updated] = await database()
+        .update(amaAvailabilityWindows)
+        .set({ ...input, updatedAt: sql`now()` })
+        .where(eq(amaAvailabilityWindows.id, id))
+        .returning()
+      return updated ?? null
+    },
+
+    async delete(id: number) {
+      const [deleted] = await database()
+        .delete(amaAvailabilityWindows)
+        .where(eq(amaAvailabilityWindows.id, id))
+        .returning({ id: amaAvailabilityWindows.id })
+      return deleted !== undefined
+    },
+
+    list() {
+      return database()
+        .select()
+        .from(amaAvailabilityWindows)
+        .orderBy(
+          asc(amaAvailabilityWindows.isoWeekday),
+          asc(amaAvailabilityWindows.startMinute),
+          asc(amaAvailabilityWindows.endMinute),
+          asc(amaAvailabilityWindows.id),
+        )
+    },
+  }
+}
+
+export const availabilityRepository = createAvailabilityRepository(getDatabase)

--- a/lib/ama/availability/service.test.ts
+++ b/lib/ama/availability/service.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import type { TimeInterval, SlotHold } from './engine'
+import {
+  createAvailabilityService,
+  type AvailabilityRepository,
+  type CalendarAvailability,
+} from './service'
+
+function fixture() {
+  let id = 3
+  const windows = [
+    {
+      id: 1,
+      isoWeekday: 3,
+      startMinute: 9 * 60,
+      endMinute: 12 * 60,
+      createdAt: new Date('2026-07-14T00:00:00.000Z'),
+      updatedAt: new Date('2026-07-14T00:00:00.000Z'),
+    },
+    {
+      id: 2,
+      isoWeekday: 3,
+      startMinute: 13 * 60,
+      endMinute: 17 * 60,
+      createdAt: new Date('2026-07-14T00:00:00.000Z'),
+      updatedAt: new Date('2026-07-14T00:00:00.000Z'),
+    },
+  ]
+  const repository: AvailabilityRepository = {
+    async list() {
+      return [...windows]
+    },
+    async create(input) {
+      const created = {
+        id: id++,
+        ...input,
+        createdAt: new Date('2026-07-14T00:00:00.000Z'),
+        updatedAt: new Date('2026-07-14T00:00:00.000Z'),
+      }
+      windows.push(created)
+      return created
+    },
+    async update(windowId, input) {
+      const existing = windows.find((window) => window.id === windowId)
+      if (!existing) return null
+      Object.assign(existing, input)
+      return existing
+    },
+    async delete(windowId) {
+      const index = windows.findIndex((window) => window.id === windowId)
+      if (index === -1) return false
+      windows.splice(index, 1)
+      return true
+    },
+  }
+  let calendarResult: Awaited<ReturnType<CalendarAvailability['queryFreeBusy']>> = {
+    status: 'connected',
+    busy: [],
+  }
+  const calendar: CalendarAvailability = {
+    async queryFreeBusy() {
+      return calendarResult
+    },
+  }
+  const service = createAvailabilityService({
+    repository,
+    calendar,
+    ownerTimeZone: 'Asia/Taipei',
+    clock: { now: () => new Date('2026-07-14T00:00:00.000Z') },
+  })
+  return {
+    service,
+    windows,
+    setCalendarResult(value: typeof calendarResult) {
+      calendarResult = value
+    },
+  }
+}
+
+describe('Availability Window service', () => {
+  it('stores touching and overlapping windows without a racy preflight check', async () => {
+    const f = fixture()
+
+    await expect(
+      f.service.create({ isoWeekday: 3, startMinute: 12 * 60, endMinute: 13 * 60 }),
+    ).resolves.toMatchObject({ startMinute: 720, endMinute: 780 })
+    await expect(
+      f.service.create({ isoWeekday: 3, startMinute: 11 * 60, endMinute: 14 * 60 }),
+    ).resolves.toMatchObject({ startMinute: 660, endMinute: 840 })
+  })
+
+  it('edits a window even when the result overlaps another window', async () => {
+    const f = fixture()
+
+    await expect(
+      f.service.update(1, { isoWeekday: 3, startMinute: 8 * 60, endMinute: 12 * 60 }),
+    ).resolves.toMatchObject({ id: 1, startMinute: 480 })
+    await expect(
+      f.service.update(1, { isoWeekday: 3, startMinute: 12 * 60, endMinute: 14 * 60 }),
+    ).resolves.toMatchObject({ id: 1, startMinute: 720, endMinute: 840 })
+  })
+
+  it('deletes only the selected Availability Window', async () => {
+    const f = fixture()
+
+    await f.service.delete(1)
+
+    expect(f.windows.map((window) => window.id)).toEqual([2])
+  })
+
+  it('previews slots through the production engine with Google busy time', async () => {
+    const f = fixture()
+    f.setCalendarResult({
+      status: 'connected',
+      busy: [
+        {
+          startsAt: new Date('2026-07-15T02:00:00.000Z'),
+          endsAt: new Date('2026-07-15T03:00:00.000Z'),
+        },
+      ],
+    })
+
+    const preview = await f.service.preview()
+
+    expect(preview.status).toBe('connected')
+    expect(preview.slots.slice(0, 3).map((slot) => slot.startsAt.toISOString())).toEqual([
+      '2026-07-15T05:00:00.000Z',
+      '2026-07-15T05:30:00.000Z',
+      '2026-07-15T06:00:00.000Z',
+    ])
+  })
+
+  it('fails closed when Calendar is disconnected or unavailable', async () => {
+    const f = fixture()
+    f.setCalendarResult({ status: 'disconnected', busy: [] })
+
+    await expect(f.service.preview()).resolves.toEqual({
+      status: 'disconnected',
+      slots: [],
+    })
+  })
+
+  it('combines caller-provided active holds and Bookings in the same preview engine', async () => {
+    const f = fixture()
+    const slotHolds: SlotHold[] = [
+      {
+        startsAt: new Date('2026-07-15T01:00:00.000Z'),
+        endsAt: new Date('2026-07-15T02:00:00.000Z'),
+        expiresAt: new Date('2026-07-14T00:15:00.000Z'),
+      },
+    ]
+    const bookings: TimeInterval[] = [
+      {
+        startsAt: new Date('2026-07-15T04:00:00.000Z'),
+        endsAt: new Date('2026-07-15T05:00:00.000Z'),
+      },
+    ]
+
+    const preview = await f.service.preview({ slotHolds, bookings })
+
+    expect(preview.slots.slice(0, 2).map((slot) => slot.startsAt.toISOString())).toEqual([
+      '2026-07-15T02:30:00.000Z',
+      '2026-07-15T05:30:00.000Z',
+    ])
+  })
+})

--- a/lib/ama/availability/service.ts
+++ b/lib/ama/availability/service.ts
@@ -1,0 +1,137 @@
+import 'server-only'
+
+import { AMA_BOOKING_POLICY } from './policy'
+import {
+  computeAvailableSlots,
+  type AvailabilityWindow,
+  type SlotHold,
+  type TimeInterval,
+} from './engine'
+
+export type AvailabilityWindowRecord = AvailabilityWindow & {
+  id: number
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface AvailabilityRepository {
+  list(): Promise<AvailabilityWindowRecord[]>
+  create(input: AvailabilityWindow): Promise<AvailabilityWindowRecord>
+  update(id: number, input: AvailabilityWindow): Promise<AvailabilityWindowRecord | null>
+  delete(id: number): Promise<boolean>
+}
+
+export type CalendarAvailabilityStatus =
+  | 'connected'
+  | 'disconnected'
+  | 'denied-scope'
+  | 'expired'
+  | 'revoked'
+  | 'unavailable'
+
+export interface CalendarAvailability {
+  queryFreeBusy(input: { timeMin: Date; timeMax: Date }): Promise<{
+    status: CalendarAvailabilityStatus
+    busy: TimeInterval[]
+  }>
+}
+
+type AvailabilityServiceDependencies = {
+  repository: AvailabilityRepository
+  calendar: CalendarAvailability
+  ownerTimeZone: string
+  clock?: { now(): Date }
+}
+
+export class InvalidAvailabilityWindowError extends Error {
+  constructor() {
+    super('Availability Window must be a same-day interval')
+    this.name = 'InvalidAvailabilityWindowError'
+  }
+}
+
+function assertWindow(input: AvailabilityWindow) {
+  if (
+    !Number.isInteger(input.isoWeekday) ||
+    input.isoWeekday < 1 ||
+    input.isoWeekday > 7 ||
+    !Number.isInteger(input.startMinute) ||
+    input.startMinute < 0 ||
+    input.startMinute > 1439 ||
+    !Number.isInteger(input.endMinute) ||
+    input.endMinute < 1 ||
+    input.endMinute > 1440 ||
+    input.startMinute >= input.endMinute
+  ) {
+    throw new InvalidAvailabilityWindowError()
+  }
+}
+
+export function createAvailabilityService(dependencies: AvailabilityServiceDependencies) {
+  const {
+    repository,
+    calendar,
+    ownerTimeZone,
+    clock = { now: () => new Date() },
+  } = dependencies
+
+  return {
+    list() {
+      return repository.list()
+    },
+
+    create(input: AvailabilityWindow) {
+      assertWindow(input)
+      return repository.create(input)
+    },
+
+    update(id: number, input: AvailabilityWindow) {
+      assertWindow(input)
+      return repository.update(id, input)
+    },
+
+    delete(id: number) {
+      return repository.delete(id)
+    },
+
+    async preview(input: {
+      slotHolds?: readonly SlotHold[]
+      bookings?: readonly TimeInterval[]
+    } = {}) {
+      const now = clock.now()
+      const calendarResult = await calendar.queryFreeBusy({
+        timeMin: new Date(
+          now.getTime() +
+            (AMA_BOOKING_POLICY.minimumNoticeMinutes -
+              AMA_BOOKING_POLICY.bufferBeforeMinutes) *
+              60_000,
+        ),
+        timeMax: new Date(
+          now.getTime() +
+            (AMA_BOOKING_POLICY.horizonDays * 24 * 60 +
+              AMA_BOOKING_POLICY.sessionMinutes +
+              AMA_BOOKING_POLICY.bufferAfterMinutes) *
+              60_000,
+        ),
+      })
+      if (calendarResult.status !== 'connected') {
+        return { status: calendarResult.status, slots: [] }
+      }
+
+      const windows = await repository.list()
+      return {
+        status: 'connected' as const,
+        slots: computeAvailableSlots({
+          now,
+          ownerTimeZone,
+          windows,
+          googleBusy: calendarResult.busy,
+          slotHolds: input.slotHolds ?? [],
+          bookings: input.bookings ?? [],
+        }),
+      }
+    },
+  }
+}
+
+export type AvailabilityService = ReturnType<typeof createAvailabilityService>

--- a/lib/ama/docs/adr/0001-first-party-paid-booking-flow.md
+++ b/lib/ama/docs/adr/0001-first-party-paid-booking-flow.md
@@ -1,0 +1,18 @@
+# Keep the AMA journey first-party around hosted payments
+
+AMA Sessions use a first-party availability, Booking, and lifecycle system on
+cali.so, while payment is delegated to Stripe-hosted Checkout. Google Calendar
+is the source of busy time and calendar invitations; Google Meet and Tencent
+Meeting sit behind meeting-provider adapters; guests manage Bookings through
+signed capability links instead of accounts. This keeps the guest journey and
+booking rules under Cali's control without taking ownership of card-entry UI,
+and replaces the v1 Alipay plus Cal.com handoff with one coherent system.
+
+## Consequences
+
+- A start time is held before Checkout and becomes a Booking only after a
+  verified Stripe event.
+- Provider work is idempotent and recoverable so a successful payment is never
+  presented as a failed purchase.
+- One-off unavailability is recorded in Google Calendar rather than a second
+  date-exceptions system.

--- a/lib/ama/google/client.test.ts
+++ b/lib/ama/google/client.test.ts
@@ -1,0 +1,493 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import {
+  GOOGLE_CALENDAR_SCOPES,
+  GoogleCalendarError,
+  createGoogleCalendarClient,
+} from './client'
+
+describe('Google Calendar provider', () => {
+  it('builds an authorization URL with caller state, exact scopes, and PKCE S256', () => {
+    const client = createGoogleCalendarClient({
+      clientId: 'google-client-id',
+      clientSecret: 'google-client-secret',
+      fetch: vi.fn(),
+      clock: { now: () => new Date('2026-07-14T04:00:00.000Z') },
+    })
+
+    const url = client.createAuthorizationUrl({
+      state: 'persisted-state-123',
+      codeVerifier: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk',
+      redirectUri: new URL('https://cali.so/api/ama/google/callback'),
+    })
+
+    expect(url.origin + url.pathname).toBe('https://accounts.google.com/o/oauth2/v2/auth')
+    expect(Object.fromEntries(url.searchParams)).toEqual({
+      access_type: 'offline',
+      client_id: 'google-client-id',
+      code_challenge: 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
+      code_challenge_method: 'S256',
+      prompt: 'consent',
+      redirect_uri: 'https://cali.so/api/ama/google/callback',
+      response_type: 'code',
+      scope: GOOGLE_CALENDAR_SCOPES.join(' '),
+      state: 'persisted-state-123',
+    })
+    expect(GOOGLE_CALENDAR_SCOPES).toEqual([
+      'https://www.googleapis.com/auth/calendar.events',
+      'https://www.googleapis.com/auth/calendar.freebusy',
+    ])
+    expect(url.toString()).not.toContain('google-client-secret')
+    expect(url.toString()).not.toContain('dBjftJeZ4CVP')
+  })
+
+  it('exchanges an authorization code with its PKCE verifier', async () => {
+    const fetch = vi.fn(async () =>
+      Response.json({
+        access_token: 'access-token-value',
+        refresh_token: 'refresh-token-value',
+        expires_in: 3600,
+        scope: GOOGLE_CALENDAR_SCOPES.join(' '),
+        token_type: 'Bearer',
+      }),
+    )
+    const client = createGoogleCalendarClient({
+      clientId: 'google-client-id',
+      clientSecret: 'google-client-secret',
+      fetch,
+      clock: { now: () => new Date('2026-07-14T04:00:00.000Z') },
+    })
+
+    const tokenSet = await client.exchangeAuthorizationCode({
+      code: 'authorization-code-value',
+      codeVerifier: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk',
+      redirectUri: new URL('https://cali.so/api/ama/google/callback'),
+    })
+
+    expect(tokenSet).toEqual({
+      accessToken: 'access-token-value',
+      refreshToken: 'refresh-token-value',
+      expiresAt: new Date('2026-07-14T05:00:00.000Z'),
+    })
+    expect(fetch).toHaveBeenCalledOnce()
+    const [url, init] = fetch.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toBe('https://oauth2.googleapis.com/token')
+    expect(init?.method).toBe('POST')
+    expect(init?.headers).toEqual({ 'Content-Type': 'application/x-www-form-urlencoded' })
+    expect(Object.fromEntries(new URLSearchParams(String(init?.body)))).toEqual({
+      client_id: 'google-client-id',
+      client_secret: 'google-client-secret',
+      code: 'authorization-code-value',
+      code_verifier: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk',
+      grant_type: 'authorization_code',
+      redirect_uri: 'https://cali.so/api/ama/google/callback',
+    })
+  })
+
+  it('rejects an authorization grant missing a required calendar scope', async () => {
+    const client = createGoogleCalendarClient({
+      clientId: 'google-client-id',
+      clientSecret: 'google-client-secret',
+      fetch: vi.fn(async () =>
+        Response.json({
+          access_token: 'access-token-value',
+          refresh_token: 'refresh-token-value',
+          expires_in: 3600,
+          scope: 'https://www.googleapis.com/auth/calendar.events',
+        }),
+      ),
+      clock: { now: () => new Date('2026-07-14T04:00:00.000Z') },
+    })
+
+    const exchange = client.exchangeAuthorizationCode({
+      code: 'authorization-code-value',
+      codeVerifier: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk',
+      redirectUri: new URL('https://cali.so/api/ama/google/callback'),
+    })
+
+    await expect(exchange).rejects.toEqual(
+      new GoogleCalendarError('denied_scope', 'Google Calendar permissions were not granted.'),
+    )
+  })
+
+  it('fails closed when Google omits the granted scope set', async () => {
+    const client = createGoogleCalendarClient({
+      clientId: 'google-client-id',
+      clientSecret: 'google-client-secret',
+      fetch: vi.fn(async () =>
+        Response.json({
+          access_token: 'access-token-value',
+          refresh_token: 'refresh-token-value',
+          expires_in: 3600,
+        }),
+      ),
+      clock: { now: () => new Date('2026-07-14T04:00:00.000Z') },
+    })
+
+    await expect(
+      client.exchangeAuthorizationCode({
+        code: 'authorization-code-value',
+        codeVerifier: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk',
+        redirectUri: new URL('https://cali.so/api/ama/google/callback'),
+      }),
+    ).rejects.toMatchObject({ code: 'denied_scope' })
+  })
+
+  it('reads the connected identity from the primary Calendar resource', async () => {
+    const fetch = vi.fn(async () =>
+      Response.json({
+        id: 'owner@example.com',
+        summary: 'Cali Castle',
+        timeZone: 'Asia/Taipei',
+      }),
+    )
+    const client = createGoogleCalendarClient({
+      clientId: 'google-client-id',
+      clientSecret: 'google-client-secret',
+      fetch,
+      clock: { now: () => new Date('2026-07-14T04:00:00.000Z') },
+    })
+
+    const identity = await client.getPrimaryCalendarIdentity('access-token-value')
+
+    expect(identity).toEqual({
+      id: 'owner@example.com',
+      summary: 'Cali Castle',
+      timeZone: 'Asia/Taipei',
+    })
+    expect(fetch).toHaveBeenCalledWith(
+      'https://www.googleapis.com/calendar/v3/calendars/primary',
+      {
+        headers: {
+          Accept: 'application/json',
+          Authorization: 'Bearer access-token-value',
+        },
+      },
+    )
+  })
+
+  it('refreshes an access token and computes its absolute expiry with the injected clock', async () => {
+    const fetch = vi.fn(async () =>
+      Response.json({ access_token: 'fresh-access-token', expires_in: 1800, token_type: 'Bearer' }),
+    )
+    const client = createGoogleCalendarClient({
+      clientId: 'google-client-id',
+      clientSecret: 'google-client-secret',
+      fetch,
+      clock: { now: () => new Date('2026-07-14T04:00:00.000Z') },
+    })
+
+    const token = await client.refreshAccessToken('refresh-token-value')
+
+    expect(token).toEqual({
+      accessToken: 'fresh-access-token',
+      expiresAt: new Date('2026-07-14T04:30:00.000Z'),
+    })
+    const [url, init] = fetch.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toBe('https://oauth2.googleapis.com/token')
+    expect(Object.fromEntries(new URLSearchParams(String(init?.body)))).toEqual({
+      client_id: 'google-client-id',
+      client_secret: 'google-client-secret',
+      grant_type: 'refresh_token',
+      refresh_token: 'refresh-token-value',
+    })
+  })
+
+  it('normalizes Google FreeBusy intervals for the requested calendar', async () => {
+    const fetch = vi.fn(async () =>
+      Response.json({
+        calendars: {
+          primary: {
+            busy: [
+              {
+                start: '2026-07-15T09:00:00+08:00',
+                end: '2026-07-15T10:00:00+08:00',
+              },
+            ],
+          },
+        },
+      }),
+    )
+    const client = createGoogleCalendarClient({
+      clientId: 'google-client-id',
+      clientSecret: 'google-client-secret',
+      fetch,
+      clock: { now: () => new Date('2026-07-14T04:00:00.000Z') },
+    })
+
+    const busy = await client.queryFreeBusy({
+      accessToken: 'access-token-value',
+      timeMin: new Date('2026-07-15T00:00:00.000Z'),
+      timeMax: new Date('2026-07-16T00:00:00.000Z'),
+    })
+
+    expect(busy).toEqual([
+      {
+        start: '2026-07-15T01:00:00.000Z',
+        end: '2026-07-15T02:00:00.000Z',
+      },
+    ])
+    expect(fetch).toHaveBeenCalledWith('https://www.googleapis.com/calendar/v3/freeBusy', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        Authorization: 'Bearer access-token-value',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        timeMin: '2026-07-15T00:00:00.000Z',
+        timeMax: '2026-07-16T00:00:00.000Z',
+        items: [{ id: 'primary' }],
+      }),
+    })
+  })
+
+  it('surfaces per-calendar permission errors as denied scope', async () => {
+    const client = createGoogleCalendarClient({
+      clientId: 'google-client-id',
+      clientSecret: 'google-client-secret',
+      fetch: vi.fn(async () =>
+        Response.json({
+          calendars: {
+            primary: {
+              errors: [
+                {
+                  domain: 'global',
+                  reason: 'insufficientPermissions',
+                  message: 'raw provider detail must not escape',
+                },
+              ],
+              busy: [],
+            },
+          },
+        }),
+      ),
+      clock: { now: () => new Date('2026-07-14T04:00:00.000Z') },
+    })
+
+    const query = client.queryFreeBusy({
+      accessToken: 'access-token-value',
+      timeMin: new Date('2026-07-15T00:00:00.000Z'),
+      timeMax: new Date('2026-07-16T00:00:00.000Z'),
+    })
+
+    await expect(query).rejects.toMatchObject({
+      code: 'denied_scope',
+      message: 'Google Calendar permissions were not granted.',
+    })
+  })
+
+  it('revokes a Google credential without placing it in the URL', async () => {
+    const fetch = vi.fn(async () => new Response(null, { status: 200 }))
+    const client = createGoogleCalendarClient({
+      clientId: 'google-client-id',
+      clientSecret: 'google-client-secret',
+      fetch,
+      clock: { now: () => new Date('2026-07-14T04:00:00.000Z') },
+    })
+
+    await client.revokeToken('refresh-token-value')
+
+    expect(fetch).toHaveBeenCalledWith('https://oauth2.googleapis.com/revoke', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ token: 'refresh-token-value' }),
+    })
+  })
+
+  it('normalizes invalid_grant during refresh as an expired or revoked connection', async () => {
+    const client = createGoogleCalendarClient({
+      clientId: 'google-client-id',
+      clientSecret: 'google-client-secret',
+      fetch: vi.fn(async () =>
+        Response.json(
+          {
+            error: 'invalid_grant',
+            error_description: 'refresh-token-value was revoked',
+          },
+          { status: 400 },
+        ),
+      ),
+      clock: { now: () => new Date('2026-07-14T04:00:00.000Z') },
+    })
+
+    const refresh = client.refreshAccessToken('refresh-token-value')
+
+    await expect(refresh).rejects.toMatchObject({
+      code: 'expired_or_revoked',
+      message: 'Google Calendar access expired or was revoked. Reconnect Google Calendar.',
+    })
+  })
+
+  it('returns a sanitized provider-unavailable error without OAuth secrets or raw bodies', async () => {
+    const secrets = {
+      clientSecret: 'client-secret-must-stay-private',
+      codeVerifier: 'verifier-must-stay-private-012345678901234567890',
+      code: 'authorization-code-must-stay-private',
+      accessToken: 'access-token-must-stay-private',
+      refreshToken: 'refresh-token-must-stay-private',
+      rawBody: 'raw-provider-body-must-stay-private',
+    }
+    const client = createGoogleCalendarClient({
+      clientId: 'google-client-id',
+      clientSecret: secrets.clientSecret,
+      fetch: vi.fn(async () =>
+        Response.json(
+          {
+            error: 'temporarily_unavailable',
+            error_description: Object.values(secrets).join(' '),
+          },
+          { status: 503 },
+        ),
+      ),
+      clock: { now: () => new Date('2026-07-14T04:00:00.000Z') },
+    })
+
+    const exchange = client.exchangeAuthorizationCode({
+      code: secrets.code,
+      codeVerifier: secrets.codeVerifier,
+      redirectUri: new URL('https://cali.so/api/ama/google/callback'),
+    })
+
+    const error = await exchange.catch((caught: unknown) => caught)
+    expect(error).toMatchObject({
+      code: 'provider_unavailable',
+      message: 'Google Calendar is temporarily unavailable.',
+    })
+    for (const secret of Object.values(secrets)) {
+      expect(String(error)).not.toContain(secret)
+      expect(JSON.stringify(error)).not.toContain(secret)
+    }
+  })
+
+  it('sanitizes transport failures from Google', async () => {
+    const client = createGoogleCalendarClient({
+      clientId: 'google-client-id',
+      clientSecret: 'client-secret-must-stay-private',
+      fetch: vi.fn(async () => {
+        throw new Error('refresh-token-must-stay-private raw network detail')
+      }),
+      clock: { now: () => new Date('2026-07-14T04:00:00.000Z') },
+    })
+
+    const error = await client
+      .refreshAccessToken('refresh-token-must-stay-private')
+      .catch((caught: unknown) => caught)
+
+    expect(error).toMatchObject({
+      code: 'provider_unavailable',
+      message: 'Google Calendar is temporarily unavailable.',
+    })
+    expect(String(error)).not.toContain('refresh-token-must-stay-private')
+    expect(String(error)).not.toContain('raw network detail')
+  })
+
+  it('normalizes a Calendar API 401 as an expired or revoked connection', async () => {
+    const client = createGoogleCalendarClient({
+      clientId: 'google-client-id',
+      clientSecret: 'google-client-secret',
+      fetch: vi.fn(async () =>
+        Response.json({ error: { message: 'access-token-value is invalid' } }, { status: 401 }),
+      ),
+      clock: { now: () => new Date('2026-07-14T04:00:00.000Z') },
+    })
+
+    await expect(client.getPrimaryCalendarIdentity('access-token-value')).rejects.toMatchObject({
+      code: 'expired_or_revoked',
+      message: 'Google Calendar access expired or was revoked. Reconnect Google Calendar.',
+    })
+  })
+
+  it('fails closed when Google returns a malformed token response', async () => {
+    const client = createGoogleCalendarClient({
+      clientId: 'google-client-id',
+      clientSecret: 'google-client-secret',
+      fetch: vi.fn(async () => Response.json({ expires_in: 'not-a-number' })),
+      clock: { now: () => new Date('2026-07-14T04:00:00.000Z') },
+    })
+
+    await expect(
+      client.exchangeAuthorizationCode({
+        code: 'authorization-code-value',
+        codeVerifier: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk',
+        redirectUri: new URL('https://cali.so/api/ama/google/callback'),
+      }),
+    ).rejects.toMatchObject({
+      code: 'invalid_response',
+      message: 'Google Calendar returned an invalid response.',
+    })
+  })
+
+  it('does not misclassify a Google quota response as denied scope', async () => {
+    const client = createGoogleCalendarClient({
+      clientId: 'google-client-id',
+      clientSecret: 'google-client-secret',
+      fetch: vi.fn(async () =>
+        Response.json(
+          {
+            error: {
+              errors: [{ reason: 'rateLimitExceeded', message: 'raw quota detail' }],
+            },
+          },
+          { status: 403 },
+        ),
+      ),
+      clock: { now: () => new Date('2026-07-14T04:00:00.000Z') },
+    })
+
+    await expect(
+      client.queryFreeBusy({
+        accessToken: 'access-token-value',
+        timeMin: new Date('2026-07-15T00:00:00.000Z'),
+        timeMax: new Date('2026-07-16T00:00:00.000Z'),
+      }),
+    ).rejects.toMatchObject({
+      code: 'provider_unavailable',
+      message: 'Google Calendar is temporarily unavailable.',
+    })
+  })
+
+  it('normalizes a non-JSON Google outage response without exposing its body', async () => {
+    const client = createGoogleCalendarClient({
+      clientId: 'google-client-id',
+      clientSecret: 'google-client-secret',
+      fetch: vi.fn(async () =>
+        new Response('raw-provider-outage-body', {
+          status: 502,
+          headers: { 'Content-Type': 'text/plain' },
+        }),
+      ),
+      clock: { now: () => new Date('2026-07-14T04:00:00.000Z') },
+    })
+
+    const error = await client
+      .exchangeAuthorizationCode({
+        code: 'authorization-code-value',
+        codeVerifier: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk',
+        redirectUri: new URL('https://cali.so/api/ama/google/callback'),
+      })
+      .catch((caught: unknown) => caught)
+
+    expect(error).toMatchObject({
+      code: 'provider_unavailable',
+      message: 'Google Calendar is temporarily unavailable.',
+    })
+    expect(String(error)).not.toContain('raw-provider-outage-body')
+  })
+
+  it('normalizes a structurally invalid Calendar response', async () => {
+    const client = createGoogleCalendarClient({
+      clientId: 'google-client-id',
+      clientSecret: 'google-client-secret',
+      fetch: vi.fn(async () => Response.json(null)),
+      clock: { now: () => new Date('2026-07-14T04:00:00.000Z') },
+    })
+
+    await expect(client.getPrimaryCalendarIdentity('access-token-value')).rejects.toMatchObject({
+      code: 'invalid_response',
+      message: 'Google Calendar returned an invalid response.',
+    })
+  })
+})

--- a/lib/ama/google/client.ts
+++ b/lib/ama/google/client.ts
@@ -1,0 +1,360 @@
+import 'server-only'
+
+import { createHash } from 'node:crypto'
+
+const GOOGLE_AUTHORIZATION_ENDPOINT = 'https://accounts.google.com/o/oauth2/v2/auth'
+const GOOGLE_TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token'
+const GOOGLE_REVOCATION_ENDPOINT = 'https://oauth2.googleapis.com/revoke'
+const GOOGLE_CALENDAR_API = 'https://www.googleapis.com/calendar/v3'
+
+export const GOOGLE_CALENDAR_SCOPES = [
+  'https://www.googleapis.com/auth/calendar.events',
+  'https://www.googleapis.com/auth/calendar.freebusy',
+] as const
+
+export type GoogleCalendarErrorCode =
+  | 'denied_scope'
+  | 'expired_or_revoked'
+  | 'provider_unavailable'
+  | 'invalid_response'
+
+export class GoogleCalendarError extends Error {
+  constructor(
+    readonly code: GoogleCalendarErrorCode,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'GoogleCalendarError'
+  }
+}
+
+type GoogleCalendarClientDependencies = {
+  clientId: string
+  clientSecret: string
+  fetch: typeof fetch
+  clock: { now(): Date }
+}
+
+type AuthorizationUrlInput = {
+  state: string
+  codeVerifier: string
+  redirectUri: URL
+}
+
+type AuthorizationCodeInput = {
+  code: string
+  codeVerifier: string
+  redirectUri: URL
+}
+
+type GoogleTokenResponse = {
+  access_token?: string
+  refresh_token?: string
+  expires_in?: number
+  scope?: string
+}
+
+export type GoogleCalendarIdentity = {
+  id: string
+  summary: string
+  timeZone: string
+}
+
+export type GoogleBusyInterval = {
+  start: string
+  end: string
+}
+
+type FreeBusyInput = {
+  accessToken: string
+  calendarId?: string
+  timeMin: Date
+  timeMax: Date
+}
+
+function pkceChallenge(codeVerifier: string) {
+  return createHash('sha256').update(codeVerifier).digest('base64url')
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+async function googleErrorReasons(response: Response): Promise<string[]> {
+  try {
+    const payload = (await response.clone().json()) as {
+      error?: { errors?: Array<{ reason?: unknown }> }
+    }
+    return (payload.error?.errors ?? []).flatMap((error) =>
+      typeof error.reason === 'string' ? [error.reason] : [],
+    )
+  } catch {
+    return []
+  }
+}
+
+async function assertCalendarResponse(response: Response) {
+  if (response.ok) return
+  if (response.status === 401) {
+    throw new GoogleCalendarError(
+      'expired_or_revoked',
+      'Google Calendar access expired or was revoked. Reconnect Google Calendar.',
+    )
+  }
+  if (response.status === 403) {
+    const denied = (await googleErrorReasons(response)).includes('insufficientPermissions')
+    throw new GoogleCalendarError(
+      denied ? 'denied_scope' : 'provider_unavailable',
+      denied
+        ? 'Google Calendar permissions were not granted.'
+        : 'Google Calendar is temporarily unavailable.',
+    )
+  }
+  throw new GoogleCalendarError(
+    'provider_unavailable',
+    'Google Calendar is temporarily unavailable.',
+  )
+}
+
+function invalidResponse(): never {
+  throw new GoogleCalendarError(
+    'invalid_response',
+    'Google Calendar returned an invalid response.',
+  )
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json()
+  } catch {
+    return invalidResponse()
+  }
+}
+
+async function readProviderErrorCode(response: Response): Promise<string | null> {
+  try {
+    const payload = (await response.json()) as { error?: unknown }
+    return typeof payload.error === 'string' ? payload.error : null
+  } catch {
+    return null
+  }
+}
+
+export function createGoogleCalendarClient(dependencies: GoogleCalendarClientDependencies) {
+  async function request(input: string, init?: RequestInit) {
+    try {
+      return await dependencies.fetch(input, init)
+    } catch {
+      throw new GoogleCalendarError(
+        'provider_unavailable',
+        'Google Calendar is temporarily unavailable.',
+      )
+    }
+  }
+
+  return {
+    createAuthorizationUrl(input: AuthorizationUrlInput) {
+      const url = new URL(GOOGLE_AUTHORIZATION_ENDPOINT)
+      url.search = new URLSearchParams({
+        access_type: 'offline',
+        client_id: dependencies.clientId,
+        code_challenge: pkceChallenge(input.codeVerifier),
+        code_challenge_method: 'S256',
+        prompt: 'consent',
+        redirect_uri: input.redirectUri.toString(),
+        response_type: 'code',
+        scope: GOOGLE_CALENDAR_SCOPES.join(' '),
+        state: input.state,
+      }).toString()
+      return url
+    },
+
+    async exchangeAuthorizationCode(input: AuthorizationCodeInput) {
+      const response = await request(GOOGLE_TOKEN_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          client_id: dependencies.clientId,
+          client_secret: dependencies.clientSecret,
+          code: input.code,
+          code_verifier: input.codeVerifier,
+          grant_type: 'authorization_code',
+          redirect_uri: input.redirectUri.toString(),
+        }),
+      })
+      if (!response.ok) {
+        const providerError = await readProviderErrorCode(response)
+        throw new GoogleCalendarError(
+          providerError === 'invalid_scope' ? 'denied_scope' : 'provider_unavailable',
+          providerError === 'invalid_scope'
+            ? 'Google Calendar permissions were not granted.'
+            : 'Google Calendar is temporarily unavailable.',
+        )
+      }
+      const parsed = await readJson(response)
+      if (!isRecord(parsed)) invalidResponse()
+      const payload = parsed as GoogleTokenResponse
+      if (
+        typeof payload.access_token !== 'string' ||
+        !payload.access_token ||
+        typeof payload.refresh_token !== 'string' ||
+        !payload.refresh_token ||
+        typeof payload.expires_in !== 'number' ||
+        !Number.isFinite(payload.expires_in) ||
+        payload.expires_in <= 0
+      ) {
+        invalidResponse()
+      }
+      if (payload.scope === undefined || payload.scope === '') {
+        throw new GoogleCalendarError(
+          'denied_scope',
+          'Google Calendar permissions were not granted.',
+        )
+      }
+      if (typeof payload.scope !== 'string') {
+        invalidResponse()
+      }
+      const grantedScopes = new Set(payload.scope.split(/\s+/).filter(Boolean))
+      if (
+        GOOGLE_CALENDAR_SCOPES.some((scope) => !grantedScopes.has(scope))
+      ) {
+        throw new GoogleCalendarError(
+          'denied_scope',
+          'Google Calendar permissions were not granted.',
+        )
+      }
+      return {
+        accessToken: payload.access_token,
+        refreshToken: payload.refresh_token,
+        expiresAt: new Date(
+          dependencies.clock.now().getTime() + payload.expires_in * 1000,
+        ),
+      }
+    },
+
+    async getPrimaryCalendarIdentity(accessToken: string): Promise<GoogleCalendarIdentity> {
+      const response = await request(`${GOOGLE_CALENDAR_API}/calendars/primary`, {
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+      })
+      await assertCalendarResponse(response)
+      const payload = await readJson(response)
+      if (
+        !isRecord(payload) ||
+        typeof payload.id !== 'string' ||
+        !payload.id ||
+        typeof payload.summary !== 'string' ||
+        typeof payload.timeZone !== 'string' ||
+        !payload.timeZone
+      ) {
+        invalidResponse()
+      }
+      return {
+        id: payload.id,
+        summary: payload.summary,
+        timeZone: payload.timeZone,
+      }
+    },
+
+    async refreshAccessToken(refreshToken: string) {
+      const response = await request(GOOGLE_TOKEN_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          client_id: dependencies.clientId,
+          client_secret: dependencies.clientSecret,
+          grant_type: 'refresh_token',
+          refresh_token: refreshToken,
+        }),
+      })
+      if (!response.ok) {
+        if ((await readProviderErrorCode(response)) === 'invalid_grant') {
+          throw new GoogleCalendarError(
+            'expired_or_revoked',
+            'Google Calendar access expired or was revoked. Reconnect Google Calendar.',
+          )
+        }
+        throw new GoogleCalendarError(
+          'provider_unavailable',
+          'Google Calendar is temporarily unavailable.',
+        )
+      }
+      const parsed = await readJson(response)
+      if (!isRecord(parsed)) invalidResponse()
+      const payload = parsed as GoogleTokenResponse
+      if (
+        typeof payload.access_token !== 'string' ||
+        !payload.access_token ||
+        typeof payload.expires_in !== 'number' ||
+        !Number.isFinite(payload.expires_in) ||
+        payload.expires_in <= 0
+      ) {
+        invalidResponse()
+      }
+      return {
+        accessToken: payload.access_token,
+        expiresAt: new Date(
+          dependencies.clock.now().getTime() + payload.expires_in * 1000,
+        ),
+      }
+    },
+
+    async queryFreeBusy(input: FreeBusyInput): Promise<GoogleBusyInterval[]> {
+      const calendarId = input.calendarId ?? 'primary'
+      const response = await request(`${GOOGLE_CALENDAR_API}/freeBusy`, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Bearer ${input.accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          timeMin: input.timeMin.toISOString(),
+          timeMax: input.timeMax.toISOString(),
+          items: [{ id: calendarId }],
+        }),
+      })
+      await assertCalendarResponse(response)
+      const payload = await readJson(response)
+      if (!isRecord(payload) || !isRecord(payload.calendars)) invalidResponse()
+      const calendar = payload.calendars[calendarId]
+      if (!isRecord(calendar) || !Array.isArray(calendar.busy)) invalidResponse()
+      if (calendar.errors !== undefined && !Array.isArray(calendar.errors)) invalidResponse()
+      const errors = calendar.errors ?? []
+      if (errors.length) {
+        const denied = errors.some(
+          (error) => isRecord(error) && error.reason === 'insufficientPermissions',
+        )
+        throw new GoogleCalendarError(
+          denied ? 'denied_scope' : 'provider_unavailable',
+          denied
+            ? 'Google Calendar permissions were not granted.'
+            : 'Google Calendar is temporarily unavailable.',
+        )
+      }
+      return calendar.busy.map((interval) => {
+        if (!isRecord(interval)) return invalidResponse()
+        const start = Date.parse(typeof interval.start === 'string' ? interval.start : '')
+        const end = Date.parse(typeof interval.end === 'string' ? interval.end : '')
+        if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) {
+          return invalidResponse()
+        }
+        return {
+          start: new Date(start).toISOString(),
+          end: new Date(end).toISOString(),
+        }
+      })
+    },
+
+    async revokeToken(token: string): Promise<void> {
+      const response = await request(GOOGLE_REVOCATION_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ token }),
+      })
+      await assertCalendarResponse(response)
+    },
+  }
+}

--- a/lib/ama/google/repository.test.ts
+++ b/lib/ama/google/repository.test.ts
@@ -1,0 +1,229 @@
+import { readFile } from 'node:fs/promises'
+
+import { PGlite } from '@electric-sql/pglite'
+import { drizzle } from 'drizzle-orm/pglite'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import { createSecretBox } from '../secrets'
+import {
+  createAvailabilityRepository,
+  type AvailabilityDatabase,
+} from '../availability/repository'
+import { createGoogleRepository, type GoogleDatabase } from './repository'
+
+const migrations = [
+  new URL('../../../db/migrations/0001_ama_owner_auth.sql', import.meta.url),
+  new URL('../../../db/migrations/0002_ama_availability.sql', import.meta.url),
+  new URL('../../../db/migrations/0003_ama_google_calendar.sql', import.meta.url),
+  new URL('../../../db/migrations/0004_ama_google_oauth.sql', import.meta.url),
+]
+
+describe('Google Calendar persistence', () => {
+  let client: PGlite
+  let repository: ReturnType<typeof createGoogleRepository>
+  let availability: ReturnType<typeof createAvailabilityRepository>
+
+  beforeEach(async () => {
+    client = new PGlite()
+    for (const migrationUrl of migrations) {
+      const migration = await readFile(migrationUrl, 'utf8')
+      await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
+    }
+    const database = drizzle(client)
+    repository = createGoogleRepository(() => database as unknown as GoogleDatabase)
+    availability = createAvailabilityRepository(
+      () => database as unknown as AvailabilityDatabase,
+    )
+  })
+
+  afterEach(async () => {
+    await client.close()
+  })
+
+  it('persists one connected calendar with an encrypted refresh-token envelope', async () => {
+    const box = createSecretBox(Buffer.alloc(32, 9).toString('base64'))
+    const refreshTokenEnvelope = box.seal('google-refresh-token', 'google-refresh-token')
+    const connectedAt = new Date('2026-07-14T06:00:00.000Z')
+
+    await repository.saveConnection({
+      status: 'connected',
+      calendarId: 'primary',
+      calendarEmail: 'owner@example.com',
+      calendarSummary: 'Cali Castle',
+      grantedScopes: ['calendar.events', 'calendar.freebusy'],
+      refreshTokenEnvelope,
+      accessTokenExpiresAt: new Date('2026-07-14T07:00:00.000Z'),
+      lastErrorCode: null,
+      connectedAt,
+      updatedAt: connectedAt,
+    })
+
+    const connection = await repository.getConnection()
+
+    expect(connection).toMatchObject({
+      status: 'connected',
+      calendarId: 'primary',
+      calendarEmail: 'owner@example.com',
+      grantedScopes: ['calendar.events', 'calendar.freebusy'],
+      refreshTokenEnvelope,
+    })
+    expect(JSON.stringify(connection)).not.toContain('google-refresh-token')
+  })
+
+  it('stores hashed OAuth state and consumes its encrypted PKCE verifier once', async () => {
+    const box = createSecretBox(Buffer.alloc(32, 5).toString('base64'))
+    const pkceVerifierEnvelope = box.seal('pkce-verifier-value', 'google-pkce-verifier')
+    const now = new Date('2026-07-14T06:00:00.000Z')
+
+    await repository.createOAuthAttempt({
+      state: 'raw-oauth-state',
+      ownerEmail: 'owner@example.com',
+      pkceVerifierEnvelope,
+      expiresAt: new Date('2026-07-14T06:10:00.000Z'),
+      createdAt: now,
+    })
+
+    const stored = await client.query<{
+      state_hash: string
+      pkce_verifier_envelope: unknown
+    }>('select state_hash, pkce_verifier_envelope from ama_google_oauth_attempts')
+    expect(stored.rows[0]?.state_hash).toHaveLength(64)
+    expect(stored.rows[0]?.state_hash).not.toBe('raw-oauth-state')
+    expect(JSON.stringify(stored.rows[0])).not.toContain('pkce-verifier-value')
+
+    const consumed = await Promise.all([
+      repository.consumeOAuthAttempt('raw-oauth-state', 'owner@example.com', now),
+      repository.consumeOAuthAttempt('raw-oauth-state', 'owner@example.com', now),
+    ])
+    const accepted = consumed.filter((attempt) => attempt !== null)
+
+    expect(accepted).toHaveLength(1)
+    expect(box.open(accepted[0]!.pkceVerifierEnvelope, 'google-pkce-verifier')).toBe(
+      'pkce-verifier-value',
+    )
+  })
+
+  it('does not consume an expired OAuth attempt', async () => {
+    const box = createSecretBox(Buffer.alloc(32, 5).toString('base64'))
+    await repository.createOAuthAttempt({
+      state: 'expired-state',
+      ownerEmail: 'owner@example.com',
+      pkceVerifierEnvelope: box.seal('expired-verifier', 'google-pkce-verifier'),
+      expiresAt: new Date('2026-07-14T06:10:00.000Z'),
+      createdAt: new Date('2026-07-14T06:00:00.000Z'),
+    })
+
+    await expect(
+      repository.consumeOAuthAttempt(
+        'expired-state',
+        'owner@example.com',
+        new Date('2026-07-14T06:10:00.000Z'),
+      ),
+    ).resolves.toBeNull()
+  })
+
+  it('does not consume an OAuth attempt for a different owner', async () => {
+    const box = createSecretBox(Buffer.alloc(32, 5).toString('base64'))
+    await repository.createOAuthAttempt({
+      state: 'owner-bound-state',
+      ownerEmail: 'owner@example.com',
+      pkceVerifierEnvelope: box.seal('owner-verifier', 'google-pkce-verifier'),
+      expiresAt: new Date('2026-07-14T06:10:00.000Z'),
+      createdAt: new Date('2026-07-14T06:00:00.000Z'),
+    })
+
+    await expect(
+      repository.consumeOAuthAttempt(
+        'owner-bound-state',
+        'other@example.com',
+        new Date('2026-07-14T06:05:00.000Z'),
+      ),
+    ).resolves.toBeNull()
+    await expect(
+      repository.consumeOAuthAttempt(
+        'owner-bound-state',
+        'owner@example.com',
+        new Date('2026-07-14T06:05:00.000Z'),
+      ),
+    ).resolves.not.toBeNull()
+  })
+
+  it('persists an actionable connection status without replacing its secret', async () => {
+    const box = createSecretBox(Buffer.alloc(32, 4).toString('base64'))
+    const refreshTokenEnvelope = box.seal('refresh-token', 'google-refresh-token')
+    const connectedAt = new Date('2026-07-14T06:00:00.000Z')
+    await repository.saveConnection({
+      status: 'connected',
+      calendarId: 'primary',
+      calendarEmail: 'owner@example.com',
+      calendarSummary: 'Cali Castle',
+      grantedScopes: ['calendar.events', 'calendar.freebusy'],
+      refreshTokenEnvelope,
+      accessTokenExpiresAt: null,
+      lastErrorCode: null,
+      connectedAt,
+      updatedAt: connectedAt,
+    })
+
+    const revoked = await repository.setConnectionStatus(
+      'revoked',
+      'invalid_grant',
+      new Date('2026-07-14T08:00:00.000Z'),
+    )
+
+    expect(revoked).toMatchObject({
+      status: 'revoked',
+      lastErrorCode: 'invalid_grant',
+      refreshTokenEnvelope,
+    })
+  })
+
+  it('records an OAuth failure before a calendar has connected', async () => {
+    const denied = await repository.setConnectionStatus(
+      'denied_scope',
+      'missing_required_scopes',
+      new Date('2026-07-14T08:00:00.000Z'),
+    )
+
+    expect(denied).toMatchObject({
+      id: 1,
+      status: 'denied_scope',
+      lastErrorCode: 'missing_required_scopes',
+      refreshTokenEnvelope: null,
+    })
+  })
+
+  it('disconnects Google without deleting Availability Windows', async () => {
+    const box = createSecretBox(Buffer.alloc(32, 3).toString('base64'))
+    const connectedAt = new Date('2026-07-14T06:00:00.000Z')
+    await availability.create({ isoWeekday: 2, startMinute: 540, endMinute: 720 })
+    await repository.saveConnection({
+      status: 'connected',
+      calendarId: 'primary',
+      calendarEmail: 'owner@example.com',
+      calendarSummary: 'Cali Castle',
+      grantedScopes: ['calendar.events', 'calendar.freebusy'],
+      refreshTokenEnvelope: box.seal('refresh-token', 'google-refresh-token'),
+      accessTokenExpiresAt: null,
+      lastErrorCode: null,
+      connectedAt,
+      updatedAt: connectedAt,
+    })
+
+    const disconnected = await repository.disconnect(
+      new Date('2026-07-14T09:00:00.000Z'),
+    )
+
+    expect(disconnected).toMatchObject({
+      status: 'disconnected',
+      calendarId: null,
+      calendarEmail: null,
+      grantedScopes: [],
+      refreshTokenEnvelope: null,
+      lastErrorCode: null,
+    })
+    expect(await availability.list()).toHaveLength(1)
+  })
+})

--- a/lib/ama/google/repository.ts
+++ b/lib/ama/google/repository.ts
@@ -1,0 +1,139 @@
+import 'server-only'
+
+import { createHash } from 'node:crypto'
+
+import { and, eq, gt, isNull } from 'drizzle-orm'
+
+import { getDatabase } from '~/db'
+import { amaGoogleCalendarConnections, amaGoogleOAuthAttempts } from '~/db/schema'
+
+import type { EncryptedSecretEnvelope } from '../secrets'
+
+export type GoogleDatabase = ReturnType<typeof getDatabase>
+
+export type GoogleConnectionStatus =
+  | 'disconnected'
+  | 'connected'
+  | 'expired'
+  | 'revoked'
+  | 'denied_scope'
+  | 'error'
+
+export type GoogleConnectionInput = {
+  status: GoogleConnectionStatus
+  calendarId: string | null
+  calendarEmail: string | null
+  calendarSummary: string | null
+  grantedScopes: string[]
+  refreshTokenEnvelope: EncryptedSecretEnvelope | null
+  accessTokenExpiresAt: Date | null
+  lastErrorCode: string | null
+  connectedAt: Date | null
+  updatedAt: Date
+}
+
+export type GoogleOAuthAttemptInput = {
+  state: string
+  ownerEmail: string
+  pkceVerifierEnvelope: EncryptedSecretEnvelope
+  expiresAt: Date
+  createdAt: Date
+}
+
+function hashState(state: string) {
+  return createHash('sha256').update(state).digest('hex')
+}
+
+export function createGoogleRepository(database: () => GoogleDatabase) {
+  return {
+    async getConnection() {
+      const [connection] = await database()
+        .select()
+        .from(amaGoogleCalendarConnections)
+        .where(eq(amaGoogleCalendarConnections.id, 1))
+        .limit(1)
+      return connection ?? null
+    },
+
+    async saveConnection(input: GoogleConnectionInput) {
+      const [connection] = await database()
+        .insert(amaGoogleCalendarConnections)
+        .values({ id: 1, ...input })
+        .onConflictDoUpdate({
+          target: amaGoogleCalendarConnections.id,
+          set: input,
+        })
+        .returning()
+      return connection
+    },
+
+    async setConnectionStatus(
+      status: GoogleConnectionStatus,
+      lastErrorCode: string | null,
+      updatedAt: Date,
+    ) {
+      const [connection] = await database()
+        .insert(amaGoogleCalendarConnections)
+        .values({ id: 1, status, lastErrorCode, updatedAt })
+        .onConflictDoUpdate({
+          target: amaGoogleCalendarConnections.id,
+          set: { status, lastErrorCode, updatedAt },
+        })
+        .returning()
+      return connection
+    },
+
+    async disconnect(updatedAt: Date) {
+      const disconnected = {
+        status: 'disconnected' as const,
+        calendarId: null,
+        calendarEmail: null,
+        calendarSummary: null,
+        grantedScopes: [],
+        refreshTokenEnvelope: null,
+        accessTokenExpiresAt: null,
+        lastErrorCode: null,
+        connectedAt: null,
+        updatedAt,
+      }
+      const [connection] = await database()
+        .insert(amaGoogleCalendarConnections)
+        .values({ id: 1, ...disconnected })
+        .onConflictDoUpdate({
+          target: amaGoogleCalendarConnections.id,
+          set: disconnected,
+        })
+        .returning()
+      return connection
+    },
+
+    async createOAuthAttempt(input: GoogleOAuthAttemptInput) {
+      await database().insert(amaGoogleOAuthAttempts).values({
+        stateHash: hashState(input.state),
+        ownerEmail: input.ownerEmail,
+        pkceVerifierEnvelope: input.pkceVerifierEnvelope,
+        expiresAt: input.expiresAt,
+        consumedAt: null,
+        createdAt: input.createdAt,
+      })
+    },
+
+    async consumeOAuthAttempt(state: string, ownerEmail: string, consumedAt: Date) {
+      const [attempt] = await database()
+        .update(amaGoogleOAuthAttempts)
+        .set({ consumedAt })
+        .where(
+          and(
+            eq(amaGoogleOAuthAttempts.stateHash, hashState(state)),
+            eq(amaGoogleOAuthAttempts.ownerEmail, ownerEmail),
+            isNull(amaGoogleOAuthAttempts.consumedAt),
+            gt(amaGoogleOAuthAttempts.expiresAt, consumedAt),
+          ),
+        )
+        .returning()
+      return attempt ?? null
+    },
+  }
+}
+
+export const googleRepository = createGoogleRepository(getDatabase)

--- a/lib/ama/google/service.test.ts
+++ b/lib/ama/google/service.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import { createSecretBox, type EncryptedSecretEnvelope } from '../secrets'
+import {
+  GOOGLE_CALENDAR_SCOPES,
+  GoogleCalendarError,
+  type GoogleCalendarIdentity,
+} from './client'
+import {
+  createGoogleCalendarService,
+  type GoogleCalendarConnection,
+  type GoogleCalendarProvider,
+  type GoogleCalendarRepository,
+  type GoogleOAuthAttempt,
+} from './service'
+
+function fixture() {
+  const box = createSecretBox(Buffer.alloc(32, 7).toString('base64'))
+  let now = new Date('2026-07-14T04:00:00.000Z')
+  let connection: GoogleCalendarConnection | null = null
+  const attempts = new Map<string, GoogleOAuthAttempt>()
+  const repository: GoogleCalendarRepository = {
+    async createOAuthAttempt(input) {
+      attempts.set(input.state, { ...input, consumedAt: null })
+    },
+    async consumeOAuthAttempt(state, ownerEmail, consumedAt) {
+      const attempt = attempts.get(state)
+      if (
+        !attempt ||
+        attempt.ownerEmail !== ownerEmail ||
+        attempt.consumedAt ||
+        attempt.expiresAt <= consumedAt
+      ) {
+        return null
+      }
+      attempt.consumedAt = consumedAt
+      return attempt
+    },
+    async getConnection() {
+      return connection
+    },
+    async saveConnection(input) {
+      connection = { id: 1, createdAt: connection?.createdAt ?? input.updatedAt, ...input }
+      return connection
+    },
+    async setConnectionStatus(status, lastErrorCode, updatedAt) {
+      connection = {
+        id: 1,
+        status,
+        calendarId: connection?.calendarId ?? null,
+        calendarEmail: connection?.calendarEmail ?? null,
+        calendarSummary: connection?.calendarSummary ?? null,
+        grantedScopes: connection?.grantedScopes ?? [],
+        refreshTokenEnvelope: connection?.refreshTokenEnvelope ?? null,
+        accessTokenExpiresAt: connection?.accessTokenExpiresAt ?? null,
+        lastErrorCode,
+        connectedAt: connection?.connectedAt ?? null,
+        createdAt: connection?.createdAt ?? updatedAt,
+        updatedAt,
+      }
+      return connection
+    },
+    async disconnect(updatedAt) {
+      connection = {
+        id: 1,
+        status: 'disconnected',
+        calendarId: null,
+        calendarEmail: null,
+        calendarSummary: null,
+        grantedScopes: [],
+        refreshTokenEnvelope: null,
+        accessTokenExpiresAt: null,
+        lastErrorCode: null,
+        connectedAt: null,
+        createdAt: connection?.createdAt ?? updatedAt,
+        updatedAt,
+      }
+      return connection
+    },
+  }
+
+  const calls: unknown[] = []
+  const provider: GoogleCalendarProvider = {
+    createAuthorizationUrl(input) {
+      calls.push(['authorize', input])
+      const url = new URL('https://accounts.google.com/o/oauth2/v2/auth')
+      url.searchParams.set('state', input.state)
+      return url
+    },
+    async exchangeAuthorizationCode(input) {
+      calls.push(['exchange', input])
+      return {
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: new Date('2026-07-14T05:00:00.000Z'),
+      }
+    },
+    async getPrimaryCalendarIdentity(accessToken) {
+      calls.push(['identity', accessToken])
+      return {
+        id: 'owner@example.com',
+        summary: 'Cali Castle',
+        timeZone: 'Asia/Taipei',
+      } satisfies GoogleCalendarIdentity
+    },
+    async refreshAccessToken(refreshToken) {
+      calls.push(['refresh', refreshToken])
+      return {
+        accessToken: 'fresh-access-token',
+        expiresAt: new Date('2026-07-14T05:00:00.000Z'),
+      }
+    },
+    async queryFreeBusy(input) {
+      calls.push(['freebusy', input])
+      return [
+        {
+          start: '2026-07-15T01:00:00.000Z',
+          end: '2026-07-15T02:00:00.000Z',
+        },
+      ]
+    },
+    async revokeToken(token) {
+      calls.push(['revoke', token])
+    },
+  }
+
+  const randomValues = ['persisted-state', 'pkce-verifier']
+  const service = createGoogleCalendarService({
+    ownerEmail: 'owner@example.com',
+    baseUrl: new URL('https://cali.so'),
+    repository,
+    provider,
+    secretBox: box,
+    clock: { now: () => now },
+    randomToken: () => randomValues.shift() ?? 'next-random-value',
+  })
+
+  return {
+    service,
+    provider,
+    calls,
+    get connection() {
+      return connection
+    },
+    setConnection(value: GoogleCalendarConnection) {
+      connection = value
+    },
+    setNow(value: string) {
+      now = new Date(value)
+    },
+  }
+}
+
+function connectedConnection(
+  refreshTokenEnvelope: EncryptedSecretEnvelope,
+): GoogleCalendarConnection {
+  const connectedAt = new Date('2026-07-14T04:00:00.000Z')
+  return {
+    id: 1,
+    status: 'connected',
+    calendarId: 'owner@example.com',
+    calendarEmail: 'owner@example.com',
+    calendarSummary: 'Cali Castle',
+    grantedScopes: [...GOOGLE_CALENDAR_SCOPES],
+    refreshTokenEnvelope,
+    accessTokenExpiresAt: new Date('2026-07-14T05:00:00.000Z'),
+    lastErrorCode: null,
+    connectedAt,
+    createdAt: connectedAt,
+    updatedAt: connectedAt,
+  }
+}
+
+describe('Google Calendar connection service', () => {
+  it('persists a one-time PKCE attempt and uses the canonical callback URL', async () => {
+    const f = fixture()
+
+    const authorizationUrl = await f.service.begin()
+
+    expect(authorizationUrl.searchParams.get('state')).toBe('persisted-state')
+    expect(f.calls).toEqual([
+      [
+        'authorize',
+        {
+          state: 'persisted-state',
+          codeVerifier: 'pkce-verifier',
+          redirectUri: new URL('https://cali.so/api/admin/ama/google/callback'),
+        },
+      ],
+    ])
+  })
+
+  it('connects the primary calendar and stores only an encrypted refresh token', async () => {
+    const f = fixture()
+    await f.service.begin()
+
+    const result = await f.service.complete({
+      state: 'persisted-state',
+      code: 'authorization-code',
+      error: null,
+    })
+
+    expect(result).toBe('connected')
+    expect(f.connection).toMatchObject({
+      status: 'connected',
+      calendarId: 'owner@example.com',
+      calendarEmail: 'owner@example.com',
+      calendarSummary: 'Cali Castle',
+      grantedScopes: [...GOOGLE_CALENDAR_SCOPES],
+      lastErrorCode: null,
+    })
+    expect(JSON.stringify(f.connection)).not.toContain('refresh-token')
+    expect(f.calls).toContainEqual([
+      'exchange',
+      {
+        code: 'authorization-code',
+        codeVerifier: 'pkce-verifier',
+        redirectUri: new URL('https://cali.so/api/admin/ama/google/callback'),
+      },
+    ])
+  })
+
+  it('rejects replayed OAuth state before exchanging another code', async () => {
+    const f = fixture()
+    await f.service.begin()
+    await f.service.complete({ state: 'persisted-state', code: 'first-code', error: null })
+
+    const replay = await f.service.complete({
+      state: 'persisted-state',
+      code: 'second-code',
+      error: null,
+    })
+
+    expect(replay).toBe('expired')
+    expect(
+      f.calls.filter((call) => Array.isArray(call) && call[0] === 'exchange'),
+    ).toHaveLength(1)
+  })
+
+  it('persists a denied-scope state without exposing provider credentials', async () => {
+    const f = fixture()
+    await f.service.begin()
+    f.provider.exchangeAuthorizationCode = async () => {
+      throw new GoogleCalendarError(
+        'denied_scope',
+        'Google Calendar permissions were not granted.',
+      )
+    }
+
+    const result = await f.service.complete({
+      state: 'persisted-state',
+      code: 'authorization-code',
+      error: null,
+    })
+
+    expect(result).toBe('denied-scope')
+    expect(f.connection).toMatchObject({
+      status: 'denied_scope',
+      lastErrorCode: 'denied_scope',
+      refreshTokenEnvelope: null,
+    })
+  })
+
+  it('does not misclassify temporary OAuth callback failures as denied scope', async () => {
+    const f = fixture()
+    await f.service.begin()
+
+    const result = await f.service.complete({
+      state: 'persisted-state',
+      code: null,
+      error: 'temporarily_unavailable',
+    })
+
+    expect(result).toBe('unavailable')
+    expect(f.connection).toBeNull()
+  })
+
+  it('refreshes credentials and returns normalized busy intervals', async () => {
+    const f = fixture()
+    const box = createSecretBox(Buffer.alloc(32, 7).toString('base64'))
+    f.setConnection(connectedConnection(box.seal('refresh-token', 'google-refresh-token')))
+
+    const result = await f.service.queryFreeBusy({
+      timeMin: new Date('2026-07-15T00:00:00.000Z'),
+      timeMax: new Date('2026-07-16T00:00:00.000Z'),
+    })
+
+    expect(result).toEqual({
+      status: 'connected',
+      busy: [
+        {
+          startsAt: new Date('2026-07-15T01:00:00.000Z'),
+          endsAt: new Date('2026-07-15T02:00:00.000Z'),
+        },
+      ],
+    })
+    expect(f.calls).toContainEqual(['refresh', 'refresh-token'])
+  })
+
+  it('marks invalid refresh credentials revoked and returns no slots', async () => {
+    const f = fixture()
+    const box = createSecretBox(Buffer.alloc(32, 7).toString('base64'))
+    f.setConnection(connectedConnection(box.seal('refresh-token', 'google-refresh-token')))
+    f.provider.refreshAccessToken = async () => {
+      throw new GoogleCalendarError(
+        'expired_or_revoked',
+        'Google Calendar access expired or was revoked. Reconnect Google Calendar.',
+      )
+    }
+
+    const result = await f.service.queryFreeBusy({
+      timeMin: new Date('2026-07-15T00:00:00.000Z'),
+      timeMax: new Date('2026-07-16T00:00:00.000Z'),
+    })
+
+    expect(result).toEqual({ status: 'revoked', busy: [] })
+    expect(f.connection).toMatchObject({ status: 'revoked', lastErrorCode: 'invalid_grant' })
+  })
+
+  it('disconnects locally even when remote revocation is unavailable', async () => {
+    const f = fixture()
+    const box = createSecretBox(Buffer.alloc(32, 7).toString('base64'))
+    f.setConnection(connectedConnection(box.seal('refresh-token', 'google-refresh-token')))
+    f.provider.revokeToken = async () => {
+      throw new GoogleCalendarError('provider_unavailable', 'Google Calendar is unavailable.')
+    }
+
+    await expect(f.service.disconnect()).resolves.toBeUndefined()
+
+    expect(f.connection).toMatchObject({
+      status: 'disconnected',
+      refreshTokenEnvelope: null,
+    })
+  })
+})

--- a/lib/ama/google/service.ts
+++ b/lib/ama/google/service.ts
@@ -1,0 +1,297 @@
+import 'server-only'
+
+import { randomBytes } from 'node:crypto'
+
+import type { EncryptedSecretEnvelope, createSecretBox } from '../secrets'
+import {
+  GOOGLE_CALENDAR_SCOPES,
+  GoogleCalendarError,
+  type GoogleCalendarIdentity,
+} from './client'
+
+const OAUTH_ATTEMPT_LIFETIME_MS = 10 * 60 * 1000
+const GOOGLE_CALLBACK_PATH = '/api/admin/ama/google/callback'
+
+export type GoogleConnectionStatus =
+  | 'disconnected'
+  | 'connected'
+  | 'expired'
+  | 'revoked'
+  | 'denied_scope'
+  | 'error'
+
+export type GoogleCalendarConnection = {
+  id: number
+  status: GoogleConnectionStatus
+  calendarId: string | null
+  calendarEmail: string | null
+  calendarSummary: string | null
+  grantedScopes: string[]
+  refreshTokenEnvelope: EncryptedSecretEnvelope | null
+  accessTokenExpiresAt: Date | null
+  lastErrorCode: string | null
+  connectedAt: Date | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+export type GoogleOAuthAttempt = {
+  state?: string
+  ownerEmail: string
+  pkceVerifierEnvelope: EncryptedSecretEnvelope
+  expiresAt: Date
+  consumedAt: Date | null
+  createdAt: Date
+}
+
+type SaveConnectionInput = Omit<GoogleCalendarConnection, 'id' | 'createdAt'>
+
+export interface GoogleCalendarRepository {
+  createOAuthAttempt(input: {
+    state: string
+    ownerEmail: string
+    pkceVerifierEnvelope: EncryptedSecretEnvelope
+    expiresAt: Date
+    createdAt: Date
+  }): Promise<unknown>
+  consumeOAuthAttempt(
+    state: string,
+    ownerEmail: string,
+    consumedAt: Date,
+  ): Promise<GoogleOAuthAttempt | null>
+  getConnection(): Promise<GoogleCalendarConnection | null>
+  saveConnection(input: SaveConnectionInput): Promise<GoogleCalendarConnection>
+  setConnectionStatus(
+    status: GoogleConnectionStatus,
+    lastErrorCode: string,
+    updatedAt: Date,
+  ): Promise<GoogleCalendarConnection>
+  disconnect(updatedAt: Date): Promise<GoogleCalendarConnection>
+}
+
+export interface GoogleCalendarProvider {
+  createAuthorizationUrl(input: {
+    state: string
+    codeVerifier: string
+    redirectUri: URL
+  }): URL
+  exchangeAuthorizationCode(input: {
+    code: string
+    codeVerifier: string
+    redirectUri: URL
+  }): Promise<{
+    accessToken?: string
+    refreshToken?: string
+    expiresAt: Date
+  }>
+  getPrimaryCalendarIdentity(accessToken: string): Promise<GoogleCalendarIdentity>
+  refreshAccessToken(refreshToken: string): Promise<{
+    accessToken?: string
+    expiresAt: Date
+  }>
+  queryFreeBusy(input: {
+    accessToken: string
+    calendarId?: string
+    timeMin: Date
+    timeMax: Date
+  }): Promise<Array<{ start: string; end: string }>>
+  revokeToken(token: string): Promise<void>
+}
+
+type GoogleCalendarServiceDependencies = {
+  ownerEmail: string
+  baseUrl: URL
+  repository: GoogleCalendarRepository
+  provider: GoogleCalendarProvider
+  secretBox: ReturnType<typeof createSecretBox>
+  clock?: { now(): Date }
+  randomToken?: () => string
+}
+
+export type GoogleConnectionResult =
+  | 'connected'
+  | 'denied-scope'
+  | 'expired'
+  | 'revoked'
+  | 'unavailable'
+
+function calendarEmail(identity: GoogleCalendarIdentity) {
+  return identity.id.includes('@') ? identity.id : null
+}
+
+function publicStatus(status: GoogleConnectionStatus | undefined): GoogleConnectionResult | 'disconnected' {
+  if (!status || status === 'disconnected') return 'disconnected'
+  if (status === 'denied_scope') return 'denied-scope'
+  if (status === 'error') return 'unavailable'
+  return status
+}
+
+export function createGoogleCalendarService(dependencies: GoogleCalendarServiceDependencies) {
+  const {
+    ownerEmail,
+    baseUrl,
+    repository,
+    provider,
+    secretBox,
+    clock = { now: () => new Date() },
+    randomToken = () => randomBytes(32).toString('base64url'),
+  } = dependencies
+  const redirectUri = new URL(GOOGLE_CALLBACK_PATH, baseUrl)
+
+  async function setFailure(error: unknown, now: Date): Promise<GoogleConnectionResult> {
+    if (error instanceof GoogleCalendarError && error.code === 'denied_scope') {
+      await repository.setConnectionStatus('denied_scope', 'denied_scope', now)
+      return 'denied-scope'
+    }
+    if (error instanceof GoogleCalendarError && error.code === 'expired_or_revoked') {
+      await repository.setConnectionStatus('revoked', 'invalid_grant', now)
+      return 'revoked'
+    }
+    return 'unavailable'
+  }
+
+  return {
+    async begin() {
+      const now = clock.now()
+      const state = randomToken()
+      const codeVerifier = randomToken()
+      await repository.createOAuthAttempt({
+        state,
+        ownerEmail,
+        pkceVerifierEnvelope: secretBox.seal(codeVerifier, 'google-pkce-verifier'),
+        expiresAt: new Date(now.getTime() + OAUTH_ATTEMPT_LIFETIME_MS),
+        createdAt: now,
+      })
+      return provider.createAuthorizationUrl({ state, codeVerifier, redirectUri })
+    },
+
+    async complete(input: {
+      state: string | null
+      code: string | null
+      error: string | null
+    }): Promise<GoogleConnectionResult> {
+      const now = clock.now()
+      if (!input.state) return 'unavailable'
+      const attempt = await repository.consumeOAuthAttempt(input.state, ownerEmail, now)
+      if (!attempt) return 'expired'
+      if (input.error === 'access_denied') {
+        await repository.setConnectionStatus('denied_scope', input.error, now)
+        return 'denied-scope'
+      }
+      if (input.error || !input.code) {
+        return 'unavailable'
+      }
+
+      try {
+        const codeVerifier = secretBox.open(
+          attempt.pkceVerifierEnvelope,
+          'google-pkce-verifier',
+        )
+        const tokens = await provider.exchangeAuthorizationCode({
+          code: input.code,
+          codeVerifier,
+          redirectUri,
+        })
+        if (!tokens.accessToken || !tokens.refreshToken) return 'unavailable'
+
+        const identity = await provider.getPrimaryCalendarIdentity(tokens.accessToken)
+        await repository.saveConnection({
+          status: 'connected',
+          calendarId: identity.id,
+          calendarEmail: calendarEmail(identity),
+          calendarSummary: identity.summary,
+          grantedScopes: [...GOOGLE_CALENDAR_SCOPES],
+          refreshTokenEnvelope: secretBox.seal(
+            tokens.refreshToken,
+            'google-refresh-token',
+          ),
+          accessTokenExpiresAt: tokens.expiresAt,
+          lastErrorCode: null,
+          connectedAt: now,
+          updatedAt: now,
+        })
+        return 'connected'
+      } catch (error) {
+        return setFailure(error, now)
+      }
+    },
+
+    getConnection() {
+      return repository.getConnection()
+    },
+
+    async queryFreeBusy(input: { timeMin: Date; timeMax: Date }) {
+      const connection = await repository.getConnection()
+      if (
+        !connection ||
+        connection.status !== 'connected' ||
+        !connection.refreshTokenEnvelope
+      ) {
+        return { status: publicStatus(connection?.status), busy: [] }
+      }
+
+      const now = clock.now()
+      try {
+        const refreshToken = secretBox.open(
+          connection.refreshTokenEnvelope,
+          'google-refresh-token',
+        )
+        const tokens = await provider.refreshAccessToken(refreshToken)
+        if (!tokens.accessToken) return { status: 'unavailable' as const, busy: [] }
+        const intervals = await provider.queryFreeBusy({
+          accessToken: tokens.accessToken,
+          calendarId: connection.calendarId ?? undefined,
+          timeMin: input.timeMin,
+          timeMax: input.timeMax,
+        })
+        const busy = intervals.map((interval) => ({
+          startsAt: new Date(interval.start),
+          endsAt: new Date(interval.end),
+        }))
+        if (
+          busy.some(
+            (interval) =>
+              !Number.isFinite(interval.startsAt.getTime()) ||
+              !Number.isFinite(interval.endsAt.getTime()) ||
+              interval.startsAt >= interval.endsAt,
+          )
+        ) {
+          return { status: 'unavailable' as const, busy: [] }
+        }
+        await repository.saveConnection({
+          status: 'connected',
+          calendarId: connection.calendarId,
+          calendarEmail: connection.calendarEmail,
+          calendarSummary: connection.calendarSummary,
+          grantedScopes: connection.grantedScopes,
+          refreshTokenEnvelope: connection.refreshTokenEnvelope,
+          accessTokenExpiresAt: tokens.expiresAt,
+          lastErrorCode: null,
+          connectedAt: connection.connectedAt,
+          updatedAt: now,
+        })
+        return { status: 'connected' as const, busy }
+      } catch (error) {
+        return { status: await setFailure(error, now), busy: [] }
+      }
+    },
+
+    async disconnect() {
+      const connection = await repository.getConnection()
+      if (connection?.refreshTokenEnvelope) {
+        try {
+          const refreshToken = secretBox.open(
+            connection.refreshTokenEnvelope,
+            'google-refresh-token',
+          )
+          await provider.revokeToken(refreshToken)
+        } catch {
+          // Local disconnect remains authoritative when Google is unavailable.
+        }
+      }
+      await repository.disconnect(clock.now())
+    },
+  }
+}
+
+export type GoogleCalendarService = ReturnType<typeof createGoogleCalendarService>

--- a/lib/ama/secrets.test.ts
+++ b/lib/ama/secrets.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import { createSecretBox, type EncryptedSecretEnvelope } from './secrets'
+
+describe('AMA encrypted secrets', () => {
+  it('round-trips a secret through a versioned AES-256-GCM envelope', () => {
+    const box = createSecretBox(Buffer.alloc(32, 7).toString('base64'))
+
+    const envelope = box.seal('refresh-token-value', 'google-refresh-token')
+
+    expect(envelope).toMatchObject({ version: 1, algorithm: 'aes-256-gcm' })
+    expect(JSON.stringify(envelope)).not.toContain('refresh-token-value')
+    expect(box.open(envelope, 'google-refresh-token')).toBe('refresh-token-value')
+  })
+
+  it('uses a fresh random IV for every sealed secret', () => {
+    const box = createSecretBox(Buffer.alloc(32, 7).toString('base64'))
+
+    const first = box.seal('same-secret', 'google-refresh-token')
+    const second = box.seal('same-secret', 'google-refresh-token')
+
+    expect(first.iv).not.toBe(second.iv)
+    expect(first.ciphertext).not.toBe(second.ciphertext)
+  })
+
+  it('rejects a tampered ciphertext with a generic error', () => {
+    const box = createSecretBox(Buffer.alloc(32, 7).toString('base64'))
+    const envelope = box.seal('do-not-expose-me', 'google-refresh-token')
+    const tampered = {
+      ...envelope,
+      ciphertext: `${envelope.ciphertext.startsWith('A') ? 'B' : 'A'}${
+        envelope.ciphertext.slice(1)
+      }`,
+    }
+
+    expect(() => box.open(tampered, 'google-refresh-token')).toThrowError(
+      'Unable to open encrypted secret',
+    )
+    try {
+      box.open(tampered, 'google-refresh-token')
+    } catch (error) {
+      expect(String(error)).not.toContain('do-not-expose-me')
+      expect(String(error)).not.toContain('authenticate')
+      expect(String(error)).not.toContain('cipher')
+    }
+  })
+
+  it('binds an encrypted secret to its declared purpose', () => {
+    const box = createSecretBox(Buffer.alloc(32, 7).toString('base64'))
+    const envelope = box.seal('refresh-token-value', 'google-refresh-token')
+
+    expect(() => box.open(envelope, 'google-pkce-verifier')).toThrowError(
+      'Unable to open encrypted secret',
+    )
+  })
+
+  it('rejects unsupported envelope versions with the same generic error', () => {
+    const box = createSecretBox(Buffer.alloc(32, 7).toString('base64'))
+    const envelope = box.seal('refresh-token-value', 'google-refresh-token')
+    const unsupported = { ...envelope, version: 2 } as unknown as EncryptedSecretEnvelope
+
+    expect(() => box.open(unsupported, 'google-refresh-token')).toThrowError(
+      'Unable to open encrypted secret',
+    )
+  })
+})

--- a/lib/ama/secrets.ts
+++ b/lib/ama/secrets.ts
@@ -1,0 +1,71 @@
+import 'server-only'
+
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto'
+
+export type SecretPurpose = 'google-refresh-token' | 'google-pkce-verifier'
+
+export type EncryptedSecretEnvelope = {
+  version: 1
+  algorithm: 'aes-256-gcm'
+  iv: string
+  ciphertext: string
+  tag: string
+}
+
+const OPEN_ERROR = 'Unable to open encrypted secret'
+
+function decodeKey(value: string) {
+  const normalized = value.trim()
+  const key = Buffer.from(normalized, 'base64')
+  const canonical = key.toString('base64').replace(/=+$/, '')
+  if (key.length !== 32 || canonical !== normalized.replace(/=+$/, '')) {
+    throw new Error('Invalid encryption key')
+  }
+  return key
+}
+
+function additionalData(purpose: SecretPurpose) {
+  return Buffer.from(`cali.so:ama:${purpose}:v1`, 'utf8')
+}
+
+export function createSecretBox(encodedKey: string) {
+  const key = decodeKey(encodedKey)
+
+  return {
+    seal(plaintext: string, purpose: SecretPurpose): EncryptedSecretEnvelope {
+      const iv = randomBytes(12)
+      const cipher = createCipheriv('aes-256-gcm', key, iv)
+      cipher.setAAD(additionalData(purpose))
+      const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()])
+
+      return {
+        version: 1,
+        algorithm: 'aes-256-gcm',
+        iv: iv.toString('base64url'),
+        ciphertext: ciphertext.toString('base64url'),
+        tag: cipher.getAuthTag().toString('base64url'),
+      }
+    },
+
+    open(envelope: EncryptedSecretEnvelope, purpose: SecretPurpose): string {
+      try {
+        if (envelope.version !== 1 || envelope.algorithm !== 'aes-256-gcm') {
+          throw new Error(OPEN_ERROR)
+        }
+        const decipher = createDecipheriv(
+          'aes-256-gcm',
+          key,
+          Buffer.from(envelope.iv, 'base64url'),
+        )
+        decipher.setAAD(additionalData(purpose))
+        decipher.setAuthTag(Buffer.from(envelope.tag, 'base64url'))
+        return Buffer.concat([
+          decipher.update(Buffer.from(envelope.ciphertext, 'base64url')),
+          decipher.final(),
+        ]).toString('utf8')
+      } catch {
+        throw new Error(OPEN_ERROR)
+      }
+    },
+  }
+}

--- a/lib/ama/server-env-schema.ts
+++ b/lib/ama/server-env-schema.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod'
+
+function isPostgresUrl(value: string) {
+  try {
+    const protocol = new URL(value).protocol
+    return protocol === 'postgres:' || protocol === 'postgresql:'
+  } catch {
+    return false
+  }
+}
+
+function isBase64Key(value: string) {
+  try {
+    return Buffer.from(value, 'base64').length === 32
+  } catch {
+    return false
+  }
+}
+
+function isResendSender(value: string) {
+  const bracketed = value.match(/^\s*[^<>]*<([^<>]+)>\s*$/)
+  const mailbox = bracketed?.[1] ?? value.trim()
+  return z.email().safeParse(mailbox).success
+}
+
+const serverEnvironmentSchema = z.object({
+  DATABASE_URL: z.string().refine(isPostgresUrl),
+  RESEND_API_KEY: z.string().min(1),
+  RESEND_FROM_EMAIL: z.string().min(3).refine(isResendSender),
+  ADMIN_EMAIL: z.email().transform((value) => value.trim().toLowerCase()),
+  SESSION_SECRET: z.string().min(32),
+  AMA_ENCRYPTION_KEY: z.string().refine(isBase64Key),
+  UPSTASH_REDIS_REST_URL: z.url(),
+  UPSTASH_REDIS_REST_TOKEN: z.string().min(1),
+  SITE_URL: z
+    .url()
+    .refine((value) => {
+      const url = new URL(value)
+      return url.protocol === 'https:' || ['localhost', '127.0.0.1'].includes(url.hostname)
+    })
+    .transform((value) => new URL(value)),
+  AUTH_RATE_LIMIT_MAX_REQUESTS: z.coerce.number().int().positive().default(5),
+  AUTH_RATE_LIMIT_WINDOW_SECONDS: z.coerce.number().int().positive().default(900),
+})
+
+export type ServerEnvironment = z.output<typeof serverEnvironmentSchema>
+
+export function parseServerEnv(source: Record<string, string | undefined>) {
+  const result = serverEnvironmentSchema.safeParse(source)
+  if (result.success) return result.data
+
+  const fields = [
+    ...new Set(result.error.issues.map((issue) => issue.path.join('.')).filter(Boolean)),
+  ]
+  throw new Error(`Invalid server environment: ${fields.join(', ')}`)
+}

--- a/lib/ama/server-env-schema.ts
+++ b/lib/ama/server-env-schema.ts
@@ -30,6 +30,8 @@ const serverEnvironmentSchema = z.object({
   ADMIN_EMAIL: z.email().transform((value) => value.trim().toLowerCase()),
   SESSION_SECRET: z.string().min(32),
   AMA_ENCRYPTION_KEY: z.string().refine(isBase64Key),
+  GOOGLE_CLIENT_ID: z.string().trim().min(1),
+  GOOGLE_CLIENT_SECRET: z.string().trim().min(1),
   UPSTASH_REDIS_REST_URL: z.url(),
   UPSTASH_REDIS_REST_TOKEN: z.string().min(1),
   SITE_URL: z

--- a/lib/ama/server-env.test.ts
+++ b/lib/ama/server-env.test.ts
@@ -9,6 +9,8 @@ const validEnvironment = {
   ADMIN_EMAIL: 'owner@example.com',
   SESSION_SECRET: 's'.repeat(64),
   AMA_ENCRYPTION_KEY: Buffer.alloc(32).toString('base64'),
+  GOOGLE_CLIENT_ID: 'google-client-id.apps.googleusercontent.com',
+  GOOGLE_CLIENT_SECRET: 'google-client-secret',
   UPSTASH_REDIS_REST_URL: 'https://example.upstash.io',
   UPSTASH_REDIS_REST_TOKEN: 'redis-secret',
   SITE_URL: 'https://cali.so',
@@ -42,5 +44,16 @@ describe('AMA server environment', () => {
     expect(() =>
       parseServerEnv({ ...validEnvironment, RESEND_FROM_EMAIL: 'Cali <@@@>' }),
     ).toThrowError(/RESEND_FROM_EMAIL/)
+  })
+
+  it('requires Google OAuth credentials without exposing their values', () => {
+    const { GOOGLE_CLIENT_SECRET: _missing, ...missingSecret } = validEnvironment
+    expect(() => parseServerEnv(missingSecret)).toThrowError(/GOOGLE_CLIENT_SECRET/)
+
+    try {
+      parseServerEnv({ ...validEnvironment, GOOGLE_CLIENT_SECRET: '' })
+    } catch (error) {
+      expect(String(error)).not.toContain('google-client-secret')
+    }
   })
 })

--- a/lib/ama/server-env.test.ts
+++ b/lib/ama/server-env.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseServerEnv } from './server-env-schema'
+
+const validEnvironment = {
+  DATABASE_URL: 'postgresql://user:password@example.neon.tech/site',
+  RESEND_API_KEY: 're_test_key',
+  RESEND_FROM_EMAIL: 'Cali <hello@cali.so>',
+  ADMIN_EMAIL: 'owner@example.com',
+  SESSION_SECRET: 's'.repeat(64),
+  AMA_ENCRYPTION_KEY: Buffer.alloc(32).toString('base64'),
+  UPSTASH_REDIS_REST_URL: 'https://example.upstash.io',
+  UPSTASH_REDIS_REST_TOKEN: 'redis-secret',
+  SITE_URL: 'https://cali.so',
+}
+
+describe('AMA server environment', () => {
+  it('accepts the complete server-only configuration', () => {
+    const environment = parseServerEnv(validEnvironment)
+
+    expect(environment.ADMIN_EMAIL).toBe('owner@example.com')
+    expect(environment.AUTH_RATE_LIMIT_MAX_REQUESTS).toBe(5)
+  })
+
+  it('reports invalid field names without exposing secret values', () => {
+    expect(() =>
+      parseServerEnv({
+        ...validEnvironment,
+        SESSION_SECRET: 'short-secret',
+        AMA_ENCRYPTION_KEY: 'another-production-secret',
+      }),
+    ).toThrowError(/SESSION_SECRET, AMA_ENCRYPTION_KEY/)
+
+    try {
+      parseServerEnv({ ...validEnvironment, SESSION_SECRET: 'do-not-print-me' })
+    } catch (error) {
+      expect(String(error)).not.toContain('do-not-print-me')
+    }
+  })
+
+  it('rejects a malformed Resend sender mailbox', () => {
+    expect(() =>
+      parseServerEnv({ ...validEnvironment, RESEND_FROM_EMAIL: 'Cali <@@@>' }),
+    ).toThrowError(/RESEND_FROM_EMAIL/)
+  })
+})

--- a/lib/ama/server-env.ts
+++ b/lib/ama/server-env.ts
@@ -1,0 +1,10 @@
+import 'server-only'
+
+import { parseServerEnv, type ServerEnvironment } from './server-env-schema'
+
+let environment: ServerEnvironment | undefined
+
+export function getServerEnv() {
+  environment ??= parseServerEnv(process.env)
+  return environment
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:validate": "node --test scripts/ama-migrations.test.mjs",
     "start": "next start",
+    "test:ama": "vitest run lib/ama && pnpm db:validate",
     "test:localization": "node --test scripts/localization.test.mjs",
     "test:port-post": "node --test scripts/port-post.test.mjs",
     "typecheck": "tsc --noEmit"
@@ -15,12 +19,16 @@
     "@base-ui/react": "^1.6.0",
     "@hugeicons/core-free-icons": "^4.2.2",
     "@hugeicons/react": "^1.1.9",
+    "@neondatabase/serverless": "^1.1.0",
     "@phosphor-icons/react": "^2.1.10",
     "@tabler/icons-react": "^3.44.0",
     "@untitledui/icons": "^0.0.22",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cuelume": "0.1.0",
+    "drizzle-orm": "^0.45.2",
     "framer-motion": "^12.42.2",
     "geist": "^1.7.2",
     "github-slugger": "^2.0.0",
@@ -35,7 +43,9 @@
     "rehype-pretty-code": "^0.14.4",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
+    "resend": "^6.17.2",
     "rss": "^1.2.2",
+    "server-only": "^0.0.1",
     "shadcn": "^4.13.0",
     "shiki": "^4.3.1",
     "subset-font": "^2.5.0",
@@ -44,13 +54,16 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.5.4",
     "@tailwindcss/postcss": "^4.1.0",
     "@types/mdx": "^2.0.14",
     "@types/node": "^24.0.0",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "@types/rss": "^0.0.32",
+    "drizzle-kit": "^0.31.10",
     "tailwindcss": "^4.1.0",
-    "typescript": "^5.8.0"
+    "typescript": "^5.8.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@base-ui/react": "^1.6.0",
     "@hugeicons/core-free-icons": "^4.2.2",
     "@hugeicons/react": "^1.1.9",
+    "@js-temporal/polyfill": "^0.5.1",
     "@neondatabase/serverless": "^1.1.0",
     "@phosphor-icons/react": "^2.1.10",
     "@tabler/icons-react": "^3.44.0",
@@ -56,12 +57,14 @@
   "devDependencies": {
     "@electric-sql/pglite": "^0.5.4",
     "@tailwindcss/postcss": "^4.1.0",
+    "@testing-library/react": "^16.3.2",
     "@types/mdx": "^2.0.14",
     "@types/node": "^24.0.0",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "@types/rss": "^0.0.32",
     "drizzle-kit": "^0.31.10",
+    "jsdom": "^29.1.1",
     "tailwindcss": "^4.1.0",
     "typescript": "^5.8.0",
     "vitest": "^4.1.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@hugeicons/react':
         specifier: ^1.1.9
         version: 1.1.9(react@19.2.7)
+      '@js-temporal/polyfill':
+        specifier: ^0.5.1
+        version: 0.5.1
       '@neondatabase/serverless':
         specifier: ^1.1.0
         version: 1.1.0
@@ -123,6 +126,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.1.0
         version: 4.3.2
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/mdx':
         specifier: ^2.0.14
         version: 2.0.14
@@ -141,6 +147,9 @@ importers:
       drizzle-kit:
         specifier: ^0.31.10
         version: 0.31.10
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       tailwindcss:
         specifier: ^4.1.0
         version: 4.3.2
@@ -149,13 +158,28 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -316,6 +340,46 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.9':
+    resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6':
+    resolution: {integrity: sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@dotenvx/dotenvx@1.75.1':
     resolution: {integrity: sha512-/BITOC9dmS/edY2zQwZNicQ059O6RKabtQfyEafV0nGtfYRNHYy1DIPiYVcov40+tob9hfmBnbR963dS+EQ1DQ==}
@@ -794,6 +858,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
@@ -975,6 +1048,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@js-temporal/polyfill@0.5.1':
+    resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
+    engines: {node: '>=12'}
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
@@ -1313,11 +1390,33 @@ packages:
   '@tailwindcss/postcss@4.3.2':
     resolution: {integrity: sha512-rjVWYCa7Ngbi5AarT6k8TkxUG3Wl1QKzHdIZVsjZSzf36Jmo2IKZt/NHRAwly8oDkbBOH0YTu+CHuf9jPxMc+g==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -1463,11 +1562,18 @@ packages:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1496,6 +1602,9 @@ packages:
     resolution: {integrity: sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
@@ -1642,6 +1751,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -1652,6 +1765,10 @@ packages:
 
   cuelume@0.1.0:
     resolution: {integrity: sha512-J2RRt92Gh1a0ztnjwLEyLfGnDIiWz14vC9aTmg7ZgxRkEk8vR+QxFOz+v1tqntFvl06n5G4si8QCQgHfWjnneA==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debounce-fn@4.0.0:
     resolution: {integrity: sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==}
@@ -1665,6 +1782,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -1715,6 +1835,9 @@ packages:
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dot-prop@6.0.1:
     resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==}
@@ -1848,6 +1971,10 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -2150,6 +2277,10 @@ packages:
     resolution: {integrity: sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
@@ -2257,6 +2388,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -2312,6 +2446,18 @@ packages:
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
+
+  jsbi@4.3.2:
+    resolution: {integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==}
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2437,6 +2583,10 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2444,6 +2594,10 @@ packages:
     resolution: {integrity: sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2506,6 +2660,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -2832,6 +2989,9 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -2895,6 +3055,10 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
@@ -2909,6 +3073,10 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
@@ -2929,6 +3097,9 @@ packages:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
       react: ^19.2.7
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
@@ -3043,6 +3214,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3219,6 +3394,9 @@ packages:
   subset-font@2.5.0:
     resolution: {integrity: sha512-Vsa8ngQ/ohhUj0an7on49y9jLZ2rK5U+T1FzPM4/ZQY0xUy5mLis6BfFtPGzecTjFgYXQlvY7FlsJF4t3R/6Ug==}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   systeminformation@5.31.15:
     resolution: {integrity: sha512-7mqCtD28TK5dVdLAQONVa/Do/NBgMH2dxqf49nh6DIKoEWuDg6tkgGBP+dN22VEJVPZa/QqiHomhWNRn4WUNTQ==}
     engines: {node: '>=8.0.0'}
@@ -3253,6 +3431,13 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.4.8:
+    resolution: {integrity: sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==}
+
+  tldts@7.4.8:
+    resolution: {integrity: sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -3260,6 +3445,14 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -3458,12 +3651,28 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   wawoff2@2.0.1:
     resolution: {integrity: sha512-r0CEmvpH63r4T15ebFqeOjGqU4+EgTx4I510NtK35EMciSdcTxCw3Byy3JnBonz7iyIFZ0AbVo0bbFpEVuhCYA==}
     hasBin: true
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -3490,8 +3699,15 @@ packages:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xml@1.0.1:
     resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -3530,6 +3746,26 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -3741,6 +3977,34 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@dotenvx/dotenvx@1.75.1':
     dependencies:
@@ -4020,6 +4284,8 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
+  '@exodus/bytes@1.15.1': {}
+
   '@floating-ui/core@1.7.5':
     dependencies:
       '@floating-ui/utils': 0.2.11
@@ -4162,6 +4428,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@js-temporal/polyfill@0.5.1':
+    dependencies:
+      jsbi: 4.3.2
 
   '@mdx-js/mdx@3.1.1':
     dependencies:
@@ -4454,6 +4724,27 @@ snapshots:
       postcss: 8.5.16
       tailwindcss: 4.3.2
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@ts-morph/common@0.27.0':
     dependencies:
       fast-glob: 3.3.3
@@ -4464,6 +4755,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -4606,11 +4899,17 @@ snapshots:
 
   ansi-regex@6.2.2: {}
 
+  ansi-styles@5.2.0: {}
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   assertion-error@2.0.1: {}
 
@@ -4627,6 +4926,10 @@ snapshots:
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.42: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   body-parser@2.3.0:
     dependencies:
@@ -4763,11 +5066,23 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
 
   cuelume@0.1.0: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   debounce-fn@4.0.0:
     dependencies:
@@ -4776,6 +5091,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -4807,6 +5124,8 @@ snapshots:
       dequal: 2.0.3
 
   diff@8.0.4: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dot-prop@6.0.1:
     dependencies:
@@ -4852,6 +5171,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   entities@6.0.1: {}
+
+  entities@8.0.0: {}
 
   env-paths@2.2.1: {}
 
@@ -5329,6 +5650,12 @@ snapshots:
 
   hono@4.12.29: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-void-elements@3.0.0: {}
 
   http-errors@2.0.1:
@@ -5403,6 +5730,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-regexp@3.1.0: {}
@@ -5441,6 +5770,34 @@ snapshots:
   js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
+
+  jsbi@4.3.2: {}
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 7.28.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -5531,6 +5888,8 @@ snapshots:
 
   longest-streak@3.1.0: {}
 
+  lru-cache@11.5.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -5538,6 +5897,8 @@ snapshots:
   lucide-react@1.24.0(react@19.2.7):
     dependencies:
       react: 19.2.7
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -5711,6 +6072,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.27.1: {}
 
   media-typer@1.1.0: {}
 
@@ -6191,6 +6554,10 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
@@ -6238,6 +6605,12 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
@@ -6253,6 +6626,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  punycode@2.3.1: {}
 
   qs@6.15.3:
     dependencies:
@@ -6274,6 +6649,8 @@ snapshots:
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react@19.2.7: {}
 
@@ -6460,6 +6837,10 @@ snapshots:
       queue-microtask: 1.2.3
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -6709,6 +7090,8 @@ snapshots:
       lodash: 4.18.1
       p-limit: 3.1.0
 
+  symbol-tree@3.2.4: {}
+
   systeminformation@5.31.15: {}
 
   tailwind-merge@3.6.0: {}
@@ -6730,11 +7113,25 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@7.4.8: {}
+
+  tldts@7.4.8:
+    dependencies:
+      tldts-core: 7.4.8
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.8
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -6875,7 +7272,7 @@ snapshots:
       tsx: 4.23.1
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -6899,14 +7296,31 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.3
+      jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
 
   wawoff2@2.0.1:
     dependencies:
       argparse: 2.0.1
 
   web-namespaces@2.0.1: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which@2.0.2:
     dependencies:
@@ -6932,7 +7346,11 @@ snapshots:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
+  xml-name-validator@5.0.0: {}
+
   xml@1.0.1: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@hugeicons/react':
         specifier: ^1.1.9
         version: 1.1.9(react@19.2.7)
+      '@neondatabase/serverless':
+        specifier: ^1.1.0
+        version: 1.1.0
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -26,6 +29,12 @@ importers:
       '@untitledui/icons':
         specifier: ^0.0.22
         version: 0.0.22(react@19.2.7)
+      '@upstash/ratelimit':
+        specifier: ^2.0.8
+        version: 2.0.8(@upstash/redis@1.38.0)
+      '@upstash/redis':
+        specifier: ^1.38.0
+        version: 1.38.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -35,6 +44,9 @@ importers:
       cuelume:
         specifier: 0.1.0
         version: 0.1.0
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@upstash/redis@1.38.0)
       framer-motion:
         specifier: ^12.42.2
         version: 12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -77,9 +89,15 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      resend:
+        specifier: ^6.17.2
+        version: 6.17.2
       rss:
         specifier: ^1.2.2
         version: 1.2.2
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       shadcn:
         specifier: ^4.13.0
         version: 4.13.0(typescript@5.9.3)
@@ -99,6 +117,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@electric-sql/pglite':
+        specifier: ^0.5.4
+        version: 0.5.4
       '@tailwindcss/postcss':
         specifier: ^4.1.0
         version: 4.3.2
@@ -117,12 +138,18 @@ importers:
       '@types/rss':
         specifier: ^0.0.32
         version: 0.0.32
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
       tailwindcss:
         specifier: ^4.1.0
         version: 4.3.2
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
 
@@ -297,8 +324,475 @@ packages:
   '@dotenvx/primitives@0.8.0':
     resolution: {integrity: sha512-VYJy0uhFm9zTJ1TxBaW/pA8bjbOM/OttaNMwZ1RHG4JKyRG7DhSdiqD1ipQoAyoD22olUtxbP78W9xY3Wd11bg==}
 
+  '@drizzle-team/brocli@0.10.2':
+    resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
+  '@electric-sql/pglite@0.5.4':
+    resolution: {integrity: sha512-yYZUyyXrHU7tPlCjwZQJ6hIG9DscdCCn7Uk0mYKwC1FeHX286AbcmFveMiRBEak8e9iPupjsoVImN3yJZVed2g==}
+
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
   '@emnapi/runtime@1.11.2':
     resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@esbuild-kit/core-utils@3.3.2':
+    resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.18.20':
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.18.20':
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.18.20':
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.18.20':
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.18.20':
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.18.20':
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.18.20':
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.18.20':
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.18.20':
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.18.20':
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.18.20':
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.18.20':
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.18.20':
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.18.20':
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.18.20':
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.18.20':
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.18.20':
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.18.20':
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.18.20':
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.18.20':
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.18.20':
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.18.20':
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -501,6 +995,16 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@neondatabase/serverless@1.1.0':
+    resolution: {integrity: sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q==}
+    engines: {node: '>=19.0.0'}
+
   '@next/env@16.3.0-preview.5':
     resolution: {integrity: sha512-XqdVR0utAWMsVc1OIyO48D32vrdmC4/uAgI3Ds088YlOO4vfGKXXVyvkGFkOZkOK0xg7bNYNfJAarX4A0tYqGg==}
 
@@ -564,12 +1068,107 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
   '@phosphor-icons/react@2.1.10':
     resolution: {integrity: sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==}
     engines: {node: '>=10'}
     peerDependencies:
       react: '>= 16.8'
       react-dom: '>= 16.8'
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -608,6 +1207,12 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -711,8 +1316,17 @@ packages:
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
 
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -762,6 +1376,47 @@ packages:
     resolution: {integrity: sha512-lEUdk2Ni7SocXMjIokJDoBeECzmZO1qAIuZc+91rAqwSMln0CKRnk+r2dC2TJ9ccION/1ZFed2fIeKvAEAs0lQ==}
     peerDependencies:
       react: '>= 16'
+
+  '@upstash/core-analytics@0.0.10':
+    resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@upstash/ratelimit@2.0.8':
+    resolution: {integrity: sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==}
+    peerDependencies:
+      '@upstash/redis': ^1.34.3
+
+  '@upstash/redis@1.38.0':
+    resolution: {integrity: sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==}
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -814,6 +1469,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
@@ -855,6 +1514,9 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -880,6 +1542,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -1058,6 +1724,102 @@ packages:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
+  drizzle-kit@0.31.10:
+    resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
+    hasBin: true
+
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -1102,6 +1864,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
@@ -1111,6 +1876,21 @@ packages:
 
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
+
+  esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1169,6 +1949,10 @@ packages:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
 
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
   express-rate-limit@8.5.2:
     resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
     engines: {node: '>= 16'}
@@ -1192,6 +1976,9 @@ packages:
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-uri@3.1.3:
     resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
@@ -1253,6 +2040,11 @@ packages:
     resolution: {integrity: sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -1291,6 +2083,9 @@ packages:
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -1960,6 +2755,10 @@ packages:
     resolution: {integrity: sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==}
     engines: {node: '>= 10'}
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -2055,6 +2854,9 @@ packages:
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2073,6 +2875,9 @@ packages:
   pkg-up@3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
+
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
 
   postcss-selector-parser@7.1.4:
     resolution: {integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==}
@@ -2193,9 +2998,21 @@ packages:
   reselect@5.2.0:
     resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
+  resend@6.17.2:
+    resolution: {integrity: sha512-hbaXEORFIFfT2Bh03NsA/akTTTKkD1hiuJ88ke64c5dWVV6DyoLxzFve3OiZqVOQ+JKLJ5uVkPR6hlUslpJFoA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
@@ -2204,6 +3021,11 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
@@ -2246,6 +3068,9 @@ packages:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
 
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
@@ -2286,6 +3111,9 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -2299,6 +3127,9 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
@@ -2314,9 +3145,18 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -2398,6 +3238,21 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -2422,6 +3277,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.23.1:
+    resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
@@ -2433,6 +3293,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -2511,6 +3374,90 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite@8.1.4:
+    resolution: {integrity: sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   wawoff2@2.0.1:
     resolution: {integrity: sha512-r0CEmvpH63r4T15ebFqeOjGqU4+EgTx4I510NtK35EMciSdcTxCw3Byy3JnBonz7iyIFZ0AbVo0bbFpEVuhCYA==}
     hasBin: true
@@ -2526,6 +3473,11 @@ packages:
   which@4.0.0:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   woff2sfnt-sfnt2woff@1.0.0:
@@ -2811,9 +3763,261 @@ snapshots:
 
   '@dotenvx/primitives@0.8.0': {}
 
+  '@drizzle-team/brocli@0.10.2': {}
+
+  '@electric-sql/pglite@0.5.4': {}
+
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.11.2':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild-kit/core-utils@3.3.2':
+    dependencies:
+      esbuild: 0.18.20
+      source-map-support: 0.5.21
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    dependencies:
+      '@esbuild-kit/core-utils': 3.3.2
+      get-tsconfig: 4.14.0
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.18.20':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.18.20':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.18.20':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.18.20':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.18.20':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@floating-ui/core@1.7.5':
@@ -3017,6 +4221,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@neondatabase/serverless@1.1.0': {}
+
   '@next/env@16.3.0-preview.5': {}
 
   '@next/swc-darwin-arm64@16.3.0-preview.5':
@@ -3055,10 +4268,63 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@oxc-project/types@0.139.0': {}
+
   '@phosphor-icons/react@2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
 
@@ -3103,6 +4369,10 @@ snapshots:
   '@shikijs/vscode-textmate@10.0.2': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@stablelib/base64@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -3190,9 +4460,21 @@ snapshots:
       minimatch: 10.2.5
       path-browserify: 1.0.1
 
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -3238,6 +4520,60 @@ snapshots:
     dependencies:
       react: 19.2.7
 
+  '@upstash/core-analytics@0.0.10':
+    dependencies:
+      '@upstash/redis': 1.38.0
+
+  '@upstash/ratelimit@2.0.8(@upstash/redis@1.38.0)':
+    dependencies:
+      '@upstash/core-analytics': 0.0.10
+      '@upstash/redis': 1.38.0
+
+  '@upstash/redis@1.38.0':
+    dependencies:
+      uncrypto: 0.1.3
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -3275,6 +4611,8 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  assertion-error@2.0.1: {}
 
   ast-types@0.16.1:
     dependencies:
@@ -3320,6 +4658,8 @@ snapshots:
       node-releases: 2.0.51
       update-browserslist-db: 1.2.3(browserslist@4.28.5)
 
+  buffer-from@1.1.2: {}
+
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -3341,6 +4681,8 @@ snapshots:
   caniuse-lite@1.0.30001803: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@5.6.2: {}
 
@@ -3472,6 +4814,19 @@ snapshots:
 
   dotenv@17.4.2: {}
 
+  drizzle-kit@0.31.10:
+    dependencies:
+      '@drizzle-team/brocli': 0.10.2
+      '@esbuild-kit/esm-loader': 2.6.5
+      esbuild: 0.25.12
+      tsx: 4.23.1
+
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@upstash/redis@1.38.0):
+    optionalDependencies:
+      '@electric-sql/pglite': 0.5.4
+      '@neondatabase/serverless': 1.1.0
+      '@upstash/redis': 1.38.0
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -3508,6 +4863,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.3.1: {}
+
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
@@ -3525,6 +4882,89 @@ snapshots:
       acorn: 8.17.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
+
+  esbuild@0.18.20:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -3602,6 +5042,8 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
+  expect-type@1.4.0: {}
+
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
       express: 5.2.1
@@ -3655,6 +5097,8 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-sha256@1.3.0: {}
 
   fast-uri@3.1.3: {}
 
@@ -3713,6 +5157,9 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fsevents@2.3.3:
+    optional: true
+
   function-bind@1.1.2: {}
 
   fuzzysort@3.1.0: {}
@@ -3751,6 +5198,10 @@ snapshots:
     dependencies:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   github-slugger@2.0.0: {}
 
@@ -4642,6 +6093,8 @@ snapshots:
 
   object-treeify@1.1.33: {}
 
+  obug@2.1.3: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -4750,6 +6203,8 @@ snapshots:
 
   path-to-regexp@8.4.2: {}
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -4761,6 +6216,8 @@ snapshots:
   pkg-up@3.1.0:
     dependencies:
       find-up: 3.0.0
+
+  postal-mime@2.7.4: {}
 
   postcss-selector-parser@7.1.4:
     dependencies:
@@ -4944,7 +6401,14 @@ snapshots:
 
   reselect@5.2.0: {}
 
+  resend@6.17.2:
+    dependencies:
+      postal-mime: 2.7.4
+      standardwebhooks: 1.0.0
+
   resolve-from@4.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   restore-cursor@5.1.0:
     dependencies:
@@ -4952,6 +6416,27 @@ snapshots:
       signal-exit: 4.1.0
 
   reusify@1.1.0: {}
+
+  rolldown@1.1.5:
+    dependencies:
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
 
   router@2.2.0:
     dependencies:
@@ -5011,6 +6496,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  server-only@0.0.1: {}
 
   setprototypeof@1.2.0: {}
 
@@ -5131,6 +6618,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -5138,6 +6627,11 @@ snapshots:
   sisteransi@1.0.5: {}
 
   source-map-js@1.2.1: {}
+
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
 
   source-map@0.6.1: {}
 
@@ -5147,7 +6641,16 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  stackback@0.0.2: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
+
+  std-env@4.2.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -5216,6 +6719,17 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -5239,6 +6753,12 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.23.1:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tw-animate-css@1.4.0: {}
 
   type-is@2.1.0:
@@ -5248,6 +6768,8 @@ snapshots:
       mime-types: 3.0.2
 
   typescript@5.9.3: {}
+
+  uncrypto@0.1.3: {}
 
   undici-types@7.18.2: {}
 
@@ -5338,6 +6860,48 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.3
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.23.1
+      yaml: 2.9.0
+
+  vitest@4.1.10(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.3
+    transitivePeerDependencies:
+      - msw
+
   wawoff2@2.0.1:
     dependencies:
       argparse: 2.0.1
@@ -5351,6 +6915,11 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.5
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   woff2sfnt-sfnt2woff@1.0.0:
     dependencies:

--- a/scripts/ama-migrations.test.mjs
+++ b/scripts/ama-migrations.test.mjs
@@ -2,14 +2,74 @@ import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 import test from 'node:test'
 
-const migrationUrl = new URL('../db/migrations/0001_ama_owner_auth.sql', import.meta.url)
+const migrationUrls = {
+  auth: new URL('../db/migrations/0001_ama_owner_auth.sql', import.meta.url),
+  availability: new URL('../db/migrations/0002_ama_availability.sql', import.meta.url),
+  googleCalendar: new URL('../db/migrations/0003_ama_google_calendar.sql', import.meta.url),
+  googleOAuth: new URL('../db/migrations/0004_ama_google_oauth.sql', import.meta.url),
+}
+
+async function readMigration(url) {
+  return (await readFile(url, 'utf8')).toLowerCase()
+}
 
 test('AMA auth migration only adds its auth tables', async () => {
-  const sql = await readFile(migrationUrl, 'utf8')
-  const normalized = sql.toLowerCase()
+  const normalized = await readMigration(migrationUrls.auth)
 
   assert.match(normalized, /create table if not exists "ama_auth_tokens"/)
   assert.match(normalized, /create table if not exists "ama_admin_sessions"/)
   assert.doesNotMatch(normalized, /\b(drop|truncate|alter)\s+table\b/)
   assert.doesNotMatch(normalized, /\b(create|drop|alter|truncate)\s+table[^;]*(subscribers|newsletters)/)
+})
+
+test('AMA Availability Window migration enforces same-day ISO weekday bounds', async () => {
+  const sql = await readMigration(migrationUrls.availability)
+
+  assert.match(sql, /create table "ama_availability_windows"/)
+  assert.match(sql, /"iso_weekday" between 1 and 7/)
+  assert.match(sql, /"start_minute" between 0 and 1439/)
+  assert.match(sql, /"end_minute" between 1 and 1440/)
+  assert.match(sql, /"start_minute" < "ama_availability_windows"\."end_minute"/)
+  assert.match(sql, /create index "ama_availability_windows_order_idx"/)
+})
+
+test('AMA Google Calendar migration creates a constrained singleton connection', async () => {
+  const sql = await readMigration(migrationUrls.googleCalendar)
+
+  assert.match(sql, /create table "ama_google_calendar_connections"/)
+  assert.match(sql, /"id" = 1/)
+  assert.match(
+    sql,
+    /"status" in \('disconnected', 'connected', 'expired', 'revoked', 'denied_scope', 'error'\)/,
+  )
+  assert.match(sql, /"refresh_token_envelope" jsonb/)
+  assert.match(sql, /"granted_scopes" jsonb/)
+})
+
+test('AMA Google OAuth migration stores hashed state and encrypted PKCE material', async () => {
+  const sql = await readMigration(migrationUrls.googleOAuth)
+
+  assert.match(sql, /create table "ama_google_oauth_attempts"/)
+  assert.match(sql, /"state_hash" varchar\(64\) primary key/)
+  assert.match(sql, /"pkce_verifier_envelope" jsonb not null/)
+  assert.match(sql, /"expires_at" timestamp with time zone not null/)
+  assert.match(sql, /"consumed_at" timestamp with time zone/)
+  assert.doesNotMatch(sql, /"state"\s/)
+  assert.doesNotMatch(sql, /"pkce_verifier"\s/)
+})
+
+test('AMA migrations never mutate legacy subscriber or newsletter tables', async () => {
+  const sql = (
+    await Promise.all(Object.values(migrationUrls).map(readMigration))
+  ).join('\n')
+
+  assert.doesNotMatch(sql, /\b(drop|truncate|alter)\s+table\b/)
+  assert.doesNotMatch(
+    sql,
+    /\b(create|drop|alter|truncate)\s+table[^;]*(subscribers|newsletters)/,
+  )
+  assert.doesNotMatch(
+    sql,
+    /\b(insert\s+into|update|delete\s+from)\s+[^;]*(subscribers|newsletters)/,
+  )
 })

--- a/scripts/ama-migrations.test.mjs
+++ b/scripts/ama-migrations.test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const migrationUrl = new URL('../db/migrations/0001_ama_owner_auth.sql', import.meta.url)
+
+test('AMA auth migration only adds its auth tables', async () => {
+  const sql = await readFile(migrationUrl, 'utf8')
+  const normalized = sql.toLowerCase()
+
+  assert.match(normalized, /create table if not exists "ama_auth_tokens"/)
+  assert.match(normalized, /create table if not exists "ama_admin_sessions"/)
+  assert.doesNotMatch(normalized, /\b(drop|truncate|alter)\s+table\b/)
+  assert.doesNotMatch(normalized, /\b(create|drop|alter|truncate)\s+table[^;]*(subscribers|newsletters)/)
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: { tsconfigPaths: true },
+  test: { environment: 'node' },
+})


### PR DESCRIPTION
Closes [#80](https://github.com/CaliCastle/cali.so/issues/80)
Closes [#81](https://github.com/CaliCastle/cali.so/issues/81)

Builds the owner-only foundation for AMA scheduling, then adds the real availability and Google Calendar path the public booking flow will consume.

## Owner authentication

- Adds an allowlisted Resend magic-link flow with non-enumerating responses and Upstash rate limiting.
- Stores only hashed, single-use login tokens, consumes them atomically, and issues signed secure `httpOnly` sessions.
- Protects the AMA admin routes and supports server-side session revocation on logout.

## Availability and Calendar

- Adds recurring weekly Availability Windows interpreted in `Asia/Taipei`, using a fixed 60-minute session, 24-hour notice, 30-day horizon, 15-minute buffers, and 30-minute start cadence.
- Computes deterministic slots across DST and time-zone boundaries while combining Google busy intervals, active holds, and Bookings through one engine.
- Connects Google Calendar with hashed OAuth state, PKCE S256, exact event and free/busy scopes, encrypted refresh credentials, and normalized recovery states.
- Provides a bilingual, touch-safe admin UI for Calendar health, Availability Window management, disconnect recovery, and real slot preview.

## Data boundaries

- Adds migrations `0001` through `0004` for auth, availability, Calendar connection, and OAuth attempts without mutating the existing subscriber or newsletter tables.
- Keeps provider credentials and encrypted token handling server-only behind one validated environment contract.
- Leaves Slot Hold and Booking persistence to the paid-booking slice while keeping both inputs in the shared availability contract.

## Verification

- `pnpm test:ama` (93 Vitest tests and 5 migration tests)
- `pnpm test:localization` (151 tests)
- `pnpm typecheck`
- `pnpm exec drizzle-kit check`
- `pnpm build` (passes with the existing `lib/og.tsx` tracing warning)
