### PR TITLE
Add Bunny media storage contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,21 @@ AMA_BOOKING_FINALIZATION_ENABLED=false
 AMA_ADMIN_ENABLED=false
 AMA_GOOGLE_INTEGRATION_ENABLED=false
 AMA_TENCENT_INTEGRATION_ENABLED=false
+
+# Bunny Media Library. Originals and Renditions must use distinct zones and
+# preview deployments must use non-production credentials.
+BUNNY_MEDIA_REGION=sg
+BUNNY_ORIGINALS_ZONE=
+BUNNY_ORIGINALS_PASSWORD=
+BUNNY_RENDITIONS_ZONE=
+BUNNY_RENDITIONS_PASSWORD=
+BUNNY_RENDITIONS_CDN_URL=
+BUNNY_CDN_API_KEY=
+
+# Used only by the opt-in non-production storage contract. Do not set the
+# confirmation flag in a deployed runtime environment.
+BUNNY_STORAGE_CONTRACT_ENVIRONMENT=non-production
+BUNNY_STORAGE_CONTRACT_ORIGIN=https://cali.so
+BUNNY_STORAGE_CONTRACT_EDGE_TTL_SECONDS=
+BUNNY_STORAGE_CONTRACT_BROWSER_TTL_SECONDS=
+# BUNNY_STORAGE_LIVE_TEST=confirmed-non-production

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Test security controls
         run: pnpm test:security
 
+      - name: Test media storage contract
+        run: pnpm test:media:storage
+
       - name: Test localization
         run: pnpm test:localization
 

--- a/lib/media/storage/bunny.browser.live.test.ts
+++ b/lib/media/storage/bunny.browser.live.test.ts
@@ -1,0 +1,163 @@
+import { createHash, randomUUID } from 'node:crypto'
+
+import { chromium, type Browser, type Page } from 'playwright'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import { BunnyStorageError, createBunnyStorage } from './bunny'
+import { parseBunnyStorageEnv } from './config'
+import {
+  assertNonProductionBunnyContract,
+  verifyBunnyAccountContract,
+} from './contract'
+import { storeOriginalFromSameOriginRequest } from './upload'
+
+const liveContractEnabled =
+  process.env.BUNNY_STORAGE_LIVE_TEST === 'confirmed-non-production'
+
+const liveDescribe = liveContractEnabled ? describe : describe.skip
+
+async function pageAtOrigin(
+  browser: Browser,
+  origin: string,
+  uploadUrl: string,
+  handleUpload: (request: Request) => Promise<Response>,
+) {
+  const page = await browser.newPage()
+  const contractPage = `${origin}/__bunny_storage_contract__`
+  await page.route(contractPage, async (route) => {
+    await route.fulfill({
+      contentType: 'text/html',
+      body: '<!doctype html><title>Bunny storage contract</title>',
+    })
+  })
+  await page.route(uploadUrl, async (route) => {
+    const browserRequest = route.request()
+    const headers = await browserRequest.allHeaders()
+    // Playwright omits Fetch Metadata from intercepted requests, so restore
+    // the value the browser derives from this contract page and upload URL.
+    headers['sec-fetch-site'] =
+      new URL(origin).origin === new URL(uploadUrl).origin
+        ? 'same-origin'
+        : 'cross-site'
+    const body = browserRequest.postDataBuffer()
+    const response = await handleUpload(
+      new Request(uploadUrl, {
+        method: browserRequest.method(),
+        headers,
+        body: body ? Uint8Array.from(body) : undefined,
+      }),
+    )
+    await route.fulfill({
+      status: response.status,
+      headers: Object.fromEntries(response.headers),
+      body: Buffer.from(await response.arrayBuffer()),
+    })
+  })
+  await page.goto(contractPage)
+  return page
+}
+
+async function uploadFromBrowser(
+  page: Page,
+  uploadUrl: string,
+  bytes: Uint8Array,
+  checksumSha256: string,
+) {
+  return page.evaluate(
+    async ({ url, body, checksum }) => {
+      try {
+        const response = await fetch(url, {
+          method: 'PUT',
+          headers: {
+            'content-type': 'image/jpeg',
+            'x-media-checksum-sha256': checksum,
+          },
+          body: Uint8Array.from(body),
+        })
+        return { blocked: false, ok: response.ok, status: response.status }
+      } catch {
+        return { blocked: true, ok: false, status: 0 }
+      }
+    },
+    { url: uploadUrl, body: Array.from(bytes), checksum: checksumSha256 },
+  )
+}
+
+liveDescribe('Bunny Media Storage browser contract', () => {
+  it(
+    'accepts the same-origin server upload and blocks a cross-site browser',
+    async () => {
+      const config = parseBunnyStorageEnv(process.env)
+      const contract = assertNonProductionBunnyContract(process.env, config)
+      await verifyBunnyAccountContract(config, contract)
+      const storage = createBunnyStorage(config)
+      const identity = randomUUID()
+      const bytes = new TextEncoder().encode(`bunny-browser-contract:${identity}`)
+      const checksumSha256 = createHash('sha256').update(bytes).digest('hex')
+      const allowedKey = `contracts/${identity}/allowed-origin.jpg`
+      const attackerKey = `contracts/${identity}/attacker-origin.jpg`
+      const uploadUrl = `${contract.origin.origin}/__bunny_storage_contract__/upload`
+      let browser: Browser | undefined
+
+      try {
+        browser = await chromium.launch()
+        const allowedPage = await pageAtOrigin(
+          browser,
+          contract.origin.origin,
+          uploadUrl,
+          (request) =>
+            storeOriginalFromSameOriginRequest({
+              request,
+              canonicalBaseUrl: contract.origin,
+              expectation: {
+                key: allowedKey,
+                contentType: 'image/jpeg',
+                byteSize: bytes.byteLength,
+                checksumSha256,
+              },
+              authorize: async () => true,
+              storage,
+            }),
+        )
+        await expect(
+          uploadFromBrowser(allowedPage, uploadUrl, bytes, checksumSha256),
+        ).resolves.toEqual({ blocked: false, ok: true, status: 204 })
+        await expect(storage.readOriginal(allowedKey)).resolves.toEqual(bytes)
+
+        const attackerPage = await pageAtOrigin(
+          browser,
+          'https://attacker.example',
+          uploadUrl,
+          (request) =>
+            storeOriginalFromSameOriginRequest({
+              request,
+              canonicalBaseUrl: contract.origin,
+              expectation: {
+                key: attackerKey,
+                contentType: 'image/jpeg',
+                byteSize: bytes.byteLength,
+                checksumSha256,
+              },
+              authorize: async () => true,
+              storage,
+            }),
+        )
+        await expect(
+          uploadFromBrowser(attackerPage, uploadUrl, bytes, checksumSha256),
+        ).resolves.toEqual({ blocked: false, ok: false, status: 403 })
+        await expect(storage.inspectOriginal(attackerKey)).rejects.toEqual(
+          new BunnyStorageError('not_found'),
+        )
+      } finally {
+        await browser?.close()
+        await Promise.allSettled([
+          storage.deleteOriginal(allowedKey),
+          storage.deleteOriginal(attackerKey),
+        ])
+      }
+    },
+    45_000,
+  )
+})

--- a/lib/media/storage/bunny.live.test.ts
+++ b/lib/media/storage/bunny.live.test.ts
@@ -1,0 +1,124 @@
+import { createHash, randomUUID } from 'node:crypto'
+
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import { BunnyStorageError, createBunnyStorage } from './bunny'
+import { parseBunnyStorageEnv } from './config'
+import {
+  assertNonProductionBunnyContract,
+  renditionDeliveryHeadersMatchContract,
+  verifyBunnyAccountContract,
+} from './contract'
+
+const liveContractEnabled =
+  process.env.BUNNY_STORAGE_LIVE_TEST === 'confirmed-non-production'
+
+const liveDescribe = liveContractEnabled ? describe : describe.skip
+
+async function waitFor(
+  assertion: () => Promise<boolean>,
+  timeoutMilliseconds = 15_000,
+) {
+  const deadline = Date.now() + timeoutMilliseconds
+  while (Date.now() < deadline) {
+    if (await assertion()) return
+    await new Promise((resolve) => setTimeout(resolve, 500))
+  }
+  throw new Error('Bunny contract condition did not become observable in time')
+}
+
+liveDescribe('Bunny Media Storage live contract', () => {
+  it(
+    'keeps Originals private and delivers then purges immutable Renditions',
+    async () => {
+      const config = parseBunnyStorageEnv(process.env)
+      const contract = assertNonProductionBunnyContract(process.env, config)
+      await verifyBunnyAccountContract(config, contract)
+      const storage = createBunnyStorage(config)
+      const identity = randomUUID()
+      const originalKey = `contracts/${identity}/original.jpg`
+      const bytes = new TextEncoder().encode(`bunny-media-contract:${identity}`)
+      const checksumSha256 = createHash('sha256').update(bytes).digest('hex')
+      const renditionKey = `contracts/${identity}/rendition-${checksumSha256}.jpg`
+      const storageEndpoint = new URL(
+        `https://${config.region}-s3.storage.bunnycdn.com`,
+      )
+      const unsignedOriginalUrl = new URL(
+        `/${config.originals.zone}/${originalKey}`,
+        storageEndpoint,
+      )
+      const unsignedListingUrl = new URL(
+        `/${config.originals.zone}`,
+        storageEndpoint,
+      )
+      unsignedListingUrl.searchParams.set('list-type', '2')
+      unsignedListingUrl.searchParams.set('prefix', `contracts/${identity}`)
+
+      try {
+        await storage.storeOriginal({
+          key: originalKey,
+          bytes,
+          contentType: 'image/jpeg',
+          checksumSha256,
+        })
+
+        await expect(storage.inspectOriginal(originalKey)).resolves.toMatchObject({
+          byteSize: bytes.byteLength,
+          contentType: 'image/jpeg',
+        })
+        await expect(storage.readOriginal(originalKey)).resolves.toEqual(bytes)
+
+        const [unsignedGet, unsignedListing] = await Promise.all([
+          fetch(unsignedOriginalUrl),
+          fetch(unsignedListingUrl),
+        ])
+        expect(unsignedGet.ok).toBe(false)
+        expect(unsignedListing.ok).toBe(false)
+        expect(await unsignedGet.text()).not.toContain(identity)
+        expect(await unsignedListing.text()).not.toContain(identity)
+
+        const publicUrl = await storage.storeRendition({
+          key: renditionKey,
+          bytes,
+          checksumSha256,
+        })
+        await expect(storage.inspectRendition(renditionKey)).resolves.toMatchObject({
+          byteSize: bytes.byteLength,
+          contentType: 'image/jpeg',
+        })
+        await waitFor(async () => {
+          const response = await fetch(publicUrl)
+          return response.ok && response.headers.get('content-type') === 'image/jpeg'
+        })
+        await waitFor(async () => {
+          const response = await fetch(publicUrl)
+          return renditionDeliveryHeadersMatchContract(
+            response.headers,
+            contract.browserTtlSeconds,
+          )
+        })
+
+        await storage.deleteRendition(renditionKey)
+        await storage.purgeRendition(renditionKey)
+        await waitFor(async () => {
+          const response = await fetch(publicUrl, { cache: 'no-store' })
+          return !response.ok
+        })
+
+        await storage.deleteOriginal(originalKey)
+        await expect(storage.inspectOriginal(originalKey)).rejects.toEqual(
+          new BunnyStorageError('not_found'),
+        )
+      } finally {
+        await Promise.allSettled([
+          storage.deleteRendition(renditionKey),
+          storage.purgeRendition(renditionKey),
+          storage.deleteOriginal(originalKey),
+        ])
+      }
+    },
+    45_000,
+  )
+})

