### PR TITLE
Harden the public security baseline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
-# Postgres (subscribers + newsletters; comments/guestbook are archived and dropped, ADR-0003)
+# Postgres runtime role: CRUD only, never schema ownership or DDL grants
 DATABASE_URL=
+
+# Drizzle commands require MIGRATION_DATABASE_URL only in that command's
+# environment. Never put the migration credential in this runtime file or Vercel.
 
 # Resend (newsletter sending + magic-link admin auth, ADR-0004)
 RESEND_API_KEY=
@@ -9,6 +12,7 @@ RESEND_FROM_EMAIL="Cali Castle <hi@cali.so>"
 ADMIN_EMAIL=
 SESSION_SECRET=
 AMA_ENCRYPTION_KEY=
+RATE_LIMIT_HASH_KEY=
 SITE_URL=https://cali.so
 
 # Google Calendar OAuth (owner availability + meeting invitations)
@@ -20,3 +24,13 @@ UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 AUTH_RATE_LIMIT_MAX_REQUESTS=5
 AUTH_RATE_LIMIT_WINDOW_SECONDS=900
+ADMIN_MUTATION_RATE_LIMIT_MAX_REQUESTS=30
+ADMIN_MUTATION_RATE_LIMIT_WINDOW_SECONDS=60
+
+# Sensitive capabilities fail closed. Enable only in the intended environment.
+AMA_PUBLIC_MUTATIONS_ENABLED=false
+AMA_PAYMENTS_ENABLED=false
+AMA_BOOKING_FINALIZATION_ENABLED=false
+AMA_ADMIN_ENABLED=false
+AMA_GOOGLE_INTEGRATION_ENABLED=false
+AMA_TENCENT_INTEGRATION_ENABLED=false

--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,9 @@ GOOGLE_CLIENT_SECRET=
 # Upstash (rate limiting the magic-link request endpoint)
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
+# Vercel Marketplace aliases are also accepted as a complete pair:
+# KV_REST_API_URL=
+# KV_REST_API_TOKEN=
 AUTH_RATE_LIMIT_MAX_REQUESTS=5
 AUTH_RATE_LIMIT_WINDOW_SECONDS=900
 ADMIN_MUTATION_RATE_LIMIT_MAX_REQUESTS=30

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Taipei
+    open-pull-requests-limit: 10
+    groups:
+      production-dependencies:
+        dependency-type: production
+      development-dependencies:
+        dependency-type: development
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: Asia/Taipei
+    open-pull-requests-limit: 5

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,99 @@
+name: Security
+
+on:
+  push:
+    branches:
+      - v2
+      - main
+  pull_request:
+    branches:
+      - v2
+      - main
+  schedule:
+    - cron: "17 1 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test AMA and migrations
+        run: pnpm test:ama
+
+      - name: Test security controls
+        run: pnpm test:security
+
+      - name: Test localization
+        run: pnpm test:localization
+
+      - name: Build
+        run: pnpm build
+        env:
+          DATABASE_URL: postgresql://runtime:runtime@127.0.0.1:5432/cali
+          RESEND_API_KEY: re_ci
+          RESEND_FROM_EMAIL: Cali <test@example.com>
+          ADMIN_EMAIL: owner@example.com
+          SESSION_SECRET: ci-session-secret-ci-session-secret-ci-session-secret
+          AMA_ENCRYPTION_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+          RATE_LIMIT_HASH_KEY: AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI=
+          GOOGLE_CLIENT_ID: ci.apps.googleusercontent.com
+          GOOGLE_CLIENT_SECRET: ci-google-secret
+          UPSTASH_REDIS_REST_URL: https://example.upstash.io
+          UPSTASH_REDIS_REST_TOKEN: ci-redis-token
+          SITE_URL: https://cali.so
+          AMA_PUBLIC_MUTATIONS_ENABLED: "false"
+          AMA_PAYMENTS_ENABLED: "false"
+          AMA_BOOKING_FINALIZATION_ENABLED: "false"
+          AMA_ADMIN_ENABLED: "false"
+          AMA_GOOGLE_INTEGRATION_ENABLED: "false"
+          AMA_TENCENT_INTEGRATION_ENABLED: "false"
+
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11
+        with:
+          languages: javascript-typescript
+          build-mode: none
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11
+        with:
+          category: /language:javascript-typescript

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security policy
+
+## Supported versions
+
+Security fixes are applied to the version deployed at
+[cali.so](https://cali.so). Pre-release v2 work is supported only while it is
+on an active repository branch.
+
+## Report a vulnerability privately
+
+Use GitHub's **Security** tab and choose **Report a vulnerability**. Do not open
+a public issue, discussion, or pull request for a suspected vulnerability, and
+do not include exploit details in public project updates.
+
+Please include the affected surface, a minimal reproduction, impact, and any
+suggested mitigation. Remove credentials, personal data, private content,
+payment data, meeting details, and raw provider payloads from the report. If a
+demonstration needs sensitive evidence, describe how to reproduce it without
+attaching live data.
+
+## Coordinated disclosure
+
+Please allow time to investigate, remediate, deploy, and notify affected users
+before publishing details. We will coordinate a disclosure date with the
+reporter when public disclosure is appropriate. We may ask that details remain
+private longer when a fix depends on an upstream provider or a safe migration.
+
+Good-faith research should avoid privacy violations, service disruption,
+social engineering, persistent access, data destruction, and access beyond the
+minimum needed to demonstrate the issue. If you encounter user data or a live
+credential, stop and report it privately.

--- a/app/api/admin/ama/availability/route.ts
+++ b/app/api/admin/ama/availability/route.ts
@@ -5,10 +5,11 @@ import {
 } from '~/lib/ama/admin/server'
 
 export async function POST(request: Request) {
-  const { availability, baseUrl } = getAmaAdminServices()
+  const { availability, security, baseUrl } = getAmaAdminServices()
   return createAvailabilityMutationHandler({
     authenticator: ownerRequestAuthenticator,
     service: availability,
+    security,
     baseUrl,
   })(request)
 }

--- a/app/api/admin/ama/google/callback/route.ts
+++ b/app/api/admin/ama/google/callback/route.ts
@@ -5,10 +5,11 @@ import {
 } from '~/lib/ama/admin/server'
 
 export async function GET(request: Request) {
-  const { google, baseUrl } = getAmaAdminServices()
+  const { google, security, baseUrl } = getAmaAdminServices()
   return createGoogleCallbackHandler({
     authenticator: ownerRequestAuthenticator,
     service: google,
+    security,
     baseUrl,
   })(request)
 }

--- a/app/api/admin/ama/google/connect/route.ts
+++ b/app/api/admin/ama/google/connect/route.ts
@@ -5,10 +5,11 @@ import {
 } from '~/lib/ama/admin/server'
 
 export async function POST(request: Request) {
-  const { google, baseUrl } = getAmaAdminServices()
+  const { google, security, baseUrl } = getAmaAdminServices()
   return createGoogleConnectHandler({
     authenticator: ownerRequestAuthenticator,
     service: google,
+    security,
     baseUrl,
   })(request)
 }

--- a/app/api/admin/ama/google/disconnect/route.ts
+++ b/app/api/admin/ama/google/disconnect/route.ts
@@ -5,10 +5,11 @@ import {
 } from '~/lib/ama/admin/server'
 
 export async function POST(request: Request) {
-  const { google, baseUrl } = getAmaAdminServices()
+  const { google, security, baseUrl } = getAmaAdminServices()
   return createGoogleDisconnectHandler({
     authenticator: ownerRequestAuthenticator,
     service: google,
+    security,
     baseUrl,
   })(request)
 }

--- a/app/api/admin/auth/logout/route.ts
+++ b/app/api/admin/auth/logout/route.ts
@@ -1,6 +1,7 @@
 import { createLogoutHandler } from '~/lib/ama/auth/http'
 import { getOwnerAuth } from '~/lib/ama/auth/server'
+import { getAmaSecurity } from '~/lib/ama/security/server'
 
 export async function POST(request: Request) {
-  return createLogoutHandler(getOwnerAuth())(request)
+  return createLogoutHandler(getOwnerAuth(), getAmaSecurity())(request)
 }

--- a/app/api/admin/auth/request/route.ts
+++ b/app/api/admin/auth/request/route.ts
@@ -2,7 +2,12 @@ import { after } from 'next/server'
 
 import { createMagicLinkRequestHandler } from '~/lib/ama/auth/http'
 import { getOwnerAuth } from '~/lib/ama/auth/server'
+import { getAmaSecurity } from '~/lib/ama/security/server'
 
 export async function POST(request: Request) {
-  return createMagicLinkRequestHandler(getOwnerAuth(), (task) => after(task))(request)
+  return createMagicLinkRequestHandler(
+    getOwnerAuth(),
+    getAmaSecurity(),
+    (task) => after(task),
+  )(request)
 }

--- a/app/api/admin/auth/verify/route.ts
+++ b/app/api/admin/auth/verify/route.ts
@@ -1,6 +1,7 @@
 import { createMagicLinkVerifyHandler } from '~/lib/ama/auth/http'
 import { getOwnerAuth } from '~/lib/ama/auth/server'
+import { getAmaSecurity } from '~/lib/ama/security/server'
 
 export async function GET(request: Request) {
-  return createMagicLinkVerifyHandler(getOwnerAuth())(request)
+  return createMagicLinkVerifyHandler(getOwnerAuth(), getAmaSecurity())(request)
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next'
-import { ThemeProvider } from 'next-themes'
 // Experimental React channel export — available because next.config.ts sets
 // experimental.viewTransition (see docs/design-language.md, page transitions)
 import { ViewTransition } from 'react'
@@ -11,6 +10,8 @@ import { Dock } from '~/components/dock'
 import { LocaleRestorer } from '~/components/locale-restorer'
 import { getGitHub, getSocial } from '~/lib/social-live'
 import { SiteFooter } from '~/components/site-footer'
+import { ThemeProvider } from '~/components/theme-provider'
+import { PREPAINT_SCRIPT } from '~/lib/security/inline-scripts'
 import { seo } from '~/lib/seo'
 import { cn } from '~/lib/utils'
 
@@ -36,12 +37,12 @@ export default async function RootLayout({
             loads) + restore the content locale before first paint */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `try{var d=document.documentElement;if(sessionStorage.v)d.dataset.visited="";sessionStorage.v=1;if(localStorage.locale==="en"){d.dataset.locale="en";d.lang="en"}}catch(e){}`,
+            __html: PREPAINT_SCRIPT,
           }}
         />
       </head>
       <body className="antialiased">
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+        <ThemeProvider>
           <LocaleRestorer />
           <AmbientBackground />
           <div className="flex min-h-screen flex-col pb-20">

--- a/components/preferences.tsx
+++ b/components/preferences.tsx
@@ -3,7 +3,7 @@
 import { Monitor, Moon, Sun, Volume2, VolumeX } from 'lucide-react'
 
 import { PreferencesIcon } from '~/components/dock-icons'
-import { useTheme } from 'next-themes'
+import { useTheme } from '~/components/theme-provider'
 import { useEffect, useState } from 'react'
 
 import { DropdownContent, DropdownMenu, DropdownTrigger } from '~/components/ui/dropdown'

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react'
+
+type Theme = 'light' | 'system' | 'dark'
+
+type ThemeContextValue = {
+  theme: Theme | undefined
+  setTheme(value: string): void
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+function validTheme(value: string | null): value is Theme {
+  return value === 'light' || value === 'system' || value === 'dark'
+}
+
+function storedTheme(): Theme {
+  try {
+    const value = localStorage.getItem('theme')
+    return validTheme(value) ? value : 'system'
+  } catch {
+    return 'system'
+  }
+}
+
+function resolvedTheme(theme: Theme) {
+  if (theme !== 'system') return theme
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light'
+}
+
+function applyTheme(theme: Theme, disableTransitions: boolean) {
+  const root = document.documentElement
+  const resolved = resolvedTheme(theme)
+  let transitionBlocker: HTMLStyleElement | undefined
+
+  if (disableTransitions) {
+    transitionBlocker = document.createElement('style')
+    transitionBlocker.textContent =
+      '*,*::before,*::after{transition:none!important}'
+    document.head.appendChild(transitionBlocker)
+  }
+
+  root.classList.remove('light', 'dark')
+  root.classList.add(resolved)
+  root.style.colorScheme = resolved
+
+  if (transitionBlocker) {
+    window.getComputedStyle(document.body)
+    window.setTimeout(() => transitionBlocker?.remove(), 1)
+  }
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setCurrentTheme] = useState<Theme>()
+
+  useEffect(() => {
+    const initial = storedTheme()
+    setCurrentTheme(initial)
+    applyTheme(initial, false)
+  }, [])
+
+  useEffect(() => {
+    if (theme !== 'system') return
+    const media = window.matchMedia('(prefers-color-scheme: dark)')
+    const update = () => applyTheme('system', false)
+    media.addEventListener('change', update)
+    return () => media.removeEventListener('change', update)
+  }, [theme])
+
+  const setTheme = useCallback((value: string) => {
+    if (!validTheme(value)) return
+    try {
+      localStorage.setItem('theme', value)
+    } catch {
+      // Private browsing may prevent persistence; the in-memory choice remains.
+    }
+    setCurrentTheme(value)
+    applyTheme(value, true)
+  }, [])
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext)
+  if (!context) throw new Error('useTheme must be used within ThemeProvider')
+  return context
+}

