### PR TITLE
Add rich link previews with og.zolplay.com

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1751,6 +1751,33 @@ a:focus-visible .external-label .external-mark {
   z-index: var(--z-card);
 }
 
+.link-card-with-image {
+  height: 17rem;
+}
+
+.link-card-image-frame {
+  display: block;
+  flex: none;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border-radius: calc(var(--radius) - 0.125rem);
+  background: color-mix(in oklch, var(--muted) 72%, var(--paper));
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+
+.link-card-image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.external-link img[data-failed],
+.link-card img[data-failed] {
+  visibility: hidden;
+}
+
 .link-card[data-open] {
   animation: link-card-in 200ms var(--ease-swift);
 }

--- a/components/external-link.test.tsx
+++ b/components/external-link.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+
+import { ExternalLink } from './external-link'
+
+beforeAll(() => {
+  class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  globalThis.ResizeObserver = ResizeObserver
+})
+
+afterEach(() => {
+  cleanup()
+  delete document.documentElement.dataset.locale
+})
+
+describe('external link preview card', () => {
+  it('shows localized rich metadata and a fixed Open Graph image slot', async () => {
+    document.documentElement.dataset.locale = 'en'
+    const href = 'https://example.com/articles/design'
+    const { getByRole } = render(
+      <ExternalLink
+        href={href}
+        favicon="https://og.zolplay.com/favicon/https%3A%2F%2Fexample.com%2Farticles%2Fdesign"
+        preview={{
+          domain: 'example.com',
+          title: '设计文章',
+          titleEn: 'A design article',
+          description: '关于设计的文章。',
+          descriptionEn: 'An article about design.',
+          hasImage: true,
+        }}
+      >
+        Example
+      </ExternalLink>,
+    )
+
+    fireEvent.focus(getByRole('link'))
+
+    await waitFor(() => {
+      const card = document.querySelector('.link-card')
+      expect(card).not.toBeNull()
+      expect(card?.classList.contains('link-card-with-image')).toBe(true)
+      expect(card?.textContent).toContain('example.com')
+      expect(card?.textContent).toContain('A design article')
+      expect(card?.textContent).toContain('An article about design.')
+      const image = card?.querySelector('.link-card-image')
+      expect(image?.getAttribute('src')).toBe(
+        'https://og.zolplay.com/image/https%3A%2F%2Fexample.com%2Farticles%2Fdesign',
+      )
+      expect(image?.getAttribute('width')).toBe('232')
+      expect(image?.getAttribute('height')).toBe('131')
+    })
+  })
+
+  it('marks a failed inline favicon without changing its slot', () => {
+    const { getByRole } = render(
+      <ExternalLink
+        href="https://example.com"
+        favicon="https://og.zolplay.com/favicon/https%3A%2F%2Fexample.com%2F"
+      >
+        Example
+      </ExternalLink>,
+    )
+
+    const icon = getByRole('link').querySelector('img')!
+    fireEvent.error(icon)
+
+    expect(icon.dataset.failed).toBe('true')
+    expect(icon.getAttribute('width')).toBe('14')
+    expect(icon.getAttribute('height')).toBe('14')
+  })
+})

--- a/components/external-link.tsx
+++ b/components/external-link.tsx
@@ -3,7 +3,7 @@
 import { PreviewCard } from '@base-ui/react/preview-card'
 
 import { ExternalLabel } from '~/components/external-mark'
-import type { LinkPreview } from '~/lib/link-previews'
+import { ogImageUrl, type LinkPreview } from '~/lib/link-previews'
 import { useLocale } from '~/lib/locale-client'
 
 const HAN = /\p{Script=Han}/u
@@ -11,6 +11,10 @@ const HAN = /\p{Script=Han}/u
 function englishOrSource(english: string | undefined, source: string | undefined) {
   if (english) return english
   return source && !HAN.test(source) ? source : undefined
+}
+
+function hideFailedImage(event: React.SyntheticEvent<HTMLImageElement>) {
+  event.currentTarget.dataset.failed = 'true'
 }
 
 // External prose links: inline favicon prefix, and — with build-time
@@ -34,9 +38,18 @@ export function ExternalLink({
       ? englishOrSource(preview?.descriptionEn, preview?.description)
       : preview?.description
   const domain = preview?.domain
+  const image = preview?.hasImage ? ogImageUrl(href) : null
   const icon = (
     // eslint-disable-next-line @next/next/no-img-element
-    <img src={favicon} alt="" width={14} height={14} loading="lazy" aria-hidden />
+    <img
+      src={favicon}
+      alt=""
+      width={14}
+      height={14}
+      loading="lazy"
+      aria-hidden
+      onError={hideFailedImage}
+    />
   )
 
   if (!title || !domain) {
@@ -65,10 +78,32 @@ export function ExternalLink({
       </PreviewCard.Trigger>
       <PreviewCard.Portal>
         <PreviewCard.Positioner sideOffset={8} collisionPadding={16} className="pointer-events-none z-[var(--z-card)]">
-          <PreviewCard.Popup className="link-card">
+          <PreviewCard.Popup className={`link-card${image ? ' link-card-with-image' : ''}`}>
+            {image && (
+              <span className="link-card-image-frame" aria-hidden>
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  className="link-card-image"
+                  src={image}
+                  alt=""
+                  width={232}
+                  height={131}
+                  loading="eager"
+                  onError={hideFailedImage}
+                />
+              </span>
+            )}
             <span className="link-card-site">
               {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={favicon} alt="" width={16} height={16} loading="lazy" aria-hidden />
+              <img
+                src={favicon}
+                alt=""
+                width={16}
+                height={16}
+                loading="lazy"
+                aria-hidden
+                onError={hideFailedImage}
+              />
               {domain}
             </span>
             <span className="link-card-title">{title}</span>

--- a/components/home-introduction.tsx
+++ b/components/home-introduction.tsx
@@ -9,10 +9,10 @@ import {
   XiaohongshuCard,
 } from '~/components/social-cards'
 import { T } from '~/lib/i18n'
-import { getLinkPreview } from '~/lib/link-previews'
+import { faviconUrl, getLinkPreview } from '~/lib/link-previews'
 
-const ZOLPLAY_FAVICON_SRC = 'https://zolplay.com/favicon.ico'
 const ZOLPLAY_URL = 'https://zolplay.com'
+const ZOLPLAY_FAVICON_SRC = faviconUrl(ZOLPLAY_URL)!
 
 function DesignEngineerMark() {
   return (

--- a/content/link-previews.json
+++ b/content/link-previews.json
@@ -2,29 +2,34 @@
   "https://antfu.me": {
     "domain": "antfu.me",
     "title": "Anthony Fu",
-    "description": "Hey! I'm Anthony Fu, a fanatical open sourceror and design engineer. Working at Vercel / Nuxt. Creator of Vitest, Slidev, VueUse, UnoCSS, Elk, Type Challenges."
+    "description": "Hey! I'm Anthony Fu, a fanatical open sourceror and design engineer. Working at Vercel / Nuxt. Creator of Vitest, Slidev, VueUse, UnoCSS, Elk, Type Challenges.",
+    "hasImage": false
   },
   "https://astro.build/": {
     "domain": "astro.build",
-    "title": "Astro | The web framework for content-driven websites",
-    "description": "Astro is a JavaScript framework for fast, content-driven websites. It uses a server-first architecture and avoids unnecessary client-side JavaScript."
+    "title": "Astro",
+    "description": "Astro builds fast content sites, powerful web applications, dynamic server APIs, and everything in-between.",
+    "hasImage": true
   },
   "https://basecamp.com/books/rework": {
     "domain": "basecamp.com",
-    "title": "Basecamp: Books we've written",
-    "description": "Business books from Basecamp and 37signals include Shape Up, REWORK, and Getting Real, with practical and unconventional advice."
+    "title": "Books we’ve written",
+    "description": "On top of making Basecamp, we write books about what we’ve learned running our own business. They’re filled with practical advice you won’t find anywhere else.",
+    "hasImage": true
   },
   "https://blog.kevinzhow.com/posts/in-memory-of-haoel/zh": {
     "domain": "blog.kevinzhow.com",
-    "title": "纪念左耳朵耗子 - Kevin Blog",
+    "title": "纪念左耳朵耗子",
     "titleEn": "In Memory of Haoel - Kevin Blog",
-    "description": "A memorial tribute to Chen Hao (左耳朵耗子), recounting the author's friendship with the tech blogger and his passing in May 2023.",
-    "descriptionEn": "A memorial tribute to Chen Hao (Haoel), recounting the author's friendship with the tech blogger and his passing in May 2023."
+    "description": "刚刚从半睡半醒中醒来，梦境的最后一刻是陈皓成为了 AI，而我刚想和“他”说说话。我相信那一天终究会到来，但此刻看着 Discord 里甚至还没显示为离线的他，我也知道再也得不到回应。在北京相识我一直称",
+    "descriptionEn": "A memorial tribute to Chen Hao (Haoel), recounting the author's friendship with the tech blogger and his passing in May 2023.",
+    "hasImage": true
   },
   "https://careers.google.com/": {
     "domain": "careers.google.com",
-    "title": "Careers | Google",
-    "description": "Search Google roles, learn about its hiring process, and explore working at Google. (301 redirects to google.com/about/careers/applications/)"
+    "title": "Search for your career at Google.",
+    "description": "Join Google Careers and build what's next, today. Explore career opportunities in engineering, design, sales, hardware, and more. Make a global impact with innovative technology that helps billions of users.",
+    "hasImage": true
   },
   "https://chat.openai.com": {
     "domain": "chat.openai.com",
@@ -37,56 +42,66 @@
   },
   "https://clerk.dev": {
     "domain": "clerk.dev",
-    "title": "Clerk: User Management",
-    "description": "308 redirects to clerk.com. Clerk provides full-stack authentication and user management."
+    "title": "Clerk | Authentication and User Management",
+    "description": "The easiest way to add authentication and user management to your application. Purpose-built for React, Next.js, Remix, and “The Modern Web”.",
+    "hasImage": true
   },
   "https://codesandbox.io": {
     "domain": "codesandbox.io",
-    "title": "CodeSandbox: Cloud Development Environments",
-    "description": "CodeSandbox provides isolated cloud sandboxes for code execution in agents and code playgrounds."
+    "title": "CodeSandbox: Instant Cloud Development Environments",
+    "description": "CodeSandbox is a cloud development platform that empowers developers to code, collaborate and ship projects of any size from any device in record time.",
+    "hasImage": true
   },
   "https://coolshell.cn/": {
     "domain": "coolshell.cn",
-    "title": "酷壳 | CoolShell.cn",
+    "title": "酷 壳 - CoolShell",
     "titleEn": "CoolShell | CoolShell.cn",
-    "description": "享受编程和技术所带来的快乐：Coding Your Ambition",
-    "descriptionEn": "Enjoy Programming and Technology: Coding Your Ambition"
+    "description": "享受编程和技术所带来的快乐 - Coding Your Ambition",
+    "descriptionEn": "Enjoy Programming and Technology: Coding Your Ambition",
+    "hasImage": true
   },
   "https://coolshell.cn/articles/20765.html": {
     "domain": "coolshell.cn",
     "title": "MegaEase的远程工作文化 | 酷 壳 - CoolShell",
     "titleEn": "MegaEase's Remote Work Culture | CoolShell",
     "description": "MegaEase 创始人陈皓分享远程工作文化的实践经验，包括团队管理原则、微观操作方法和远程工作协议。",
-    "descriptionEn": "MegaEase founder Chen Hao shares practical experience with remote work culture, including principles for managing teams, day-to-day operating practices, and remote work protocols."
+    "descriptionEn": "MegaEase founder Chen Hao shares practical experience with remote work culture, including principles for managing teams, day-to-day operating practices, and remote work protocols.",
+    "hasImage": true
   },
   "https://coolshell.cn/articles/22298.html": {
     "domain": "coolshell.cn",
     "title": "聊聊团队协同和协同工具 | 酷 壳 - CoolShell",
     "titleEn": "A Conversation About Teamwork and Collaboration Tools | CoolShell",
     "description": "讨论企业 IM 工具的本质差别、国内外协同工具的区别，以及什么是真正好的协同工具。",
-    "descriptionEn": "A discussion of differences between enterprise messaging tools in China and abroad, and criteria for choosing a collaboration tool."
+    "descriptionEn": "A discussion of differences between enterprise messaging tools in China and abroad, and criteria for choosing a collaboration tool.",
+    "hasImage": true
   },
   "https://cusdis.com/": {
     "domain": "cusdis.com",
     "title": "Cusdis - Lightweight, privacy-first, open-source comment system",
-    "description": "An open-source, lightweight alternative to Disqus that integrates with existing websites without tracking users."
+    "description": "Cusdis is an open-source, lightweight (~5kb gzipped), privacy-first alternative to Disqus. It's super easy to use and integrate with your existed website",
+    "hasImage": true
   },
   "https://developer.apple.com/tutorials/swiftui": {
     "domain": "developer.apple.com",
-    "title": "Introducing SwiftUI | Apple Developer Documentation"
+    "title": "Introducing SwiftUI | Apple Developer Documentation",
+    "description": "There's never been a better time to develop for Apple platforms.",
+    "hasImage": true
   },
   "https://diagram.com": {
     "domain": "diagram.com"
   },
   "https://discord.com": {
     "domain": "discord.com",
-    "title": "Discord - Group Chat That's All Fun & Games",
-    "description": "Discord provides customizable spaces where people can talk, play games, and build communities."
+    "title": "Discord - Group Chat That’s All Fun & Games",
+    "description": "Discord is great for playing games and chilling with friends, or even building a worldwide community. Customize your own space to talk, play, and hang out.",
+    "hasImage": true
   },
   "https://emilkowal.ski/": {
     "domain": "emilkowal.ski",
-    "title": "Emil Kowalski | Design Engineer",
-    "description": "Design engineer at Linear creating web animations, React components, and design education; previously at Vercel. (no meta description tag; summary from page content)"
+    "title": "Emil Kowalski",
+    "description": "Design engineer working at Linear.",
+    "hasImage": true
   },
   "https://en.wikipedia.org/wiki/Cursor_(user_interface)": {
     "domain": "en.wikipedia.org",
@@ -96,106 +111,125 @@
   "https://evanyou.me": {
     "domain": "evanyou.me",
     "title": "Evan You",
-    "description": "Founder of VoidZero, creator of Vue.js and Vite. Independent open-source developer based in Singapore building JavaScript and TypeScript tools."
+    "description": "Founder of VoidZero, creator of Vue.js and Vite. Independent open-source developer based in Singapore building JavaScript and TypeScript tools.",
+    "hasImage": false
   },
   "https://evervault.com/": {
     "domain": "evervault.com",
-    "title": "Evervault: Payments Security",
-    "description": "Evervault lets teams tokenize cards, optimize margins, meet PCI requirements, avoid gateway lock-in, and run card-issuing programs."
+    "title": "Evervault - Flexible Payments Security",
+    "description": "Take control of your payments stack with Evervaults powerful encryption model, secure your data while maintaining full control and flexibility of your payment experience.",
+    "hasImage": true
   },
   "https://feedly.com": {
     "domain": "feedly.com",
-    "title": "Feedly Threat Intelligence",
-    "description": "Feedly helps threat-intelligence teams track threats, add context, and share reports. (Its homepage now focuses on threat intelligence rather than the RSS reader.)"
+    "title": "Feedly Threat Intelligence: Collect, analyze, and share actionable intelligence",
+    "description": "Collect, analyze, share actionable intel faster - Feedly TI",
+    "hasImage": true
   },
   "https://feyapp.com": {
     "domain": "feyapp.com",
     "title": "Fey joined Wealthsimple",
-    "description": "301 redirects to fey.com. Fey's technology, design philosophy, and focus on clarity now shape Wealthsimple's investing and banking products. (The product was absorbed into Wealthsimple.)"
+    "description": "Fey has joined Wealthsimple.",
+    "hasImage": true
   },
   "https://figma.com": {
     "domain": "figma.com",
     "title": "Figma: The collaborative canvas for design, code, and AI",
-    "description": "A shared workspace for product development, from work in progress through release."
+    "description": "Figma is the canvas where design, code, and AI come together. From first idea to shipped product - go from concept to production with your whole team, in one place.",
+    "hasImage": true
   },
   "https://fm.cali.so": {
     "domain": "fm.cali.so",
     "title": "TechniCality",
-    "description": "A podcast hosted by Cali Castle featuring interviews with people working in tech and gaming, including Anthony Fu and Sean Vesce."
+    "hasImage": true
   },
   "https://framer.com": {
     "domain": "framer.com",
-    "title": "Framer: Website Builder",
-    "description": "Framer's no-code website builder includes visual design, CMS, SEO, collaboration, and publishing tools."
+    "title": "Framer: AI website builder for professional sites",
+    "description": "Create a professional website with Framer’s no-code AI website builder. Design freely, manage CMS content, optimize SEO, collaborate, and publish fast.",
+    "hasImage": true
   },
   "https://github.com/CaliCastle/cali.so": {
     "domain": "github.com",
     "title": "GitHub - CaliCastle/cali.so: Cali 的个人官网开源项目",
-    "titleEn": "GitHub - CaliCastle/cali.so: Open-Source Project for Cali's Personal Website",
+    "titleEn": "GitHub - CaliCastle/cali.so: Personal website for Cali Castle",
     "description": "Cali 的个人博客网站 https://cali.so/ 的源代码。A personal website project built with Next.js, React, TypeScript, and Tailwind CSS.",
-    "descriptionEn": "The source code for Cali's personal blog at https://cali.so/. A personal website project built with Next.js, React, TypeScript, and Tailwind CSS."
+    "descriptionEn": "Personal website for Cali Castle. Contribute to CaliCastle/cali.so development by creating an account on GitHub.",
+    "hasImage": true
   },
   "https://github.com/CaliCastle/cali.so/commit/2b10d8e45868b670e36b6e73c401304e5eae045e": {
     "domain": "github.com",
-    "title": "feat: add blocked page and IP blocking · CaliCastle/cali.so@2b10d8e · GitHub",
-    "description": "Commit adding a blocked page feature and IP blocking functionality to the cali.so repository."
+    "title": "feat: add blocked page and IP blocking · CaliCastle/cali.so@2b10d8e",
+    "description": "Personal website for Cali Castle. Contribute to CaliCastle/cali.so development by creating an account on GitHub.",
+    "hasImage": true
   },
   "https://github.com/CaliCastle/cali.so/commit/50635c7d94f9d7e0299ddc63a6fb190c6c0858c7": {
     "domain": "github.com",
-    "title": "fix: add ratelimit to reactions endpoint · CaliCastle/cali.so@50635c7 · GitHub",
-    "description": "Commit adding Upstash Ratelimit sliding-window limits (30 req/10s GET, 50 req/10s PATCH) to the reactions API endpoint."
+    "title": "fix: add ratelimit to reactions endpoint · CaliCastle/cali.so@50635c7",
+    "description": "Personal website for Cali Castle. Contribute to CaliCastle/cali.so development by creating an account on GitHub.",
+    "hasImage": true
   },
   "https://github.com/pmndrs": {
     "domain": "github.com",
-    "title": "Poimandres · GitHub",
-    "description": "Open source developer collective."
+    "title": "Poimandres",
+    "description": "Open source developer collective. Poimandres has 96 repositories available. Follow their code on GitHub.",
+    "hasImage": true
   },
   "https://github.com/vadimdemedes/ink": {
     "domain": "github.com",
     "title": "GitHub - vadimdemedes/ink: 🌈 React for interactive command-line apps",
-    "description": "Ink provides the same component-based UI building experience that React offers in the browser, but for command-line apps. It uses Yoga to build Flexbox layouts in the terminal."
+    "description": "🌈 React for interactive command-line apps. Contribute to vadimdemedes/ink development by creating an account on GitHub.",
+    "hasImage": true
   },
   "https://gitlab.com": {
     "domain": "gitlab.com",
-    "title": "GitLab",
-    "description": "301 redirects to about.gitlab.com. GitLab provides tools for planning, building, securing, and deploying software."
+    "title": "Finally, AI for the entire software lifecycle.",
+    "description": "Your intelligent orchestration platform for DevSecOps",
+    "hasImage": true
   },
   "https://hashnode.com": {
     "domain": "hashnode.com",
-    "title": "Hashnode: Blogging Platform for Tech Builders",
-    "description": "A blogging community where engineers and tech leaders publish ideas and connect with readers."
+    "title": "Where builders write, and get read",
+    "description": "Start a blog on your own domain, keep your audience, and reach readers across search and AI engines. Free to start.",
+    "hasImage": true
   },
   "https://hexo.io/zh-cn/": {
     "domain": "hexo.io",
     "title": "Hexo | 快速、简洁且高效的博客框架",
-    "titleEn": "Hexo | Blog Framework",
-    "description": "快速、简洁且高效的博客框架：a fast, concise, and efficient blogging framework powered by Node.js with Markdown support, one-click deployment, and 448+ themes.",
-    "descriptionEn": "A Node.js blogging framework with Markdown support, one-click deployment, and more than 448 themes."
+    "titleEn": "Hexo",
+    "description": "Hexo 是一个由Node.js驱动的快速、简单的 & 强大的博客框架。",
+    "descriptionEn": "A Node.js blogging framework with Markdown support, one-click deployment, and more than 448 themes.",
+    "hasImage": true
   },
   "https://icons8.com": {
     "domain": "icons8.com",
     "title": "Free Icons, Clipart Illustrations, Photos, and Music",
-    "description": "Download free icons, photos, vector illustrations, and music made by designers. (Returns HTTP 403 to some automated clients; metadata was fetched with a browser user agent.)"
+    "description": "Download design elements for free: icons, photos, vector illustrations, and music for your videos. All the assets made by designers → consistent quality ⚡️",
+    "hasImage": true
   },
   "https://joebell.co.uk/": {
     "domain": "joebell.co.uk",
     "title": "Joe Bell",
-    "description": "Designer / Developer / Creator. (302 redirects to joebell.studio)"
+    "description": "Designer / Developer / Creator",
+    "hasImage": true
   },
   "https://linear.app": {
     "domain": "linear.app",
-    "title": "Linear: The product development system for teams and agents",
-    "description": "A system for planning and building products with teams and AI agents."
+    "title": "Linear - The system for product development",
+    "description": "Purpose-built for planning and building products with AI agents.",
+    "hasImage": true
   },
   "https://liveblocks.io": {
     "domain": "liveblocks.io",
-    "title": "Liveblocks",
-    "description": "Liveblocks provides real-time infrastructure for concurrent edits to shared data by people and AI agents."
+    "title": "Liveblocks | Realtime infrastructure for multiplayer apps and agents",
+    "description": "Liveblocks provides the infrastructure to handle concurrent edits on shared data, so people and AI agents can collaborate without breaking your app.",
+    "hasImage": true
   },
   "https://lutaonan.com/": {
     "domain": "lutaonan.com",
     "title": "Randy's Blog",
-    "description": "About life, technology and reading."
+    "description": "About life, technology and reading",
+    "hasImage": true
   },
   "https://medium.com": {
     "domain": "medium.com",
@@ -211,43 +245,50 @@
   "https://music.apple.com/us/artist/twenty-one-pilots/349736311?l=zh-Hans-CN": {
     "domain": "music.apple.com",
     "title": "Apple Music - 网页播放器",
-    "titleEn": "Apple Music - Web Player",
-    "description": "[Artist page for Twenty One Pilots; page is a client-rendered Apple Music web player shell, so artist-specific metadata was not served to the fetcher]"
+    "titleEn": "Apple Music - twenty one pilots",
+    "hasImage": true
   },
   "https://nativescript.org/": {
     "domain": "nativescript.org",
-    "title": "NativeScript",
-    "description": "[Live site, but heavily client-rendered: only the title and minimal content are served to fetchers; no meta description found]"
+    "title": "NativeScript - Write Native with TypeScript",
+    "description": "Build native iOS and Android apps with TypeScript, direct platform API access, and the JavaScript tooling you already know.",
+    "hasImage": true
   },
   "https://neon.tech": {
     "domain": "neon.tech",
-    "title": "Neon: Postgres backends for apps and agents",
-    "description": "308 redirects to neon.com. Serverless Postgres with database branching, authentication, and autoscaling compute."
+    "title": "Neon - Postgres backends for apps and agents",
+    "description": "The backend for apps and agents. Build with Serverless Postgres, Auth, Functions, Storage, and an AI Gateway: instant, branchable, serverless.",
+    "hasImage": true
   },
   "https://nextjs.org": {
     "domain": "nextjs.org",
     "title": "Next.js by Vercel - The React Framework",
-    "description": "Next.js is a React framework for building web applications."
+    "description": "Next.js by Vercel is the full-stack React framework for the web.",
+    "hasImage": true
   },
   "https://nextjs.org/blog/next-13-4": {
     "domain": "nextjs.org",
     "title": "Next.js 13.4",
-    "description": "Next.js 13.4 moves App Router to stable, Turbopack to beta, and introduces experimental support for Server Actions."
+    "description": "Next.js 13.4 moves App Router to stable, Turbopack to beta, and introduces experimental support for Server Actions.",
+    "hasImage": true
   },
   "https://nextjs.org/docs/app/api-reference/next-config-js/rewrites": {
     "domain": "nextjs.org",
-    "title": "rewrites",
-    "description": "Add rewrites to your Next.js app. (old docs path; now redirects internally to /docs/app/api-reference/config/next-config-js/rewrites)"
+    "title": "next.config.js: rewrites | Next.js",
+    "description": "Add rewrites to your Next.js app.",
+    "hasImage": true
   },
   "https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions#action": {
     "domain": "nextjs.org",
-    "title": "How to create forms with Server Actions",
-    "description": "Learn how to create forms in Next.js with React Server Actions. (The old docs path now redirects internally to /docs/app/guides/forms; the #action anchor no longer exists.)"
+    "title": "Guides: Forms | Next.js",
+    "description": "Learn how to create forms in Next.js with React Server Actions.",
+    "hasImage": true
   },
   "https://nextjs.org/docs/app/building-your-application/optimizing/metadata": {
     "domain": "nextjs.org",
-    "title": "Metadata and OG images",
-    "description": "Learn how to add metadata to your pages and create dynamic OG images. (old docs path; now redirects internally to /docs/app/getting-started/metadata-and-og-images)"
+    "title": "Getting Started: Metadata and OG images | Next.js",
+    "description": "Learn how to add metadata to your pages and create dynamic OG images.",
+    "hasImage": true
   },
   "https://nextjs.org/docs/app/building-your-application/routing/router-handlers": {
     "domain": "nextjs.org",
@@ -256,28 +297,33 @@
   },
   "https://nextjs.org/docs/app/building-your-application/routing/router-handlers#static-route-handlers": {
     "domain": "nextjs.org",
-    "title": "route.js",
-    "description": "API reference for the route.js special file. (same page as above; old docs path redirects internally, and the #static-route-handlers anchor no longer exists on the new page)"
+    "title": "File-system conventions: route.js | Next.js",
+    "description": "API reference for the route.js special file.",
+    "hasImage": true
   },
   "https://nextra.site/": {
     "domain": "nextra.site",
-    "title": "Nextra: Next.js Static Site Generator",
-    "description": "A site generation framework built on Next.js."
+    "title": "Nextra - Next.js Static Site Generator",
+    "description": "Build fast, customizable, and content-rich websites with Nextra. Powered by Next.js, it offers seamless Markdown support, customizable themes, file conventions, and easy integration with MDX, making it perfect for documentation, blogs, and static websites.",
+    "hasImage": false
   },
   "https://notion.so": {
     "domain": "notion.so",
-    "title": "Notion",
-    "description": "301 redirects to notion.com. Notion combines documents, databases, search, and task automation in a shared workspace."
+    "title": "The AI workspace that works for you. | Notion",
+    "description": "Build Custom Agents, search across all your apps, and automate busywork. The AI workspace where teams get more done, faster.",
+    "hasImage": true
   },
   "https://nuxt.com/blog/introducing-nuxt-devtools": {
     "domain": "nuxt.com",
     "title": "Introducing Nuxt DevTools · Nuxt Blog",
-    "description": "Nuxt DevTools lets developers inspect Nuxt applications, view performance data, and debug interactively."
+    "description": "Unleash the Developer Experience with Nuxt and understand your app better than ever.",
+    "hasImage": true
   },
   "https://nuxt.studio/": {
     "domain": "nuxt.studio",
-    "title": "Nuxt Studio",
-    "description": "Edit your Nuxt Content website in production. Self-hosted, open-source CMS for Nuxt Content websites. Edit content visually, manage media, and publish directly to Git."
+    "title": "Edit your Nuxt Content website in production",
+    "description": "Self-hosted, open-source CMS for Nuxt Content websites. Edit content visually, manage media, and publish directly to Git from your production site.",
+    "hasImage": true
   },
   "https://openai.com": {
     "domain": "openai.com",
@@ -286,52 +332,62 @@
   "https://paco.me": {
     "domain": "paco.me",
     "title": "Paco Coursey",
-    "description": "Paco Coursey is a webmaster at Linear who builds software, web experiences, and interface details."
+    "description": "Crafting interfaces. Webmaster at Linear. Building polished software and web experiences.",
+    "hasImage": true
   },
   "https://planetscale.com/": {
     "domain": "planetscale.com",
-    "title": "PlanetScale: Cloud Hosting for Vitess and Postgres",
-    "description": "PlanetScale provides cloud hosting for Vitess and Postgres databases."
+    "title": "PlanetScale - the world’s fastest and most scalable cloud hosting for Vitess and Postgres",
+    "description": "PlanetScale offers the world’s fastest and most scalable cloud hosting for Vitess and Postgres.",
+    "hasImage": true
   },
   "https://planetscale.com/blog/planetscale-forever": {
     "domain": "planetscale.com",
-    "title": "PlanetScale forever: PlanetScale",
-    "description": "PlanetScale says it is prioritizing profitability to support a reliable, sustainable platform over the long term."
+    "title": "PlanetScale forever - PlanetScale",
+    "description": "PlanetScale is committed to providing a reliable and sustainable platform for our customers, not just in the short-term, but forever. For this reason, we are prioritizing profitability.",
+    "hasImage": true
   },
   "https://pnpm.io/installation": {
     "domain": "pnpm.io",
     "title": "Installation | pnpm",
-    "description": "How to install pnpm: standalone scripts, Corepack, npm, Homebrew, and other package managers, with Node.js compatibility information."
+    "description": "Prerequisites",
+    "hasImage": true
   },
   "https://rauno.me": {
     "domain": "rauno.me",
     "title": "Rauno Freiberg",
-    "description": "Estonian interaction designer working with Vercel and Devouring Details, focusing on design craft and software history."
+    "description": "Rauno Freiberg is an Estonian interaction designer working with Vercel and Devouring Details.",
+    "hasImage": true
   },
   "https://raycast.com": {
     "domain": "raycast.com",
-    "title": "Raycast",
-    "description": "An extensible launcher that brings productivity tools into one interface."
+    "title": "Raycast - Your shortcut to everything",
+    "description": "A collection of powerful productivity tools all within an extendable launcher.",
+    "hasImage": true
   },
   "https://react.dev/": {
     "domain": "react.dev",
     "title": "React",
-    "description": "React is the library for web and native user interfaces. Build user interfaces out of individual pieces called components written in JavaScript."
+    "description": "React is the library for web and native user interfaces. Build user interfaces out of individual pieces called components written in JavaScript. React is designed to let you seamlessly combine components written by independent people, teams, and organizations.",
+    "hasImage": true
   },
   "https://react.email": {
     "domain": "react.email",
-    "title": "React Email: React Components for Email",
-    "description": "React Email provides unstyled components for creating emails with React, Tailwind, and TypeScript."
+    "title": "React Email",
+    "description": "A collection of high-quality, unstyled components for creating beautiful emails using React and TypeScript.",
+    "hasImage": true
   },
   "https://reactnative.dev/": {
     "domain": "reactnative.dev",
-    "title": "React Native",
-    "description": "Create native apps for Android, iOS, and other platforms using React components."
+    "title": "React Native · Learn once, write anywhere",
+    "description": "A framework for building native apps for Android, iOS, and more using React",
+    "hasImage": true
   },
   "https://resend.com": {
     "domain": "resend.com",
-    "title": "Resend",
-    "description": "Resend is an API for sending transactional and marketing email."
+    "title": "Resend · Email for developers",
+    "description": "The best way to reach humans instead of spam folders. Deliver transactional and marketing emails at scale.",
+    "hasImage": true
   },
   "https://rode.com/en/interfaces-and-mixers/rodecaster-series/rodecaster-pro-ii": {
     "domain": "rode.com",
@@ -341,21 +397,25 @@
   "https://roe.dev": {
     "domain": "roe.dev",
     "title": "Daniel Roe",
-    "description": "The personal website of Daniel Roe, Nuxt core team lead. (WebFetch hit a cookie-based redirect loop; verified live via direct HTTP request, 200 OK)"
+    "description": "The personal website of Daniel Roe, Nuxt core team lead",
+    "hasImage": true
   },
   "https://sanity.io/manage": {
     "domain": "sanity.io",
-    "description": "[Login-gated Sanity management console (redirects to www.sanity.io/manage, 200 OK but SPA shell with no metadata); live for users]"
+    "description": "[Login-gated Sanity management console (redirects to www.sanity.io/manage, 200 OK but SPA shell with no metadata); live for users]",
+    "hasImage": false
   },
   "https://sentry.io": {
     "domain": "sentry.io",
-    "title": "Sentry",
-    "description": "[Live; Sentry serves an agent-targeted notice to automated clients instead of the human marketing page, so the real meta description was not retrievable]"
+    "title": "Application Performance Monitoring & Error Tracking Software",
+    "description": "Application performance monitoring for developers & software teams to see errors clearer, solve issues faster & continue learning continuously. Get started at sentry.io.",
+    "hasImage": true
   },
   "https://shadcn.com/": {
     "domain": "shadcn.com",
     "title": "shadcn",
-    "description": "I'm a design engineer on the AI team at Vercel. I created shadcn/ui and shadcn/registry. I co-created v0 with Jared, Shu and Max."
+    "description": "design engineer",
+    "hasImage": true
   },
   "https://shop.zolplay.cn": {
     "domain": "shop.zolplay.cn"
@@ -363,21 +423,25 @@
   "https://shud.in": {
     "domain": "shud.in",
     "title": "Shu Ding",
-    "description": "Designer and developer at Vercel interested in web development, creative coding, game design, and human-computer interaction."
+    "description": "Designer and developer at Vercel interested in web development, creative coding, game design, and human-computer interaction.",
+    "hasImage": false
   },
   "https://slack.com": {
     "domain": "slack.com",
-    "title": "Slack | AI Work Platform & Productivity Tools",
-    "description": "Slack brings team communication, AI agents, and productivity tools into one workspace."
+    "title": "Slack | AI work platform and productivity tools",
+    "description": "Boost productivity and save time with Slack‌ - ‌the AI work platform for managing projects, automating workflows and connecting teams securely. Start working smarter today.",
+    "hasImage": true
   },
   "https://tfwiki.net/wiki/Transformers:_Heavy_Metal": {
     "domain": "tfwiki.net",
-    "title": "Transformers: Heavy Metal",
-    "description": "A location-based augmented reality mobile game developed by Very Very Spaceship and Niantic that soft-launched in 2021 before being officially canceled in June 2022."
+    "title": "Transformers: Heavy Metal - Transformers Wiki",
+    "description": "A location-based augmented reality mobile game developed by Very Very Spaceship and Niantic that soft-launched in 2021 before being officially canceled in June 2022.",
+    "hasImage": true
   },
   "https://twitter.com": {
     "domain": "twitter.com",
-    "description": "[301 redirects to x.com, which returns HTTP 402 to automated clients; live for real users, metadata not fetchable]"
+    "description": "[301 redirects to x.com, which returns HTTP 402 to automated clients; live for real users, metadata not fetchable]",
+    "hasImage": true
   },
   "https://twitter.com/CoooolXyh": {
     "domain": "twitter.com",
@@ -389,19 +453,22 @@
   },
   "https://twitter.com/Lakr233": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "hasImage": true
   },
   "https://twitter.com/PolarisC0": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "title": "Brandon Chen (@PolarisC0) on X",
+    "description": "Co-Founder & CEO of Intent. brandon@intent.inc",
+    "hasImage": true
   },
   "https://twitter.com/Shenqingchuan": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "hasImage": true
   },
   "https://twitter.com/__oQuery": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "description": "Orchestrating ideas with Code & AI | All views are my own",
+    "hasImage": true
   },
   "https://twitter.com/_cuvii_": {
     "domain": "twitter.com",
@@ -409,9 +476,10 @@
   },
   "https://twitter.com/bearbig/status/1657997853585997824?s=20": {
     "domain": "twitter.com",
-    "title": "Tweet by Bear Liu (@bearliu)",
-    "description": "我和陈皓的交集只是在社交媒体，但他突然离世的消息冲击实在太大…… (tweet verified live via Twitter syndication API; direct x.com fetch is blocked)",
-    "descriptionEn": "My only connection with Chen Hao was through social media, but the news of his sudden passing still hit me incredibly hard... (tweet verified live via Twitter syndication API; direct x.com fetch is blocked)"
+    "title": "Bear Liu (@bearliu) on X",
+    "description": "我和陈皓的交集只是在社交媒体，但他突然离世的消息冲击实在太大。我的一些个人感受（仅仅是自己的生活感悟，与他和别人的生活或观点无关）\n\n1 / 现在的时代，不要想着抓住所有机会，不错过风口。生活是一条大河，个人无法停住每一滴水，特别是在技术领域。",
+    "descriptionEn": "My only connection with Chen Hao was through social media, but the news of his sudden passing still hit me incredibly hard... (tweet verified live via Twitter syndication API; direct x.com fetch is blocked)",
+    "hasImage": true
   },
   "https://twitter.com/brotzky_": {
     "domain": "twitter.com",
@@ -419,29 +487,39 @@
   },
   "https://twitter.com/buaaxhm": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "title": "supermao (@buaaxhm) on X",
+    "hasImage": true
   },
   "https://twitter.com/dingyi": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "title": "Ding (@dingyi) on X",
+    "description": "promote your product  ‣ dingyi@me.com\nnewsletter ‣ https://t.co/q1JG1yCzdb\nrefine your startup ‣ https://t.co/FfUYboxOr5\nnewest product ‣ https://t.co/cP6NQ3keo5",
+    "hasImage": true
   },
   "https://twitter.com/fanweixiao": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "title": "C.C. (@fanweixiao) on X",
+    "description": "Build bridges, not walls. Spread love, not hate.",
+    "hasImage": true
   },
   "https://twitter.com/ghosTM55": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "title": "Thomas Yao  (@ghosTM55) on X",
+    "description": "Hacker | Entrepreneur | Archer | Gamer | World Citizen",
+    "hasImage": true
   },
   "https://twitter.com/ghosTM55/status/1657946836643241985?s=20": {
     "domain": "twitter.com",
-    "title": "Tweet by Thomas Yao (@ghosTM55)",
-    "description": "经过 @kevinzhow 确认，我们的挚友左耳朵耗子 @haoel 已于周六晚突发心梗辞世……R.I.P. (tweet verified live via Twitter syndication API; direct x.com fetch is blocked)",
-    "descriptionEn": "As confirmed by @kevinzhow, our dear friend Haoel @haoel passed away from a sudden heart attack on Saturday night... R.I.P. (tweet verified live via Twitter syndication API; direct x.com fetch is blocked)"
+    "title": "Thomas Yao  (@ghosTM55) on X",
+    "description": "经过 @kevinzhow 确认，我们的挚友左耳朵耗子 @haoel 已于周六晚突发心梗辞世\n\n陈皓是个有原则、正直、风趣、聪明的人，他对 IT 行业作出了不可磨灭的贡献\n\n他一生有很多成就，而我愿意最后以一起打游戏的好友记住他\n\nR.I.P.",
+    "descriptionEn": "As confirmed by @kevinzhow, our dear friend Haoel @haoel passed away from a sudden heart attack on Saturday night... R.I.P. (tweet verified live via Twitter syndication API; direct x.com fetch is blocked)",
+    "hasImage": true
   },
   "https://twitter.com/hi_caicai": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "title": "CaiCai (@hi_caicai) on X",
+    "description": "Creator of @YouMind_AI，Product designer",
+    "hasImage": true
   },
   "https://twitter.com/huozhi": {
     "domain": "twitter.com",
@@ -453,27 +531,37 @@
   },
   "https://twitter.com/jsngr": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "title": "Jordan Singer (@jsngr) on X",
+    "description": "co-founder/ceo @mainframe • prev. @figma @diagram (acq) @square",
+    "hasImage": true
   },
   "https://twitter.com/liulinboyi": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "description": "@vuejs team member.",
+    "hasImage": true
   },
   "https://twitter.com/liuyi0922": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "title": "61 (@liuyi0922) on X",
+    "description": " Apple Design Award Winner (2025) & Finalist (2022) 🧘‍♂️𝗥𝗲𝗮𝗹 𝗮𝗿𝘁𝗶𝘀𝘁𝘀 𝘀𝗵𝗶𝗽. Founder of @MDStudioHQ ✍️https://t.co/i5KR6xW5GZ",
+    "hasImage": true
   },
   "https://twitter.com/localhost_4173": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "description": "ChatWise CEO",
+    "hasImage": true
   },
   "https://twitter.com/luoleiorg": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "title": "luolei (@luoleiorg) on X",
+    "description": "💻 Full-Stack Developer / 📖 Lifetime Learner / 🚧 Building & Sharing / 🎬 YouTuber https://t.co/7g47VdNMnN / 📝 https://t.co/6ucNiJ2gyg / 👨‍🚀 More https://t.co/smbFyIb6Hc",
+    "hasImage": true
   },
   "https://twitter.com/marcbouchenoire": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "title": "Marc Bouchenoire (@marcbouchenoire) on X",
