### PR TITLE
Add Media Library catalog schema

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Test media storage contract
         run: pnpm test:media:storage
 
+      - name: Test media catalog constraints
+        run: pnpm test:media:catalog
+
       - name: Test localization
         run: pnpm test:localization
 

--- a/db/migrations/0005_media_catalog.sql
+++ b/db/migrations/0005_media_catalog.sql
@@ -69,7 +69,7 @@ CREATE TABLE "media_renditions" (
 	CONSTRAINT "media_renditions_object_key_check" CHECK (length(btrim("media_renditions"."object_key")) > 0),
 	CONSTRAINT "media_renditions_profile_check" CHECK ("media_renditions"."profile_width" IN (640, 1024, 1600)),
 	CONSTRAINT "media_renditions_checksum_check" CHECK ("media_renditions"."checksum_sha256" ~ '^[0-9a-f]{64}$'),
-	CONSTRAINT "media_renditions_dimensions_check" CHECK ("media_renditions"."width" BETWEEN 1 AND "media_renditions"."profile_width" AND "media_renditions"."height" > 0),
+	CONSTRAINT "media_renditions_dimensions_check" CHECK ("media_renditions"."width" BETWEEN 1 AND "media_renditions"."profile_width" AND "media_renditions"."height" > 0 AND ("media_renditions"."width"::bigint * "media_renditions"."height"::bigint) <= 100000000),
 	CONSTRAINT "media_renditions_byte_size_check" CHECK ("media_renditions"."byte_size" > 0),
 	CONSTRAINT "media_renditions_content_type_check" CHECK ("media_renditions"."content_type" = 'image/jpeg'),
 	CONSTRAINT "media_renditions_color_space_check" CHECK ("media_renditions"."color_space" = 'srgb'),
@@ -95,7 +95,7 @@ CREATE TABLE "media_upload_intents" (
 	CONSTRAINT "media_upload_intents_byte_size_check" CHECK ("media_upload_intents"."byte_size" BETWEEN 1 AND 52428800),
 	CONSTRAINT "media_upload_intents_checksum_check" CHECK ("media_upload_intents"."checksum_sha256" ~ '^[0-9a-f]{64}$'),
 	CONSTRAINT "media_upload_intents_expiry_check" CHECK ("media_upload_intents"."expires_at" > "media_upload_intents"."created_at"),
-	CONSTRAINT "media_upload_intents_completion_check" CHECK ("media_upload_intents"."completed_at" IS NULL OR ("media_upload_intents"."completed_at" >= "media_upload_intents"."created_at" AND "media_upload_intents"."completed_at" <= "media_upload_intents"."expires_at"))
+	CONSTRAINT "media_upload_intents_completion_check" CHECK ("media_upload_intents"."completed_at" IS NULL OR "media_upload_intents"."completed_at" >= "media_upload_intents"."created_at")
 );
 --> statement-breakpoint
 ALTER TABLE "media_assets" ADD CONSTRAINT "media_assets_upload_intent_id_media_upload_intents_id_fk" FOREIGN KEY ("upload_intent_id") REFERENCES "public"."media_upload_intents"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint

--- a/db/migrations/0005_media_catalog.sql
+++ b/db/migrations/0005_media_catalog.sql
@@ -1,0 +1,110 @@
+CREATE TABLE "media_assets" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"upload_intent_id" uuid NOT NULL,
+	"kind" varchar(16) DEFAULT 'image' NOT NULL,
+	"lifecycle" varchar(16) DEFAULT 'active' NOT NULL,
+	"processing_state" varchar(32) DEFAULT 'upload_initiated' NOT NULL,
+	"processing_error_code" varchar(64),
+	"original_key" text NOT NULL,
+	"original_content_type" varchar(64) NOT NULL,
+	"original_byte_size" integer NOT NULL,
+	"original_checksum_sha256" varchar(64) NOT NULL,
+	"width" integer,
+	"height" integer,
+	"captured_at" timestamp with time zone,
+	"camera_make" text,
+	"camera_model" text,
+	"lens" text,
+	"focal_length_millimeters" numeric(8, 3),
+	"aperture" numeric(6, 3),
+	"shutter_speed_seconds" numeric(12, 8),
+	"iso" integer,
+	"focal_point_x" numeric(5, 4),
+	"focal_point_y" numeric(5, 4),
+	"capture_location_envelope" jsonb,
+	"location_label_zh_hans" text,
+	"location_label_en" text,
+	"alt_text_suggestion_zh_hans" text,
+	"alt_text_suggestion_en" text,
+	"alt_text_suggestion_model" varchar(255),
+	"alt_text_suggested_at" timestamp with time zone,
+	"alt_text_zh_hans" text,
+	"alt_text_en" text,
+	"alt_text_approved_at" timestamp with time zone,
+	"archived_at" timestamp with time zone,
+	"purge_started_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "media_assets_kind_check" CHECK ("media_assets"."kind" = 'image'),
+	CONSTRAINT "media_assets_lifecycle_check" CHECK ("media_assets"."lifecycle" IN ('active', 'archived', 'purging')),
+	CONSTRAINT "media_assets_processing_state_check" CHECK ("media_assets"."processing_state" IN ('upload_initiated', 'original_verified', 'processing', 'ready', 'retryable_failure', 'repair_required')),
+	CONSTRAINT "media_assets_processing_error_check" CHECK (("media_assets"."processing_state" IN ('retryable_failure', 'repair_required')) = ("media_assets"."processing_error_code" IS NOT NULL AND length(btrim("media_assets"."processing_error_code")) > 0)),
+	CONSTRAINT "media_assets_original_key_check" CHECK (length(btrim("media_assets"."original_key")) > 0),
+	CONSTRAINT "media_assets_original_content_type_check" CHECK ("media_assets"."original_content_type" IN ('image/jpeg', 'image/png', 'image/heic', 'image/heif')),
+	CONSTRAINT "media_assets_original_byte_size_check" CHECK ("media_assets"."original_byte_size" BETWEEN 1 AND 52428800),
+	CONSTRAINT "media_assets_original_checksum_check" CHECK ("media_assets"."original_checksum_sha256" ~ '^[0-9a-f]{64}$'),
+	CONSTRAINT "media_assets_dimensions_check" CHECK (num_nonnulls("media_assets"."width", "media_assets"."height") IN (0, 2) AND ("media_assets"."width" IS NULL OR ("media_assets"."width" > 0 AND "media_assets"."height" > 0 AND ("media_assets"."width"::bigint * "media_assets"."height"::bigint) <= 100000000))),
+	CONSTRAINT "media_assets_focal_point_check" CHECK (num_nonnulls("media_assets"."focal_point_x", "media_assets"."focal_point_y") IN (0, 2) AND ("media_assets"."focal_point_x" IS NULL OR ("media_assets"."focal_point_x" BETWEEN 0 AND 1 AND "media_assets"."focal_point_y" BETWEEN 0 AND 1))),
+	CONSTRAINT "media_assets_camera_values_check" CHECK (("media_assets"."focal_length_millimeters" IS NULL OR "media_assets"."focal_length_millimeters" > 0) AND ("media_assets"."aperture" IS NULL OR "media_assets"."aperture" > 0) AND ("media_assets"."shutter_speed_seconds" IS NULL OR "media_assets"."shutter_speed_seconds" > 0) AND ("media_assets"."iso" IS NULL OR "media_assets"."iso" > 0)),
+	CONSTRAINT "media_assets_alt_suggestion_check" CHECK (num_nonnulls("media_assets"."alt_text_suggestion_zh_hans", "media_assets"."alt_text_suggestion_en", "media_assets"."alt_text_suggestion_model", "media_assets"."alt_text_suggested_at") IN (0, 4) AND ("media_assets"."alt_text_suggestion_zh_hans" IS NULL OR (length(btrim("media_assets"."alt_text_suggestion_zh_hans")) > 0 AND length(btrim("media_assets"."alt_text_suggestion_en")) > 0 AND length(btrim("media_assets"."alt_text_suggestion_model")) > 0))),
+	CONSTRAINT "media_assets_alt_text_check" CHECK (num_nonnulls("media_assets"."alt_text_zh_hans", "media_assets"."alt_text_en", "media_assets"."alt_text_approved_at") IN (0, 3) AND ("media_assets"."alt_text_zh_hans" IS NULL OR (length(btrim("media_assets"."alt_text_zh_hans")) > 0 AND length(btrim("media_assets"."alt_text_en")) > 0))),
+	CONSTRAINT "media_assets_archive_check" CHECK (("media_assets"."lifecycle" = 'active' AND "media_assets"."archived_at" IS NULL AND "media_assets"."purge_started_at" IS NULL) OR ("media_assets"."lifecycle" = 'archived' AND "media_assets"."archived_at" IS NOT NULL AND "media_assets"."purge_started_at" IS NULL) OR ("media_assets"."lifecycle" = 'purging' AND "media_assets"."archived_at" IS NOT NULL AND "media_assets"."purge_started_at" IS NOT NULL))
+);
+--> statement-breakpoint
+CREATE TABLE "media_renditions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"media_asset_id" uuid NOT NULL,
+	"profile_width" integer NOT NULL,
+	"object_key" text NOT NULL,
+	"checksum_sha256" varchar(64) NOT NULL,
+	"byte_size" integer NOT NULL,
+	"width" integer NOT NULL,
+	"height" integer NOT NULL,
+	"content_type" varchar(64) DEFAULT 'image/jpeg' NOT NULL,
+	"color_space" varchar(16) DEFAULT 'srgb' NOT NULL,
+	"progressive" boolean DEFAULT true NOT NULL,
+	"metadata_stripped" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "media_renditions_object_key_check" CHECK (length(btrim("media_renditions"."object_key")) > 0),
+	CONSTRAINT "media_renditions_profile_check" CHECK ("media_renditions"."profile_width" IN (640, 1024, 1600)),
+	CONSTRAINT "media_renditions_checksum_check" CHECK ("media_renditions"."checksum_sha256" ~ '^[0-9a-f]{64}$'),
+	CONSTRAINT "media_renditions_dimensions_check" CHECK ("media_renditions"."width" BETWEEN 1 AND "media_renditions"."profile_width" AND "media_renditions"."height" > 0),
+	CONSTRAINT "media_renditions_byte_size_check" CHECK ("media_renditions"."byte_size" > 0),
+	CONSTRAINT "media_renditions_content_type_check" CHECK ("media_renditions"."content_type" = 'image/jpeg'),
+	CONSTRAINT "media_renditions_color_space_check" CHECK ("media_renditions"."color_space" = 'srgb'),
+	CONSTRAINT "media_renditions_progressive_check" CHECK ("media_renditions"."progressive" = true),
+	CONSTRAINT "media_renditions_metadata_stripped_check" CHECK ("media_renditions"."metadata_stripped" = true)
+);
+--> statement-breakpoint
+CREATE TABLE "media_upload_intents" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"owner_user_id" varchar(255) NOT NULL,
+	"idempotency_key" varchar(128) NOT NULL,
+	"original_key" text NOT NULL,
+	"content_type" varchar(64) NOT NULL,
+	"byte_size" integer NOT NULL,
+	"checksum_sha256" varchar(64) NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"completed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "media_upload_intents_identity_check" CHECK (length(btrim("media_upload_intents"."owner_user_id")) > 0 AND length(btrim("media_upload_intents"."idempotency_key")) > 0),
+	CONSTRAINT "media_upload_intents_original_key_check" CHECK (length(btrim("media_upload_intents"."original_key")) > 0),
+	CONSTRAINT "media_upload_intents_content_type_check" CHECK ("media_upload_intents"."content_type" IN ('image/jpeg', 'image/png', 'image/heic', 'image/heif')),
+	CONSTRAINT "media_upload_intents_byte_size_check" CHECK ("media_upload_intents"."byte_size" BETWEEN 1 AND 52428800),
+	CONSTRAINT "media_upload_intents_checksum_check" CHECK ("media_upload_intents"."checksum_sha256" ~ '^[0-9a-f]{64}$'),
+	CONSTRAINT "media_upload_intents_expiry_check" CHECK ("media_upload_intents"."expires_at" > "media_upload_intents"."created_at"),
+	CONSTRAINT "media_upload_intents_completion_check" CHECK ("media_upload_intents"."completed_at" IS NULL OR ("media_upload_intents"."completed_at" >= "media_upload_intents"."created_at" AND "media_upload_intents"."completed_at" <= "media_upload_intents"."expires_at"))
+);
+--> statement-breakpoint
+ALTER TABLE "media_assets" ADD CONSTRAINT "media_assets_upload_intent_id_media_upload_intents_id_fk" FOREIGN KEY ("upload_intent_id") REFERENCES "public"."media_upload_intents"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "media_renditions" ADD CONSTRAINT "media_renditions_media_asset_id_media_assets_id_fk" FOREIGN KEY ("media_asset_id") REFERENCES "public"."media_assets"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "media_assets_upload_intent_uidx" ON "media_assets" USING btree ("upload_intent_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "media_assets_original_key_uidx" ON "media_assets" USING btree ("original_key");--> statement-breakpoint
+CREATE INDEX "media_assets_library_idx" ON "media_assets" USING btree ("lifecycle","processing_state","created_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "media_renditions_asset_profile_uidx" ON "media_renditions" USING btree ("media_asset_id","profile_width");--> statement-breakpoint
+CREATE UNIQUE INDEX "media_renditions_object_key_uidx" ON "media_renditions" USING btree ("object_key");--> statement-breakpoint
+CREATE UNIQUE INDEX "media_upload_intents_owner_idempotency_uidx" ON "media_upload_intents" USING btree ("owner_user_id","idempotency_key");--> statement-breakpoint
+CREATE UNIQUE INDEX "media_upload_intents_original_key_uidx" ON "media_upload_intents" USING btree ("original_key");--> statement-breakpoint
+CREATE INDEX "media_upload_intents_expiry_idx" ON "media_upload_intents" USING btree ("expires_at","completed_at");

--- a/db/migrations/meta/0005_snapshot.json
+++ b/db/migrations/meta/0005_snapshot.json
@@ -915,7 +915,7 @@
         },
         "media_renditions_dimensions_check": {
           "name": "media_renditions_dimensions_check",
-          "value": "\"media_renditions\".\"width\" BETWEEN 1 AND \"media_renditions\".\"profile_width\" AND \"media_renditions\".\"height\" > 0"
+          "value": "\"media_renditions\".\"width\" BETWEEN 1 AND \"media_renditions\".\"profile_width\" AND \"media_renditions\".\"height\" > 0 AND (\"media_renditions\".\"width\"::bigint * \"media_renditions\".\"height\"::bigint) <= 100000000"
         },
         "media_renditions_byte_size_check": {
           "name": "media_renditions_byte_size_check",
@@ -1104,7 +1104,7 @@
         },
         "media_upload_intents_completion_check": {
           "name": "media_upload_intents_completion_check",
-          "value": "\"media_upload_intents\".\"completed_at\" IS NULL OR (\"media_upload_intents\".\"completed_at\" >= \"media_upload_intents\".\"created_at\" AND \"media_upload_intents\".\"completed_at\" <= \"media_upload_intents\".\"expires_at\")"
+          "value": "\"media_upload_intents\".\"completed_at\" IS NULL OR \"media_upload_intents\".\"completed_at\" >= \"media_upload_intents\".\"created_at\""
         }
       },
       "isRLSEnabled": false