--- a/docs/security/baseline.md
+++ b/docs/security/baseline.md
@@ -1,0 +1,100 @@
+# Public-repository security baseline
+
+The repository is public. Source code, route names, and client-visible
+configuration are not security boundaries. Controls must remain effective when
+an attacker can read the implementation.
+
+## Deployment and secret isolation
+
+| Environment | Data and integrations | Secret policy |
+| --- | --- | --- |
+| Production | Production-only accounts and durable data | Available only to protected production deployments |
+| Preview | Test accounts and disposable, isolated data | Preview-scoped credentials; never production credentials |
+| Local and CI | Local emulators, fixtures, or dedicated test accounts | Developer-local or CI-scoped credentials with the minimum privilege |
+
+- Keep production and preview credentials in separate provider projects or
+  accounts wherever the provider supports it. Never encode secrets in source,
+  build output, client bundles, logs, issue text, or workflow files.
+- Scope Vercel environment variables explicitly. A production secret must not
+  be exposed to Preview or Development. Protect the production deployment and
+  require an audited approval path for exceptional access.
+- Forks and untrusted pull requests receive no sensitive credentials. Workflows
+  triggered by pull requests must not use `pull_request_target` to execute
+  contributor-controlled code.
+- Give each integration a distinct credential and the narrowest scopes it
+  supports. Rotate on suspected exposure and remove old credentials after a
+  verified cutover.
+- Keep public mutations, payments, booking finalization, admin access, Google,
+  and Tencent behind independent server-side kill switches that fail closed.
+  Client-only flags are not controls.
+
+## Database privilege separation
+
+Production uses separate database identities:
+
+- The runtime role receives only the schema usage and table or sequence
+  privileges required for application CRUD. It cannot create or alter schema,
+  manage roles, grant privileges, or run migrations.
+- The migration role may perform approved DDL but is never present in runtime,
+  Preview, browser, or routine CI environments.
+- An owner or emergency role is break-glass only, access-controlled and
+  audited. It is not an application credential.
+- Preview uses a separate database and credentials. Production snapshots are
+  not copied into Preview unless they are irreversibly sanitized first.
+
+Review grants whenever the schema changes. Prefer explicit grants over broad
+database ownership, require encrypted connections, and revoke default/public
+privileges that are not needed.
+
+## Logging and audit events
+
+Application logs must not contain cookies, session or API tokens,
+authorization headers, full email addresses, Booking Brief contents, payment
+payloads, meeting credentials, raw provider payloads, or request/response
+bodies that may carry those values. Redaction is a fallback, not permission to
+log sensitive input.
+
+Security events use a small allowlist by default:
+
+- event type and timestamp;
+- outcome or denial reason category;
+- request ID or trace ID;
+- pseudonymous actor, tenant, or resource identifier.
+
+Do not derive pseudonymous identifiers with a public or reversible value. Keep
+access to logs least-privileged, set retention deliberately, and audit access.
+Authenticated admin denials and privileged actions should be auditable without
+recording their sensitive payloads.
+
+## Repository and CI controls
+
+- Keep Actions' repository default at read-only. Each workflow declares its
+  own minimum permissions; the CodeQL upload job is allowed only
+  `security-events: write` in addition to `contents: read`.
+- Pin every action to a verified full commit SHA and retain the release tag in
+  a comment so updates remain reviewable.
+- Require pull requests and required CI/security checks on the integration and
+  production branches. Disable force pushes and branch deletion. Keep any
+  emergency-admin bypass narrow, audited, and tested.
+- Enable private vulnerability reporting, secret scanning, push protection,
+  non-provider pattern scanning, validity checks, Dependabot alerts/security
+  updates, and CodeQL in GitHub repository settings.
+- Run a full-history secret scan before launch. Treat findings as exposed:
+  rotate the credential first, then remove it from current code and, where
+  appropriate, rewrite history through a separately approved process.
+
+The public production CSP keeps `script-src 'unsafe-inline'` because Next.js
+static, ISR, and partial-prerendered output includes inline hydration payloads.
+A per-request nonce would disable those rendering modes. Next.js SRI is enabled
+for supported build assets, `unsafe-eval` is development-only, script
+attributes are blocked, and all other directives remain restricted. The
+dynamic `/admin` surface receives a fresh nonce CSP through `proxy.ts` and does
+not inherit the public production script exception. Its owned pre-paint
+bootstrap is limited by a tested hash, while framework scripts receive the
+request nonce. Inline styles remain allowed because shared React UI emits style
+attributes. Revisit the public script and shared style exceptions when Next.js
+and the UI can remove them without giving up static shells or functionality.
+
+Configuration committed to this repository does not prove that a hosted
+setting is enabled. Track hosted verification separately in
+[verification.md](./verification.md).

--- a/docs/security/verification.md
+++ b/docs/security/verification.md
@@ -1,0 +1,83 @@
+# Security verification
+
+Last checked: 2026-07-14. This note separates repository evidence from hosted
+settings. Do not paste credentials, scan findings, or exploit details into this
+file; use GitHub private vulnerability reporting.
+
+## Local repository
+
+- [x] `SECURITY.md` directs coordinated disclosure to GitHub private
+  vulnerability reporting.
+- [x] `.github/dependabot.yml` covers pnpm/npm dependencies and GitHub Actions.
+- [x] `.github/workflows/security.yml` runs the build, typecheck, AMA,
+  migration, localization, and CodeQL checks on pull requests and pushes;
+  CodeQL also runs on a schedule and manually.
+- [x] Workflow actions are pinned to full, verified commit SHAs with release
+  tag comments.
+- [x] Workflow permissions default to read-only; only the CodeQL job adds the
+  required `security-events: write` permission.
+- [x] Gitleaks 8.30.1 scanned all reachable refs and 302 commits on
+  2026-07-14 with redaction enabled; no findings were reported. Re-run before
+  launch and rotate any real credential before discussing cleanup publicly.
+
+Local recheck:
+
+```sh
+pnpm typecheck
+pnpm test:ama
+pnpm test:security
+git grep -nE 'uses: [^#[:space:]]+@(v|main|master|[0-9a-f]{1,39})([[:space:]]|$)' -- '.github/workflows/*.yml'
+```
+
+The `git grep` command should return no unpinned action references. Security
+scan output must remain private.
+
+## GitHub
+
+Repository API checks on 2026-07-14 verified:
+
+- [x] Private vulnerability reporting, secret scanning, push protection, and
+  Dependabot security updates are enabled.
+- [x] Default Actions workflow permissions are read-only and workflows cannot
+  approve pull requests.
+- [x] Actions must be pinned to a full commit SHA.
+- [x] The `v2` ruleset requires pull requests, blocks force pushes and branch
+  deletion, and limits emergency bypass to repository administrators so GitHub
+  retains the audit trail. It currently requires no approval while the project
+  has one maintainer.
+- [x] CodeQL default setup remains disabled so the committed advanced workflow
+  is the single analysis source.
+- [ ] Add `Quality` and `CodeQL` as required `v2` checks after both check names
+  have completed successfully at least once.
+- [ ] Non-provider secret patterns and validity checks remain unavailable in
+  the repository's current GitHub product mode. Recheck the setting before
+  launch or after a plan change.
+- [ ] Confirm Dependabot can open an update without repository or production
+  credentials after this configuration reaches `v2`.
+
+Recheck these settings through the GitHub Security and Actions settings pages
+or with read-only `gh api` calls. Keep sensitive evidence in private
+vulnerability reports rather than public issues or logs.
+
+## Vercel
+
+Project API checks on 2026-07-14 verified:
+
+- [x] The production branch remains `main`, matching the documented plan to
+  keep v1 live until the one-time v2 cutover.
+- [x] Git fork protection is enabled.
+- [x] Production and Preview use distinct database credentials.
+- [x] Credentials identified as production-only were removed from Preview and
+  Development. Those deployments now fail closed until isolated test
+  credentials and disposable data are provisioned.
+- [ ] Provision isolated Preview and Development credentials before expecting
+  those deployments to exercise authenticated AMA or provider integrations.
+- [ ] Verify the production runtime database role cannot perform DDL or role
+  management, and keep `MIGRATION_DATABASE_URL` absent from Vercel.
+- [ ] Add a custom Vercel Challenge rule for the abuse-prone public
+  authentication mutation. The current plan rejected a rate-limit rule, and
+  managed WAF rules were not activated by the API response.
+- [ ] Verify logs and drains follow the allowlist in `baseline.md`, with
+  deliberate access and retention.
+- [ ] Configure the six kill switches explicitly in each environment; keep
+  them false until the corresponding capability is approved for release.

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -4,5 +4,5 @@ export default defineConfig({
   dialect: 'postgresql',
   schema: './db/schema.ts',
   out: './db/migrations',
-  dbCredentials: { url: process.env.DATABASE_URL ?? '' },
+  dbCredentials: { url: process.env.MIGRATION_DATABASE_URL ?? '' },
 })