+    "description": "Design Engineer at @liveblocks, previously at @framer ~ he/they ~ 🌱🌸",
+    "hasImage": true
   },
   "https://twitter.com/miableem": {
     "domain": "twitter.com",
@@ -485,19 +573,26 @@
   },
   "https://twitter.com/pie6k": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "title": "Adam Pietrasiak (@pie6k) on X",
+    "description": "I design through code. Building https://t.co/6ceZFejl4s (@screenstudio). Support → please reach out at team@screen.studio instead of DMs.",
+    "hasImage": true
   },
   "https://twitter.com/randyloop": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "title": "Randy Lu (@randyloop) on X",
+    "description": "Product Engineer, Blogger.",
+    "hasImage": true
   },
   "https://twitter.com/real_kai42": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "title": "Kai (@real_kai42) on X",
+    "hasImage": true
   },
   "https://twitter.com/sanxiaozhizi": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "title": "Kevin Deng 🦋 @sxzz.dev (@sanxiaozhizi) on X",
+    "description": "Gen Z 🏳️‍🌈\n\n✦ @vuejs @vite_js @vueuse @unjsio team member\n✦ 🦋 @sxzz.dev • 🐘 @sxzz@webtoo.ls",
+    "hasImage": true
   },
   "https://twitter.com/shengxj1": {
     "domain": "twitter.com",
@@ -505,26 +600,33 @@
   },
   "https://twitter.com/strrlthedev": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "title": "STRRL.gpt (@strrlthedev) on X",