--- a/lib/media/storage/bunny.live.test.ts
+++ b/lib/media/storage/bunny.live.test.ts
@@ -83,6 +83,7 @@ liveDescribe('Bunny Media Storage live contract', () => {
           key: renditionKey,
           bytes,
           checksumSha256,
+          contentType: 'image/jpeg',
         })
         await expect(storage.inspectRendition(renditionKey)).resolves.toMatchObject({
           byteSize: bytes.byteLength,

--- a/lib/media/storage/bunny.test.ts
+++ b/lib/media/storage/bunny.test.ts
@@ -91,6 +91,7 @@ describe('Bunny Media Storage', () => {
       key: renditionKey,
       bytes,
       checksumSha256: checksum,
+      contentType: 'image/jpeg',
     })
 
     const command = send.mock.calls[0]?.[0]
@@ -122,8 +123,28 @@ describe('Bunny Media Storage', () => {
         key: 'renditions/asset_01/photo-1600-v1.jpg',
         bytes,
         checksumSha256: checksum,
+        contentType: 'image/jpeg',
       }),
     ).rejects.toThrow('Rendition key must contain its SHA-256 checksum')
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-JPEG Rendition contract before contacting Bunny', async () => {
+    const send = vi.fn(async (_command: unknown) => ({}))
+    const storage = createBunnyStorage(config, {
+      renditionsClient: { send } as never,
+    })
+    const bytes = new TextEncoder().encode('public image bytes')
+    const checksum = createHash('sha256').update(bytes).digest('hex')
+
+    await expect(
+      storage.storeRendition({
+        key: `renditions/asset_01/photo-1600-${checksum}.webp`,
+        bytes,
+        checksumSha256: checksum,
+        contentType: 'image/webp',
+      } as never),
+    ).rejects.toThrow('JPEG object key')
     expect(send).not.toHaveBeenCalled()
   })
 