--- a/lib/ama/admin/http.test.ts
+++ b/lib/ama/admin/http.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
 
 import {
   createAvailabilityMutationHandler,
@@ -9,18 +11,23 @@ import {
   type AvailabilityMutationService,
   type OwnerRequestAuthenticator,
 } from './http'
+import { createAmaSecurity, type SecurityAuditEvent } from '../security/service'
 
 function formRequest(path: string, values: Record<string, string>, authenticated = true) {
   const body = new FormData()
   for (const [key, value] of Object.entries(values)) body.set(key, value)
-  return new Request(`https://attacker.example${path}`, {
+  return new Request(`https://cali.so${path}`, {
     method: 'POST',
-    headers: authenticated ? { cookie: 'owner=valid' } : undefined,
+    headers: {
+      origin: 'https://cali.so',
+      'sec-fetch-site': 'same-origin',
+      ...(authenticated ? { cookie: 'owner=valid' } : {}),
+    },
     body,
   })
 }
 
-function fixture() {
+function fixture(rateLimitAllows = true) {
   const mutations: unknown[] = []
   const authenticator: OwnerRequestAuthenticator = {
     async authenticate(request) {
@@ -52,7 +59,39 @@ function fixture() {
       googleEvents.push(['disconnect'])
     },
   }
-  return { authenticator, availability, google, mutations, googleEvents }
+  const securityEvents: SecurityAuditEvent[] = []
+  const security = createAmaSecurity({
+    baseUrl: new URL('https://cali.so'),
+    features: {
+      publicMutations: false,
+      payments: false,
+      bookingFinalization: false,
+      admin: true,
+      google: true,
+      tencent: false,
+    },
+    pseudonymKey: Buffer.alloc(32, 4),
+    rateLimiter: {
+      async limit() {
+        return { success: rateLimitAllows }
+      },
+    },
+    audit: {
+      write(event) {
+        securityEvents.push(event)
+      },
+    },
+    requestId: () => 'admin-request-id',
+  })
+  return {
+    authenticator,
+    availability,
+    google,
+    mutations,
+    googleEvents,
+    security,
+    securityEvents,
+  }
 }
 
 describe('AMA admin HTTP contract', () => {
@@ -61,6 +100,7 @@ describe('AMA admin HTTP contract', () => {
     const handler = createAvailabilityMutationHandler({
       authenticator: f.authenticator,
       service: f.availability,
+      security: f.security,
       baseUrl: new URL('https://cali.so'),
     })
 
@@ -82,6 +122,7 @@ describe('AMA admin HTTP contract', () => {
     const handler = createAvailabilityMutationHandler({
       authenticator: f.authenticator,
       service: f.availability,
+      security: f.security,
       baseUrl: new URL('https://cali.so'),
     })
 
@@ -124,6 +165,7 @@ describe('AMA admin HTTP contract', () => {
     const handler = createAvailabilityMutationHandler({
       authenticator: f.authenticator,
       service: f.availability,
+      security: f.security,
       baseUrl: new URL('https://cali.so'),
     })
 
@@ -147,6 +189,7 @@ describe('AMA admin HTTP contract', () => {
     const handler = createAvailabilityMutationHandler({
       authenticator: f.authenticator,
       service: f.availability,
+      security: f.security,
       baseUrl: new URL('https://cali.so'),
     })
 
@@ -174,12 +217,18 @@ describe('AMA admin HTTP contract', () => {
     const handler = createGoogleConnectHandler({
       authenticator: f.authenticator,
       service: f.google,
+      security: f.security,
       baseUrl: new URL('https://cali.so'),
     })
 
     const response = await handler(
-      new Request('https://attacker.example/api/admin/ama/google/connect', {
-        headers: { cookie: 'owner=valid' },
+      new Request('https://cali.so/api/admin/ama/google/connect', {
+        method: 'POST',
+        headers: {
+          cookie: 'owner=valid',
+          origin: 'https://cali.so',
+          'sec-fetch-site': 'same-origin',
+        },
       }),
     )
 
@@ -193,6 +242,7 @@ describe('AMA admin HTTP contract', () => {
     const handler = createGoogleCallbackHandler({
       authenticator: f.authenticator,
       service: f.google,
+      security: f.security,
       baseUrl: new URL('https://cali.so'),
     })
     const request = new Request(
@@ -213,6 +263,7 @@ describe('AMA admin HTTP contract', () => {
     const handler = createGoogleDisconnectHandler({
       authenticator: f.authenticator,
       service: f.google,
+      security: f.security,
       baseUrl: new URL('https://cali.so'),
     })
 
@@ -225,5 +276,52 @@ describe('AMA admin HTTP contract', () => {
     expect(response.headers.get('location')).toBe(
       'https://cali.so/admin?calendar=disconnected',
     )
+  })
+
+  it('rejects cross-site admin mutations before authentication or service work', async () => {
+    const f = fixture()
+    const handler = createAvailabilityMutationHandler({
+      authenticator: {
+        async authenticate() {
+          throw new Error('authentication must not run')
+        },
+      },
+      service: f.availability,
+      security: f.security,
+      baseUrl: new URL('https://cali.so'),
+    })
+
+    const response = await handler(
+      new Request('https://cali.so/api/admin/ama/availability', {
+        method: 'POST',
+        headers: {
+          origin: 'https://attacker.example',
+          'sec-fetch-site': 'cross-site',
+          cookie: 'owner=valid',
+        },
+      }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(f.mutations).toEqual([])
+    expect(f.securityEvents[0]?.event).toBe('browser_mutation.denied')
+  })
+
+  it('rate limits authenticated admin mutations before service work', async () => {
+    const f = fixture(false)
+    const handler = createGoogleDisconnectHandler({
+      authenticator: f.authenticator,
+      service: f.google,
+      security: f.security,
+      baseUrl: new URL('https://cali.so'),
+    })
+
+    const response = await handler(
+      formRequest('/api/admin/ama/google/disconnect', {}),
+    )
+
+    expect(response.status).toBe(429)
+    expect(f.googleEvents).toEqual([])
+    expect(f.securityEvents[0]?.event).toBe('admin_mutation.rate_limited')
   })
 })

--- a/lib/ama/admin/http.ts
+++ b/lib/ama/admin/http.ts
@@ -1,3 +1,5 @@
+import type { AmaFeature, AmaSecurity } from '../security/service'
+
 export interface OwnerRequestAuthenticator {
   authenticate(request: Request): Promise<boolean>
 }
@@ -34,8 +36,11 @@ export interface AdminGoogleService {
 type HandlerDependencies<T> = {
   authenticator: OwnerRequestAuthenticator
   service: T
+  security: AmaSecurity
   baseUrl: URL
 }
+
+type AdminRequestMode = 'browser-mutation' | 'provider-callback'
 
 function redirect(baseUrl: URL, pathOrUrl: string | URL) {
   const location = pathOrUrl instanceof URL ? pathOrUrl : new URL(pathOrUrl, baseUrl)
@@ -49,13 +54,24 @@ function redirect(baseUrl: URL, pathOrUrl: string | URL) {
   })
 }
 
-async function requireOwner(
-  authenticator: OwnerRequestAuthenticator,
+async function enforceAdminRequestPolicy(
+  dependencies: HandlerDependencies<unknown>,
   request: Request,
-  baseUrl: URL,
+  requiredFeatures: readonly AmaFeature[],
+  mode: AdminRequestMode,
 ) {
-  if (await authenticator.authenticate(request)) return null
-  return redirect(baseUrl, '/admin/login')
+  const { authenticator, security, baseUrl } = dependencies
+  const blocked = mode === 'browser-mutation'
+    ? await security.protectBrowserMutation(request, requiredFeatures)
+    : security.protectFeatures(request, requiredFeatures)
+  if (blocked) return blocked
+
+  if (!(await authenticator.authenticate(request))) {
+    security.recordAuthenticationDenial(request)
+    return redirect(baseUrl, '/admin/login')
+  }
+
+  return security.limitAdminMutation(request)
 }
 
 function formString(formData: FormData, name: string) {
@@ -120,14 +136,18 @@ function availabilityWindowFrom(formData: FormData): AvailabilityWindowInput | n
   return { isoWeekday: weekday, startMinute, endMinute }
 }
 
-export function createAvailabilityMutationHandler({
-  authenticator,
-  service,
-  baseUrl,
-}: HandlerDependencies<AvailabilityMutationService>) {
+export function createAvailabilityMutationHandler(
+  dependencies: HandlerDependencies<AvailabilityMutationService>,
+) {
+  const { service, baseUrl } = dependencies
   return async function POST(request: Request) {
-    const unauthorized = await requireOwner(authenticator, request, baseUrl)
-    if (unauthorized) return unauthorized
+    const blocked = await enforceAdminRequestPolicy(
+      dependencies,
+      request,
+      ['admin'],
+      'browser-mutation',
+    )
+    if (blocked) return blocked
 
     try {
       const formData = await request.formData()
@@ -146,6 +166,10 @@ export function createAvailabilityMutationHandler({
         else return redirect(baseUrl, '/admin?availability=invalid')
       }
 
+      dependencies.security.recordPrivilegedAction(
+        request,
+        'availability_mutation.succeeded',
+      )
       return redirect(baseUrl, '/admin?availability=saved')
     } catch {
       return redirect(baseUrl, '/admin?availability=failed')
@@ -153,30 +177,40 @@ export function createAvailabilityMutationHandler({
   }
 }
 
-export function createGoogleConnectHandler({
-  authenticator,
-  service,
-  baseUrl,
-}: HandlerDependencies<AdminGoogleService>) {
-  return async function GET(request: Request) {
-    const unauthorized = await requireOwner(authenticator, request, baseUrl)
-    if (unauthorized) return unauthorized
+export function createGoogleConnectHandler(
+  dependencies: HandlerDependencies<AdminGoogleService>,
+) {
+  const { service, baseUrl } = dependencies
+  return async function POST(request: Request) {
+    const blocked = await enforceAdminRequestPolicy(
+      dependencies,
+      request,
+      ['admin', 'google'],
+      'browser-mutation',
+    )
+    if (blocked) return blocked
     try {
-      return redirect(baseUrl, await service.begin())
+      const providerUrl = await service.begin()
+      dependencies.security.recordPrivilegedAction(request, 'google_connect.started')
+      return redirect(baseUrl, providerUrl)
     } catch {
       return redirect(baseUrl, '/admin?calendar=unavailable')
     }
   }
 }
 
-export function createGoogleCallbackHandler({
-  authenticator,
-  service,
-  baseUrl,
-}: HandlerDependencies<AdminGoogleService>) {
+export function createGoogleCallbackHandler(
+  dependencies: HandlerDependencies<AdminGoogleService>,
+) {
+  const { service, baseUrl } = dependencies
   return async function GET(request: Request) {
-    const unauthorized = await requireOwner(authenticator, request, baseUrl)
-    if (unauthorized) return unauthorized
+    const blocked = await enforceAdminRequestPolicy(
+      dependencies,
+      request,
+      ['admin', 'google'],
+      'provider-callback',
+    )
+    if (blocked) return blocked
     const params = new URL(request.url).searchParams
     try {
       const result = await service.complete({
@@ -184,6 +218,10 @@ export function createGoogleCallbackHandler({
         code: params.get('code'),
         error: params.get('error'),
       })
+      dependencies.security.recordPrivilegedAction(
+        request,
+        'google_callback.completed',
+      )
       return redirect(baseUrl, `/admin?calendar=${result}`)
     } catch {
       return redirect(baseUrl, '/admin?calendar=unavailable')
@@ -191,16 +229,24 @@ export function createGoogleCallbackHandler({
   }
 }
 
-export function createGoogleDisconnectHandler({
-  authenticator,
-  service,
-  baseUrl,
-}: HandlerDependencies<AdminGoogleService>) {
+export function createGoogleDisconnectHandler(
+  dependencies: HandlerDependencies<AdminGoogleService>,
+) {
+  const { service, baseUrl } = dependencies
   return async function POST(request: Request) {
-    const unauthorized = await requireOwner(authenticator, request, baseUrl)
-    if (unauthorized) return unauthorized
+    const blocked = await enforceAdminRequestPolicy(
+      dependencies,
+      request,
+      ['admin', 'google'],
+      'browser-mutation',
+    )
+    if (blocked) return blocked
     try {
       await service.disconnect()
+      dependencies.security.recordPrivilegedAction(
+        request,
+        'google_disconnect.succeeded',
+      )
       return redirect(baseUrl, '/admin?calendar=disconnected')
     } catch {
       return redirect(baseUrl, '/admin?calendar=unavailable')

--- a/lib/ama/admin/server.ts
+++ b/lib/ama/admin/server.ts
@@ -9,6 +9,7 @@ import { googleRepository } from '../google/repository'
 import { createGoogleCalendarService } from '../google/service'
 import { getServerEnv } from '../server-env'
 import { createSecretBox } from '../secrets'
+import { getAmaSecurity } from '../security/server'
 
 export const AMA_OWNER_TIME_ZONE = 'Asia/Taipei'
 const GOOGLE_REQUEST_TIMEOUT_MS = 8_000
@@ -39,12 +40,23 @@ function createServices() {
   })
   const availability = createAvailabilityService({
     repository: availabilityRepository,
-    calendar: google,
+    calendar: environment.features.google
+      ? google
+      : {
+          async queryFreeBusy() {
+            return { status: 'disconnected' as const, busy: [] }
+          },
+        },
     ownerTimeZone: AMA_OWNER_TIME_ZONE,
     clock,
   })
 
-  return { google, availability, baseUrl: environment.SITE_URL }
+  return {
+    google,
+    availability,
+    security: getAmaSecurity(),
+    baseUrl: environment.SITE_URL,
+  }
 }
 
 export function getAmaAdminServices() {

--- a/lib/ama/auth/auth.test.ts
+++ b/lib/ama/auth/auth.test.ts
@@ -189,6 +189,7 @@ describe('owner authentication HTTP contract', () => {
     expect(response.status).toBe(303)
     expect(response.headers.get('location')).toBe('https://cali.so/admin/login?sent=1')
     expect(fixture.sentLinks).toHaveLength(0)
+    expect(fixture.rateLimitKeys).toEqual(['request:untrusted-proxy'])
   })
 
   it('rejects an expired magic link', async () => {

--- a/lib/ama/auth/auth.test.ts
+++ b/lib/ama/auth/auth.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
 
 import {
   authenticateOwnerRequest,
@@ -13,12 +15,14 @@ import {
   type AuthSessionRecord,
   type LoginTokenRecord,
 } from './service'
+import { createAmaSecurity, type SecurityAuditEvent } from '../security/service'
 
 function createFixture() {
   let now = new Date('2026-07-14T04:00:00.000Z')
   const tokens = new Map<string, LoginTokenRecord>()
   const sessions = new Map<string, AuthSessionRecord>()
   const sentLinks: string[] = []
+  const rateLimitKeys: string[] = []
   let rateLimitAllowsRequest = true
 
   const repository: AuthRepository = {
@@ -67,7 +71,8 @@ function createFixture() {
       repository,
       clock: { now: () => now },
       rateLimiter: {
-        async limit() {
+        async limit(key) {
+          rateLimitKeys.push(key)
           return { success: rateLimitAllowsRequest }
         },
       },
@@ -80,11 +85,30 @@ function createFixture() {
   }
 
   const auth = authFor('owner@example.com')
+  const securityEvents: SecurityAuditEvent[] = []
+  const security = createAmaSecurity({
+    baseUrl: new URL('https://cali.so'),
+    features: {
+      publicMutations: false,
+      payments: false,
+      bookingFinalization: false,
+      admin: true,
+      google: true,
+      tencent: false,
+    },
+    pseudonymKey: Buffer.alloc(32, 5),
+    rateLimiter: { async limit() { return { success: true } } },
+    audit: { write(event) { securityEvents.push(event) } },
+    requestId: () => 'auth-request-id',
+  })
 
   return {
     auth,
     authFor,
+    security,
+    securityEvents,
     sentLinks,
+    rateLimitKeys,
     setNow(value: string) {
       now = new Date(value)
     },
@@ -98,9 +122,13 @@ function requestMagicLink(handler: (request: Request) => Promise<Response>, emai
   const body = new FormData()
   body.set('email', email)
   return handler(
-    new Request('https://attacker.example/api/admin/auth/request', {
+    new Request('https://cali.so/api/admin/auth/request', {
       method: 'POST',
-      headers: { 'x-forwarded-for': '203.0.113.5' },
+      headers: {
+        origin: 'https://cali.so',
+        'sec-fetch-site': 'same-origin',
+        'x-forwarded-for': '203.0.113.5',
+      },
       body,
     }),
   )
@@ -116,7 +144,7 @@ function cookieValue(response: Response) {
 describe('owner authentication HTTP contract', () => {
   it('does not reveal whether an email is allowlisted', async () => {
     const fixture = createFixture()
-    const handler = createMagicLinkRequestHandler(fixture.auth)
+    const handler = createMagicLinkRequestHandler(fixture.auth, fixture.security)
 
     const denied = await requestMagicLink(handler, 'guest@example.com')
     const allowed = await requestMagicLink(handler, 'OWNER@example.com')
@@ -126,12 +154,17 @@ describe('owner authentication HTTP contract', () => {
     expect(denied.headers.get('location')).toBe('https://cali.so/admin/login?sent=1')
     expect(allowed.headers.get('location')).toBe(denied.headers.get('location'))
     expect(fixture.sentLinks).toHaveLength(1)
+    expect(fixture.rateLimitKeys).toEqual([
+      'request:untrusted-proxy',
+      'request:untrusted-proxy',
+      'owner-recipient',
+    ])
   })
 
   it('returns the same response before deferred delivery work runs', async () => {
     const fixture = createFixture()
     const tasks: Array<() => Promise<void>> = []
-    const handler = createMagicLinkRequestHandler(fixture.auth, (task) => {
+    const handler = createMagicLinkRequestHandler(fixture.auth, fixture.security, (task) => {
       tasks.push(task)
     })
 
@@ -149,7 +182,7 @@ describe('owner authentication HTTP contract', () => {
     fixture.denyRateLimit()
 
     const response = await requestMagicLink(
-      createMagicLinkRequestHandler(fixture.auth),
+      createMagicLinkRequestHandler(fixture.auth, fixture.security),
       'owner@example.com',
     )
 
@@ -161,13 +194,16 @@ describe('owner authentication HTTP contract', () => {
   it('rejects an expired magic link', async () => {
     const fixture = createFixture()
     await requestMagicLink(
-      createMagicLinkRequestHandler(fixture.auth),
+      createMagicLinkRequestHandler(fixture.auth, fixture.security),
       'owner@example.com',
     )
     const link = fixture.sentLinks[0]
     fixture.setNow('2026-07-14T04:15:00.001Z')
 
-    const response = await createMagicLinkVerifyHandler(fixture.auth)(new Request(link))
+    const response = await createMagicLinkVerifyHandler(
+      fixture.auth,
+      fixture.security,
+    )(new Request(link))
 
     expect(response.status).toBe(303)
     expect(response.headers.get('location')).toBe(
@@ -179,10 +215,10 @@ describe('owner authentication HTTP contract', () => {
   it('consumes a magic link exactly once under concurrent requests', async () => {
     const fixture = createFixture()
     await requestMagicLink(
-      createMagicLinkRequestHandler(fixture.auth),
+      createMagicLinkRequestHandler(fixture.auth, fixture.security),
       'owner@example.com',
     )
-    const verify = createMagicLinkVerifyHandler(fixture.auth)
+    const verify = createMagicLinkVerifyHandler(fixture.auth, fixture.security)
 
     const responses = await Promise.all([
       verify(new Request(fixture.sentLinks[0])),
@@ -199,22 +235,28 @@ describe('owner authentication HTTP contract', () => {
   it('rejects links and sessions issued to a previous allowlisted owner', async () => {
     const fixture = createFixture()
     await requestMagicLink(
-      createMagicLinkRequestHandler(fixture.auth),
+      createMagicLinkRequestHandler(fixture.auth, fixture.security),
       'owner@example.com',
     )
     const oldLink = fixture.sentLinks[0]
     const newOwner = fixture.authFor('new-owner@example.com')
 
-    const oldLinkResponse = await createMagicLinkVerifyHandler(newOwner)(
+    const oldLinkResponse = await createMagicLinkVerifyHandler(
+      newOwner,
+      fixture.security,
+    )(
       new Request(oldLink),
     )
     expect(cookieValue(oldLinkResponse)).toBeUndefined()
 
     await requestMagicLink(
-      createMagicLinkRequestHandler(fixture.auth),
+      createMagicLinkRequestHandler(fixture.auth, fixture.security),
       'owner@example.com',
     )
-    const oldSessionResponse = await createMagicLinkVerifyHandler(fixture.auth)(
+    const oldSessionResponse = await createMagicLinkVerifyHandler(
+      fixture.auth,
+      fixture.security,
+    )(
       new Request(fixture.sentLinks[1]),
     )
     expect(await newOwner.authenticate(cookieValue(oldSessionResponse))).toBe(false)
@@ -223,11 +265,14 @@ describe('owner authentication HTTP contract', () => {
   it('sets a signed 30-day secure session cookie', async () => {
     const fixture = createFixture()
     await requestMagicLink(
-      createMagicLinkRequestHandler(fixture.auth),
+      createMagicLinkRequestHandler(fixture.auth, fixture.security),
       'owner@example.com',
     )
 
-    const response = await createMagicLinkVerifyHandler(fixture.auth)(
+    const response = await createMagicLinkVerifyHandler(
+      fixture.auth,
+      fixture.security,
+    )(
       new Request(fixture.sentLinks[0]),
     )
     const setCookie = response.headers.get('set-cookie') ?? ''
@@ -243,10 +288,13 @@ describe('owner authentication HTTP contract', () => {
   it('expires sessions after 30 days', async () => {
     const fixture = createFixture()
     await requestMagicLink(
-      createMagicLinkRequestHandler(fixture.auth),
+      createMagicLinkRequestHandler(fixture.auth, fixture.security),
       'owner@example.com',
     )
-    const response = await createMagicLinkVerifyHandler(fixture.auth)(
+    const response = await createMagicLinkVerifyHandler(
+      fixture.auth,
+      fixture.security,
+    )(
       new Request(fixture.sentLinks[0]),
     )
     const sessionCookie = cookieValue(response)
@@ -258,18 +306,25 @@ describe('owner authentication HTTP contract', () => {
   it('revokes the current session on logout and clears its cookie', async () => {
     const fixture = createFixture()
     await requestMagicLink(
-      createMagicLinkRequestHandler(fixture.auth),
+      createMagicLinkRequestHandler(fixture.auth, fixture.security),
       'owner@example.com',
     )
-    const loginResponse = await createMagicLinkVerifyHandler(fixture.auth)(
+    const loginResponse = await createMagicLinkVerifyHandler(
+      fixture.auth,
+      fixture.security,
+    )(
       new Request(fixture.sentLinks[0]),
     )
     const sessionCookie = cookieValue(loginResponse)
 
-    const logoutResponse = await createLogoutHandler(fixture.auth)(
-      new Request('https://attacker.example/api/admin/auth/logout', {
+    const logoutResponse = await createLogoutHandler(fixture.auth, fixture.security)(
+      new Request('https://cali.so/api/admin/auth/logout', {
         method: 'POST',
-        headers: { cookie: `${AUTH_SESSION_COOKIE}=${sessionCookie}` },
+        headers: {
+          cookie: `${AUTH_SESSION_COOKIE}=${sessionCookie}`,
+          origin: 'https://cali.so',
+          'sec-fetch-site': 'same-origin',
+        },
       }),
     )
 
@@ -277,15 +332,43 @@ describe('owner authentication HTTP contract', () => {
     expect(logoutResponse.headers.get('location')).toBe('https://cali.so/admin/login')
     expect(logoutResponse.headers.get('set-cookie')).toContain('Max-Age=0')
     expect(await fixture.auth.authenticate(sessionCookie)).toBe(false)
+    expect(fixture.securityEvents.at(-1)?.event).toBe('admin_logout.succeeded')
+  })
+
+  it('rejects cross-site login requests before scheduling mail work', async () => {
+    const fixture = createFixture()
+    const body = new FormData()
+    body.set('email', 'owner@example.com')
+
+    const response = await createMagicLinkRequestHandler(
+      fixture.auth,
+      fixture.security,
+    )(
+      new Request('https://cali.so/api/admin/auth/request', {
+        method: 'POST',
+        headers: {
+          origin: 'https://attacker.example',
+          'sec-fetch-site': 'cross-site',
+        },
+        body,
+      }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(fixture.sentLinks).toEqual([])
+    expect(fixture.securityEvents[0]?.event).toBe('browser_mutation.denied')
   })
 
   it('authenticates protected API requests from the signed owner cookie', async () => {
     const fixture = createFixture()
     await requestMagicLink(
-      createMagicLinkRequestHandler(fixture.auth),
+      createMagicLinkRequestHandler(fixture.auth, fixture.security),
       'owner@example.com',
     )
-    const response = await createMagicLinkVerifyHandler(fixture.auth)(
+    const response = await createMagicLinkVerifyHandler(
+      fixture.auth,
+      fixture.security,
+    )(
       new Request(fixture.sentLinks[0]),
     )
     const session = cookieValue(response)

--- a/lib/ama/auth/http.ts
+++ b/lib/ama/auth/http.ts
@@ -3,6 +3,8 @@ import {
   SESSION_LIFETIME_SECONDS,
   type OwnerAuth,
 } from './service'
+import { readRequestCookie } from '../cookies'
+import type { AmaSecurity } from '../security/service'
 
 type Defer = (task: () => Promise<void>) => void | Promise<void>
 
@@ -28,30 +30,24 @@ function sessionCookie(value: string, maxAge = SESSION_LIFETIME_SECONDS) {
 }
 
 function requestKey(request: Request) {
+  if (!request.headers.has('x-vercel-id')) return 'untrusted-proxy'
   const forwarded = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
-  return forwarded || request.headers.get('x-real-ip') || 'unknown'
-}
-
-function readCookie(request: Request, name: string) {
-  const cookie = request.headers.get('cookie')
-  if (!cookie) return undefined
-  for (const item of cookie.split(';')) {
-    const separator = item.indexOf('=')
-    if (separator === -1) continue
-    if (item.slice(0, separator).trim() === name) return item.slice(separator + 1).trim()
-  }
-  return undefined
+  return forwarded || 'unknown-vercel-client'
 }
 
 export function authenticateOwnerRequest(auth: OwnerAuth, request: Request) {
-  return auth.authenticate(readCookie(request, AUTH_SESSION_COOKIE))
+  return auth.authenticate(readRequestCookie(request, AUTH_SESSION_COOKIE))
 }
 
 export function createMagicLinkRequestHandler(
   auth: OwnerAuth,
+  security: AmaSecurity,
   defer: Defer = (task) => task(),
 ) {
   return async function POST(request: Request) {
+    const blocked = await security.protectBrowserMutation(request, ['admin'])
+    if (blocked) return blocked
+
     let email = ''
     try {
       const formData = await request.formData()
@@ -65,7 +61,7 @@ export function createMagicLinkRequestHandler(
       try {
         await auth.requestMagicLink(email, requestKey(request))
       } catch {
-        console.error('AMA magic-link request failed')
+        security.recordAuthRequestFailure(request)
       }
     })
 
@@ -73,8 +69,11 @@ export function createMagicLinkRequestHandler(
   }
 }
 
-export function createMagicLinkVerifyHandler(auth: OwnerAuth) {
+export function createMagicLinkVerifyHandler(auth: OwnerAuth, security: AmaSecurity) {
   return async function GET(request: Request) {
+    const blocked = security.protectFeatures(request, ['admin'])
+    if (blocked) return blocked
+
     const token = new URL(request.url).searchParams.get('token')
     const session = await auth.verifyMagicToken(token)
     if (!session) return redirect(auth.url('/admin/login?error=invalid-link'))
@@ -82,9 +81,21 @@ export function createMagicLinkVerifyHandler(auth: OwnerAuth) {
   }
 }
 
-export function createLogoutHandler(auth: OwnerAuth) {
+export function createLogoutHandler(auth: OwnerAuth, security: AmaSecurity) {
   return async function POST(request: Request) {
-    await auth.logout(readCookie(request, AUTH_SESSION_COOKIE))
+    const blocked = await security.protectBrowserMutation(request, [])
+    if (blocked) return blocked
+
+    const session = readRequestCookie(request, AUTH_SESSION_COOKIE)
+    if (await auth.authenticate(session)) {
+      const limited = await security.limitAdminMutation(request)
+      if (limited) return limited
+
+      await auth.logout(session)
+      security.recordPrivilegedAction(request, 'admin_logout.succeeded')
+    } else {
+      security.recordAuthenticationDenial(request)
+    }
     return redirect(auth.url('/admin/login'), sessionCookie('', 0))
   }
 }

--- a/lib/ama/auth/server.ts
+++ b/lib/ama/auth/server.ts
@@ -33,7 +33,7 @@ export function getOwnerAuth() {
   })
   const limiterKey = createHmac(
     'sha256',
-    Buffer.from(environment.AMA_ENCRYPTION_KEY, 'base64'),
+    Buffer.from(environment.RATE_LIMIT_HASH_KEY, 'base64'),
   )
     .update('ama-auth-rate-limit')
     .digest()
@@ -72,6 +72,7 @@ export function getOwnerAuth() {
 }
 
 export async function isOwnerAuthenticated() {
+  if (!getServerEnv().features.admin) return false
   const cookieStore = await cookies()
   return getOwnerAuth().authenticate(cookieStore.get(AUTH_SESSION_COOKIE)?.value)
 }

--- a/lib/ama/auth/service.ts
+++ b/lib/ama/auth/service.ts
@@ -96,8 +96,11 @@ export function createOwnerAuth(dependencies: OwnerAuthDependencies) {
     },
 
     async requestMagicLink(email: string, requestKey: string) {
-      const limit = await rateLimiter.limit(requestKey)
-      if (!limit.success || normalizeEmail(email) !== ownerEmail) return
+      const requestLimit = await rateLimiter.limit(`request:${requestKey}`)
+      if (normalizeEmail(email) !== ownerEmail) return
+
+      const ownerLimit = await rateLimiter.limit('owner-recipient')
+      if (!requestLimit.success || !ownerLimit.success) return
 
       const now = clock.now()
       const expiresAt = new Date(now.getTime() + MAGIC_LINK_LIFETIME_MS)

--- a/lib/ama/auth/service.ts
+++ b/lib/ama/auth/service.ts
@@ -97,10 +97,10 @@ export function createOwnerAuth(dependencies: OwnerAuthDependencies) {
 
     async requestMagicLink(email: string, requestKey: string) {
       const requestLimit = await rateLimiter.limit(`request:${requestKey}`)
-      if (normalizeEmail(email) !== ownerEmail) return
+      if (!requestLimit.success || normalizeEmail(email) !== ownerEmail) return
 
       const ownerLimit = await rateLimiter.limit('owner-recipient')
-      if (!requestLimit.success || !ownerLimit.success) return
+      if (!ownerLimit.success) return
 
       const now = clock.now()
       const expiresAt = new Date(now.getTime() + MAGIC_LINK_LIFETIME_MS)

--- a/lib/ama/cookies.ts
+++ b/lib/ama/cookies.ts
@@ -1,0 +1,14 @@
+export function readRequestCookie(request: Request, name: string) {
+  const cookie = request.headers.get('cookie')
+  if (!cookie) return undefined
+
+  for (const item of cookie.split(';')) {
+    const separator = item.indexOf('=')
+    if (separator === -1) continue
+    if (item.slice(0, separator).trim() === name) {
+      return item.slice(separator + 1).trim()
+    }
+  }
+
+  return undefined
+}

--- a/lib/ama/security/request-policy.test.ts
+++ b/lib/ama/security/request-policy.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { checkBrowserMutationRequest } from './request-policy'
+
+const canonicalOrigin = new URL('https://cali.so')
+
+function mutationRequest(headers: HeadersInit = {}) {
+  return new Request('https://cali.so/api/admin/ama/availability', {
+    method: 'POST',
+    headers,
+  })
+}
+
+describe('browser mutation request policy', () => {
+  it('accepts an exact same-origin browser request', () => {
+    expect(
+      checkBrowserMutationRequest(
+        mutationRequest({ origin: 'https://cali.so', 'sec-fetch-site': 'same-origin' }),
+        canonicalOrigin,
+      ),
+    ).toBeNull()
+  })
+
+  it.each([
+    [{ 'sec-fetch-site': 'same-origin' }, 'missing-origin'],
+    [{ origin: 'null', 'sec-fetch-site': 'same-origin' }, 'origin-mismatch'],
+    [
+      { origin: 'https://attacker.example', 'sec-fetch-site': 'cross-site' },
+      'origin-mismatch',
+    ],
+    [{ origin: 'http://cali.so', 'sec-fetch-site': 'same-origin' }, 'origin-mismatch'],
+    [{ origin: 'https://cali.so:444', 'sec-fetch-site': 'same-origin' }, 'origin-mismatch'],
+    [{ origin: 'https://cali.so' }, 'missing-fetch-metadata'],
+    [{ origin: 'https://cali.so', 'sec-fetch-site': 'same-site' }, 'cross-site-context'],
+    [{ origin: 'https://cali.so', 'sec-fetch-site': 'cross-site' }, 'cross-site-context'],
+    [{ origin: 'https://cali.so', 'sec-fetch-site': 'none' }, 'cross-site-context'],
+  ] as const)('rejects unsafe browser context %#', (headers, reason) => {
+    expect(checkBrowserMutationRequest(mutationRequest(headers), canonicalOrigin)).toBe(
+      reason,
+    )
+  })
+})

--- a/lib/ama/security/request-policy.ts
+++ b/lib/ama/security/request-policy.ts
@@ -1,0 +1,34 @@
+export type BrowserMutationDenial =
+  | 'missing-origin'
+  | 'origin-mismatch'
+  | 'missing-fetch-metadata'
+  | 'cross-site-context'
+
+export function securityDenialHeaders() {
+  return new Headers({
+    'cache-control': 'no-store',
+    'referrer-policy': 'no-referrer',
+  })
+}
+
+export function checkBrowserMutationRequest(
+  request: Request,
+  canonicalBaseUrl: URL,
+): BrowserMutationDenial | null {
+  const origin = request.headers.get('origin')
+  if (!origin) return 'missing-origin'
+  if (origin !== canonicalBaseUrl.origin) return 'origin-mismatch'
+
+  const fetchSite = request.headers.get('sec-fetch-site')
+  if (!fetchSite) return 'missing-fetch-metadata'
+  if (fetchSite !== 'same-origin') return 'cross-site-context'
+
+  return null
+}
+
+export function browserMutationDeniedResponse() {
+  return new Response(null, {
+    status: 403,
+    headers: securityDenialHeaders(),
+  })
+}

--- a/lib/ama/security/server.ts
+++ b/lib/ama/security/server.ts
@@ -1,0 +1,41 @@
+import 'server-only'
+
+import { Ratelimit } from '@upstash/ratelimit'
+import { Redis } from '@upstash/redis'
+
+import { getServerEnv } from '../server-env'
+import { createAmaSecurity } from './service'
+
+let security: ReturnType<typeof createAmaSecurity> | undefined
+
+export function getAmaSecurity() {
+  if (security) return security
+
+  const environment = getServerEnv()
+  const redis = new Redis({
+    url: environment.UPSTASH_REDIS_REST_URL,
+    token: environment.UPSTASH_REDIS_REST_TOKEN,
+  })
+  const limiter = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(
+      environment.ADMIN_MUTATION_RATE_LIMIT_MAX_REQUESTS,
+      `${environment.ADMIN_MUTATION_RATE_LIMIT_WINDOW_SECONDS} s`,
+    ),
+    prefix: 'cali:ama:admin-mutation',
+  })
+
+  security = createAmaSecurity({
+    baseUrl: environment.SITE_URL,
+    features: environment.features,
+    pseudonymKey: Buffer.from(environment.RATE_LIMIT_HASH_KEY, 'base64'),
+    rateLimiter: limiter,
+    retryAfterSeconds: environment.ADMIN_MUTATION_RATE_LIMIT_WINDOW_SECONDS,
+    audit: {
+      write(event) {
+        console.warn(JSON.stringify(event))
+      },
+    },
+  })
+  return security
+}

--- a/lib/ama/security/service.test.ts
+++ b/lib/ama/security/service.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import {
+  createAmaSecurity,
+  type AmaFeatureFlags,
+  type SecurityAuditEvent,
+} from './service'
+
+const allFeatures: AmaFeatureFlags = {
+  publicMutations: true,
+  payments: true,
+  bookingFinalization: true,
+  admin: true,
+  google: true,
+  tencent: true,
+}
+
+function browserMutation(cookie = '__Host-cali_ama_admin_session=private-session') {
+  return new Request('https://cali.so/api/admin/ama/availability', {
+    method: 'POST',
+    headers: {
+      origin: 'https://cali.so',
+      'sec-fetch-site': 'same-origin',
+      cookie,
+    },
+  })
+}
+
+function fixture(input?: {
+  features?: AmaFeatureFlags
+  limit?: (key: string) => Promise<{ success: boolean }>
+}) {
+  const events: SecurityAuditEvent[] = []
+  const security = createAmaSecurity({
+    baseUrl: new URL('https://cali.so'),
+    features: input?.features ?? allFeatures,
+    pseudonymKey: Buffer.alloc(32, 3),
+    rateLimiter: { limit: input?.limit ?? (async () => ({ success: true })) },
+    audit: {
+      write(event) {
+        events.push(event)
+      },
+    },
+    clock: { now: () => new Date('2026-07-14T08:00:00.000Z') },
+    requestId: () => 'request-123',
+  })
+  return { security, events }
+}
+
+describe('AMA security service', () => {
+  it('allows an enabled same-origin browser mutation', async () => {
+    const { security, events } = fixture()
+
+    await expect(
+      security.protectBrowserMutation(browserMutation(), ['admin']),
+    ).resolves.toBeNull()
+    expect(events).toEqual([])
+  })
+
+  it('fails closed when a sensitive feature is disabled', async () => {
+    const { security, events } = fixture({
+      features: { ...allFeatures, google: false },
+    })
+
+    const response = await security.protectBrowserMutation(browserMutation(), [
+      'admin',
+      'google',
+    ])
+
+    expect(response?.status).toBe(503)
+    expect(response?.headers.get('cache-control')).toBe('no-store')
+    expect(events).toEqual([
+      {
+        event: 'feature.disabled',
+        timestamp: '2026-07-14T08:00:00.000Z',
+        outcome: 'denied',
+        requestId: 'request-123',
+      },
+    ])
+  })
+
+  it('rejects cross-site mutations without logging request data', async () => {
+    const { security, events } = fixture()
+    const request = new Request('https://cali.so/api/admin/ama/availability', {
+      method: 'POST',
+      headers: {
+        origin: 'https://attacker.example/private-email@example.com',
+        'sec-fetch-site': 'cross-site',
+        cookie: 'secret-cookie-value',
+      },
+    })
+
+    const response = await security.protectBrowserMutation(request, ['admin'])
+
+    expect(response?.status).toBe(403)
+    expect(events[0]).toEqual({
+      event: 'browser_mutation.denied',
+      timestamp: '2026-07-14T08:00:00.000Z',
+      outcome: 'denied',
+      requestId: 'request-123',
+    })
+    expect(JSON.stringify(events)).not.toContain('attacker.example')
+    expect(JSON.stringify(events)).not.toContain('private-email')
+    expect(JSON.stringify(events)).not.toContain('secret-cookie')
+  })
+
+  it('rate limits authenticated admin mutations with a pseudonymous key', async () => {
+    let limiterKey = ''
+    const { security, events } = fixture({
+      limit: async (key) => {
+        limiterKey = key
+        return { success: false }
+      },
+    })
+
+    const response = await security.limitAdminMutation(browserMutation())
+
+    expect(response?.status).toBe(429)
+    expect(limiterKey).toMatch(/^[a-f0-9]{64}$/)
+    expect(limiterKey).not.toContain('private-session')
+    expect(events).toEqual([
+      {
+        event: 'admin_mutation.rate_limited',
+        timestamp: '2026-07-14T08:00:00.000Z',
+        outcome: 'denied',
+        requestId: 'request-123',
+        actorId: limiterKey,
+      },
+    ])
+  })
+
+  it('keeps the limiter identity stable when unrelated cookies change', async () => {
+    const limiterKeys: string[] = []
+    const { security } = fixture({
+      limit: async (key) => {
+        limiterKeys.push(key)
+        return { success: true }
+      },
+    })
+
+    await security.limitAdminMutation(
+      browserMutation('theme=dark; __Host-cali_ama_admin_session=private-session'),
+    )
+    await security.limitAdminMutation(
+      browserMutation(
+        '__Host-cali_ama_admin_session=private-session; analytics=new-value',
+      ),
+    )
+
+    expect(limiterKeys).toHaveLength(2)
+    expect(limiterKeys[0]).toBe(limiterKeys[1])
+  })
+
+  it('records privileged actions without logging the session', () => {
+    const { security, events } = fixture()
+
+    security.recordPrivilegedAction(
+      browserMutation(),
+      'availability_mutation.succeeded',
+    )
+
+    expect(events[0]).toMatchObject({
+      event: 'availability_mutation.succeeded',
+      outcome: 'allowed',
+      requestId: 'request-123',
+      actorId: expect.stringMatching(/^[a-f0-9]{64}$/),
+    })
+    expect(JSON.stringify(events)).not.toContain('private-session')
+  })
+
+  it('denies the mutation when the rate limiter is unavailable', async () => {
+    const { security, events } = fixture({
+      limit: async () => {
+        throw new Error('provider payload must stay private')
+      },
+    })
+
+    const response = await security.limitAdminMutation(browserMutation())
+
+    expect(response?.status).toBe(503)
+    expect(events[0]).toMatchObject({
+      event: 'admin_mutation.limiter_error',
+      outcome: 'error',
+      requestId: 'request-123',
+    })
+    expect(JSON.stringify(events)).not.toContain('provider payload')
+  })
+})

--- a/lib/ama/security/service.ts
+++ b/lib/ama/security/service.ts
@@ -1,0 +1,193 @@
+import 'server-only'
+
+import { createHmac, randomUUID } from 'node:crypto'
+
+import { AUTH_SESSION_COOKIE } from '../auth/service'
+import { readRequestCookie } from '../cookies'
+import {
+  browserMutationDeniedResponse,
+  checkBrowserMutationRequest,
+  securityDenialHeaders,
+} from './request-policy'
+
+export type PrivilegedAuditEvent =
+  | 'availability_mutation.succeeded'
+  | 'google_connect.started'
+  | 'google_callback.completed'
+  | 'google_disconnect.succeeded'
+  | 'admin_logout.succeeded'
+
+export type AmaFeatureFlags = {
+  publicMutations: boolean
+  payments: boolean
+  bookingFinalization: boolean
+  admin: boolean
+  google: boolean
+  tencent: boolean
+}
+
+export type AmaFeature = keyof AmaFeatureFlags
+
+export type SecurityAuditEvent = {
+  event:
+    | 'feature.disabled'
+    | 'browser_mutation.denied'
+    | 'admin_authentication.denied'
+    | 'admin_mutation.rate_limited'
+    | 'admin_mutation.limiter_error'
+    | 'auth_request.failed'
+    | PrivilegedAuditEvent
+  timestamp: string
+  outcome: 'allowed' | 'denied' | 'error'
+  requestId: string
+  actorId?: string
+}
+
+export interface SecurityAuditSink {
+  write(event: SecurityAuditEvent): void | Promise<void>
+}
+
+export interface SecurityRateLimiter {
+  limit(key: string): Promise<{ success: boolean }>
+}
+
+type AmaSecurityDependencies = {
+  baseUrl: URL
+  features: AmaFeatureFlags
+  pseudonymKey: Buffer
+  rateLimiter: SecurityRateLimiter
+  audit: SecurityAuditSink
+  clock?: { now(): Date }
+  requestId?: () => string
+  retryAfterSeconds?: number
+}
+
+function unavailableResponse(retryAfterSeconds?: number) {
+  const headers = securityDenialHeaders()
+  if (retryAfterSeconds) headers.set('retry-after', String(retryAfterSeconds))
+  return new Response(null, { status: 503, headers })
+}
+
+function rateLimitedResponse(retryAfterSeconds: number) {
+  const headers = securityDenialHeaders()
+  headers.set('retry-after', String(retryAfterSeconds))
+  return new Response(null, {
+    status: 429,
+    headers,
+  })
+}
+
+export function createAmaSecurity({
+  baseUrl,
+  features,
+  pseudonymKey,
+  rateLimiter,
+  audit,
+  clock = { now: () => new Date() },
+  requestId = randomUUID,
+  retryAfterSeconds = 60,
+}: AmaSecurityDependencies) {
+  const requestIds = new WeakMap<Request, string>()
+
+  function record(event: SecurityAuditEvent) {
+    try {
+      const result = audit.write(event)
+      if (result instanceof Promise) void result.catch(() => {})
+    } catch {
+      // Security logging must never turn a denial into an availability incident.
+    }
+  }
+
+  function recordAuditEvent(
+    request: Request,
+    input: Omit<SecurityAuditEvent, 'timestamp' | 'requestId'>,
+  ) {
+    let currentRequestId = requestIds.get(request)
+    if (!currentRequestId) {
+      currentRequestId = requestId()
+      requestIds.set(request, currentRequestId)
+    }
+    record({
+      ...input,
+      timestamp: clock.now().toISOString(),
+      requestId: currentRequestId,
+    })
+  }
+
+  function disabledFeature(request: Request, required: readonly AmaFeature[]) {
+    if (required.every((feature) => features[feature])) return null
+    recordAuditEvent(request, { event: 'feature.disabled', outcome: 'denied' })
+    return unavailableResponse()
+  }
+
+  function actorId(request: Request) {
+    const session =
+      readRequestCookie(request, AUTH_SESSION_COOKIE) ?? 'missing-admin-session'
+    return createHmac('sha256', pseudonymKey).update(session).digest('hex')
+  }
+
+  return {
+    protectFeatures(request: Request, required: readonly AmaFeature[]) {
+      return disabledFeature(request, required)
+    },
+
+    async protectBrowserMutation(request: Request, required: readonly AmaFeature[]) {
+      const disabled = disabledFeature(request, required)
+      if (disabled) return disabled
+
+      if (checkBrowserMutationRequest(request, baseUrl)) {
+        recordAuditEvent(request, {
+          event: 'browser_mutation.denied',
+          outcome: 'denied',
+        })
+        return browserMutationDeniedResponse()
+      }
+      return null
+    },
+
+    recordAuthenticationDenial(request: Request) {
+      recordAuditEvent(request, {
+        event: 'admin_authentication.denied',
+        outcome: 'denied',
+      })
+    },
+
+    recordAuthRequestFailure(request: Request) {
+      recordAuditEvent(request, {
+        event: 'auth_request.failed',
+        outcome: 'error',
+      })
+    },
+
+    recordPrivilegedAction(request: Request, action: PrivilegedAuditEvent) {
+      recordAuditEvent(request, {
+        event: action,
+        outcome: 'allowed',
+        actorId: actorId(request),
+      })
+    },
+
+    async limitAdminMutation(request: Request) {
+      const privateActorId = actorId(request)
+      try {
+        const result = await rateLimiter.limit(privateActorId)
+        if (result.success) return null
+        recordAuditEvent(request, {
+          event: 'admin_mutation.rate_limited',
+          outcome: 'denied',
+          actorId: privateActorId,
+        })
+        return rateLimitedResponse(retryAfterSeconds)
+      } catch {
+        recordAuditEvent(request, {
+          event: 'admin_mutation.limiter_error',
+          outcome: 'error',
+          actorId: privateActorId,
+        })
+        return unavailableResponse(retryAfterSeconds)
+      }
+    },
+  }
+}
+
+export type AmaSecurity = ReturnType<typeof createAmaSecurity>

--- a/lib/ama/server-env-schema.ts
+++ b/lib/ama/server-env-schema.ts
@@ -23,27 +23,72 @@ function isResendSender(value: string) {
   return z.email().safeParse(mailbox).success
 }
 
-const serverEnvironmentSchema = z.object({
-  DATABASE_URL: z.string().refine(isPostgresUrl),
-  RESEND_API_KEY: z.string().min(1),
-  RESEND_FROM_EMAIL: z.string().min(3).refine(isResendSender),
-  ADMIN_EMAIL: z.email().transform((value) => value.trim().toLowerCase()),
-  SESSION_SECRET: z.string().min(32),
-  AMA_ENCRYPTION_KEY: z.string().refine(isBase64Key),
-  GOOGLE_CLIENT_ID: z.string().trim().min(1),
-  GOOGLE_CLIENT_SECRET: z.string().trim().min(1),
-  UPSTASH_REDIS_REST_URL: z.url(),
-  UPSTASH_REDIS_REST_TOKEN: z.string().min(1),
-  SITE_URL: z
-    .url()
-    .refine((value) => {
-      const url = new URL(value)
-      return url.protocol === 'https:' || ['localhost', '127.0.0.1'].includes(url.hostname)
-    })
-    .transform((value) => new URL(value)),
-  AUTH_RATE_LIMIT_MAX_REQUESTS: z.coerce.number().int().positive().default(5),
-  AUTH_RATE_LIMIT_WINDOW_SECONDS: z.coerce.number().int().positive().default(900),
-})
+const featureSwitch = z
+  .enum(['true', 'false'])
+  .default('false')
+  .transform((value) => value === 'true')
+
+const serverEnvironmentSchema = z
+  .object({
+    DATABASE_URL: z.string().refine(isPostgresUrl),
+    MIGRATION_DATABASE_URL: z.never().optional(),
+    RESEND_API_KEY: z.string().min(1),
+    RESEND_FROM_EMAIL: z.string().min(3).refine(isResendSender),
+    ADMIN_EMAIL: z.email().transform((value) => value.trim().toLowerCase()),
+    SESSION_SECRET: z.string().min(32),
+    AMA_ENCRYPTION_KEY: z.string().refine(isBase64Key),
+    RATE_LIMIT_HASH_KEY: z.string().refine(isBase64Key),
+    GOOGLE_CLIENT_ID: z.string().trim().min(1),
+    GOOGLE_CLIENT_SECRET: z.string().trim().min(1),
+    UPSTASH_REDIS_REST_URL: z.url(),
+    UPSTASH_REDIS_REST_TOKEN: z.string().min(1),
+    SITE_URL: z
+      .url()
+      .refine((value) => {
+        const url = new URL(value)
+        return url.protocol === 'https:' || ['localhost', '127.0.0.1'].includes(url.hostname)
+      })
+      .transform((value) => new URL(value)),
+    AUTH_RATE_LIMIT_MAX_REQUESTS: z.coerce.number().int().positive().default(5),
+    AUTH_RATE_LIMIT_WINDOW_SECONDS: z.coerce.number().int().positive().default(900),
+    ADMIN_MUTATION_RATE_LIMIT_MAX_REQUESTS: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(30),
+    ADMIN_MUTATION_RATE_LIMIT_WINDOW_SECONDS: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(60),
+    AMA_PUBLIC_MUTATIONS_ENABLED: featureSwitch,
+    AMA_PAYMENTS_ENABLED: featureSwitch,
+    AMA_BOOKING_FINALIZATION_ENABLED: featureSwitch,
+    AMA_ADMIN_ENABLED: featureSwitch,
+    AMA_GOOGLE_INTEGRATION_ENABLED: featureSwitch,
+    AMA_TENCENT_INTEGRATION_ENABLED: featureSwitch,
+  })
+  .transform(
+    ({
+      AMA_PUBLIC_MUTATIONS_ENABLED,
+      AMA_PAYMENTS_ENABLED,
+      AMA_BOOKING_FINALIZATION_ENABLED,
+      AMA_ADMIN_ENABLED,
+      AMA_GOOGLE_INTEGRATION_ENABLED,
+      AMA_TENCENT_INTEGRATION_ENABLED,
+      ...environment
+    }) => ({
+      ...environment,
+      features: {
+        publicMutations: AMA_PUBLIC_MUTATIONS_ENABLED,
+        payments: AMA_PAYMENTS_ENABLED,
+        bookingFinalization: AMA_BOOKING_FINALIZATION_ENABLED,
+        admin: AMA_ADMIN_ENABLED,
+        google: AMA_GOOGLE_INTEGRATION_ENABLED,
+        tencent: AMA_TENCENT_INTEGRATION_ENABLED,
+      },
+    }),
+  )
 
 export type ServerEnvironment = z.output<typeof serverEnvironmentSchema>
 

--- a/lib/ama/server-env-schema.ts
+++ b/lib/ama/server-env-schema.ts
@@ -23,10 +23,20 @@ function isResendSender(value: string) {
   return z.email().safeParse(mailbox).success
 }
 
+function isHttpsUrl(value: string) {
+  try {
+    return new URL(value).protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
 const featureSwitch = z
   .enum(['true', 'false'])
   .default('false')
   .transform((value) => value === 'true')
+
+const redisRestUrl = z.url().refine(isHttpsUrl)
 
 const serverEnvironmentSchema = z
   .object({
@@ -40,8 +50,10 @@ const serverEnvironmentSchema = z
     RATE_LIMIT_HASH_KEY: z.string().refine(isBase64Key),
     GOOGLE_CLIENT_ID: z.string().trim().min(1),
     GOOGLE_CLIENT_SECRET: z.string().trim().min(1),
-    UPSTASH_REDIS_REST_URL: z.url(),
-    UPSTASH_REDIS_REST_TOKEN: z.string().min(1),
+    UPSTASH_REDIS_REST_URL: redisRestUrl.optional(),
+    UPSTASH_REDIS_REST_TOKEN: z.string().trim().min(1).optional(),
+    KV_REST_API_URL: redisRestUrl.optional(),
+    KV_REST_API_TOKEN: z.string().trim().min(1).optional(),
     SITE_URL: z
       .url()
       .refine((value) => {
@@ -68,8 +80,71 @@ const serverEnvironmentSchema = z
     AMA_GOOGLE_INTEGRATION_ENABLED: featureSwitch,
     AMA_TENCENT_INTEGRATION_ENABLED: featureSwitch,
   })
+  .superRefine(
+    (
+      {
+        UPSTASH_REDIS_REST_URL,
+        UPSTASH_REDIS_REST_TOKEN,
+        KV_REST_API_URL,
+        KV_REST_API_TOKEN,
+      },
+      context,
+    ) => {
+      const upstashPairComplete = Boolean(
+        UPSTASH_REDIS_REST_URL && UPSTASH_REDIS_REST_TOKEN,
+      )
+      const marketplacePairComplete = Boolean(
+        KV_REST_API_URL && KV_REST_API_TOKEN,
+      )
+
+      if (
+        Boolean(UPSTASH_REDIS_REST_URL) !== Boolean(UPSTASH_REDIS_REST_TOKEN)
+      ) {
+        context.addIssue({
+          code: 'custom',
+          path: [
+            UPSTASH_REDIS_REST_URL
+              ? 'UPSTASH_REDIS_REST_TOKEN'
+              : 'UPSTASH_REDIS_REST_URL',
+          ],
+          message:
+            'Upstash Redis credentials must be configured as a complete pair',
+        })
+      }
+
+      if (Boolean(KV_REST_API_URL) !== Boolean(KV_REST_API_TOKEN)) {
+        context.addIssue({
+          code: 'custom',
+          path: [KV_REST_API_URL ? 'KV_REST_API_TOKEN' : 'KV_REST_API_URL'],
+          message:
+            'Vercel KV credentials must be configured as a complete pair',
+        })
+      }
+
+      if (!upstashPairComplete && !marketplacePairComplete) {
+        if (!UPSTASH_REDIS_REST_URL) {
+          context.addIssue({
+            code: 'custom',
+            path: ['UPSTASH_REDIS_REST_URL'],
+            message: 'A complete Redis credential pair is required',
+          })
+        }
+        if (!UPSTASH_REDIS_REST_TOKEN) {
+          context.addIssue({
+            code: 'custom',
+            path: ['UPSTASH_REDIS_REST_TOKEN'],
+            message: 'A complete Redis credential pair is required',
+          })
+        }
+      }
+    },
+  )
   .transform(
     ({
+      UPSTASH_REDIS_REST_URL,
+      UPSTASH_REDIS_REST_TOKEN,
+      KV_REST_API_URL,
+      KV_REST_API_TOKEN,
       AMA_PUBLIC_MUTATIONS_ENABLED,
       AMA_PAYMENTS_ENABLED,
       AMA_BOOKING_FINALIZATION_ENABLED,
@@ -79,6 +154,8 @@ const serverEnvironmentSchema = z
       ...environment
     }) => ({
       ...environment,
+      UPSTASH_REDIS_REST_URL: UPSTASH_REDIS_REST_URL ?? KV_REST_API_URL!,
+      UPSTASH_REDIS_REST_TOKEN: UPSTASH_REDIS_REST_TOKEN ?? KV_REST_API_TOKEN!,
       features: {
         publicMutations: AMA_PUBLIC_MUTATIONS_ENABLED,
         payments: AMA_PAYMENTS_ENABLED,

--- a/lib/ama/server-env.test.ts
+++ b/lib/ama/server-env.test.ts
@@ -34,6 +34,139 @@ describe('AMA server environment', () => {
     })
   })
 
+  it('accepts Vercel Marketplace Redis aliases', () => {
+    const {
+      UPSTASH_REDIS_REST_URL: _upstashUrl,
+      UPSTASH_REDIS_REST_TOKEN: _upstashToken,
+      ...withoutUpstash
+    } = validEnvironment
+    const environment = parseServerEnv({
+      ...withoutUpstash,
+      KV_REST_API_URL: 'https://marketplace.upstash.io',
+      KV_REST_API_TOKEN: 'marketplace-secret',
+    })
+
+    expect(environment.UPSTASH_REDIS_REST_URL).toBe(
+      'https://marketplace.upstash.io',
+    )
+    expect(environment.UPSTASH_REDIS_REST_TOKEN).toBe('marketplace-secret')
+    expect(environment).not.toHaveProperty('KV_REST_API_URL')
+    expect(environment).not.toHaveProperty('KV_REST_API_TOKEN')
+  })
+
+  it('prefers native Upstash credentials when both pairs are complete', () => {
+    const environment = parseServerEnv({
+      ...validEnvironment,
+      KV_REST_API_URL: 'https://marketplace.upstash.io',
+      KV_REST_API_TOKEN: 'marketplace-secret',
+    })
+
+    expect(environment.UPSTASH_REDIS_REST_URL).toBe(
+      validEnvironment.UPSTASH_REDIS_REST_URL,
+    )
+    expect(environment.UPSTASH_REDIS_REST_TOKEN).toBe(
+      validEnvironment.UPSTASH_REDIS_REST_TOKEN,
+    )
+  })
+
+  it('rejects partial Redis credential pairs', () => {
+    const {
+      UPSTASH_REDIS_REST_URL: _upstashUrl,
+      UPSTASH_REDIS_REST_TOKEN: _upstashToken,
+      ...withoutUpstash
+    } = validEnvironment
+
+    expect(() =>
+      parseServerEnv({
+        ...withoutUpstash,
+        KV_REST_API_URL: 'https://marketplace.upstash.io',
+      }),
+    ).toThrowError(/KV_REST_API_TOKEN/)
+
+    const { UPSTASH_REDIS_REST_TOKEN: _missingToken, ...partialUpstash } =
+      validEnvironment
+    expect(() =>
+      parseServerEnv({
+        ...partialUpstash,
+        KV_REST_API_URL: 'https://marketplace.upstash.io',
+        KV_REST_API_TOKEN: 'marketplace-secret',
+      }),
+    ).toThrowError(/UPSTASH_REDIS_REST_TOKEN/)
+
+    for (const partialPair of [
+      { UPSTASH_REDIS_REST_URL: 'https://example.upstash.io' },
+      { UPSTASH_REDIS_REST_TOKEN: 'partial-secret' },
+      { KV_REST_API_TOKEN: 'partial-secret' },
+      {
+        UPSTASH_REDIS_REST_URL: 'https://example.upstash.io',
+        KV_REST_API_TOKEN: 'partial-secret',
+      },
+      {
+        UPSTASH_REDIS_REST_TOKEN: 'partial-secret',
+        KV_REST_API_URL: 'https://marketplace.upstash.io',
+      },
+    ]) {
+      expect(() =>
+        parseServerEnv({ ...withoutUpstash, ...partialPair }),
+      ).toThrow()
+    }
+  })
+
+  it('rejects missing or non-HTTPS Redis configuration', () => {
+    const {
+      UPSTASH_REDIS_REST_URL: _upstashUrl,
+      UPSTASH_REDIS_REST_TOKEN: _upstashToken,
+      ...withoutUpstash
+    } = validEnvironment
+
+    expect(() => parseServerEnv(withoutUpstash)).toThrowError(
+      /UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN/,
+    )
+    expect(() =>
+      parseServerEnv({
+        ...validEnvironment,
+        UPSTASH_REDIS_REST_URL: 'http://example.upstash.io',
+      }),
+    ).toThrowError(/UPSTASH_REDIS_REST_URL/)
+    expect(() =>
+      parseServerEnv({
+        ...validEnvironment,
+        UPSTASH_REDIS_REST_URL: 'not-a-url',
+      }),
+    ).toThrowError(/UPSTASH_REDIS_REST_URL/)
+    expect(() =>
+      parseServerEnv({
+        ...validEnvironment,
+        UPSTASH_REDIS_REST_TOKEN: '   ',
+      }),
+    ).toThrowError(/UPSTASH_REDIS_REST_TOKEN/)
+    expect(() =>
+      parseServerEnv({
+        ...withoutUpstash,
+        KV_REST_API_URL: 'http://marketplace.upstash.io',
+        KV_REST_API_TOKEN: 'do-not-print-me',
+      }),
+    ).toThrowError(/KV_REST_API_URL/)
+    expect(() =>
+      parseServerEnv({
+        ...withoutUpstash,
+        KV_REST_API_URL: 'https://marketplace.upstash.io',
+        KV_REST_API_TOKEN: '   ',
+      }),
+    ).toThrowError(/KV_REST_API_TOKEN/)
+
+    try {
+      parseServerEnv({
+        ...withoutUpstash,
+        KV_REST_API_URL: 'http://marketplace.upstash.io',
+        KV_REST_API_TOKEN: 'do-not-print-me',
+      })
+    } catch (error) {
+      expect(String(error)).not.toContain('do-not-print-me')
+      expect(String(error)).not.toContain('marketplace.upstash.io')
+    }
+  })
+
   it('enables each sensitive feature only through an explicit switch', () => {
     const environment = parseServerEnv({
       ...validEnvironment,

--- a/lib/ama/server-env.test.ts
+++ b/lib/ama/server-env.test.ts
@@ -9,6 +9,7 @@ const validEnvironment = {
   ADMIN_EMAIL: 'owner@example.com',
   SESSION_SECRET: 's'.repeat(64),
   AMA_ENCRYPTION_KEY: Buffer.alloc(32).toString('base64'),
+  RATE_LIMIT_HASH_KEY: Buffer.alloc(32, 2).toString('base64'),
   GOOGLE_CLIENT_ID: 'google-client-id.apps.googleusercontent.com',
   GOOGLE_CLIENT_SECRET: 'google-client-secret',
   UPSTASH_REDIS_REST_URL: 'https://example.upstash.io',
@@ -22,6 +23,51 @@ describe('AMA server environment', () => {
 
     expect(environment.ADMIN_EMAIL).toBe('owner@example.com')
     expect(environment.AUTH_RATE_LIMIT_MAX_REQUESTS).toBe(5)
+    expect(environment.ADMIN_MUTATION_RATE_LIMIT_MAX_REQUESTS).toBe(30)
+    expect(environment.features).toEqual({
+      publicMutations: false,
+      payments: false,
+      bookingFinalization: false,
+      admin: false,
+      google: false,
+      tencent: false,
+    })
+  })
+
+  it('enables each sensitive feature only through an explicit switch', () => {
+    const environment = parseServerEnv({
+      ...validEnvironment,
+      AMA_PUBLIC_MUTATIONS_ENABLED: 'true',
+      AMA_PAYMENTS_ENABLED: 'true',
+      AMA_BOOKING_FINALIZATION_ENABLED: 'true',
+      AMA_ADMIN_ENABLED: 'true',
+      AMA_GOOGLE_INTEGRATION_ENABLED: 'true',
+      AMA_TENCENT_INTEGRATION_ENABLED: 'true',
+    })
+
+    expect(environment.features).toEqual({
+      publicMutations: true,
+      payments: true,
+      bookingFinalization: true,
+      admin: true,
+      google: true,
+      tencent: true,
+    })
+  })
+
+  it('rejects ambiguous feature-switch values', () => {
+    expect(() =>
+      parseServerEnv({ ...validEnvironment, AMA_ADMIN_ENABLED: 'yes' }),
+    ).toThrowError(/AMA_ADMIN_ENABLED/)
+  })
+
+  it('rejects migration credentials in the runtime environment', () => {
+    expect(() =>
+      parseServerEnv({
+        ...validEnvironment,
+        MIGRATION_DATABASE_URL: 'postgresql://migration:secret@db.example/cali',
+      }),
+    ).toThrowError(/MIGRATION_DATABASE_URL/)
   })
 
   it('reports invalid field names without exposing secret values', () => {

--- a/lib/security/admin-proxy.test.ts
+++ b/lib/security/admin-proxy.test.ts
@@ -1,0 +1,20 @@
+import { NextRequest } from 'next/server'
+import { describe, expect, it } from 'vitest'
+
+import { proxy } from '../../proxy'
+
+describe('admin CSP proxy', () => {
+  it('uses a fresh strict nonce policy for each admin render', () => {
+    const request = new NextRequest('https://cali.so/admin/login')
+    const first = proxy(request).headers.get('content-security-policy')
+    const second = proxy(request).headers.get('content-security-policy')
+
+    expect(first).toMatch(
+      /script-src 'self' 'nonce-[^']+' 'sha256-[^']+' 'strict-dynamic'/,
+    )
+    expect(first).not.toContain("script-src 'self' 'unsafe-inline'")
+    expect(first?.match(/'sha256-[^']+'/g)).toHaveLength(1)
+    expect(first).toContain("style-src 'self' 'unsafe-inline'")
+    expect(first).not.toBe(second)
+  })
+})

--- a/lib/security/headers.test.ts
+++ b/lib/security/headers.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { securityHeaders } from './headers'
+
+describe('site security headers', () => {
+  it('sets a restrictive browser security baseline for every route', () => {
+    const headers = Object.fromEntries(
+      securityHeaders.map(({ key, value }) => [key.toLowerCase(), value]),
+    )
+
+    expect(headers['content-security-policy']).toContain("default-src 'self'")
+    expect(headers['content-security-policy']).toContain("frame-ancestors 'none'")
+    expect(headers['content-security-policy']).toContain("object-src 'none'")
+    expect(headers['content-security-policy']).toContain("base-uri 'self'")
+    expect(headers['content-security-policy']).toContain("form-action 'self'")
+    expect(headers['content-security-policy']).toContain("script-src 'self' 'unsafe-inline'")
+    expect(headers['content-security-policy']).not.toContain("'unsafe-eval'")
+    expect(headers['strict-transport-security']).toBe(
+      'max-age=63072000; includeSubDomains; preload',
+    )
+    expect(headers['x-frame-options']).toBe('DENY')
+    expect(headers['x-content-type-options']).toBe('nosniff')
+    expect(headers['referrer-policy']).toBe('strict-origin-when-cross-origin')
+    expect(headers['permissions-policy']).toContain('camera=()')
+    expect(headers['permissions-policy']).toContain('microphone=()')
+    expect(headers['permissions-policy']).toContain('payment=()')
+  })
+})

--- a/lib/security/headers.ts
+++ b/lib/security/headers.ts
@@ -10,21 +10,21 @@ const prepaintScriptHash = `'sha256-${createHash('sha256')
 
 function contentSecurityPolicy(scriptSources: string, styleSources: string) {
   return [
-  "default-src 'self'",
-  "base-uri 'self'",
-  "form-action 'self'",
-  "frame-ancestors 'none'",
-  "object-src 'none'",
-  `script-src ${scriptSources}`,
-  "script-src-attr 'none'",
-  `style-src ${styleSources}`,
-  "img-src 'self' data: blob: https://www.google.com https://zolplay.com",
-  "font-src 'self' data:",
-  "connect-src 'self'",
-  "media-src 'self' blob:",
-  "worker-src 'self' blob:",
-  "frame-src 'none'",
-  "manifest-src 'self'",
+    "default-src 'self'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    "object-src 'none'",
+    `script-src ${scriptSources}`,
+    "script-src-attr 'none'",
+    `style-src ${styleSources}`,
+    "img-src 'self' data: blob: https://www.google.com https://zolplay.com",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "media-src 'self' blob:",
+    "worker-src 'self' blob:",
+    "frame-src 'none'",
+    "manifest-src 'self'",
   ].join('; ')
 }
 

--- a/lib/security/headers.ts
+++ b/lib/security/headers.ts
@@ -1,0 +1,66 @@
+import { createHash } from 'node:crypto'
+
+import { PREPAINT_SCRIPT } from './inline-scripts'
+
+const isDevelopment = process.env.NODE_ENV === 'development'
+
+const prepaintScriptHash = `'sha256-${createHash('sha256')
+  .update(PREPAINT_SCRIPT)
+  .digest('base64')}'`
+
+function contentSecurityPolicy(scriptSources: string, styleSources: string) {
+  return [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  "object-src 'none'",
+  `script-src ${scriptSources}`,
+  "script-src-attr 'none'",
+  `style-src ${styleSources}`,
+  "img-src 'self' data: blob: https://www.google.com https://zolplay.com",
+  "font-src 'self' data:",
+  "connect-src 'self'",
+  "media-src 'self' blob:",
+  "worker-src 'self' blob:",
+  "frame-src 'none'",
+  "manifest-src 'self'",
+  ].join('; ')
+}
+
+const publicContentSecurityPolicy = contentSecurityPolicy(
+  `'self' 'unsafe-inline'${isDevelopment ? " 'unsafe-eval'" : ''}`,
+  "'self' 'unsafe-inline'",
+)
+
+export function adminContentSecurityPolicy(nonce: string) {
+  const nonceSource = `'nonce-${nonce}'`
+  return contentSecurityPolicy(
+    `'self' ${nonceSource} ${prepaintScriptHash} 'strict-dynamic'${isDevelopment ? " 'unsafe-eval'" : ''}`,
+    "'self' 'unsafe-inline'",
+  )
+}
+
+export const securityHeaders = [
+  { key: 'Content-Security-Policy', value: publicContentSecurityPolicy },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  {
+    key: 'Permissions-Policy',
+    value: [
+      'accelerometer=()',
+      'camera=()',
+      'geolocation=()',
+      'gyroscope=()',
+      'magnetometer=()',
+      'microphone=()',
+      'payment=()',
+      'usb=()',
+    ].join(', '),
+  },
+] as const

--- a/lib/security/inline-scripts.test.ts
+++ b/lib/security/inline-scripts.test.ts
@@ -1,0 +1,15 @@
+import { createHash } from 'node:crypto'
+
+import { describe, expect, it } from 'vitest'
+
+import { adminContentSecurityPolicy } from './headers'
+import { PREPAINT_SCRIPT } from './inline-scripts'
+
+describe('hashed inline scripts', () => {
+  it('allows only the owned pre-paint bootstrap by hash', () => {
+    const hash = `'sha256-${createHash('sha256')
+      .update(PREPAINT_SCRIPT)
+      .digest('base64')}'`
+    expect(adminContentSecurityPolicy('test-nonce')).toContain(hash)
+  })
+})

--- a/lib/security/inline-scripts.ts
+++ b/lib/security/inline-scripts.ts
@@ -1,0 +1,2 @@
+export const PREPAINT_SCRIPT =
+  'try{var d=document.documentElement;if(sessionStorage.v)d.dataset.visited="";sessionStorage.v=1;if(localStorage.locale==="en"){d.dataset.locale="en";d.lang="en"}var t=localStorage.theme||"system",r=t==="system"?(matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light"):t;if(r==="light"||r==="dark"){d.classList.remove("light","dark");d.classList.add(r);d.style.colorScheme=r}}catch(e){}'

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,7 @@
 import type { NextConfig } from 'next'
 
+import { securityHeaders } from './lib/security/headers'
+
 const nextConfig: NextConfig = {
   // Pin the project root: when developing from a git worktree nested inside
   // another checkout, Next's lockfile-based root inference walks too far up.
@@ -11,7 +13,10 @@ const nextConfig: NextConfig = {
 
   // Shared-element morphs (cover/title) on route navigation; browsers
   // without the View Transitions API just navigate instantly.
-  experimental: { viewTransition: true },
+  experimental: {
+    viewTransition: true,
+    sri: { algorithm: 'sha256' },
+  },
 
   images: {
     // Post images are served from content/ via app/content/[...path]/route.ts;
@@ -22,6 +27,13 @@ const nextConfig: NextConfig = {
       { pathname: '/_next/static/**' },
     ],
   },
+
+  headers: async () => [
+    {
+      source: '/:path*',
+      headers: [...securityHeaders],
+    },
+  ],
 
   // v1 URL back-compat (issue #75): every URL Google or anyone else has
   // indexed must keep working. Routes that survive in v2 (blog, feeds,

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "db:validate": "node --test scripts/ama-migrations.test.mjs",
     "start": "next start",
     "test:ama": "vitest run lib/ama && pnpm db:validate",
+    "test:security": "vitest run lib/security",
     "test:localization": "node --test scripts/localization.test.mjs",
     "test:port-post": "node --test scripts/port-post.test.mjs",
     "typecheck": "tsc --noEmit"
@@ -38,7 +39,6 @@
     "motion": "^12.42.2",
     "next": "16.3.0-preview.5",
     "next-mdx-remote": "^6.0.0",
-    "next-themes": "^0.4.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "rehype-pretty-code": "^0.14.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,6 @@ importers:
       next-mdx-remote:
         specifier: ^6.0.0
         version: 6.0.0(@types/react@19.2.17)(react@19.2.7)
-      next-themes:
-        specifier: ^0.4.6
-        version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.1.0
         version: 19.2.7
@@ -2860,12 +2857,6 @@ packages:
     engines: {node: '>=14', npm: '>=7'}
     peerDependencies:
       react: '>=16'
-
-  next-themes@0.4.6:
-    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
-    peerDependencies:
-      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   next@16.3.0-preview.5:
     resolution: {integrity: sha512-I5rVC4VcvAL1FPr6AY5WEQUSe6o1Bt0Oa/qH5hfPhci4FRMCPeAQ95tgxFOgJDk2wME1K009k0bjS17nQ0Bq1w==}
@@ -6409,11 +6400,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
-
-  next-themes@0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   next@16.3.0-preview.5(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,22 @@
+import { randomUUID } from 'node:crypto'
+
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+import { adminContentSecurityPolicy } from './lib/security/headers'
+
+export function proxy(request: NextRequest) {
+  const nonce = Buffer.from(randomUUID()).toString('base64')
+  const policy = adminContentSecurityPolicy(nonce)
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set('content-security-policy', policy)
+  requestHeaders.set('x-nonce', nonce)
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } })
+  response.headers.set('content-security-policy', policy)
+  return response
+}
+
+export const config = {
+  matcher: '/admin/:path*',
+}


### PR DESCRIPTION
Progresses [#92](https://github.com/CaliCastle/cali.so/issues/92).

## Summary

- add site-wide security headers, SRI, and a nonce-strict CSP for the dynamic admin surface
- enforce same-origin browser mutations, fail-closed feature switches, admin rate limits, and privacy-safe audit events
- separate runtime and migration database credentials and isolate rate-limit pseudonym material
- add coordinated disclosure guidance, Dependabot, CodeQL, SHA-pinned Actions, and security verification notes
- preserve static and ISR rendering for public pages while replacing the transformed theme bootstrap with an owned, hash-verified implementation

## Why

The public v2 repository and AMA admin surface cannot rely on source-code secrecy. These controls establish a fail-closed baseline before payment, booking, calendar, and meeting integrations expand the attack surface.

## Verification

- `pnpm typecheck`
- `pnpm test:ama` (116 tests plus 5 migration validations)
- `pnpm test:security` (3 tests)
- `pnpm test:localization` (151 checks)
- `pnpm build`
- `pnpm audit --prod`
- YAML parsing, full-SHA Action scan, and `git diff --check`
- production-server verification that every inline admin script is request-nonced or matches the single owned bootstrap hash
- full-history Gitleaks scan documented with no findings

## Hosted follow-up

- add the Vercel Challenge rule for the public authentication mutation
- require `Quality` and `CodeQL` after their first successful run
- provision isolated Preview credentials and verify production runtime database grants, log retention, and kill-switch values
- revisit non-provider secret scanning and validity checks when the GitHub product mode allows them