+    "hasImage": true
   },
   "https://twitter.com/taylorotwell": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "title": "Taylor Otwell (@taylorotwell) on X",
+    "description": "@laravelphp creator • ship or die",
+    "hasImage": true
   },
   "https://twitter.com/taylorotwell/status/1534178479201259520?s=20": {
     "domain": "twitter.com",
-    "title": "Tweet by Taylor Otwell (@taylorotwell)",
-    "description": "gm - laravel forever 🍊 (tweet verified live via Twitter syndication API; direct x.com fetch is blocked)"
+    "title": "Taylor Otwell (@taylorotwell) on X",
+    "description": "gm - laravel forever 🍊\n\n🤓🤝🇮🇹",
+    "hasImage": true
   },
   "https://twitter.com/thecalicastle/status/1655421012530569216?s=20": {
     "domain": "twitter.com",
-    "title": "Tweet by Cali Castle (@calicastle)",
-    "description": "今天晚上做客 MegaEase 做个设计分享会，主题是「How to Create Good UI/UX」 (tweet verified live via Twitter syndication API; direct x.com fetch is blocked)",
-    "descriptionEn": "I'll be a guest at MegaEase tonight for a design talk titled \"How to Create Good UI/UX.\" (tweet verified live via Twitter syndication API; direct x.com fetch is blocked)"
+    "title": "Cali Castle (@calicastle) on X",
+    "description": "今天晚上做客 MegaEase 做个设计分享会\n主题是「How to Create Good UI/UX」\n第一次分享讲纯设计内容\n我一直认为好的开发和好的设计应该是相辅相成的",
+    "descriptionEn": "I'll be a guest at MegaEase tonight for a design talk titled \"How to Create Good UI/UX.\" (tweet verified live via Twitter syndication API; direct x.com fetch is blocked)",
+    "hasImage": true
   },
   "https://twitter.com/theterryfei": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "title": "Terry Fei (@theterryfei) on X",