--- a/lib/media/storage/bunny.test.ts
+++ b/lib/media/storage/bunny.test.ts
@@ -1,0 +1,315 @@
+import { createHash } from 'node:crypto'
+
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+} from '@aws-sdk/client-s3'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import { BunnyStorageError, createBunnyStorage } from './bunny'
+
+const config = {
+  region: 'sg' as const,
+  originals: {
+    zone: 'cali-media-originals-preview',
+    password: 'originals-zone-password',
+  },
+  renditions: {
+    zone: 'cali-media-renditions-preview',
+    password: 'renditions-zone-password',
+    cdnBaseUrl: new URL('https://media-preview.cali.so/'),
+  },
+  cdnApiKey: 'preview-cdn-api-key',
+}
+
+describe('Bunny Media Storage', () => {
+  it('stores an Original only in the private zone with explicit integrity metadata', async () => {
+    const send = vi.fn(async (_command: unknown) => ({}))
+    const storage = createBunnyStorage(config, {
+      originalsClient: { send } as never,
+    })
+    const bytes = new TextEncoder().encode('private image bytes')
+    const checksum = createHash('sha256').update(bytes).digest('hex')
+
+    await storage.storeOriginal({
+      key: 'originals/asset_01/revision_01.heic',
+      bytes,
+      contentType: 'image/heic',
+      checksumSha256: checksum,
+    })
+
+    const command = send.mock.calls[0]?.[0]
+    expect(command).toBeInstanceOf(PutObjectCommand)
+    if (!(command instanceof PutObjectCommand)) throw new TypeError('Expected PutObject')
+    expect(command.input).toEqual({
+      Bucket: 'cali-media-originals-preview',
+      Key: 'originals/asset_01/revision_01.heic',
+      Body: bytes,
+      ContentLength: 19,
+      ContentType: 'image/heic',
+      ChecksumSHA256: Buffer.from(checksum, 'hex').toString('base64'),
+    })
+  })
+
+  it('normalizes provider failures while storing an Original', async () => {
+    const storage = createBunnyStorage(config, {
+      originalsClient: {
+        send: vi.fn(async (_command: unknown) => {
+          throw new Error('originals-zone-password raw provider detail')
+        }),
+      } as never,
+    })
+    const bytes = new TextEncoder().encode('private image bytes')
+
+    const write = storage.storeOriginal({
+      key: 'originals/asset_01/revision_01.heic',
+      bytes,
+      contentType: 'image/heic',
+      checksumSha256: createHash('sha256').update(bytes).digest('hex'),
+    })
+
+    await expect(write).rejects.toEqual(
+      new BunnyStorageError('provider_unavailable'),
+    )
+    await expect(write).rejects.not.toThrow(/raw provider detail/)
+  })
+
+  it('stores a Rendition in the public zone and derives its immutable CDN URL', async () => {
+    const send = vi.fn(async (_command: unknown) => ({}))
+    const storage = createBunnyStorage(config, {
+      renditionsClient: { send } as never,
+    })
+    const bytes = new TextEncoder().encode('public jpeg bytes')
+    const checksum = createHash('sha256').update(bytes).digest('hex')
+    const renditionKey = `renditions/asset_01/photo-1600-${checksum}.jpg`
+
+    const publicUrl = await storage.storeRendition({
+      key: renditionKey,
+      bytes,
+      checksumSha256: checksum,
+    })
+
+    const command = send.mock.calls[0]?.[0]
+    expect(command).toBeInstanceOf(PutObjectCommand)
+    if (!(command instanceof PutObjectCommand)) throw new TypeError('Expected PutObject')
+    expect(command.input).toEqual({
+      Bucket: 'cali-media-renditions-preview',
+      Key: renditionKey,
+      Body: bytes,
+      ContentLength: 17,
+      ContentType: 'image/jpeg',
+      ChecksumSHA256: Buffer.from(checksum, 'hex').toString('base64'),
+    })
+    expect(publicUrl).toBe(
+      `https://media-preview.cali.so/${renditionKey}`,
+    )
+  })
+
+  it('rejects an overwriteable Rendition key before contacting Bunny', async () => {
+    const send = vi.fn(async (_command: unknown) => ({}))
+    const storage = createBunnyStorage(config, {
+      renditionsClient: { send } as never,
+    })
+    const bytes = new TextEncoder().encode('public jpeg bytes')
+    const checksum = createHash('sha256').update(bytes).digest('hex')
+
+    await expect(
+      storage.storeRendition({
+        key: 'renditions/asset_01/photo-1600-v1.jpg',
+        bytes,
+        checksumSha256: checksum,
+      }),
+    ).rejects.toThrow('Rendition key must contain its SHA-256 checksum')
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('verifies a Rendition in the public zone', async () => {
+    const send = vi.fn(async (_command: unknown) => ({
+      ContentLength: 756_727,
+      ContentType: 'image/jpeg',
+      LastModified: new Date('2026-07-15T00:00:00.000Z'),
+    }))
+    const storage = createBunnyStorage(config, {
+      renditionsClient: { send } as never,
+    })
+
+    const object = await storage.inspectRendition(
+      'renditions/asset_01/photo-1600-v1.jpg',
+    )
+
+    const command = send.mock.calls[0]?.[0]
+    expect(command).toBeInstanceOf(HeadObjectCommand)
+    if (!(command instanceof HeadObjectCommand)) throw new TypeError('Expected HeadObject')
+    expect(command.input).toEqual({
+      Bucket: 'cali-media-renditions-preview',
+      Key: 'renditions/asset_01/photo-1600-v1.jpg',
+    })
+    expect(object).toEqual({
+      byteSize: 756_727,
+      contentType: 'image/jpeg',
+      lastModified: new Date('2026-07-15T00:00:00.000Z'),
+    })
+  })
+
+  it('verifies an Original without relying on an ETag', async () => {
+    const send = vi.fn(async (_command: unknown) => ({
+      ContentLength: 2_660_052,
+      ContentType: 'image/heic',
+      LastModified: new Date('2026-07-15T00:00:00.000Z'),
+      ETag: undefined,
+    }))
+    const storage = createBunnyStorage(config, {
+      originalsClient: { send } as never,
+    })
+
+    const object = await storage.inspectOriginal(
+      'originals/asset_01/revision_01.heic',
+    )
+
+    const command = send.mock.calls[0]?.[0]
+    expect(command).toBeInstanceOf(HeadObjectCommand)
+    if (!(command instanceof HeadObjectCommand)) throw new TypeError('Expected HeadObject')
+    expect(command.input).toEqual({
+      Bucket: 'cali-media-originals-preview',
+      Key: 'originals/asset_01/revision_01.heic',
+    })
+    expect(object).toEqual({
+      byteSize: 2_660_052,
+      contentType: 'image/heic',
+      lastModified: new Date('2026-07-15T00:00:00.000Z'),
+    })
+    expect(object).not.toHaveProperty('etag')
+  })
+
+  it('reports a missing Original without exposing Bunny provider details', async () => {
+    const providerError = Object.assign(
+      new Error('cali-media-originals-preview secret provider response'),
+      { $metadata: { httpStatusCode: 404 } },
+    )
+    const storage = createBunnyStorage(config, {
+      originalsClient: {
+        send: vi.fn(async (_command: unknown) => {
+          throw providerError
+        }),
+      } as never,
+    })
+
+    const inspection = storage.inspectOriginal(
+      'originals/asset_01/revision_01.heic',
+    )
+
+    await expect(inspection).rejects.toEqual(new BunnyStorageError('not_found'))
+    await expect(inspection).rejects.not.toThrow(/secret provider response/)
+  })
+
+  it('reads private Original bytes through the authenticated storage client', async () => {
+    const bytes = new TextEncoder().encode('private image bytes')
+    const send = vi.fn(async (_command: unknown) => ({
+      Body: {
+        transformToByteArray: async () => bytes,
+      },
+    }))
+    const storage = createBunnyStorage(config, {
+      originalsClient: { send } as never,
+    })
+
+    const original = await storage.readOriginal(
+      'originals/asset_01/revision_01.heic',
+    )
+
+    const command = send.mock.calls[0]?.[0]
+    expect(command).toBeInstanceOf(GetObjectCommand)
+    if (!(command instanceof GetObjectCommand)) throw new TypeError('Expected GetObject')
+    expect(command.input).toEqual({
+      Bucket: 'cali-media-originals-preview',
+      Key: 'originals/asset_01/revision_01.heic',
+    })
+    expect(original).toEqual(bytes)
+  })
+
+  it('deletes Originals and Renditions individually from their own zones', async () => {
+    const originalsSend = vi.fn(async (_command: unknown) => ({}))
+    const renditionsSend = vi.fn(async (_command: unknown) => ({}))
+    const storage = createBunnyStorage(config, {
+      originalsClient: { send: originalsSend } as never,
+      renditionsClient: { send: renditionsSend } as never,
+    })
+
+    await storage.deleteOriginal('originals/asset_01/revision_01.heic')
+    await storage.deleteRendition('renditions/asset_01/photo-1600-v1.jpg')
+
+    const originalCommand = originalsSend.mock.calls[0]?.[0]
+    const renditionCommand = renditionsSend.mock.calls[0]?.[0]
+    expect(originalCommand).toBeInstanceOf(DeleteObjectCommand)
+    expect(renditionCommand).toBeInstanceOf(DeleteObjectCommand)
+    if (
+      !(originalCommand instanceof DeleteObjectCommand) ||
+      !(renditionCommand instanceof DeleteObjectCommand)
+    ) {
+      throw new TypeError('Expected DeleteObject commands')
+    }
+    expect(originalCommand.input).toEqual({
+      Bucket: 'cali-media-originals-preview',
+      Key: 'originals/asset_01/revision_01.heic',
+    })
+    expect(renditionCommand.input).toEqual({
+      Bucket: 'cali-media-renditions-preview',
+      Key: 'renditions/asset_01/photo-1600-v1.jpg',
+    })
+  })
+
+  it('purges the exact immutable Rendition URL from Bunny CDN', async () => {
+    const fetch = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) =>
+      Response.json({ Message: 'Purged' }),
+    )
+    const storage = createBunnyStorage(config, { fetch })
+
+    await storage.purgeRendition('renditions/asset_01/photo-1600-v1.jpg')
+
+    const [requestUrl, init] = fetch.mock.calls[0] ?? []
+    const url = new URL(String(requestUrl))
+    expect(url.origin + url.pathname).toBe('https://api.bunny.net/purge')
+    expect(url.searchParams.get('url')).toBe(
+      'https://media-preview.cali.so/renditions/asset_01/photo-1600-v1.jpg',
+    )
+    expect(url.searchParams.get('async')).toBe('false')
+    expect(init).toMatchObject({
+      method: 'POST',
+      headers: { AccessKey: 'preview-cdn-api-key' },
+    })
+    expect(init?.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it.each([404, 503])(
+    'keeps an unconfirmed CDN purge retryable after HTTP %i',
+    async (status) => {
+      const storage = createBunnyStorage(config, {
+        fetch: vi.fn(async () => new Response(null, { status })),
+      })
+
+      await expect(
+        storage.purgeRendition('renditions/asset_01/photo-1600-v1.jpg'),
+      ).rejects.toEqual(new BunnyStorageError('provider_unavailable'))
+    },
+  )
+
+  it('exposes a partial Rendition removal when deletion succeeds but purge fails', async () => {
+    const send = vi.fn(async (_command: unknown) => ({}))
+    const storage = createBunnyStorage(config, {
+      renditionsClient: { send } as never,
+      fetch: vi.fn(async () => new Response(null, { status: 503 })),
+    })
+    const key = 'renditions/asset_01/photo-1600-v1.jpg'
+
+    await expect(storage.deleteRendition(key)).resolves.toBeUndefined()
+    await expect(storage.purgeRendition(key)).rejects.toEqual(
+      new BunnyStorageError('provider_unavailable'),
+    )
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send.mock.calls[0]?.[0]).toBeInstanceOf(DeleteObjectCommand)
+  })
+})

--- a/lib/media/storage/bunny.ts
+++ b/lib/media/storage/bunny.ts
@@ -1,0 +1,277 @@
+import 'server-only'
+
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3'
+
+export const BUNNY_STORAGE_REGIONS = [
+  'de',
+  'ny',
+  'sg',
+  'uk',
+  'se',
+  'la',
+  'jh',
+  'syd',
+] as const
+
+export type BunnyStorageRegion = (typeof BUNNY_STORAGE_REGIONS)[number]
+
+export type BunnyStorageConfig = {
+  region: BunnyStorageRegion
+  originals: {
+    zone: string
+    password: string
+  }
+  renditions: {
+    zone: string
+    password: string
+    cdnBaseUrl: URL
+  }
+  cdnApiKey: string
+}
+
+export type BunnyStorageErrorCode =
+  | 'not_found'
+  | 'invalid_response'
+  | 'provider_unavailable'
+
+export class BunnyStorageError extends Error {
+  constructor(readonly code: BunnyStorageErrorCode) {
+    super(
+      code === 'not_found'
+        ? 'Media object was not found.'
+        : 'Media storage is temporarily unavailable.',
+    )
+    this.name = 'BunnyStorageError'
+  }
+}
+
+type BunnyStorageDependencies = {
+  originalsClient?: S3Client
+  renditionsClient?: S3Client
+  fetch?: typeof fetch
+}
+
+function createClient(
+  region: BunnyStorageRegion,
+  credentials: { zone: string; password: string },
+) {
+  return new S3Client({
+    endpoint: `https://${region}-s3.storage.bunnycdn.com`,
+    region,
+    forcePathStyle: true,
+    credentials: {
+      accessKeyId: credentials.zone,
+      secretAccessKey: credentials.password,
+    },
+  })
+}
+
+function assertObjectKey(key: string) {
+  if (
+    !key ||
+    key.startsWith('/') ||
+    key.includes('\\') ||
+    key.split('/').some((segment) => !segment || segment === '.' || segment === '..') ||
+    /[\u0000-\u001f?#]/.test(key)
+  ) {
+    throw new TypeError('Invalid Bunny object key')
+  }
+}
+
+function checksumBase64(checksumSha256: string) {
+  if (!/^[a-f0-9]{64}$/.test(checksumSha256)) {
+    throw new TypeError('Invalid SHA-256 checksum')
+  }
+  return Buffer.from(checksumSha256, 'hex').toString('base64')
+}
+
+function assertContentAddressedRenditionKey(
+  key: string,
+  checksumSha256: string,
+) {
+  assertObjectKey(key)
+  checksumBase64(checksumSha256)
+  if (!key.includes(checksumSha256)) {
+    throw new TypeError('Rendition key must contain its SHA-256 checksum')
+  }
+}
+
+function providerStatus(error: unknown) {
+  if (typeof error !== 'object' || error === null) return undefined
+  const metadata = Reflect.get(error, '$metadata')
+  if (typeof metadata !== 'object' || metadata === null) return undefined
+  const status = Reflect.get(metadata, 'httpStatusCode')
+  return typeof status === 'number' ? status : undefined
+}
+
+export function createBunnyStorage(
+  config: BunnyStorageConfig,
+  dependencies: BunnyStorageDependencies = {},
+) {
+  const originals =
+    dependencies.originalsClient ?? createClient(config.region, config.originals)
+  const renditions =
+    dependencies.renditionsClient ?? createClient(config.region, config.renditions)
+  const request = dependencies.fetch ?? fetch
+
+  function publicRenditionUrl(key: string) {
+    assertObjectKey(key)
+    const encodedKey = key.split('/').map(encodeURIComponent).join('/')
+    return new URL(encodedKey, config.renditions.cdnBaseUrl).toString()
+  }
+
+  async function deleteObject(client: S3Client, bucket: string, key: string) {
+    assertObjectKey(key)
+    try {
+      await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }))
+    } catch (error) {
+      if (providerStatus(error) === 404) return
+      throw new BunnyStorageError('provider_unavailable')
+    }
+  }
+
+  async function inspectObject(client: S3Client, bucket: string, key: string) {
+    assertObjectKey(key)
+    let output
+    try {
+      output = await client.send(
+        new HeadObjectCommand({
+          Bucket: bucket,
+          Key: key,
+        }),
+      )
+    } catch (error) {
+      throw new BunnyStorageError(
+        providerStatus(error) === 404 ? 'not_found' : 'provider_unavailable',
+      )
+    }
+    if (
+      typeof output.ContentLength !== 'number' ||
+      output.ContentLength < 0 ||
+      typeof output.ContentType !== 'string' ||
+      !output.ContentType ||
+      !(output.LastModified instanceof Date)
+    ) {
+      throw new BunnyStorageError('invalid_response')
+    }
+    return {
+      byteSize: output.ContentLength,
+      contentType: output.ContentType,
+      lastModified: output.LastModified,
+    }
+  }
+
+  return {
+    async storeOriginal(input: {
+      key: string
+      bytes: Uint8Array
+      contentType: string
+      checksumSha256: string
+    }) {
+      assertObjectKey(input.key)
+      const checksum = checksumBase64(input.checksumSha256)
+      try {
+        await originals.send(
+          new PutObjectCommand({
+            Bucket: config.originals.zone,
+            Key: input.key,
+            Body: input.bytes,
+            ContentLength: input.bytes.byteLength,
+            ContentType: input.contentType,
+            ChecksumSHA256: checksum,
+          }),
+        )
+      } catch {
+        throw new BunnyStorageError('provider_unavailable')
+      }
+    },
+
+    async inspectOriginal(key: string) {
+      return inspectObject(originals, config.originals.zone, key)
+    },
+
+    async readOriginal(key: string) {
+      assertObjectKey(key)
+      let output
+      try {
+        output = await originals.send(
+          new GetObjectCommand({
+            Bucket: config.originals.zone,
+            Key: key,
+          }),
+        )
+      } catch (error) {
+        throw new BunnyStorageError(
+          providerStatus(error) === 404 ? 'not_found' : 'provider_unavailable',
+        )
+      }
+      if (!output.Body) throw new BunnyStorageError('invalid_response')
+      try {
+        return await output.Body.transformToByteArray()
+      } catch {
+        throw new BunnyStorageError('provider_unavailable')
+      }
+    },
+
+    async storeRendition(input: {
+      key: string
+      bytes: Uint8Array
+      checksumSha256: string
+    }) {
+      assertContentAddressedRenditionKey(input.key, input.checksumSha256)
+      const checksum = checksumBase64(input.checksumSha256)
+      try {
+        await renditions.send(
+          new PutObjectCommand({
+            Bucket: config.renditions.zone,
+            Key: input.key,
+            Body: input.bytes,
+            ContentLength: input.bytes.byteLength,
+            ContentType: 'image/jpeg',
+            ChecksumSHA256: checksum,
+          }),
+        )
+      } catch {
+        throw new BunnyStorageError('provider_unavailable')
+      }
+      return publicRenditionUrl(input.key)
+    },
+
+    async inspectRendition(key: string) {
+      return inspectObject(renditions, config.renditions.zone, key)
+    },
+
+    deleteOriginal(key: string) {
+      return deleteObject(originals, config.originals.zone, key)
+    },
+
+    deleteRendition(key: string) {
+      return deleteObject(renditions, config.renditions.zone, key)
+    },
+
+    async purgeRendition(key: string) {
+      const url = new URL('https://api.bunny.net/purge')
+      url.searchParams.set('url', publicRenditionUrl(key))
+      url.searchParams.set('async', 'false')
+      try {
+        const response = await request(url, {
+          method: 'POST',
+          headers: { AccessKey: config.cdnApiKey },
+          signal: AbortSignal.timeout(10_000),
+        })
+        if (response.ok) return
+      } catch {
+        throw new BunnyStorageError('provider_unavailable')
+      }
+      throw new BunnyStorageError('provider_unavailable')
+    },
+
+    publicRenditionUrl,
+  }
+}