--- a/db/migrations/meta/0005_snapshot.json
+++ b/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,1225 @@
+{
+  "id": "30ef34e7-1a50-4b25-9211-ef7355f3c825",
+  "prevId": "263ae2a4-1993-42b2-9786-4c7643759ec5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ama_admin_sessions": {
+      "name": "ama_admin_sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_admin_sessions_expires_at_idx": {
+          "name": "ama_admin_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ama_auth_tokens": {
+      "name": "ama_auth_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_auth_tokens_expires_at_idx": {
+          "name": "ama_auth_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ama_availability_windows": {
+      "name": "ama_availability_windows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "iso_weekday": {
+          "name": "iso_weekday",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_minute": {
+          "name": "start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_minute": {
+          "name": "end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_availability_windows_order_idx": {
+          "name": "ama_availability_windows_order_idx",
+          "columns": [
+            {
+              "expression": "iso_weekday",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_minute",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_minute",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_availability_windows_iso_weekday_check": {
+          "name": "ama_availability_windows_iso_weekday_check",
+          "value": "\"ama_availability_windows\".\"iso_weekday\" BETWEEN 1 AND 7"
+        },
+        "ama_availability_windows_start_minute_check": {
+          "name": "ama_availability_windows_start_minute_check",
+          "value": "\"ama_availability_windows\".\"start_minute\" BETWEEN 0 AND 1439"
+        },
+        "ama_availability_windows_end_minute_check": {
+          "name": "ama_availability_windows_end_minute_check",
+          "value": "\"ama_availability_windows\".\"end_minute\" BETWEEN 1 AND 1440"
+        },
+        "ama_availability_windows_same_day_check": {
+          "name": "ama_availability_windows_same_day_check",
+          "value": "\"ama_availability_windows\".\"start_minute\" < \"ama_availability_windows\".\"end_minute\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_google_calendar_connections": {
+      "name": "ama_google_calendar_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_email": {
+          "name": "calendar_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_summary": {
+          "name": "calendar_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_scopes": {
+          "name": "granted_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "refresh_token_envelope": {
+          "name": "refresh_token_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_google_calendar_connections_singleton_check": {
+          "name": "ama_google_calendar_connections_singleton_check",
+          "value": "\"ama_google_calendar_connections\".\"id\" = 1"
+        },
+        "ama_google_calendar_connections_status_check": {
+          "name": "ama_google_calendar_connections_status_check",
+          "value": "\"ama_google_calendar_connections\".\"status\" IN ('disconnected', 'connected', 'expired', 'revoked', 'denied_scope', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_google_oauth_attempts": {
+      "name": "ama_google_oauth_attempts",
+      "schema": "",
+      "columns": {
+        "state_hash": {
+          "name": "state_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pkce_verifier_envelope": {
+          "name": "pkce_verifier_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_google_oauth_attempts_expires_at_idx": {
+          "name": "ama_google_oauth_attempts_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_assets": {
+      "name": "media_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "upload_intent_id": {
+          "name": "upload_intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'image'"
+        },
+        "lifecycle": {
+          "name": "lifecycle",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "processing_state": {
+          "name": "processing_state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upload_initiated'"
+        },
+        "processing_error_code": {
+          "name": "processing_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_content_type": {
+          "name": "original_content_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_byte_size": {
+          "name": "original_byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_checksum_sha256": {
+          "name": "original_checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera_make": {
+          "name": "camera_make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera_model": {
+          "name": "camera_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lens": {
+          "name": "lens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_length_millimeters": {
+          "name": "focal_length_millimeters",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aperture": {
+          "name": "aperture",
+          "type": "numeric(6, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutter_speed_seconds": {
+          "name": "shutter_speed_seconds",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iso": {
+          "name": "iso",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_point_x": {
+          "name": "focal_point_x",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_point_y": {
+          "name": "focal_point_y",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_location_envelope": {
+          "name": "capture_location_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_label_zh_hans": {
+          "name": "location_label_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_label_en": {
+          "name": "location_label_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_suggestion_zh_hans": {
+          "name": "alt_text_suggestion_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_suggestion_en": {
+          "name": "alt_text_suggestion_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_suggestion_model": {
+          "name": "alt_text_suggestion_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_suggested_at": {
+          "name": "alt_text_suggested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_zh_hans": {
+          "name": "alt_text_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_en": {
+          "name": "alt_text_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_approved_at": {
+          "name": "alt_text_approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purge_started_at": {
+          "name": "purge_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_assets_upload_intent_uidx": {
+          "name": "media_assets_upload_intent_uidx",
+          "columns": [
+            {
+              "expression": "upload_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_assets_original_key_uidx": {
+          "name": "media_assets_original_key_uidx",
+          "columns": [
+            {
+              "expression": "original_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_assets_library_idx": {
+          "name": "media_assets_library_idx",
+          "columns": [
+            {
+              "expression": "lifecycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processing_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_assets_upload_intent_id_media_upload_intents_id_fk": {
+          "name": "media_assets_upload_intent_id_media_upload_intents_id_fk",
+          "tableFrom": "media_assets",
+          "tableTo": "media_upload_intents",
+          "columnsFrom": [
+            "upload_intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_assets_kind_check": {
+          "name": "media_assets_kind_check",
+          "value": "\"media_assets\".\"kind\" = 'image'"
+        },
+        "media_assets_lifecycle_check": {
+          "name": "media_assets_lifecycle_check",
+          "value": "\"media_assets\".\"lifecycle\" IN ('active', 'archived', 'purging')"
+        },
+        "media_assets_processing_state_check": {
+          "name": "media_assets_processing_state_check",
+          "value": "\"media_assets\".\"processing_state\" IN ('upload_initiated', 'original_verified', 'processing', 'ready', 'retryable_failure', 'repair_required')"
+        },
+        "media_assets_processing_error_check": {
+          "name": "media_assets_processing_error_check",
+          "value": "(\"media_assets\".\"processing_state\" IN ('retryable_failure', 'repair_required')) = (\"media_assets\".\"processing_error_code\" IS NOT NULL AND length(btrim(\"media_assets\".\"processing_error_code\")) > 0)"
+        },
+        "media_assets_original_key_check": {
+          "name": "media_assets_original_key_check",
+          "value": "length(btrim(\"media_assets\".\"original_key\")) > 0"
+        },
+        "media_assets_original_content_type_check": {
+          "name": "media_assets_original_content_type_check",
+          "value": "\"media_assets\".\"original_content_type\" IN ('image/jpeg', 'image/png', 'image/heic', 'image/heif')"
+        },
+        "media_assets_original_byte_size_check": {
+          "name": "media_assets_original_byte_size_check",
+          "value": "\"media_assets\".\"original_byte_size\" BETWEEN 1 AND 52428800"
+        },
+        "media_assets_original_checksum_check": {
+          "name": "media_assets_original_checksum_check",
+          "value": "\"media_assets\".\"original_checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "media_assets_dimensions_check": {
+          "name": "media_assets_dimensions_check",
+          "value": "num_nonnulls(\"media_assets\".\"width\", \"media_assets\".\"height\") IN (0, 2) AND (\"media_assets\".\"width\" IS NULL OR (\"media_assets\".\"width\" > 0 AND \"media_assets\".\"height\" > 0 AND (\"media_assets\".\"width\"::bigint * \"media_assets\".\"height\"::bigint) <= 100000000))"
+        },
+        "media_assets_focal_point_check": {
+          "name": "media_assets_focal_point_check",
+          "value": "num_nonnulls(\"media_assets\".\"focal_point_x\", \"media_assets\".\"focal_point_y\") IN (0, 2) AND (\"media_assets\".\"focal_point_x\" IS NULL OR (\"media_assets\".\"focal_point_x\" BETWEEN 0 AND 1 AND \"media_assets\".\"focal_point_y\" BETWEEN 0 AND 1))"
+        },
+        "media_assets_camera_values_check": {
+          "name": "media_assets_camera_values_check",
+          "value": "(\"media_assets\".\"focal_length_millimeters\" IS NULL OR \"media_assets\".\"focal_length_millimeters\" > 0) AND (\"media_assets\".\"aperture\" IS NULL OR \"media_assets\".\"aperture\" > 0) AND (\"media_assets\".\"shutter_speed_seconds\" IS NULL OR \"media_assets\".\"shutter_speed_seconds\" > 0) AND (\"media_assets\".\"iso\" IS NULL OR \"media_assets\".\"iso\" > 0)"
+        },
+        "media_assets_alt_suggestion_check": {
+          "name": "media_assets_alt_suggestion_check",
+          "value": "num_nonnulls(\"media_assets\".\"alt_text_suggestion_zh_hans\", \"media_assets\".\"alt_text_suggestion_en\", \"media_assets\".\"alt_text_suggestion_model\", \"media_assets\".\"alt_text_suggested_at\") IN (0, 4) AND (\"media_assets\".\"alt_text_suggestion_zh_hans\" IS NULL OR (length(btrim(\"media_assets\".\"alt_text_suggestion_zh_hans\")) > 0 AND length(btrim(\"media_assets\".\"alt_text_suggestion_en\")) > 0 AND length(btrim(\"media_assets\".\"alt_text_suggestion_model\")) > 0))"
+        },
+        "media_assets_alt_text_check": {
+          "name": "media_assets_alt_text_check",
+          "value": "num_nonnulls(\"media_assets\".\"alt_text_zh_hans\", \"media_assets\".\"alt_text_en\", \"media_assets\".\"alt_text_approved_at\") IN (0, 3) AND (\"media_assets\".\"alt_text_zh_hans\" IS NULL OR (length(btrim(\"media_assets\".\"alt_text_zh_hans\")) > 0 AND length(btrim(\"media_assets\".\"alt_text_en\")) > 0))"
+        },
+        "media_assets_archive_check": {
+          "name": "media_assets_archive_check",
+          "value": "(\"media_assets\".\"lifecycle\" = 'active' AND \"media_assets\".\"archived_at\" IS NULL AND \"media_assets\".\"purge_started_at\" IS NULL) OR (\"media_assets\".\"lifecycle\" = 'archived' AND \"media_assets\".\"archived_at\" IS NOT NULL AND \"media_assets\".\"purge_started_at\" IS NULL) OR (\"media_assets\".\"lifecycle\" = 'purging' AND \"media_assets\".\"archived_at\" IS NOT NULL AND \"media_assets\".\"purge_started_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_renditions": {
+      "name": "media_renditions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_width": {
+          "name": "profile_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum_sha256": {
+          "name": "checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'image/jpeg'"
+        },
+        "color_space": {
+          "name": "color_space",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'srgb'"
+        },
+        "progressive": {
+          "name": "progressive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata_stripped": {
+          "name": "metadata_stripped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_renditions_asset_profile_uidx": {
+          "name": "media_renditions_asset_profile_uidx",
+          "columns": [
+            {
+              "expression": "media_asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_width",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_renditions_object_key_uidx": {
+          "name": "media_renditions_object_key_uidx",
+          "columns": [
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_renditions_media_asset_id_media_assets_id_fk": {
+          "name": "media_renditions_media_asset_id_media_assets_id_fk",
+          "tableFrom": "media_renditions",
+          "tableTo": "media_assets",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_renditions_object_key_check": {
+          "name": "media_renditions_object_key_check",
+          "value": "length(btrim(\"media_renditions\".\"object_key\")) > 0"
+        },
+        "media_renditions_profile_check": {
+          "name": "media_renditions_profile_check",
+          "value": "\"media_renditions\".\"profile_width\" IN (640, 1024, 1600)"
+        },
+        "media_renditions_checksum_check": {
+          "name": "media_renditions_checksum_check",
+          "value": "\"media_renditions\".\"checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "media_renditions_dimensions_check": {
+          "name": "media_renditions_dimensions_check",
+          "value": "\"media_renditions\".\"width\" BETWEEN 1 AND \"media_renditions\".\"profile_width\" AND \"media_renditions\".\"height\" > 0"
+        },
+        "media_renditions_byte_size_check": {
+          "name": "media_renditions_byte_size_check",
+          "value": "\"media_renditions\".\"byte_size\" > 0"
+        },
+        "media_renditions_content_type_check": {
+          "name": "media_renditions_content_type_check",
+          "value": "\"media_renditions\".\"content_type\" = 'image/jpeg'"
+        },
+        "media_renditions_color_space_check": {
+          "name": "media_renditions_color_space_check",
+          "value": "\"media_renditions\".\"color_space\" = 'srgb'"
+        },
+        "media_renditions_progressive_check": {
+          "name": "media_renditions_progressive_check",
+          "value": "\"media_renditions\".\"progressive\" = true"
+        },
+        "media_renditions_metadata_stripped_check": {
+          "name": "media_renditions_metadata_stripped_check",
+          "value": "\"media_renditions\".\"metadata_stripped\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_upload_intents": {
+      "name": "media_upload_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum_sha256": {
+          "name": "checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_upload_intents_owner_idempotency_uidx": {
+          "name": "media_upload_intents_owner_idempotency_uidx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_upload_intents_original_key_uidx": {
+          "name": "media_upload_intents_original_key_uidx",
+          "columns": [
+            {
+              "expression": "original_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_upload_intents_expiry_idx": {
+          "name": "media_upload_intents_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_upload_intents_identity_check": {
+          "name": "media_upload_intents_identity_check",
+          "value": "length(btrim(\"media_upload_intents\".\"owner_user_id\")) > 0 AND length(btrim(\"media_upload_intents\".\"idempotency_key\")) > 0"
+        },
+        "media_upload_intents_original_key_check": {
+          "name": "media_upload_intents_original_key_check",
+          "value": "length(btrim(\"media_upload_intents\".\"original_key\")) > 0"
+        },
+        "media_upload_intents_content_type_check": {
+          "name": "media_upload_intents_content_type_check",
+          "value": "\"media_upload_intents\".\"content_type\" IN ('image/jpeg', 'image/png', 'image/heic', 'image/heif')"
+        },
+        "media_upload_intents_byte_size_check": {
+          "name": "media_upload_intents_byte_size_check",
+          "value": "\"media_upload_intents\".\"byte_size\" BETWEEN 1 AND 52428800"
+        },
+        "media_upload_intents_checksum_check": {
+          "name": "media_upload_intents_checksum_check",
+          "value": "\"media_upload_intents\".\"checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "media_upload_intents_expiry_check": {
+          "name": "media_upload_intents_expiry_check",
+          "value": "\"media_upload_intents\".\"expires_at\" > \"media_upload_intents\".\"created_at\""
+        },
+        "media_upload_intents_completion_check": {
+          "name": "media_upload_intents_completion_check",
+          "value": "\"media_upload_intents\".\"completed_at\" IS NULL OR (\"media_upload_intents\".\"completed_at\" >= \"media_upload_intents\".\"created_at\" AND \"media_upload_intents\".\"completed_at\" <= \"media_upload_intents\".\"expires_at\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.newsletters": {
+      "name": "newsletters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscribers": {
+      "name": "subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1784012013999,
       "tag": "0004_ama_google_oauth",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1784086450712,
+      "tag": "0005_media_catalog",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,13 +1,17 @@
 import { sql } from 'drizzle-orm'
 import {
+  boolean,
   check,
   index,
   integer,
   jsonb,
+  numeric,
   pgTable,
   serial,
   text,
   timestamp,
+  uniqueIndex,
+  uuid,
   varchar,
 } from 'drizzle-orm/pg-core'
 
@@ -120,4 +124,237 @@ export const amaGoogleOAuthAttempts = pgTable(
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
   },
   (table) => [index('ama_google_oauth_attempts_expires_at_idx').on(table.expiresAt)],
+)
+
+export const mediaUploadIntents = pgTable(
+  'media_upload_intents',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    ownerUserId: varchar('owner_user_id', { length: 255 }).notNull(),
+    idempotencyKey: varchar('idempotency_key', { length: 128 }).notNull(),
+    originalKey: text('original_key').notNull(),
+    contentType: varchar('content_type', { length: 64 }).notNull(),
+    byteSize: integer('byte_size').notNull(),
+    checksumSha256: varchar('checksum_sha256', { length: 64 }).notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    completedAt: timestamp('completed_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex('media_upload_intents_owner_idempotency_uidx').on(
+      table.ownerUserId,
+      table.idempotencyKey,
+    ),
+    uniqueIndex('media_upload_intents_original_key_uidx').on(table.originalKey),
+    index('media_upload_intents_expiry_idx').on(table.expiresAt, table.completedAt),
+    check(
+      'media_upload_intents_identity_check',
+      sql`length(btrim(${table.ownerUserId})) > 0 AND length(btrim(${table.idempotencyKey})) > 0`,
+    ),
+    check(
+      'media_upload_intents_original_key_check',
+      sql`length(btrim(${table.originalKey})) > 0`,
+    ),
+    check(
+      'media_upload_intents_content_type_check',
+      sql`${table.contentType} IN ('image/jpeg', 'image/png', 'image/heic', 'image/heif')`,
+    ),
+    check(
+      'media_upload_intents_byte_size_check',
+      sql`${table.byteSize} BETWEEN 1 AND 52428800`,
+    ),
+    check(
+      'media_upload_intents_checksum_check',
+      sql`${table.checksumSha256} ~ '^[0-9a-f]{64}$'`,
+    ),
+    check(
+      'media_upload_intents_expiry_check',
+      sql`${table.expiresAt} > ${table.createdAt}`,
+    ),
+    check(
+      'media_upload_intents_completion_check',
+      sql`${table.completedAt} IS NULL OR (${table.completedAt} >= ${table.createdAt} AND ${table.completedAt} <= ${table.expiresAt})`,
+    ),
+  ],
+)
+
+export const mediaAssets = pgTable(
+  'media_assets',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    uploadIntentId: uuid('upload_intent_id')
+      .notNull()
+      .references(() => mediaUploadIntents.id, { onDelete: 'restrict' }),
+    kind: varchar('kind', { length: 16 }).default('image').notNull(),
+    lifecycle: varchar('lifecycle', { length: 16 })
+      .$type<'active' | 'archived' | 'purging'>()
+      .default('active')
+      .notNull(),
+    processingState: varchar('processing_state', { length: 32 })
+      .$type<
+        | 'upload_initiated'
+        | 'original_verified'
+        | 'processing'
+        | 'ready'
+        | 'retryable_failure'
+        | 'repair_required'
+      >()
+      .default('upload_initiated')
+      .notNull(),
+    processingErrorCode: varchar('processing_error_code', { length: 64 }),
+    originalKey: text('original_key').notNull(),
+    originalContentType: varchar('original_content_type', { length: 64 }).notNull(),
+    originalByteSize: integer('original_byte_size').notNull(),
+    originalChecksumSha256: varchar('original_checksum_sha256', {
+      length: 64,
+    }).notNull(),
+    width: integer('width'),
+    height: integer('height'),
+    capturedAt: timestamp('captured_at', { withTimezone: true }),
+    cameraMake: text('camera_make'),
+    cameraModel: text('camera_model'),
+    lens: text('lens'),
+    focalLengthMillimeters: numeric('focal_length_millimeters', {
+      precision: 8,
+      scale: 3,
+    }),
+    aperture: numeric('aperture', { precision: 6, scale: 3 }),
+    shutterSpeedSeconds: numeric('shutter_speed_seconds', {
+      precision: 12,
+      scale: 8,
+    }),
+    iso: integer('iso'),
+    focalPointX: numeric('focal_point_x', { precision: 5, scale: 4 }),
+    focalPointY: numeric('focal_point_y', { precision: 5, scale: 4 }),
+    captureLocationEnvelope: jsonb('capture_location_envelope'),
+    locationLabelZhHans: text('location_label_zh_hans'),
+    locationLabelEn: text('location_label_en'),
+    altTextSuggestionZhHans: text('alt_text_suggestion_zh_hans'),
+    altTextSuggestionEn: text('alt_text_suggestion_en'),
+    altTextSuggestionModel: varchar('alt_text_suggestion_model', { length: 255 }),
+    altTextSuggestedAt: timestamp('alt_text_suggested_at', { withTimezone: true }),
+    altTextZhHans: text('alt_text_zh_hans'),
+    altTextEn: text('alt_text_en'),
+    altTextApprovedAt: timestamp('alt_text_approved_at', { withTimezone: true }),
+    archivedAt: timestamp('archived_at', { withTimezone: true }),
+    purgeStartedAt: timestamp('purge_started_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex('media_assets_upload_intent_uidx').on(table.uploadIntentId),
+    uniqueIndex('media_assets_original_key_uidx').on(table.originalKey),
+    index('media_assets_library_idx').on(
+      table.lifecycle,
+      table.processingState,
+      table.createdAt,
+    ),
+    check('media_assets_kind_check', sql`${table.kind} = 'image'`),
+    check(
+      'media_assets_lifecycle_check',
+      sql`${table.lifecycle} IN ('active', 'archived', 'purging')`,
+    ),
+    check(
+      'media_assets_processing_state_check',
+      sql`${table.processingState} IN ('upload_initiated', 'original_verified', 'processing', 'ready', 'retryable_failure', 'repair_required')`,
+    ),
+    check(
+      'media_assets_processing_error_check',
+      sql`(${table.processingState} IN ('retryable_failure', 'repair_required')) = (${table.processingErrorCode} IS NOT NULL AND length(btrim(${table.processingErrorCode})) > 0)`,
+    ),
+    check(
+      'media_assets_original_key_check',
+      sql`length(btrim(${table.originalKey})) > 0`,
+    ),
+    check(
+      'media_assets_original_content_type_check',
+      sql`${table.originalContentType} IN ('image/jpeg', 'image/png', 'image/heic', 'image/heif')`,
+    ),
+    check(
+      'media_assets_original_byte_size_check',
+      sql`${table.originalByteSize} BETWEEN 1 AND 52428800`,
+    ),
+    check(
+      'media_assets_original_checksum_check',
+      sql`${table.originalChecksumSha256} ~ '^[0-9a-f]{64}$'`,
+    ),
+    check(
+      'media_assets_dimensions_check',
+      sql`num_nonnulls(${table.width}, ${table.height}) IN (0, 2) AND (${table.width} IS NULL OR (${table.width} > 0 AND ${table.height} > 0 AND (${table.width}::bigint * ${table.height}::bigint) <= 100000000))`,
+    ),
+    check(
+      'media_assets_focal_point_check',
+      sql`num_nonnulls(${table.focalPointX}, ${table.focalPointY}) IN (0, 2) AND (${table.focalPointX} IS NULL OR (${table.focalPointX} BETWEEN 0 AND 1 AND ${table.focalPointY} BETWEEN 0 AND 1))`,
+    ),
+    check(
+      'media_assets_camera_values_check',
+      sql`(${table.focalLengthMillimeters} IS NULL OR ${table.focalLengthMillimeters} > 0) AND (${table.aperture} IS NULL OR ${table.aperture} > 0) AND (${table.shutterSpeedSeconds} IS NULL OR ${table.shutterSpeedSeconds} > 0) AND (${table.iso} IS NULL OR ${table.iso} > 0)`,
+    ),
+    check(
+      'media_assets_alt_suggestion_check',
+      sql`num_nonnulls(${table.altTextSuggestionZhHans}, ${table.altTextSuggestionEn}, ${table.altTextSuggestionModel}, ${table.altTextSuggestedAt}) IN (0, 4) AND (${table.altTextSuggestionZhHans} IS NULL OR (length(btrim(${table.altTextSuggestionZhHans})) > 0 AND length(btrim(${table.altTextSuggestionEn})) > 0 AND length(btrim(${table.altTextSuggestionModel})) > 0))`,
+    ),
+    check(
+      'media_assets_alt_text_check',
+      sql`num_nonnulls(${table.altTextZhHans}, ${table.altTextEn}, ${table.altTextApprovedAt}) IN (0, 3) AND (${table.altTextZhHans} IS NULL OR (length(btrim(${table.altTextZhHans})) > 0 AND length(btrim(${table.altTextEn})) > 0))`,
+    ),
+    check(
+      'media_assets_archive_check',
+      sql`(${table.lifecycle} = 'active' AND ${table.archivedAt} IS NULL AND ${table.purgeStartedAt} IS NULL) OR (${table.lifecycle} = 'archived' AND ${table.archivedAt} IS NOT NULL AND ${table.purgeStartedAt} IS NULL) OR (${table.lifecycle} = 'purging' AND ${table.archivedAt} IS NOT NULL AND ${table.purgeStartedAt} IS NOT NULL)`,
+    ),
+  ],
+)
+
+export const mediaRenditions = pgTable(
+  'media_renditions',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    mediaAssetId: uuid('media_asset_id')
+      .notNull()
+      .references(() => mediaAssets.id, { onDelete: 'restrict' }),
+    profileWidth: integer('profile_width').notNull(),
+    objectKey: text('object_key').notNull(),
+    checksumSha256: varchar('checksum_sha256', { length: 64 }).notNull(),
+    byteSize: integer('byte_size').notNull(),
+    width: integer('width').notNull(),
+    height: integer('height').notNull(),
+    contentType: varchar('content_type', { length: 64 }).default('image/jpeg').notNull(),
+    colorSpace: varchar('color_space', { length: 16 }).default('srgb').notNull(),
+    progressive: boolean('progressive').default(true).notNull(),
+    metadataStripped: boolean('metadata_stripped').default(true).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex('media_renditions_asset_profile_uidx').on(
+      table.mediaAssetId,
+      table.profileWidth,
+    ),
+    uniqueIndex('media_renditions_object_key_uidx').on(table.objectKey),
+    check(
+      'media_renditions_object_key_check',
+      sql`length(btrim(${table.objectKey})) > 0`,
+    ),
+    check(
+      'media_renditions_profile_check',
+      sql`${table.profileWidth} IN (640, 1024, 1600)`,
+    ),
+    check(
+      'media_renditions_checksum_check',
+      sql`${table.checksumSha256} ~ '^[0-9a-f]{64}$'`,
+    ),
+    check(
+      'media_renditions_dimensions_check',
+      sql`${table.width} BETWEEN 1 AND ${table.profileWidth} AND ${table.height} > 0`,
+    ),
+    check('media_renditions_byte_size_check', sql`${table.byteSize} > 0`),
+    check('media_renditions_content_type_check', sql`${table.contentType} = 'image/jpeg'`),
+    check('media_renditions_color_space_check', sql`${table.colorSpace} = 'srgb'`),
+    check('media_renditions_progressive_check', sql`${table.progressive} = true`),
+    check(
+      'media_renditions_metadata_stripped_check',
+      sql`${table.metadataStripped} = true`,
+    ),
+  ],
 )

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -174,7 +174,7 @@ export const mediaUploadIntents = pgTable(
     ),
     check(
       'media_upload_intents_completion_check',
-      sql`${table.completedAt} IS NULL OR (${table.completedAt} >= ${table.createdAt} AND ${table.completedAt} <= ${table.expiresAt})`,
+      sql`${table.completedAt} IS NULL OR ${table.completedAt} >= ${table.createdAt}`,
     ),
   ],
 )
@@ -346,7 +346,7 @@ export const mediaRenditions = pgTable(
     ),
     check(
       'media_renditions_dimensions_check',
-      sql`${table.width} BETWEEN 1 AND ${table.profileWidth} AND ${table.height} > 0`,
+      sql`${table.width} BETWEEN 1 AND ${table.profileWidth} AND ${table.height} > 0 AND (${table.width}::bigint * ${table.height}::bigint) <= 100000000`,
     ),
     check('media_renditions_byte_size_check', sql`${table.byteSize} > 0`),
     check('media_renditions_content_type_check', sql`${table.contentType} = 'image/jpeg'`),

--- a/lib/media/catalog/schema.test.ts
+++ b/lib/media/catalog/schema.test.ts
@@ -1,0 +1,311 @@
+import { readFile } from 'node:fs/promises'
+
+import { PGlite } from '@electric-sql/pglite'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+const migrations = [
+  new URL('../../../db/migrations/0001_ama_owner_auth.sql', import.meta.url),
+  new URL('../../../db/migrations/0002_ama_availability.sql', import.meta.url),
+  new URL('../../../db/migrations/0003_ama_google_calendar.sql', import.meta.url),
+  new URL('../../../db/migrations/0004_ama_google_oauth.sql', import.meta.url),
+  new URL('../../../db/migrations/0005_media_catalog.sql', import.meta.url),
+]
+
+const checksum = 'a'.repeat(64)
+
+describe('Media Library catalog migration', () => {
+  let client: PGlite
+
+  beforeEach(async () => {
+    client = new PGlite()
+    for (const migrationUrl of migrations) {
+      const migration = await readFile(migrationUrl, 'utf8')
+      await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
+    }
+  })
+
+  afterEach(async () => {
+    await client.close()
+  })
+
+  async function createUploadIntent(overrides: Record<string, unknown> = {}) {
+    const values = {
+      ownerUserId: 'user_owner',
+      idempotencyKey: crypto.randomUUID(),
+      originalKey: `originals/${crypto.randomUUID()}/photo.heic`,
+      contentType: 'image/heic',
+      byteSize: 2_660_052,
+      checksumSha256: checksum,
+      expiresAt: '2026-07-16T00:00:00.000Z',
+      createdAt: '2026-07-15T00:00:00.000Z',
+      ...overrides,
+    }
+    const result = await client.query<{ id: string }>(
+      `INSERT INTO media_upload_intents
+        (owner_user_id, idempotency_key, original_key, content_type, byte_size,
+         checksum_sha256, expires_at, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       RETURNING id`,
+      [
+        values.ownerUserId,
+        values.idempotencyKey,
+        values.originalKey,
+        values.contentType,
+        values.byteSize,
+        values.checksumSha256,
+        values.expiresAt,
+        values.createdAt,
+      ],
+    )
+    return { ...values, id: result.rows[0]!.id }
+  }
+
+  async function createMediaAsset(
+    uploadIntentId: string,
+    overrides: Record<string, unknown> = {},
+  ) {
+    const values = {
+      originalKey: `originals/${crypto.randomUUID()}/photo.heic`,
+      originalContentType: 'image/heic',
+      originalByteSize: 2_660_052,
+      originalChecksumSha256: checksum,
+      ...overrides,
+    }
+    const result = await client.query<{ id: string }>(
+      `INSERT INTO media_assets
+        (upload_intent_id, original_key, original_content_type,
+         original_byte_size, original_checksum_sha256)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING id`,
+      [
+        uploadIntentId,
+        values.originalKey,
+        values.originalContentType,
+        values.originalByteSize,
+        values.originalChecksumSha256,
+      ],
+    )
+    return { ...values, id: result.rows[0]!.id }
+  }
+
+  it('stores an Upload Intent, Media Asset, and verified Rendition manifest', async () => {
+    const intent = await createUploadIntent()
+    const asset = await createMediaAsset(intent.id, {
+      originalKey: intent.originalKey,
+    })
+
+    await client.query(
+      `INSERT INTO media_renditions
+        (media_asset_id, profile_width, object_key, checksum_sha256,
+         byte_size, width, height)
+       VALUES ($1, 1600, $2, $3, 756727, 1600, 1067)`,
+      [
+        asset.id,
+        `renditions/${asset.id}/photo-1600-${checksum}.jpg`,
+        checksum,
+      ],
+    )
+
+    const result = await client.query<{
+      profile_width: number
+      content_type: string
+      color_space: string
+      progressive: boolean
+      metadata_stripped: boolean
+    }>('SELECT * FROM media_renditions WHERE media_asset_id = $1', [asset.id])
+
+    expect(result.rows).toMatchObject([
+      {
+        profile_width: 1600,
+        content_type: 'image/jpeg',
+        color_space: 'srgb',
+        progressive: true,
+        metadata_stripped: true,
+      },
+    ])
+  })
+
+  it('keeps Upload Intent completion idempotent per owner', async () => {
+    const idempotencyKey = crypto.randomUUID()
+    await createUploadIntent({ idempotencyKey })
+
+    await expect(createUploadIntent({ idempotencyKey })).rejects.toThrow()
+    await expect(
+      createUploadIntent({ ownerUserId: 'user_other', idempotencyKey }),
+    ).resolves.toMatchObject({ ownerUserId: 'user_other' })
+  })
+
+  it('keeps the migration additive over the existing AMA tables', async () => {
+    const tables = await client.query<{ table_name: string }>(
+      `SELECT table_name
+       FROM information_schema.tables
+       WHERE table_schema = 'public'`,
+    )
+    const names = tables.rows.map((table) => table.table_name)
+
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'ama_admin_sessions',
+        'ama_auth_tokens',
+        'ama_availability_windows',
+        'ama_google_calendar_connections',
+        'ama_google_oauth_attempts',
+        'media_assets',
+        'media_renditions',
+        'media_upload_intents',
+      ]),
+    )
+  })
+
+  it.each([
+    { contentType: 'image/svg+xml' },
+    { byteSize: 0 },
+    { byteSize: 52_428_801 },
+    { checksumSha256: 'not-a-checksum' },
+    { expiresAt: '2026-07-14T00:00:00.000Z' },
+  ])('rejects an unsafe Upload Intent: %o', async (overrides) => {
+    await expect(createUploadIntent(overrides)).rejects.toThrow()
+  })
+
+  it('allows repeated content digests but not reused Original keys', async () => {
+    const firstIntent = await createUploadIntent()
+    await expect(
+      createUploadIntent({ originalKey: firstIntent.originalKey }),
+    ).rejects.toThrow()
+    const first = await createMediaAsset(firstIntent.id, {
+      originalKey: firstIntent.originalKey,
+    })
+    const secondIntent = await createUploadIntent()
+    const second = await createMediaAsset(secondIntent.id, {
+      originalKey: secondIntent.originalKey,
+    })
+
+    expect(first.originalChecksumSha256).toBe(second.originalChecksumSha256)
+    await expect(
+      createMediaAsset((await createUploadIntent()).id, {
+        originalKey: first.originalKey,
+      }),
+    ).rejects.toThrow()
+  })
+
+  it.each([
+    { width: 4000, height: null },
+    { width: 20_000, height: 20_000 },
+    { focal_point_x: -0.1, focal_point_y: 0.5 },
+    { focal_point_x: 0.5, focal_point_y: null },
+    { iso: 0 },
+  ])('rejects invalid owned image metadata: %o', async (metadata) => {
+    const intent = await createUploadIntent()
+    const columns = Object.keys(metadata)
+    const parameters = Object.values(metadata)
+    const columnSql = columns.length ? `, ${columns.join(', ')}` : ''
+    const valueSql = columns.map((_, index) => `$${index + 4}`).join(', ')
+
+    await expect(
+      client.query(
+        `INSERT INTO media_assets
+          (upload_intent_id, original_key, original_content_type,
+           original_byte_size, original_checksum_sha256${columnSql})
+         VALUES ($1, $2, 'image/heic', 2660052, $3${valueSql ? `, ${valueSql}` : ''})`,
+        [intent.id, intent.originalKey, checksum, ...parameters],
+      ),
+    ).rejects.toThrow()
+  })
+
+  it('requires complete bilingual Alt Text Suggestions and approved Alt Text', async () => {
+    const intent = await createUploadIntent()
+    const asset = await createMediaAsset(intent.id, {
+      originalKey: intent.originalKey,
+    })
+
+    await expect(
+      client.query(
+        `UPDATE media_assets
+         SET alt_text_suggestion_en = 'A cable car'
+         WHERE id = $1`,
+        [asset.id],
+      ),
+    ).rejects.toThrow()
+    await expect(
+      client.query(
+        `UPDATE media_assets
+         SET alt_text_zh_hans = '一辆缆车', alt_text_en = '',
+             alt_text_approved_at = now()
+         WHERE id = $1`,
+        [asset.id],
+      ),
+    ).rejects.toThrow()
+  })
+
+  it('enforces lifecycle timestamps and retryable processing failures', async () => {
+    const intent = await createUploadIntent()
+    const asset = await createMediaAsset(intent.id, {
+      originalKey: intent.originalKey,
+    })
+
+    await expect(
+      client.query(`UPDATE media_assets SET lifecycle = 'archived' WHERE id = $1`, [
+        asset.id,
+      ]),
+    ).rejects.toThrow()
+    await expect(
+      client.query(
+        `UPDATE media_assets
+         SET processing_state = 'retryable_failure'
+         WHERE id = $1`,
+        [asset.id],
+      ),
+    ).rejects.toThrow()
+    await expect(
+      client.query(
+        `UPDATE media_assets
+         SET lifecycle = 'archived', archived_at = now()
+         WHERE id = $1`,
+        [asset.id],
+      ),
+    ).resolves.toBeDefined()
+    await expect(
+      client.query(
+        `UPDATE media_assets
+         SET processing_state = 'retryable_failure',
+             processing_error_code = 'provider_unavailable'
+         WHERE id = $1`,
+        [asset.id],
+      ),
+    ).resolves.toBeDefined()
+  })
+
+  it('constrains Rendition profiles and immutable object keys', async () => {
+    const intent = await createUploadIntent()
+    const asset = await createMediaAsset(intent.id, {
+      originalKey: intent.originalKey,
+    })
+    const objectKey = `renditions/${asset.id}/photo-${checksum}.jpg`
+    const insert = (profileWidth: number, key = objectKey) =>
+      client.query(
+        `INSERT INTO media_renditions
+          (media_asset_id, profile_width, object_key, checksum_sha256,
+           byte_size, width, height)
+         VALUES ($1, $2, $3, $4, 1000, 640, 427)`,
+        [asset.id, profileWidth, key, checksum],
+      )
+
+    await insert(640)
+    await expect(insert(640, `${objectKey}-other`)).rejects.toThrow()
+    await expect(insert(800, `${objectKey}-invalid`)).rejects.toThrow()
+    await expect(insert(1024, objectKey)).rejects.toThrow()
+  })
+
+  it('stores Capture Location only as an encrypted envelope column', async () => {
+    const columns = await client.query<{ column_name: string }>(
+      `SELECT column_name
+       FROM information_schema.columns
+       WHERE table_name = 'media_assets'`,
+    )
+    const names = columns.rows.map((column) => column.column_name)
+
+    expect(names).toContain('capture_location_envelope')
+    expect(names).not.toContain('latitude')
+    expect(names).not.toContain('longitude')
+  })
+})

--- a/lib/media/catalog/schema.test.ts
+++ b/lib/media/catalog/schema.test.ts
@@ -135,6 +135,27 @@ describe('Media Library catalog migration', () => {
     ).resolves.toMatchObject({ ownerUserId: 'user_other' })
   })
 
+  it('allows recovery to record a verified completion after intent expiry', async () => {
+    const intent = await createUploadIntent()
+
+    await expect(
+      client.query(
+        `UPDATE media_upload_intents
+         SET completed_at = '2026-07-16T00:05:00.000Z'
+         WHERE id = $1`,
+        [intent.id],
+      ),
+    ).resolves.toBeDefined()
+    await expect(
+      client.query(
+        `UPDATE media_upload_intents
+         SET completed_at = '2026-07-14T23:59:59.000Z'
+         WHERE id = $1`,
+        [intent.id],
+      ),
+    ).rejects.toThrow()
+  })
+
   it('keeps the migration additive over the existing AMA tables', async () => {
     const tables = await client.query<{ table_name: string }>(
       `SELECT table_name
@@ -281,19 +302,27 @@ describe('Media Library catalog migration', () => {
       originalKey: intent.originalKey,
     })
     const objectKey = `renditions/${asset.id}/photo-${checksum}.jpg`
-    const insert = (profileWidth: number, key = objectKey) =>
+    const insert = (
+      profileWidth: number,
+      key = objectKey,
+      width = 640,
+      height = 427,
+    ) =>
       client.query(
         `INSERT INTO media_renditions
           (media_asset_id, profile_width, object_key, checksum_sha256,
            byte_size, width, height)
-         VALUES ($1, $2, $3, $4, 1000, 640, 427)`,
-        [asset.id, profileWidth, key, checksum],
+         VALUES ($1, $2, $3, $4, 1000, $5, $6)`,
+        [asset.id, profileWidth, key, checksum, width, height],
       )
 
     await insert(640)
     await expect(insert(640, `${objectKey}-other`)).rejects.toThrow()
     await expect(insert(800, `${objectKey}-invalid`)).rejects.toThrow()
     await expect(insert(1024, objectKey)).rejects.toThrow()
+    await expect(
+      insert(1024, `${objectKey}-oversized`, 1, 100_000_001),
+    ).rejects.toThrow()
   })
 
   it('stores Capture Location only as an encrypted envelope column', async () => {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:ama": "vitest run lib/ama && pnpm db:validate",
     "test:security": "vitest run lib/security",
     "test:localization": "node --test scripts/localization.test.mjs",
+    "test:media:catalog": "vitest run lib/media/catalog",
     "test:media:storage": "vitest run lib/media/storage --exclude='**/*.live.test.ts'",
     "test:media:storage:live": "pnpm test:media:storage:live:server && pnpm test:media:storage:live:browser",
     "test:media:storage:live:server": "vitest run lib/media/storage/bunny.live.test.ts",


### PR DESCRIPTION
Stacked on #114.

## Summary

- add Upload Intent, Media Asset, and Rendition catalog tables
- constrain lifecycle, processing, metadata, bilingual Alt Text, and encrypted Capture Location storage
- add the generated migration and catalog constraint coverage to CI

## Tests

- `pnpm test:media:catalog`
- `pnpm test:media:storage`
- `pnpm test:ama`
- `pnpm typecheck`