+    "description": "Building interesting things @zolplay 2AS5FRRZ",
+    "hasImage": true
   },
   "https://twitter.com/uuoapp": {
     "domain": "twitter.com",
@@ -532,7 +634,8 @@
   },
   "https://twitter.com/wangjie000": {
     "domain": "twitter.com",
-    "description": "[X profile not independently verifiable: twitter.com redirects to x.com, which returns HTTP 402 to automated clients]"
+    "title": "Wang Jie 🔆 (@wangjie000) on X",
+    "hasImage": true
   },
   "https://twitter.com/zuozizhen": {
     "domain": "twitter.com",
@@ -544,78 +647,93 @@
   },
   "https://x.com/thecalicastle/status/1667490519906410496?s=20": {
     "domain": "x.com",
-    "title": "Tweet by Cali Castle (@calicastle)",
-    "description": "明年的美国旧金山👇 (with image; tweet verified live via Twitter syndication API; direct x.com fetch is blocked)",
-    "descriptionEn": "San Francisco, USA, next year 👇 (with image; tweet verified live via Twitter syndication API; direct x.com fetch is blocked)"
+    "title": "Cali Castle (@calicastle) on X",
+    "description": "明年的美国旧金山👇\n https://t.co/LRu4zNAIYf",
+    "descriptionEn": "San Francisco, USA, next year 👇 (with image; tweet verified live via Twitter syndication API; direct x.com fetch is blocked)",
+    "hasImage": true
   },
   "https://x.com/thecalicastle/status/1700895469281690015?s=20": {
     "domain": "x.com",
-    "title": "Tweet by Cali Castle (@calicastle)",
-    "description": "佐玩首届「开发者交流会」已圆满结束！感谢来参与的每位朋友们！ (tweet verified live via Twitter syndication API; direct x.com fetch is blocked)",
-    "descriptionEn": "Zolplay's first Developer Meetup has successfully wrapped up! Thank you to every friend who joined us! (tweet verified live via Twitter syndication API; direct x.com fetch is blocked)"
+    "title": "Cali Castle (@calicastle) on X",
+    "description": "佐玩首届「开发者交流会」已圆满结束！\n感谢来参与的每位朋友们！认识了很多新朋友，面基了老朋友 🙏\n\n9月03日场照片：https://t.co/Fr9DXrS8N9\n9月10日场照片：https://t.co/CEWs6dlJL0\n\n以后还会举办 🤘\n\n也感谢本次 @BeWaterOfficial 的大力支持提供的 T 恤\n\n我们下次再见 👋",
+    "descriptionEn": "Zolplay's first Developer Meetup has successfully wrapped up! Thank you to every friend who joined us! (tweet verified live via Twitter syndication API; direct x.com fetch is blocked)",
+    "hasImage": true
   },
   "https://x.com/thecalicastle/status/1726632903738888412?s=20": {
     "domain": "x.com",
-    "title": "Tweet by Cali Castle (@calicastle)",
-    "description": "昨天跟 @huozhi 聊的很开心～ 晚上还一起给我过了个生日 🎂 谢谢 @theterryfei @_cuvii_ (tweet verified live via Twitter syndication API; direct x.com fetch is blocked)",
-    "descriptionEn": "I had a great time chatting with @huozhi yesterday. We even celebrated my birthday together that evening 🎂 Thank you, @theterryfei and @_cuvii_ (tweet verified live via Twitter syndication API; direct x.com fetch is blocked)"
+    "title": "Cali Castle (@calicastle) on X",
+    "description": "昨天跟 @huozhi 聊的很开心～\n晚上还一起给我过了个生日 🎂\n谢谢 @theterryfei @_cuvii_",
+    "descriptionEn": "I had a great time chatting with @huozhi yesterday. We even celebrated my birthday together that evening 🎂 Thank you, @theterryfei and @_cuvii_ (tweet verified live via Twitter syndication API; direct x.com fetch is blocked)",
+    "hasImage": true
   },
   "https://ui.nuxtlabs.com/getting-started": {
     "domain": "ui.nuxtlabs.com",
-    "title": "Introduction",
-    "description": "301 redirects to ui.nuxt.com/getting-started. Nuxt UI offers more than 125 accessible Tailwind CSS components for Vue, with optional Nuxt integration."
+    "title": "Introduction - Nuxt UI",
+    "description": "Nuxt UI is a comprehensive Vue UI component library (Nuxt optional), offering 125+ accessible, Tailwind CSS components for building modern web applications.",
+    "hasImage": true
   },
   "https://ui.shadcn.com": {
     "domain": "ui.shadcn.com",
-    "title": "shadcn/ui: Components for Your Design System",
-    "description": "An open-source set of components that can be customized, extended, and built upon."
+    "title": "The Foundation for your Design System - shadcn/ui",
+    "description": "A set of beautifully designed components that you can customize, extend, and build on. Start here then make it your own. Open Source. Open Code.",
+    "hasImage": true
   },
   "https://umami.is/": {
     "domain": "umami.is",
-    "title": "Umami: Privacy-Focused Web Analytics"
+    "title": "Umami - Privacy-Focused Web Analytics",
+    "description": "Umami is a simple, fast, privacy-focused alternative to Google Analytics. Open source, cookie-free, and easy to use.",
+    "hasImage": true
   },
   "https://upstash.com": {
     "domain": "upstash.com",
     "title": "Upstash: Serverless Data Platform",
-    "description": "Upstash provides serverless Redis, Vector, QStash, Workflow, and Box for low-latency, globally distributed data."
+    "description": "Upstash is a serverless data platform providing low latency and high scalability for real-time applications. Optimize your data infrastructure with Upstash's managed services for Redis, Vector, QStash, and other key data technologies.",
+    "hasImage": true
   },
   "https://upwork.com": {
     "domain": "upwork.com",
-    "description": "[Live site but serves an HTTP 403 bot-challenge page to automated clients; metadata not fetchable]"
+    "title": "Upwork | Hire Top Freelance Talent with Confidence",
+    "description": "Upwork is the world’s largest human and AI-powered freelance marketplace to hire top talent - trusted by businesses and professionals worldwide.",
+    "hasImage": true
   },
   "https://vercel.com": {
     "domain": "vercel.com",
-    "title": "Vercel: Infrastructure for Apps and Agents",
-    "description": "Vercel deploys apps and agents in sandboxed VMs with durable backends and access to hundreds of models."
+    "title": "Agentic Infrastructure - Vercel",
+    "description": "The autonomous stack for every app and agent.",
+    "hasImage": true
   },
   "https://vercel.com/storage/edge-config": {
     "domain": "vercel.com",
-    "title": "Vercel Edge Config: Experiments and Feature Flags",
-    "description": "Edge Config colocates globally distributed data with compute for A/B tests, feature flags, and dynamic redirects without additional network requests."
+    "title": "Edge Config: For ultra-low latency experimentation - Vercel",
+    "description": "Store your config data with your compute for near-zero ms reads and no added network requests.",
+    "hasImage": true
   },
   "https://volta.net/": {
     "domain": "volta.net",
     "title": "Volta",
-    "description": "[Live (HTTP 200) but serves a client-rendered app shell with only the title 'Volta' and no meta description]"
+    "description": "[Live (HTTP 200) but serves a client-rendered app shell with only the title 'Volta' and no meta description]",
+    "hasImage": false
   },
   "https://vuejs.org/": {
     "domain": "vuejs.org",
     "title": "Vue.js",
-    "description": "A JavaScript framework for building web user interfaces."
+    "description": "Vue.js - The Progressive JavaScript Framework",
+    "hasImage": true
   },
   "https://vvspaceship.website": {
     "domain": "vvspaceship.website"
   },
   "https://workos.com/": {
     "domain": "workos.com",
-    "title": "WorkOS: Enterprise Features for Your App",
-    "description": "WorkOS provides enterprise features such as single sign-on through a small integration."
+    "title": "WorkOS - Your app, Enterprise Ready.",
+    "description": "Developer APIs/SDKs for Enterprise Ready features like Single Sign-On, Directory Sync, Audit Logging, and more. Get started for free.",
+    "hasImage": true
   },
   "https://www.apple.com.cn/iphone-14-pro/": {
     "domain": "www.apple.com.cn",
     "title": "iPhone - Apple (中国大陆)",
-    "titleEn": "iPhone - Apple (Mainland China)",
-    "description": "[Original iPhone 14 Pro product page no longer exists; URL now redirects to Apple China's general iPhone lineup page]"
+    "titleEn": "iPhone",
+    "hasImage": true
   },
   "https://www.bilibili.com/video/BV1kH4y157xg/": {
     "domain": "www.bilibili.com",
@@ -634,22 +752,26 @@
   "https://www.radix-ui.com/": {
     "domain": "www.radix-ui.com",
     "title": "Radix UI",
-    "description": "An open-source component library designed for fast development, maintainability, and accessibility. It requires no additional configuration."
+    "description": "Components, icons, and colors for building high‑quality, accessible UI. Free and open-source.",
+    "hasImage": false
   },
   "https://www.shure.com/en-US/products/microphones/sm7b": {
     "domain": "www.shure.com",
-    "title": "SM7B - Vocal Microphone - Shure USA",
-    "description": "The SM7B is a dynamic microphone for broadcasting, podcasts, studio recording, vocals, and speech."
+    "title": "Vocal Microphone",
+    "description": "The Shure SM7B is the iconic dynamic vocal microphone you've already heard. It is perfect for professional podcasters, streamers, and vocalists alike.",
+    "hasImage": true
   },
   "https://www.tiktok.com/business/en": {
     "domain": "www.tiktok.com",
     "title": "TikTok for Business | Marketing & Advertising on TikTok",
-    "description": "301 redirects to ads.tiktok.com/business/en. TikTok for Business provides tools for creating ads and reaching audiences on TikTok."
+    "description": "Advertise on TikTok. Make ads that entertain and campaigns that connect. Where large and small businesses, agencies & creators can achieve big results.",
+    "hasImage": true
   },
   "https://www.urlbox.io/": {
     "domain": "www.urlbox.io",
-    "title": "Urlbox: Website Screenshot Automation",
-    "description": "301 redirects to urlbox.com. Urlbox automates full-page website screenshots and reports more than 1,700 customers and 99.99% uptime."
+    "title": "Screenshots you'll stake your reputation on, flawless full page captures and more.",
+    "description": "Take accurate screen grabs of web content with Urlbox. Trusted by 1,700+ customers generating thousands of images per minute. Start your free trial today.",
+    "hasImage": true
   },
   "https://www.w3.org/TR/CSS21/ui.html#propdef-cursor": {
     "domain": "www.w3.org",
@@ -668,8 +790,32 @@
   "https://zolplay.com": {
     "domain": "zolplay.com",
     "title": "佐玩（AI 原生设计工作室）",
-    "titleEn": "Zolplay (AI-native Design Studio)",
+    "titleEn": "Zolplay (Design Studio)",
     "description": "一家位于深圳的 AI 原生设计工作室，打造产品、品牌与数字体验。",
-    "descriptionEn": "A Shenzhen-based AI-native design studio creating products, brands, and digital experiences."
+    "descriptionEn": "A design studio for people with good taste.",
+    "hasImage": true
+  },
+  "https://antfu.me/": {
+    "domain": "antfu.me",
+    "title": "Anthony Fu",
+    "hasImage": false
+  },
+  "https://neon.tech/": {
+    "domain": "neon.tech",
+    "title": "Neon - Postgres backends for apps and agents",
+    "description": "The backend for apps and agents. Build with Serverless Postgres, Auth, Functions, Storage, and an AI Gateway: instant, branchable, serverless.",
+    "hasImage": true
+  },
+  "https://resend.com/": {
+    "domain": "resend.com",
+    "title": "Resend · Email for developers",
+    "description": "The best way to reach humans instead of spam folders. Deliver transactional and marketing emails at scale.",
+    "hasImage": true
+  },
+  "https://upstash.com/": {
+    "domain": "upstash.com",
+    "title": "Upstash: Serverless Data Platform",
+    "description": "Upstash is a serverless data platform providing low latency and high scalability for real-time applications. Optimize your data infrastructure with Upstash's managed services for Redis, Vector, QStash, and other key data technologies.",
+    "hasImage": true
   }
 }

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -194,10 +194,13 @@ open rich hover cards. The contract:
   popup is informational and noninteractive, and touch follows that link
   without opening a separate surface.
 - **The implemented base: external-link previews.** Every external link in
-  prose carries a 14px inline favicon (fixed slot, no layout shift) and — when
-  build-time metadata exists in `content/link-previews.json` — a preview card
-  (favicon + domain, title, two-line description) on the shared hover-card
-  primitive (`components/external-link.tsx`). Refresh the metadata with
+  prose carries a 14px inline favicon (fixed slot, no layout shift) served by
+  `og.zolplay.com` and — when build-time metadata exists in
+  `content/link-previews.json` — a preview card on the shared hover-card
+  primitive (`components/external-link.tsx`). Image-enabled cards reserve one
+  fixed 16:9 slot for the proxied Open Graph image above the favicon, domain,
+  title, and two-line description; media failure keeps the slot and link stable.
+  Refresh the metadata from the same first-party service with
   `node scripts/refresh-link-previews.mjs`.
 - **External-link mark.** Text links that leave the site carry the shared
   northeast arrow inline; internal links, RSS, and Email do not. Shelf covers

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -30,6 +30,10 @@ Current as of July 2026.
   images must follow the route, not browser-local state.
 - Public pages are static where possible. GitHub and YouTube social values use
   ISR-backed fetches with committed JSON snapshots as outage fallbacks.
+- External-link cards keep metadata in a committed snapshot refreshed through
+  `og.zolplay.com`; the same first-party service proxies fixed-slot favicons and
+  Open Graph images, and missing media remains a non-blocking presentation
+  failure.
 - The fixed bottom dock is the primary navigation. The visual contract lives
   in `docs/design-language.md`.
 - The AMA domain has owner-auth, availability, database, and security

--- a/docs/research/og-zolplay-http-api.md
+++ b/docs/research/og-zolplay-http-api.md
@@ -2,6 +2,10 @@
 
 _Internal first-party contract supplied by Cali and live-verified on 2026-07-14._
 
+The cali.so external-link preview integration tracked in issue #112 uses this
+service for build-time metadata snapshots and non-critical favicon and Open
+Graph image delivery. Site-generated sharing images remain independent.
+
 `og.zolplay.com` is an HTTP service for fetching metadata and media derived
 from a target webpage. The target URL is passed as a URL-encoded path segment.
 The service automatically adds `https` when the target omits a scheme and
@@ -110,6 +114,12 @@ The following behavior was observed against `https://og.zolplay.com` on
 | Favicon proxy for `zolplay.com` | `200 image/x-icon` |
 | Favicon redirect for `zolplay.com` | `302` to the source favicon |
 
-Authentication, caching guarantees, rate limits, response-size limits, and
-formal error schemas are not yet documented. Verify those before making the
-service a runtime-critical dependency.
+A second live check on 2026-07-15 observed `Cache-Control: public,
+max-age=3600, s-maxage=86400` on metadata and Open Graph images, and `public,
+max-age=86400, s-maxage=604800` on favicons. These are observations, not a
+formal service guarantee.
+
+Authentication, formal caching guarantees, rate limits, response-size limits,
+and formal error schemas are not yet documented. The integration therefore
+keeps metadata in a checked-in snapshot and treats missing media as a normal,
+layout-stable failure rather than making the service runtime-critical.

--- a/lib/link-previews.ts
+++ b/lib/link-previews.ts
@@ -1,12 +1,10 @@
 import previews from '~/content/link-previews.json'
+import {
+  ogZolplayUrl,
+  type LinkPreviewSnapshot,
+} from '~/lib/og-zolplay.mjs'
 
-export interface LinkPreview {
-  domain: string
-  title?: string
-  titleEn?: string
-  description?: string
-  descriptionEn?: string
-}
+export interface LinkPreview extends LinkPreviewSnapshot {}
 
 const data = previews as Record<string, LinkPreview>
 
@@ -17,12 +15,12 @@ export function getLinkPreview(url: string): LinkPreview | undefined {
   return data[url]
 }
 
-// null for malformed hrefs (`https://`, embedded spaces…) — a bad link in
-// a post must degrade to a plain anchor, never crash the build.
-export function faviconUrl(href: string, size: 32 | 64 = 32): string | null {
-  try {
-    return `https://www.google.com/s2/favicons?domain=${new URL(href).hostname}&sz=${size}`
-  } catch {
-    return null
-  }
+// Bad links in a post degrade to plain anchors instead of reaching the
+// first-party preview service or crashing the build.
+export function faviconUrl(href: string): string | null {
+  return ogZolplayUrl('favicon', href)
+}
+
+export function ogImageUrl(href: string): string | null {
+  return ogZolplayUrl('image', href)
 }

--- a/lib/og-zolplay.d.mts
+++ b/lib/og-zolplay.d.mts
@@ -1,0 +1,18 @@
+export type OgZolplayEndpoint = 'metadata' | 'favicon' | 'image'
+
+export interface LinkPreviewSnapshot {
+  domain: string
+  title?: string
+  titleEn?: string
+  description?: string
+  descriptionEn?: string
+  hasImage?: boolean
+}
+
+export function ogZolplayUrl(endpoint: OgZolplayEndpoint, target: string): string | null
+
+export function normalizeOgMetadata(
+  target: string,
+  metadata: unknown,
+  previous?: LinkPreviewSnapshot,
+): LinkPreviewSnapshot | undefined

--- a/lib/og-zolplay.mjs
+++ b/lib/og-zolplay.mjs
@@ -119,7 +119,6 @@ function localizedField(freshValue, previousSource, previousEnglish) {
 
   if (source && HAN.test(source) && !english) {
     if (previous && !HAN.test(previous)) english = previous
-    else source = undefined
   }
 
   return { source, english }

--- a/lib/og-zolplay.mjs
+++ b/lib/og-zolplay.mjs
@@ -1,0 +1,159 @@
+const BASE_URL = 'https://og.zolplay.com'
+const PRIVATE_HOST_SUFFIXES = ['.internal', '.invalid', '.local', '.localhost', '.test']
+const HAN = /\p{Script=Han}/u
+
+function isNonPublicIpv4(hostname) {
+  const octets = hostname.split('.').map(Number)
+  if (octets.length !== 4 || octets.some((octet) => !Number.isInteger(octet))) return false
+
+  const [first, second] = octets
+  return (
+    first === 0 ||
+    first === 10 ||
+    first === 127 ||
+    (first === 100 && second >= 64 && second <= 127) ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 0 && octets[2] === 0) ||
+    (first === 192 && second === 0 && octets[2] === 2) ||
+    (first === 192 && second === 168) ||
+    (first === 192 && second === 88 && octets[2] === 99) ||
+    (first === 198 && (second === 18 || second === 19)) ||
+    (first === 198 && second === 51 && octets[2] === 100) ||
+    (first === 203 && second === 0 && octets[2] === 113) ||
+    first >= 224
+  )
+}
+
+function ipv6Hextets(hostname) {
+  const address = hostname.replace(/^\[|\]$/g, '').toLowerCase()
+  const [head = '', tail = ''] = address.split('::')
+  const leading = head ? head.split(':') : []
+  const trailing = tail ? tail.split(':') : []
+  const missing = 8 - leading.length - trailing.length
+  if (missing < 0 || (!address.includes('::') && missing !== 0)) return null
+
+  const hextets = [
+    ...leading,
+    ...Array.from({ length: missing }, () => '0'),
+    ...trailing,
+  ].map((part) => Number.parseInt(part, 16))
+
+  return hextets.length === 8 && hextets.every((part) => Number.isInteger(part))
+    ? hextets
+    : null
+}
+
+function isNonPublicIpv6(hostname) {
+  const hextets = ipv6Hextets(hostname)
+  if (!hextets) return true
+
+  const [first, second, third] = hextets
+  const globallyRoutable = first >= 0x2000 && first <= 0x3fff
+  const documentation =
+    (first === 0x2001 && second === 0x0db8) ||
+    (first === 0x3fff && (second & 0xf000) === 0)
+  const benchmarking =
+    first === 0x2001 && second === 0x0002 && third === 0
+  const orchid =
+    first === 0x2001 &&
+    ((second & 0xfff0) === 0x0010 || (second & 0xfff0) === 0x0020)
+
+  if (!globallyRoutable || documentation || benchmarking || orchid) return true
+
+  if (first === 0x2002) {
+    const embeddedIpv4 = [second >> 8, second & 0xff, third >> 8, third & 0xff].join('.')
+    return isNonPublicIpv4(embeddedIpv4)
+  }
+
+  return false
+}
+
+function publicHttpUrl(target) {
+  try {
+    const url = new URL(target)
+    const hostname = url.hostname.toLowerCase()
+    const privateHostname =
+      hostname === 'localhost' ||
+      PRIVATE_HOST_SUFFIXES.some((suffix) => hostname.endsWith(suffix))
+
+    if (
+      (url.protocol !== 'http:' && url.protocol !== 'https:') ||
+      url.username ||
+      url.password ||
+      (!hostname.includes('.') && !hostname.includes(':')) ||
+      privateHostname ||
+      isNonPublicIpv4(hostname) ||
+      (hostname.includes(':') && isNonPublicIpv6(hostname))
+    ) {
+      return null
+    }
+
+    return url
+  } catch {
+    return null
+  }
+}
+
+export function ogZolplayUrl(endpoint, target) {
+  const url = publicHttpUrl(target)
+  return url ? `${BASE_URL}/${endpoint}/${encodeURIComponent(url.href)}` : null
+}
+
+function normalizePreviewText(value) {
+  if (typeof value !== 'string' || !value.trim()) return undefined
+  return value.trim().replace(/\s*[—–]\s*/gu, ' - ')
+}
+
+function localizedField(freshValue, previousSource, previousEnglish) {
+  const fresh = normalizePreviewText(freshValue)
+  const previous = normalizePreviewText(previousSource)
+  const previousEn = normalizePreviewText(previousEnglish)
+
+  if (fresh && !HAN.test(fresh) && previous && HAN.test(previous)) {
+    return { source: previous, english: fresh }
+  }
+
+  let source = fresh ?? previous
+  let english = previousEn
+
+  if (source && HAN.test(source) && !english) {
+    if (previous && !HAN.test(previous)) english = previous
+    else source = undefined
+  }
+
+  return { source, english }
+}
+
+function hasOgImage(value) {
+  return (
+    Array.isArray(value) &&
+    value.some(
+      (image) =>
+        typeof image === 'object' &&
+        image !== null &&
+        typeof image.url === 'string' && image.url.trim() !== '',
+    )
+  )
+}
+
+export function normalizeOgMetadata(target, metadata, previous) {
+  const url = publicHttpUrl(target)
+  if (!url || typeof metadata !== 'object' || metadata === null) return undefined
+
+  const title = localizedField(metadata.ogTitle, previous?.title, previous?.titleEn)
+  const description = localizedField(
+    metadata.ogDescription,
+    previous?.description,
+    previous?.descriptionEn,
+  )
+
+  return {
+    domain: url.hostname,
+    title: title.source,
+    titleEn: title.english,
+    description: description.source,
+    descriptionEn: description.english,
+    hasImage: hasOgImage(metadata.ogImage),
+  }
+}

--- a/lib/og-zolplay.test.ts
+++ b/lib/og-zolplay.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeOgMetadata, ogZolplayUrl } from './og-zolplay.mjs'
+
+describe('og.zolplay.com link previews', () => {
+  it('builds encoded first-party service URLs for public targets', () => {
+    const target = 'https://example.com/articles/design?lang=en#preview'
+
+    expect(ogZolplayUrl('metadata', target)).toBe(
+      'https://og.zolplay.com/metadata/https%3A%2F%2Fexample.com%2Farticles%2Fdesign%3Flang%3Den%23preview',
+    )
+    expect(ogZolplayUrl('favicon', target)).toBe(
+      'https://og.zolplay.com/favicon/https%3A%2F%2Fexample.com%2Farticles%2Fdesign%3Flang%3Den%23preview',
+    )
+    expect(ogZolplayUrl('image', target)).toBe(
+      'https://og.zolplay.com/image/https%3A%2F%2Fexample.com%2Farticles%2Fdesign%3Flang%3Den%23preview',
+    )
+  })
+
+  it.each([
+    'javascript:alert(1)',
+    'file:///etc/passwd',
+    'http://localhost/admin',
+    'http://metadata/private',
+    'http://127.0.0.1/private',
+    'http://[::1]/private',
+    'http://[::ffff:127.0.0.1]/private',
+    'http://[::7f00:1]/private',
+    'http://[fec0::1]/private',
+    'http://[ff02::1]/private',
+    'http://[2001:db8::1]/private',
+    'http://192.0.0.1/private',
+    'http://192.0.2.1/private',
+    'http://198.18.0.1/private',
+    'http://198.51.100.1/private',
+    'http://203.0.113.1/private',
+  ])('rejects non-public targets: %s', (target) => {
+    expect(ogZolplayUrl('metadata', target)).toBeNull()
+  })
+
+  it('allows globally routable IPv4 and IPv6 targets', () => {
+    expect(ogZolplayUrl('metadata', 'http://1.1.1.1/')).not.toBeNull()
+    expect(ogZolplayUrl('metadata', 'http://[2606:4700:4700::1111]/')).not.toBeNull()
+  })
+
+  it('normalizes documented metadata while preserving localized copy', () => {
+    expect(
+      normalizeOgMetadata(
+        'https://zolplay.com/work',
+        {
+          ogTitle: 'Zolplay (Design Studio)',
+          ogDescription: 'A design studio for people with good taste.',
+          ogImage: [{ type: 'image/png', url: 'https://zolplay.com/opengraph-image' }],
+        },
+        {
+          domain: 'zolplay.com',
+          titleEn: 'Zolplay (Design Studio)',
+          descriptionEn: 'A design studio for people with good taste.',
+        },
+      ),
+    ).toEqual({
+      domain: 'zolplay.com',
+      title: 'Zolplay (Design Studio)',
+      titleEn: 'Zolplay (Design Studio)',
+      description: 'A design studio for people with good taste.',
+      descriptionEn: 'A design studio for people with good taste.',
+      hasImage: true,
+    })
+  })
+
+  it('sanitizes dashes and promotes prior source copy when new metadata contains Han', () => {
+    expect(
+      normalizeOgMetadata(
+        'https://example.com',
+        {
+          ogTitle: '设计 — Example',
+          ogDescription: '面向设计师的平台',
+          ogImage: [],
+        },
+        {
+          domain: 'example.com',
+          title: 'Example for designers',
+          description: 'A platform for designers',
+        },
+      ),
+    ).toEqual({
+      domain: 'example.com',
+      title: '设计 - Example',
+      titleEn: 'Example for designers',
+      description: '面向设计师的平台',
+      descriptionEn: 'A platform for designers',
+      hasImage: false,
+    })
+  })
+
+  it('preserves prior Chinese copy when fresh service metadata is English', () => {
+    expect(
+      normalizeOgMetadata(
+        'https://zolplay.com',
+        {
+          ogTitle: 'Zolplay (Design Studio)',
+          ogDescription: 'A design studio for people with good taste.',
+          ogImage: [{ url: 'https://zolplay.com/opengraph-image' }],
+        },
+        {
+          domain: 'zolplay.com',
+          title: '佐玩（AI 原生设计工作室）',
+          titleEn: 'Zolplay (AI-native Design Studio)',
+          description: '一家位于深圳的 AI 原生设计工作室，打造产品、品牌与数字体验。',
+          descriptionEn: 'A Shenzhen-based AI-native design studio.',
+        },
+      ),
+    ).toEqual({
+      domain: 'zolplay.com',
+      title: '佐玩（AI 原生设计工作室）',
+      titleEn: 'Zolplay (Design Studio)',
+      description: '一家位于深圳的 AI 原生设计工作室，打造产品、品牌与数字体验。',
+      descriptionEn: 'A design studio for people with good taste.',
+      hasImage: true,
+    })
+  })
+})

--- a/lib/og-zolplay.test.ts
+++ b/lib/og-zolplay.test.ts
@@ -119,4 +119,21 @@ describe('og.zolplay.com link previews', () => {
       hasImage: true,
     })
   })