--- a/lib/media/storage/bunny.ts
+++ b/lib/media/storage/bunny.ts
@@ -97,6 +97,9 @@ function assertContentAddressedRenditionKey(
 ) {
   assertObjectKey(key)
   checksumBase64(checksumSha256)
+  if (!key.toLowerCase().endsWith('.jpg')) {
+    throw new TypeError('Renditions must use a JPEG object key')
+  }
   if (!key.includes(checksumSha256)) {
     throw new TypeError('Rendition key must contain its SHA-256 checksum')
   }
@@ -223,8 +226,12 @@ export function createBunnyStorage(
       key: string
       bytes: Uint8Array
       checksumSha256: string
+      contentType: 'image/jpeg'
     }) {
       assertContentAddressedRenditionKey(input.key, input.checksumSha256)
+      if (input.contentType !== 'image/jpeg') {
+        throw new TypeError('Renditions must use the image/jpeg content type')
+      }
       const checksum = checksumBase64(input.checksumSha256)
       try {
         await renditions.send(
@@ -233,7 +240,7 @@ export function createBunnyStorage(
             Key: input.key,
             Body: input.bytes,
             ContentLength: input.bytes.byteLength,
-            ContentType: 'image/jpeg',
+            ContentType: input.contentType,
             ChecksumSHA256: checksum,
           }),
         )

--- a/lib/media/storage/config.test.ts
+++ b/lib/media/storage/config.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import { parseBunnyStorageEnv } from './config'
+
+const validEnvironment = {
+  BUNNY_MEDIA_REGION: 'sg',
+  BUNNY_ORIGINALS_ZONE: 'cali-media-originals-preview',
+  BUNNY_ORIGINALS_PASSWORD: 'originals-zone-password',
+  BUNNY_RENDITIONS_ZONE: 'cali-media-renditions-preview',
+  BUNNY_RENDITIONS_PASSWORD: 'renditions-zone-password',
+  BUNNY_RENDITIONS_CDN_URL: 'https://media-preview.cali.so',
+  BUNNY_CDN_API_KEY: 'preview-cdn-api-key',
+}
+
+describe('Bunny Media Storage configuration', () => {
+  it('accepts distinct private and public zones in a supported region', () => {
+    expect(parseBunnyStorageEnv(validEnvironment)).toEqual({
+      region: 'sg',
+      originals: {
+        zone: 'cali-media-originals-preview',
+        password: 'originals-zone-password',
+      },
+      renditions: {
+        zone: 'cali-media-renditions-preview',
+        password: 'renditions-zone-password',
+        cdnBaseUrl: new URL('https://media-preview.cali.so/'),
+      },
+      cdnApiKey: 'preview-cdn-api-key',
+    })
+  })
+
+  it('rejects a storage endpoint as the public CDN origin without exposing secrets', () => {
+    const unsafe = {
+      ...validEnvironment,
+      BUNNY_ORIGINALS_PASSWORD: 'do-not-print-originals-secret',
+      BUNNY_RENDITIONS_PASSWORD: 'do-not-print-renditions-secret',
+      BUNNY_CDN_API_KEY: 'do-not-print-cdn-secret',
+      BUNNY_RENDITIONS_CDN_URL: 'https://sg-s3.storage.bunnycdn.com',
+    }
+
+    let message = ''
+    try {
+      parseBunnyStorageEnv(unsafe)
+    } catch (error) {
+      message = String(error)
+    }
+
+    expect(message).toContain('BUNNY_RENDITIONS_CDN_URL')
+    expect(message).not.toContain('do-not-print')
+    expect(message).not.toContain('storage.bunnycdn.com')
+  })
+})

--- a/lib/media/storage/config.ts
+++ b/lib/media/storage/config.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod'
+
+import {
+  BUNNY_STORAGE_REGIONS,
+  type BunnyStorageConfig,
+} from './bunny'
+
+const nonEmptySecret = z.string().trim().min(1)
+const zoneName = z.string().trim().min(1).max(64).regex(/^[a-zA-Z0-9-]+$/)
+
+const cdnBaseUrl = z.url().transform((value, context) => {
+  const url = new URL(value)
+  if (
+    url.protocol !== 'https:' ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash ||
+    url.hostname === 'storage.bunnycdn.com' ||
+    url.hostname.endsWith('.storage.bunnycdn.com') ||
+    (url.pathname !== '/' && url.pathname !== '')
+  ) {
+    context.addIssue({
+      code: 'custom',
+      message: 'Rendition CDN URL must be an HTTPS origin',
+    })
+    return z.NEVER
+  }
+  url.pathname = '/'
+  return url
+})
+
+const bunnyStorageEnvironmentSchema = z
+  .object({
+    BUNNY_MEDIA_REGION: z.enum(BUNNY_STORAGE_REGIONS),
+    BUNNY_ORIGINALS_ZONE: zoneName,
+    BUNNY_ORIGINALS_PASSWORD: nonEmptySecret,
+    BUNNY_RENDITIONS_ZONE: zoneName,
+    BUNNY_RENDITIONS_PASSWORD: nonEmptySecret,
+    BUNNY_RENDITIONS_CDN_URL: cdnBaseUrl,
+    BUNNY_CDN_API_KEY: nonEmptySecret,
+  })
+  .superRefine((environment, context) => {
+    if (environment.BUNNY_ORIGINALS_ZONE === environment.BUNNY_RENDITIONS_ZONE) {
+      context.addIssue({
+        code: 'custom',
+        path: ['BUNNY_RENDITIONS_ZONE'],
+        message: 'Originals and Renditions require distinct zones',
+      })
+    }
+  })
+  .transform(
+    (environment): BunnyStorageConfig => ({
+      region: environment.BUNNY_MEDIA_REGION,
+      originals: {
+        zone: environment.BUNNY_ORIGINALS_ZONE,
+        password: environment.BUNNY_ORIGINALS_PASSWORD,
+      },
+      renditions: {
+        zone: environment.BUNNY_RENDITIONS_ZONE,
+        password: environment.BUNNY_RENDITIONS_PASSWORD,
+        cdnBaseUrl: environment.BUNNY_RENDITIONS_CDN_URL,
+      },
+      cdnApiKey: environment.BUNNY_CDN_API_KEY,
+    }),
+  )
+
+export function parseBunnyStorageEnv(source: Record<string, string | undefined>) {
+  const result = bunnyStorageEnvironmentSchema.safeParse(source)
+  if (result.success) return result.data
+
+  const fields = [
+    ...new Set(result.error.issues.map((issue) => issue.path.join('.')).filter(Boolean)),
+  ]
+  throw new Error(`Invalid Bunny Media Storage environment: ${fields.join(', ')}`)
+}

--- a/lib/media/storage/contract.test.ts
+++ b/lib/media/storage/contract.test.ts
@@ -35,7 +35,11 @@ const contractExpectations = {
   browserTtlSeconds: 31_536_000,
 }
 
-function accountFetch(options?: { originalsPullZone?: boolean; ttl?: number }) {
+function accountFetch(options?: {
+  forceSsl?: boolean
+  originalsPullZone?: boolean
+  ttl?: number
+}) {
   const ttl = options?.ttl ?? contractExpectations.edgeTtlSeconds
   return vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
     expect(init?.headers).toEqual({ AccessKey: 'preview-account-api-key' })
@@ -73,7 +77,12 @@ function accountFetch(options?: { originalsPullZone?: boolean; ttl?: number }) {
             Enabled: true,
             Suspended: false,
             StorageZoneId: 202,
-            Hostnames: [{ Value: 'media-preview.cali.so', ForceSSL: true }],
+            Hostnames: [
+              {
+                Value: 'media-preview.cali.so',
+                ForceSSL: options?.forceSsl ?? true,
+              },
+            ],
             CacheControlMaxAgeOverride: ttl,
             CacheControlPublicMaxAgeOverride: ttl,
           },
@@ -167,6 +176,16 @@ describe('Bunny Media Storage account contract', () => {
         config,
         contractExpectations,
         accountFetch({ ttl: contractExpectations.edgeTtlSeconds - 1 }),
+      ),
+    ).rejects.toThrow('cache contract')
+  })
+
+  it('requires HTTPS enforcement on the public Rendition hostname', async () => {
+    await expect(
+      verifyBunnyAccountContract(
+        config,
+        contractExpectations,
+        accountFetch({ forceSsl: false }),
       ),
     ).rejects.toThrow('cache contract')
   })

--- a/lib/media/storage/contract.test.ts
+++ b/lib/media/storage/contract.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import {
+  assertNonProductionBunnyContract,
+  renditionDeliveryHeadersMatchContract,
+  verifyBunnyAccountContract,
+} from './contract'
+
+const config = {
+  region: 'sg' as const,
+  originals: {
+    zone: 'cali-media-originals-preview',
+    password: 'originals-zone-password',
+  },
+  renditions: {
+    zone: 'cali-media-renditions-preview',
+    password: 'renditions-zone-password',
+    cdnBaseUrl: new URL('https://media-preview.cali.so/'),
+  },
+  cdnApiKey: 'preview-account-api-key',
+}
+
+const contractEnvironment = {
+  BUNNY_STORAGE_CONTRACT_ENVIRONMENT: 'non-production',
+  BUNNY_STORAGE_CONTRACT_ORIGIN: 'https://cali.so',
+  BUNNY_STORAGE_CONTRACT_EDGE_TTL_SECONDS: '31536000',
+  BUNNY_STORAGE_CONTRACT_BROWSER_TTL_SECONDS: '31536000',
+}
+
+const contractExpectations = {
+  origin: new URL('https://cali.so'),
+  edgeTtlSeconds: 31_536_000,
+  browserTtlSeconds: 31_536_000,
+}
+
+function accountFetch(options?: { originalsPullZone?: boolean; ttl?: number }) {
+  const ttl = options?.ttl ?? contractExpectations.edgeTtlSeconds
+  return vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    expect(init?.headers).toEqual({ AccessKey: 'preview-account-api-key' })
+    const url = new URL(String(input))
+    if (url.pathname === '/storagezone') {
+      return Response.json([
+        { Id: 101, Name: 'cali-media-originals-preview', Deleted: false },
+        { Id: 202, Name: 'cali-media-renditions-preview', Deleted: false },
+      ])
+    }
+    if (url.pathname === '/pullzone') {
+      return Response.json({
+        Items: [
+          ...(options?.originalsPullZone
+            ? [
+                {
+                  Id: 303,
+                  Name: 'unsafe-originals-preview',
+                  OriginUrl:
+                    'https://storage.bunnycdn.com/cali-media-originals-preview',
+                  Enabled: true,
+                  Suspended: false,
+                  StorageZoneId: 101,
+                  Hostnames: [{ Value: 'originals-preview.cali.so' }],
+                  CacheControlMaxAgeOverride: ttl,
+                  CacheControlPublicMaxAgeOverride: ttl,
+                },
+              ]
+            : []),
+          {
+            Id: 404,
+            Name: 'media-renditions-preview',
+            OriginUrl:
+              'https://storage.bunnycdn.com/cali-media-renditions-preview',
+            Enabled: true,
+            Suspended: false,
+            StorageZoneId: 202,
+            Hostnames: [{ Value: 'media-preview.cali.so', ForceSSL: true }],
+            CacheControlMaxAgeOverride: ttl,
+            CacheControlPublicMaxAgeOverride: ttl,
+          },
+        ],
+      })
+    }
+    return new Response(null, { status: 404 })
+  })
+}
+
+describe('Bunny Media Storage live contract guards', () => {
+  it('accepts only an explicit non-production environment and exact site origin', () => {
+    expect(
+      assertNonProductionBunnyContract(contractEnvironment, config),
+    ).toEqual(contractExpectations)
+  })
+
+  it.each([
+    [{}, 'BUNNY_STORAGE_CONTRACT_ENVIRONMENT'],
+    [
+      {
+        ...contractEnvironment,
+        BUNNY_STORAGE_CONTRACT_ENVIRONMENT: 'production',
+      },
+      'BUNNY_STORAGE_CONTRACT_ENVIRONMENT',
+    ],
+    [
+      {
+        ...contractEnvironment,
+        BUNNY_STORAGE_CONTRACT_ORIGIN: 'https://preview.cali.so',
+      },
+      'BUNNY_STORAGE_CONTRACT_ORIGIN',
+    ],
+    [
+      {
+        ...contractEnvironment,
+        BUNNY_STORAGE_CONTRACT_EDGE_TTL_SECONDS: '',
+      },
+      'BUNNY_STORAGE_CONTRACT_EDGE_TTL_SECONDS',
+    ],
+  ])('rejects unsafe activation through %s', (environment, field) => {
+    expect(() =>
+      assertNonProductionBunnyContract(environment, config),
+    ).toThrow(field)
+  })
+
+  it('rejects production-looking remote resources before a live request', () => {
+    expect(() =>
+      assertNonProductionBunnyContract(contractEnvironment, {
+        ...config,
+        originals: { ...config.originals, zone: 'cali-media-originals-prod' },
+      }),
+    ).toThrow('BUNNY_ORIGINALS_ZONE')
+
+    expect(() =>
+      assertNonProductionBunnyContract(contractEnvironment, {
+        ...config,
+        renditions: {
+          ...config.renditions,
+          cdnBaseUrl: new URL('https://media.cali.so'),
+        },
+      }),
+    ).toThrow('BUNNY_RENDITIONS_CDN_URL')
+  })
+})
+
+describe('Bunny Media Storage account contract', () => {
+  it('verifies Original privacy and the Rendition Pull Zone cache policy', async () => {
+    await expect(
+      verifyBunnyAccountContract(config, contractExpectations, accountFetch()),
+    ).resolves.toEqual({
+        originalsZoneId: 101,
+        renditionsZoneId: 202,
+        renditionsPullZoneId: 404,
+      })
+  })
+
+  it('rejects an Original Storage Zone attached to a Pull Zone', async () => {
+    await expect(
+      verifyBunnyAccountContract(
+        config,
+        contractExpectations,
+        accountFetch({ originalsPullZone: true }),
+      ),
+    ).rejects.toThrow('Original Storage Zone')
+  })
+
+  it('rejects an insufficient browser or edge TTL', async () => {
+    await expect(
+      verifyBunnyAccountContract(
+        config,
+        contractExpectations,
+        accountFetch({ ttl: contractExpectations.edgeTtlSeconds - 1 }),
+      ),
+    ).rejects.toThrow('cache contract')
+  })
+
+  it('requires long-lived browser headers and an observable edge cache hit', () => {
+    expect(
+      renditionDeliveryHeadersMatchContract(
+        new Headers({
+          'cache-control': 'public, max-age=31536000',
+          'cdn-cache': 'HIT',
+        }),
+        contractExpectations.browserTtlSeconds,
+      ),
+    ).toBe(true)
+    expect(
+      renditionDeliveryHeadersMatchContract(
+        new Headers({
+          'cache-control': 'public, max-age=3600',
+          'cdn-cache': 'HIT',
+        }),
+        contractExpectations.browserTtlSeconds,
+      ),
+    ).toBe(false)
+    expect(
+      renditionDeliveryHeadersMatchContract(
+        new Headers({ 'cache-control': 'public, max-age=31536000' }),
+        contractExpectations.browserTtlSeconds,
+      ),
+    ).toBe(false)
+  })
+})