+
+  it('keeps Han-only metadata when no English fallback exists', () => {
+    expect(
+      normalizeOgMetadata('https://example.com', {
+        ogTitle: '纯中文标题',
+        ogDescription: '只有中文的页面描述。',
+        ogImage: [],
+      }),
+    ).toEqual({
+      domain: 'example.com',
+      title: '纯中文标题',
+      titleEn: undefined,
+      description: '只有中文的页面描述。',
+      descriptionEn: undefined,
+      hasImage: false,
+    })
+  })
 })

--- a/lib/security/headers.test.ts
+++ b/lib/security/headers.test.ts
@@ -14,6 +14,8 @@ describe('site security headers', () => {
     expect(headers['content-security-policy']).toContain("base-uri 'self'")
     expect(headers['content-security-policy']).toContain("form-action 'self'")
     expect(headers['content-security-policy']).toContain("script-src 'self' 'unsafe-inline'")
+    expect(headers['content-security-policy']).toContain('https://og.zolplay.com')
+    expect(headers['content-security-policy']).not.toContain('https://www.google.com')
     expect(headers['content-security-policy']).not.toContain("'unsafe-eval'")
     expect(headers['strict-transport-security']).toBe(
       'max-age=63072000; includeSubDomains; preload',

--- a/lib/security/headers.ts
+++ b/lib/security/headers.ts
@@ -18,7 +18,7 @@ function contentSecurityPolicy(scriptSources: string, styleSources: string) {
     `script-src ${scriptSources}`,
     "script-src-attr 'none'",
     `style-src ${styleSources}`,
-    "img-src 'self' data: blob: https://www.google.com https://zolplay.com",
+    "img-src 'self' data: blob: https://og.zolplay.com",
     "font-src 'self' data:",
     "connect-src 'self'",
     "media-src 'self' blob:",

--- a/scripts/refresh-link-previews.mjs
+++ b/scripts/refresh-link-previews.mjs
@@ -2,7 +2,7 @@
 // links found in both localized post sources. Run manually when posts change:
 //   node scripts/refresh-link-previews.mjs
 // Requires network access; existing entries are kept when a fetch fails.
-import { readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 
 import { normalizeOgMetadata, ogZolplayUrl } from '../lib/og-zolplay.mjs'
@@ -19,7 +19,10 @@ for (const dir of readdirSync(POSTS_DIR, { withFileTypes: true })) {
   if (!dir.isDirectory()) continue
 
   for (const file of POST_FILES) {
-    const mdx = readFileSync(path.join(POSTS_DIR, dir.name, file), 'utf8')
+    const source = path.join(POSTS_DIR, dir.name, file)
+    if (!existsSync(source)) continue
+
+    const mdx = readFileSync(source, 'utf8')
     for (const [, href] of mdx.matchAll(MARKDOWN_LINK)) urls.add(href)
     for (const [, href] of mdx.matchAll(MDX_LINK)) urls.add(href)
   }

--- a/scripts/refresh-link-previews.mjs
+++ b/scripts/refresh-link-previews.mjs
@@ -1,50 +1,53 @@
-// Rebuilds content/link-previews.json from the external links found in
-// content/blog/*/index.mdx. Run manually when posts change:
+// Rebuilds content/link-previews.json through og.zolplay.com for the external
+// links found in both localized post sources. Run manually when posts change:
 //   node scripts/refresh-link-previews.mjs
 // Requires network access; existing entries are kept when a fetch fails.
 import { readFileSync, readdirSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 
+import { normalizeOgMetadata, ogZolplayUrl } from '../lib/og-zolplay.mjs'
+
 const POSTS_DIR = 'content/blog'
 const CACHE = 'content/link-previews.json'
+const MAX_METADATA_BYTES = 64 * 1024
+const POST_FILES = ['index.mdx', 'index.en.mdx']
+const MARKDOWN_LINK = /\]\((https?:\/\/(?:[^()\s]|\([^()\s]*\))+)\)/g
+const MDX_LINK = /href="(https?:\/\/[^"]+)"/g
 
 const urls = new Set()
 for (const dir of readdirSync(POSTS_DIR, { withFileTypes: true })) {
   if (!dir.isDirectory()) continue
-  const mdx = readFileSync(path.join(POSTS_DIR, dir.name, 'index.mdx'), 'utf8')
-  for (const [, href] of mdx.matchAll(/\]\((https?:\/\/[^)\s]+)\)/g)) urls.add(href)
-  for (const [, href] of mdx.matchAll(/href="(https?:\/\/[^"]+)"/g)) urls.add(href)
+
+  for (const file of POST_FILES) {
+    const mdx = readFileSync(path.join(POSTS_DIR, dir.name, file), 'utf8')
+    for (const [, href] of mdx.matchAll(MARKDOWN_LINK)) urls.add(href)
+    for (const [, href] of mdx.matchAll(MDX_LINK)) urls.add(href)
+  }
 }
 
 const cache = JSON.parse(readFileSync(CACHE, 'utf8'))
 
-function pick(html, patterns) {
-  for (const p of patterns) {
-    const m = html.match(p)
-    if (m) return m[1].trim().replace(/&amp;/g, '&').replace(/&#x27;|&#39;/g, "'").replace(/&quot;/g, '"')
-  }
-}
-
 for (const url of urls) {
   try {
-    const res = await fetch(url, {
+    const metadataUrl = ogZolplayUrl('metadata', url)
+    if (!metadataUrl) throw new Error('invalid public HTTP(S) target')
+
+    const res = await fetch(metadataUrl, {
       redirect: 'follow',
       signal: AbortSignal.timeout(10_000),
       headers: { 'user-agent': 'Mozilla/5.0 (compatible; cali.so link previews)' },
     })
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
-    const html = (await res.text()).slice(0, 200_000)
-    const title = pick(html, [
-      /<meta[^>]+property="og:title"[^>]+content="([^"]+)"/i,
-      /<meta[^>]+content="([^"]+)"[^>]+property="og:title"/i,
-      /<title[^>]*>([^<]+)<\/title>/i,
-    ])
-    const description = pick(html, [
-      /<meta[^>]+property="og:description"[^>]+content="([^"]+)"/i,
-      /<meta[^>]+content="([^"]+)"[^>]+property="og:description"/i,
-      /<meta[^>]+name="description"[^>]+content="([^"]+)"/i,
-    ])
-    cache[url] = { domain: new URL(url).hostname, title, description }
+
+    const body = await res.text()
+    if (Buffer.byteLength(body, 'utf8') > MAX_METADATA_BYTES) {
+      throw new Error('metadata response exceeds 64 KiB')
+    }
+
+    const preview = normalizeOgMetadata(url, JSON.parse(body), cache[url])
+    if (!preview) throw new Error('invalid metadata response')
+
+    cache[url] = preview
     console.log('ok', url)
   } catch (err) {
     if (!cache[url]) cache[url] = { domain: new URL(url).hostname }


### PR DESCRIPTION
Closes [#112](https://github.com/CaliCastle/cali.so/issues/112)

## Summary

- replace Google S2 favicons and direct page scraping with `og.zolplay.com`
- keep localized metadata in the committed preview snapshot and preserve it through refresh failures
- add fixed 16:9 Open Graph images to informational hover cards with stable media-failure behavior
- reject non-public targets, tighten the image CSP, and cover the adapter and card behavior with focused tests

## Verification

- `pnpm exec vitest run lib/og-zolplay.test.ts components/external-link.test.tsx lib/security/headers.test.ts`
- `pnpm test:localization`
- `pnpm test:security`
- `pnpm test:ama`
- `pnpm test:port-post`
- `pnpm typecheck`
- `pnpm build`
- browser review in light and dark modes, keyboard focus, reduced motion, touch-pointer fallback, failed media, and fixed card geometry
- separate standards and issue-spec reviews