--- a/lib/media/storage/contract.ts
+++ b/lib/media/storage/contract.ts
@@ -1,0 +1,231 @@
+import 'server-only'
+
+import { z } from 'zod'
+
+import type { BunnyStorageConfig } from './bunny'
+
+export const BUNNY_CONTRACT_ORIGIN = 'https://cali.so'
+
+export type BunnyContractExpectations = {
+  origin: URL
+  edgeTtlSeconds: number
+  browserTtlSeconds: number
+}
+
+const nonProductionMarker =
+  /(^|[.-])(dev|test|testing|stage|staging|preview|sandbox|nonprod|non-production)([.-]|$)/i
+const productionMarker = /(^|[.-])(prod|production|live)([.-]|$)/i
+
+const storageZoneSchema = z.object({
+  Id: z.number().int().positive(),
+  Name: z.string().trim().min(1).nullable(),
+  Deleted: z.boolean().optional(),
+})
+
+const hostnameSchema = z.object({
+  Value: z.string().trim().min(1).nullable().optional(),
+  ForceSSL: z.boolean().optional(),
+})
+
+const pullZoneSchema = z.object({
+  Id: z.number().int().positive(),
+  Name: z.string().trim().min(1).nullable().optional(),
+  OriginUrl: z.string().trim().nullable().optional(),
+  Enabled: z.boolean(),
+  Suspended: z.boolean(),
+  StorageZoneId: z.number().int().nullable().optional(),
+  Hostnames: z.array(hostnameSchema).nullable().optional(),
+  CacheControlMaxAgeOverride: z.number().int().nullable().optional(),
+  CacheControlPublicMaxAgeOverride: z.number().int().nullable().optional(),
+})
+
+const storageZonesSchema = z
+  .union([
+    z.array(storageZoneSchema),
+    z.object({ Items: z.array(storageZoneSchema) }),
+  ])
+  .transform((value) => (Array.isArray(value) ? value : value.Items))
+
+const pullZonesSchema = z
+  .union([
+    z.array(pullZoneSchema),
+    z.object({ Items: z.array(pullZoneSchema) }),
+  ])
+  .transform((value) => (Array.isArray(value) ? value : value.Items))
+
+function assertNonProductionResource(field: string, value: string) {
+  if (productionMarker.test(value) || !nonProductionMarker.test(value)) {
+    throw new Error(`Unsafe Bunny storage contract environment: ${field}`)
+  }
+}
+
+function contractTtlSeconds(
+  source: Record<string, string | undefined>,
+  field:
+    | 'BUNNY_STORAGE_CONTRACT_EDGE_TTL_SECONDS'
+    | 'BUNNY_STORAGE_CONTRACT_BROWSER_TTL_SECONDS',
+) {
+  const value = source[field]
+  if (!value || !/^\d+$/.test(value)) {
+    throw new Error(`Unsafe Bunny storage contract environment: ${field}`)
+  }
+  const seconds = Number(value)
+  if (!Number.isSafeInteger(seconds) || seconds <= 0) {
+    throw new Error(`Unsafe Bunny storage contract environment: ${field}`)
+  }
+  return seconds
+}
+
+export function assertNonProductionBunnyContract(
+  source: Record<string, string | undefined>,
+  config: BunnyStorageConfig,
+) {
+  if (source.BUNNY_STORAGE_CONTRACT_ENVIRONMENT !== 'non-production') {
+    throw new Error(
+      'Unsafe Bunny storage contract environment: BUNNY_STORAGE_CONTRACT_ENVIRONMENT',
+    )
+  }
+  if (source.BUNNY_STORAGE_CONTRACT_ORIGIN !== BUNNY_CONTRACT_ORIGIN) {
+    throw new Error(
+      'Unsafe Bunny storage contract environment: BUNNY_STORAGE_CONTRACT_ORIGIN',
+    )
+  }
+
+  assertNonProductionResource('BUNNY_ORIGINALS_ZONE', config.originals.zone)
+  assertNonProductionResource('BUNNY_RENDITIONS_ZONE', config.renditions.zone)
+  assertNonProductionResource(
+    'BUNNY_RENDITIONS_CDN_URL',
+    config.renditions.cdnBaseUrl.hostname,
+  )
+
+  return {
+    origin: new URL(BUNNY_CONTRACT_ORIGIN),
+    edgeTtlSeconds: contractTtlSeconds(
+      source,
+      'BUNNY_STORAGE_CONTRACT_EDGE_TTL_SECONDS',
+    ),
+    browserTtlSeconds: contractTtlSeconds(
+      source,
+      'BUNNY_STORAGE_CONTRACT_BROWSER_TTL_SECONDS',
+    ),
+  }
+}
+
+function originReferencesStorageZone(origin: string | null | undefined, zone: string) {
+  if (!origin) return false
+  try {
+    const url = new URL(origin)
+    return url.pathname.split('/').filter(Boolean).includes(zone)
+  } catch {
+    return origin.includes(zone)
+  }
+}
+
+async function requestBunnyJson(
+  path: string,
+  apiKey: string,
+  request: typeof fetch,
+) {
+  let response: Response
+  try {
+    response = await request(new URL(path, 'https://api.bunny.net'), {
+      headers: { AccessKey: apiKey },
+      signal: AbortSignal.timeout(10_000),
+    })
+  } catch {
+    throw new Error('Bunny account contract is unavailable')
+  }
+  if (!response.ok) {
+    throw new Error('Bunny account contract is unavailable')
+  }
+  try {
+    return await response.json()
+  } catch {
+    throw new Error('Bunny account contract returned an invalid response')
+  }
+}
+
+export async function verifyBunnyAccountContract(
+  config: BunnyStorageConfig,
+  expectations: BunnyContractExpectations,
+  request: typeof fetch = fetch,
+) {
+  const [storagePayload, pullPayload] = await Promise.all([
+    requestBunnyJson('/storagezone?perPage=1000', config.cdnApiKey, request),
+    requestBunnyJson(
+      '/pullzone?perPage=1000&includeCertificate=false',
+      config.cdnApiKey,
+      request,
+    ),
+  ])
+  const storageResult = storageZonesSchema.safeParse(storagePayload)
+  const pullResult = pullZonesSchema.safeParse(pullPayload)
+  if (!storageResult.success || !pullResult.success) {
+    throw new Error('Bunny account contract returned an invalid response')
+  }
+
+  const originalsZone = storageResult.data.find(
+    (zone) => zone.Name === config.originals.zone && !zone.Deleted,
+  )
+  const renditionsZone = storageResult.data.find(
+    (zone) => zone.Name === config.renditions.zone && !zone.Deleted,
+  )
+  if (!originalsZone || !renditionsZone || originalsZone.Id === renditionsZone.Id) {
+    throw new Error('Bunny storage zones do not match the Media Library contract')
+  }
+
+  const originalsPullZone = pullResult.data.find(
+    (zone) =>
+      zone.StorageZoneId === originalsZone.Id ||
+      originReferencesStorageZone(zone.OriginUrl, config.originals.zone),
+  )
+  if (originalsPullZone) {
+    throw new Error('The Original Storage Zone must not have a Pull Zone')
+  }
+
+  const cdnHostname = config.renditions.cdnBaseUrl.hostname.toLowerCase()
+  const renditionsPullZone = pullResult.data.find(
+    (zone) =>
+      zone.StorageZoneId === renditionsZone.Id &&
+      zone.Hostnames?.some(
+        (hostname) => hostname.Value?.toLowerCase() === cdnHostname,
+      ),
+  )
+  if (
+    !renditionsPullZone ||
+    !renditionsPullZone.Enabled ||
+    renditionsPullZone.Suspended ||
+    renditionsPullZone.CacheControlMaxAgeOverride !==
+      expectations.edgeTtlSeconds ||
+    renditionsPullZone.CacheControlPublicMaxAgeOverride !==
+      expectations.browserTtlSeconds
+  ) {
+    throw new Error('The Rendition Pull Zone does not match the cache contract')
+  }
+
+  return {
+    originalsZoneId: originalsZone.Id,
+    renditionsZoneId: renditionsZone.Id,
+    renditionsPullZoneId: renditionsPullZone.Id,
+  }
+}
+
+function cacheControlMaxAge(headers: Headers) {
+  const cacheControl = headers.get('cache-control')
+  const match = cacheControl?.match(/(?:^|,)\s*max-age=(?:")?(\d+)/i)
+  return match ? Number(match[1]) : undefined
+}
+
+export function renditionDeliveryHeadersMatchContract(
+  headers: Headers,
+  browserTtlSeconds: number,
+) {
+  const maxAge = cacheControlMaxAge(headers)
+  const edgeCache = headers.get('cdn-cache')?.toUpperCase()
+  const age = Number(headers.get('age'))
+  return (
+    maxAge !== undefined &&
+    maxAge === browserTtlSeconds &&
+    (edgeCache === 'HIT' || (Number.isFinite(age) && age > 0))
+  )
+}

--- a/lib/media/storage/contract.ts
+++ b/lib/media/storage/contract.ts
@@ -188,7 +188,9 @@ export async function verifyBunnyAccountContract(
     (zone) =>
       zone.StorageZoneId === renditionsZone.Id &&
       zone.Hostnames?.some(
-        (hostname) => hostname.Value?.toLowerCase() === cdnHostname,
+        (hostname) =>
+          hostname.Value?.toLowerCase() === cdnHostname &&
+          hostname.ForceSSL === true,
       ),
   )
   if (

--- a/lib/media/storage/server.ts
+++ b/lib/media/storage/server.ts
@@ -1,0 +1,11 @@
+import 'server-only'
+
+import { createBunnyStorage } from './bunny'
+import { parseBunnyStorageEnv } from './config'
+
+let storage: ReturnType<typeof createBunnyStorage> | undefined
+
+export function getMediaStorage() {
+  storage ??= createBunnyStorage(parseBunnyStorageEnv(process.env))
+  return storage
+}

--- a/lib/media/storage/upload.test.ts
+++ b/lib/media/storage/upload.test.ts
@@ -98,6 +98,22 @@ describe('same-origin Original upload transfer', () => {
     expect(f.storage.storeOriginal).not.toHaveBeenCalled()
   })
 
+  it('keeps authorization infrastructure failures retryable', async () => {
+    const f = fixture()
+    f.authorize.mockRejectedValue(new Error('database unavailable'))
+
+    const response = await storeOriginalFromSameOriginRequest({
+      request: uploadRequest(),
+      canonicalBaseUrl,
+      expectation,
+      ...f,
+    })
+
+    expect(response.status).toBe(503)
+    expect(response.headers.get('retry-after')).toBe('5')
+    expect(f.storage.storeOriginal).not.toHaveBeenCalled()
+  })
+
   it.each<
     [
       string,

--- a/lib/media/storage/upload.test.ts
+++ b/lib/media/storage/upload.test.ts
@@ -1,0 +1,189 @@
+import { createHash } from 'node:crypto'
+
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import {
+  MAX_ORIGINAL_UPLOAD_BYTES,
+  storeOriginalFromSameOriginRequest,
+} from './upload'
+
+const canonicalBaseUrl = new URL('https://cali.so')
+const bytes = new TextEncoder().encode('private image bytes')
+const expectation = {
+  key: 'originals/asset_01/revision_01.heic',
+  contentType: 'image/heic',
+  byteSize: bytes.byteLength,
+  checksumSha256: createHash('sha256').update(bytes).digest('hex'),
+}
+
+function uploadRequest(
+  body: BodyInit = bytes,
+  headers: Record<string, string> = {},
+) {
+  return new Request('https://cali.so/api/admin/media/uploads/intent_01', {
+    method: 'PUT',
+    headers: {
+      'content-type': expectation.contentType,
+      origin: canonicalBaseUrl.origin,
+      'sec-fetch-site': 'same-origin',
+      'x-media-checksum-sha256': expectation.checksumSha256,
+      ...headers,
+    },
+    body,
+  })
+}
+
+function fixture() {
+  return {
+    authorize: vi.fn(async () => true),
+    storage: { storeOriginal: vi.fn(async () => undefined) },
+  }
+}
+
+describe('same-origin Original upload transfer', () => {
+  it('stores bytes only after binding them to an authorized Upload Intent', async () => {
+    const f = fixture()
+
+    const response = await storeOriginalFromSameOriginRequest({
+      request: uploadRequest(),
+      canonicalBaseUrl,
+      expectation,
+      ...f,
+    })
+
+    expect(response.status).toBe(204)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(f.authorize).toHaveBeenCalledTimes(1)
+    expect(f.storage.storeOriginal).toHaveBeenCalledWith({
+      key: expectation.key,
+      bytes,
+      contentType: expectation.contentType,
+      checksumSha256: expectation.checksumSha256,
+    })
+  })
+
+  it.each<[string, Record<string, string>]>([
+    ['wrong origin', { origin: 'https://attacker.example' }],
+    ['cross-site context', { 'sec-fetch-site': 'cross-site' }],
+    ['missing origin', { origin: '' }],
+  ])('rejects a %s before authorization or storage', async (_label, headers) => {
+    const f = fixture()
+
+    const response = await storeOriginalFromSameOriginRequest({
+      request: uploadRequest(bytes, headers),
+      canonicalBaseUrl,
+      expectation,
+      ...f,
+    })
+
+    expect(response.status).toBe(403)
+    expect(f.authorize).not.toHaveBeenCalled()
+    expect(f.storage.storeOriginal).not.toHaveBeenCalled()
+  })
+
+  it('requires owner authorization on every transfer', async () => {
+    const f = fixture()
+    f.authorize.mockResolvedValue(false)
+
+    const response = await storeOriginalFromSameOriginRequest({
+      request: uploadRequest(),
+      canonicalBaseUrl,
+      expectation,
+      ...f,
+    })
+
+    expect(response.status).toBe(401)
+    expect(f.storage.storeOriginal).not.toHaveBeenCalled()
+  })
+
+  it.each<
+    [
+      string,
+      Record<string, string>,
+      typeof expectation,
+      typeof bytes,
+      number,
+    ]
+  >([
+    [
+      'content type',
+      { 'content-type': 'image/png' },
+      expectation,
+      bytes,
+      415,
+    ],
+    [
+      'checksum header',
+      { 'x-media-checksum-sha256': '0'.repeat(64) },
+      expectation,
+      bytes,
+      422,
+    ],
+    [
+      'byte size',
+      {},
+      { ...expectation, byteSize: expectation.byteSize - 1 },
+      bytes,
+      422,
+    ],
+    [
+      'body checksum',
+      {},
+      { ...expectation, checksumSha256: '0'.repeat(64) },
+      bytes,
+      422,
+    ],
+  ])(
+    'rejects a mismatched %s without writing to Bunny',
+    async (_label, headers, uploadExpectation, body, status) => {
+      const f = fixture()
+
+      const response = await storeOriginalFromSameOriginRequest({
+        request: uploadRequest(body, headers),
+        canonicalBaseUrl,
+        expectation: uploadExpectation,
+        ...f,
+      })
+
+      expect(response.status).toBe(status)
+      expect(f.storage.storeOriginal).not.toHaveBeenCalled()
+    },
+  )
+
+  it('rejects an Upload Intent larger than the explicit server limit', async () => {
+    const f = fixture()
+
+    const response = await storeOriginalFromSameOriginRequest({
+      request: uploadRequest(),
+      canonicalBaseUrl,
+      expectation: {
+        ...expectation,
+        byteSize: MAX_ORIGINAL_UPLOAD_BYTES + 1,
+      },
+      ...f,
+    })
+
+    expect(response.status).toBe(413)
+    expect(f.storage.storeOriginal).not.toHaveBeenCalled()
+  })
+
+  it('returns a retryable safe response when Bunny is unavailable', async () => {
+    const f = fixture()
+    f.storage.storeOriginal.mockRejectedValue(
+      new Error('originals-zone-password raw provider detail'),
+    )
+
+    const response = await storeOriginalFromSameOriginRequest({
+      request: uploadRequest(),
+      canonicalBaseUrl,
+      expectation,
+      ...f,
+    })
+
+    expect(response.status).toBe(503)
+    expect(response.headers.get('retry-after')).toBe('5')
+    expect(await response.text()).not.toContain('raw provider detail')
+  })
+})

--- a/lib/media/storage/upload.ts
+++ b/lib/media/storage/upload.ts
@@ -107,7 +107,7 @@ export async function storeOriginalFromSameOriginRequest({
   try {
     authorized = await authorize(request)
   } catch {
-    return uploadResponse(401)
+    return uploadResponse(503, { 'retry-after': '5' })
   }
   if (!authorized) return uploadResponse(401)
 

--- a/lib/media/storage/upload.ts
+++ b/lib/media/storage/upload.ts
@@ -1,0 +1,169 @@
+import 'server-only'
+
+import { createHash, timingSafeEqual } from 'node:crypto'
+
+export const MAX_ORIGINAL_UPLOAD_BYTES = 50 * 1024 * 1024
+
+const originalContentTypes = new Set([
+  'image/heic',
+  'image/heif',
+  'image/jpeg',
+  'image/png',
+])
+
+export type OriginalUploadExpectation = {
+  key: string
+  contentType: string
+  byteSize: number
+  checksumSha256: string
+}
+
+type OriginalStorage = {
+  storeOriginal(input: {
+    key: string
+    bytes: Uint8Array
+    contentType: string
+    checksumSha256: string
+  }): Promise<void>
+}
+
+type SameOriginOriginalUpload = {
+  request: Request
+  canonicalBaseUrl: URL
+  expectation: OriginalUploadExpectation
+  authorize(request: Request): boolean | Promise<boolean>
+  storage: OriginalStorage
+}
+
+function uploadResponse(status: number, headers?: HeadersInit) {
+  return new Response(null, {
+    status,
+    headers: {
+      'cache-control': 'no-store',
+      'referrer-policy': 'no-referrer',
+      'x-content-type-options': 'nosniff',
+      ...headers,
+    },
+  })
+}
+
+function checksumMatches(bytes: Uint8Array, expectedHex: string) {
+  if (!/^[a-f0-9]{64}$/.test(expectedHex)) return false
+  const actual = createHash('sha256').update(bytes).digest()
+  const expected = Buffer.from(expectedHex, 'hex')
+  return timingSafeEqual(actual, expected)
+}
+
+async function readBoundedBody(request: Request, maximumBytes: number) {
+  const reader = request.body?.getReader()
+  if (!reader) return new Uint8Array()
+
+  const chunks: Uint8Array[] = []
+  let byteSize = 0
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    byteSize += value.byteLength
+    if (byteSize > maximumBytes) {
+      await reader.cancel()
+      return null
+    }
+    chunks.push(value)
+  }
+
+  const bytes = new Uint8Array(byteSize)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return bytes
+}
+
+/**
+ * Server-side transfer boundary for an owner-authorized Upload Intent.
+ * The caller resolves the intent and supplies its immutable expectations;
+ * this function never exposes Bunny credentials or a provider upload URL.
+ */
+export async function storeOriginalFromSameOriginRequest({
+  request,
+  canonicalBaseUrl,
+  expectation,
+  authorize,
+  storage,
+}: SameOriginOriginalUpload) {
+  if (request.method !== 'PUT') {
+    return uploadResponse(405, { allow: 'PUT' })
+  }
+
+  if (
+    request.headers.get('origin') !== canonicalBaseUrl.origin ||
+    request.headers.get('sec-fetch-site') !== 'same-origin'
+  ) {
+    return uploadResponse(403)
+  }
+
+  let authorized = false
+  try {
+    authorized = await authorize(request)
+  } catch {
+    return uploadResponse(401)
+  }
+  if (!authorized) return uploadResponse(401)
+
+  if (
+    !Number.isSafeInteger(expectation.byteSize) ||
+    expectation.byteSize <= 0 ||
+    expectation.byteSize > MAX_ORIGINAL_UPLOAD_BYTES
+  ) {
+    return uploadResponse(413)
+  }
+  if (
+    !originalContentTypes.has(expectation.contentType) ||
+    request.headers.get('content-type') !== expectation.contentType
+  ) {
+    return uploadResponse(415)
+  }
+  if (
+    request.headers.get('x-media-checksum-sha256') !==
+    expectation.checksumSha256
+  ) {
+    return uploadResponse(422)
+  }
+
+  const declaredByteSize = request.headers.get('content-length')
+  if (
+    declaredByteSize !== null &&
+    (!/^\d+$/.test(declaredByteSize) ||
+      Number(declaredByteSize) !== expectation.byteSize)
+  ) {
+    return uploadResponse(422)
+  }
+
+  let bytes: Uint8Array | null
+  try {
+    bytes = await readBoundedBody(request, expectation.byteSize)
+  } catch {
+    return uploadResponse(400)
+  }
+  if (
+    !bytes ||
+    bytes.byteLength !== expectation.byteSize ||
+    !checksumMatches(bytes, expectation.checksumSha256)
+  ) {
+    return uploadResponse(422)
+  }
+
+  try {
+    await storage.storeOriginal({
+      key: expectation.key,
+      bytes,
+      contentType: expectation.contentType,
+      checksumSha256: expectation.checksumSha256,
+    })
+  } catch {
+    return uploadResponse(503, { 'retry-after': '5' })
+  }
+
+  return uploadResponse(204)
+}

--- a/package.json
+++ b/package.json
@@ -13,10 +13,15 @@
     "test:ama": "vitest run lib/ama && pnpm db:validate",
     "test:security": "vitest run lib/security",
     "test:localization": "node --test scripts/localization.test.mjs",
+    "test:media:storage": "vitest run lib/media/storage --exclude='**/*.live.test.ts'",
+    "test:media:storage:live": "pnpm test:media:storage:live:server && pnpm test:media:storage:live:browser",
+    "test:media:storage:live:server": "vitest run lib/media/storage/bunny.live.test.ts",
+    "test:media:storage:live:browser": "vitest run lib/media/storage/bunny.browser.live.test.ts",
     "test:port-post": "node --test scripts/port-post.test.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1086.0",
     "@base-ui/react": "^1.6.0",
     "@hugeicons/core-free-icons": "^4.2.2",
     "@hugeicons/react": "^1.1.9",
@@ -65,6 +70,7 @@
     "@types/rss": "^0.0.32",
     "drizzle-kit": "^0.31.10",
     "jsdom": "^29.1.1",
+    "playwright": "^1.61.1",
     "tailwindcss": "^4.1.0",
     "typescript": "^5.8.0",
     "vitest": "^4.1.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1086.0
+        version: 3.1086.0
       '@base-ui/react':
         specifier: ^1.6.0
         version: 1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -147,6 +150,9 @@ importers:
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
+      playwright:
+        specifier: ^1.61.1
+        version: 1.61.1
       tailwindcss:
         specifier: ^4.1.0
         version: 4.3.2
@@ -177,6 +183,78 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@aws-sdk/checksums@3.1000.16':
+    resolution: {integrity: sha512-EKnvkXSmz3IpA99tCNuI+dLFXyZyClSm8zns9sB/elvkU+MTuomAs6toJMPMBf98/fICG/urXDkzGz0/c3yyAQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1086.0':
+    resolution: {integrity: sha512-6+7mVMPKetZmmF2L1yRJ+rN9b1OwVgc5sju2mj8ixdxuGjtVZ0ekFlcWGBFMQT9gpFk55PPLBng/XRYO3qah5A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.975.1':
+    resolution: {integrity: sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.57':
+    resolution: {integrity: sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.59':
+    resolution: {integrity: sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.1':
+    resolution: {integrity: sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.63':
+    resolution: {integrity: sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.67':
+    resolution: {integrity: sha512-oYlzWst56rlhhjbYnexwv5hVLYe1cW4liLObhDfxDLI4RAQzleMVHQgQgx7XsC4HKj4e3kjT8v9DId+Pi/dndw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.57':
+    resolution: {integrity: sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.1':
+    resolution: {integrity: sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.63':
+    resolution: {integrity: sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.62':
+    resolution: {integrity: sha512-k8JJwYXVYlOOjWnPZDThQS1xDFJgi5Dokt73qFlDtrZAbdcint5aIdjB9XgJAAQVP5OoqcefQmh1FYXiPpvsvw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.31':
+    resolution: {integrity: sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.39':
+    resolution: {integrity: sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1083.0':
+    resolution: {integrity: sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.0':
+    resolution: {integrity: sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.34':
+    resolution: {integrity: sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -1282,6 +1360,30 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@smithy/core@3.29.3':
+    resolution: {integrity: sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.8':
+    resolution: {integrity: sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.5':
+    resolution: {integrity: sha512-SuqeisTyPoiIPtIYru/sGxGyXzmZ+8nnFOhC+qRPglt06Ebd1yH//CDltZB2J/3WBNVhwfUaZ0EtHB3cm2X32g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.9.5':
+    resolution: {integrity: sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.4':
+    resolution: {integrity: sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
+    engines: {node: '>=18.0.0'}
+
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
@@ -1606,6 +1708,9 @@ packages:
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@5.0.7:
     resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
@@ -2163,6 +2268,11 @@ packages:
   fs-extra@11.3.6:
     resolution: {integrity: sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==}
     engines: {node: '>=14.14'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -3027,6 +3137,16 @@ packages:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
 
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   postal-mime@2.7.4:
     resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
 
@@ -3757,6 +3877,171 @@ snapshots:
   '@asamuzakjp/generational-cache@1.0.1': {}
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@aws-sdk/checksums@3.1000.16':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1086.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.16
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
+      '@aws-sdk/middleware-sdk-s3': 3.972.62
+      '@aws-sdk/signature-v4-multi-region': 3.996.39
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.975.1':
+    dependencies:
+      '@aws-sdk/types': 3.974.0
+      '@aws-sdk/xml-builder': 3.972.34
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.29.3
+      '@smithy/signature-v4': 5.6.4
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.57':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.1':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-env': 3.972.57
+      '@aws-sdk/credential-provider-http': 3.972.59
+      '@aws-sdk/credential-provider-login': 3.972.63
+      '@aws-sdk/credential-provider-process': 3.972.57
+      '@aws-sdk/credential-provider-sso': 3.973.1
+      '@aws-sdk/credential-provider-web-identity': 3.972.63
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/credential-provider-imds': 4.4.8
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.63':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.67':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.57
+      '@aws-sdk/credential-provider-http': 3.972.59
+      '@aws-sdk/credential-provider-ini': 3.973.1
+      '@aws-sdk/credential-provider-process': 3.972.57
+      '@aws-sdk/credential-provider-sso': 3.973.1
+      '@aws-sdk/credential-provider-web-identity': 3.972.63
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/credential-provider-imds': 4.4.8
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.57':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.1':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/token-providers': 3.1083.0
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.63':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.62':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/signature-v4-multi-region': 3.996.39
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.31':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/signature-v4-multi-region': 3.996.39
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.39':
+    dependencies:
+      '@aws-sdk/types': 3.974.0
+      '@smithy/signature-v4': 5.6.4
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1083.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.0':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.34':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -4631,6 +4916,39 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@smithy/core@3.29.3':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.8':
+    dependencies:
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.5':
+    dependencies:
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.9.5':
+    dependencies:
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.4':
+    dependencies:
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.1':
+    dependencies:
+      tslib: 2.8.1
+
   '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -4935,6 +5253,8 @@ snapshots:
       type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
+
+  bowser@2.14.1: {}
 
   brace-expansion@5.0.7:
     dependencies:
@@ -5468,6 +5788,9 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -6569,6 +6892,14 @@ snapshots:
   pkg-up@3.1.0:
     dependencies:
       find-up: 3.0.0
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postal-mime@2.7.4: {}
 


### PR DESCRIPTION
Part of #96

## Summary

- add a server-only Bunny S3 adapter for private Originals and public Renditions
- verify non-production zone separation, Original privacy, CDN attachment, and cache behavior
- use an owner-authorized same-origin upload boundary with byte, content-type, and checksum validation
- add unit, live provider, and browser contract coverage plus the Preview environment template

## Testing

- `pnpm test:media:storage`
- `pnpm test:media:storage:live`
- `pnpm test:ama`
- `pnpm test:security`
- `pnpm test:localization`
- `pnpm test:port-post`
- `pnpm typecheck`
- `pnpm build`
