### PR TITLE
Add durable Media Library ingestion

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Test media image processing
         run: pnpm test:media:processing
 
+      - name: Test media ingestion workflow
+        run: pnpm test:media:ingestion
+
       - name: Test localization
         run: pnpm test:localization
 

--- a/lib/media/ingestion/repository.test.ts
+++ b/lib/media/ingestion/repository.test.ts
@@ -138,6 +138,7 @@ describe('Media Library ingestion repository', () => {
         },
       },
       completedAt: now,
+      requiredRenditionCount: 3,
     }
     await expect(repository.markReady(readyInput)).rejects.toThrow(
       'Rendition manifest is incomplete',

--- a/lib/media/ingestion/repository.test.ts
+++ b/lib/media/ingestion/repository.test.ts
@@ -1,0 +1,172 @@
+import { readFile } from 'node:fs/promises'
+
+import { PGlite } from '@electric-sql/pglite'
+import { drizzle } from 'drizzle-orm/pglite'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import {
+  createMediaIngestionRepository,
+  type MediaIngestionDatabase,
+} from './repository'
+
+const migrationUrl = new URL(
+  '../../../db/migrations/0005_media_catalog.sql',
+  import.meta.url,
+)
+const intentInput = {
+  id: '11111111-1111-4111-8111-111111111111',
+  ownerUserId: 'owner_01',
+  idempotencyKey: 'upload_01',
+  originalKey: 'originals/11111111-1111-4111-8111-111111111111.jpg',
+  contentType: 'image/jpeg' as const,
+  byteSize: 2_660_052,
+  checksumSha256:
+    '1825bebd811ee2ff341932b96967bd13a0102e1aec90a699af981eaec8991c51',
+  expiresAt: new Date('2026-07-16T00:00:00.000Z'),
+  createdAt: new Date('2026-07-15T00:00:00.000Z'),
+}
+
+describe('Media Library ingestion repository', () => {
+  let client: PGlite
+  let repository: ReturnType<typeof createMediaIngestionRepository>
+
+  beforeEach(async () => {
+    client = new PGlite()
+    const migration = await readFile(migrationUrl, 'utf8')
+    await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
+    const database = drizzle(client)
+    repository = createMediaIngestionRepository(
+      () => database as unknown as MediaIngestionDatabase,
+    )
+  })
+
+  afterEach(async () => {
+    await client.close()
+  })
+
+  it('returns the first Upload Intent for an idempotency replay', async () => {
+    const first = await repository.createUploadIntent(intentInput)
+    const replay = await repository.createUploadIntent({
+      ...intentInput,
+      id: '22222222-2222-4222-8222-222222222222',
+      originalKey: 'originals/22222222-2222-4222-8222-222222222222.jpg',
+    })
+
+    expect(replay).toEqual(first)
+    const stored = await client.query('select id from media_upload_intents')
+    expect(stored.rows).toHaveLength(1)
+  })
+
+  it('atomically completes a late Upload Intent and claims one processor', async () => {
+    const intent = await repository.createUploadIntent(intentInput)
+    const completedAt = new Date('2026-07-17T00:00:00.000Z')
+    const asset = await repository.createVerifiedMediaAsset({
+      uploadIntent: intent,
+      completedAt,
+    })
+
+    const claims = await Promise.all([
+      repository.claimProcessing({
+        mediaAssetId: asset.id,
+        claimedAt: completedAt,
+        staleBefore: new Date('2026-07-16T23:55:00.000Z'),
+      }),
+      repository.claimProcessing({
+        mediaAssetId: asset.id,
+        claimedAt: completedAt,
+        staleBefore: new Date('2026-07-16T23:55:00.000Z'),
+      }),
+    ])
+
+    expect(claims.filter(Boolean)).toHaveLength(1)
+    expect(
+      await repository.findUploadIntent(intent.ownerUserId, intent.id),
+    ).toMatchObject({ completedAt })
+    expect(await repository.findMediaAsset(intent.id)).toMatchObject({
+      id: asset.id,
+      processingState: 'processing',
+      originalKey: intent.originalKey,
+    })
+  })
+
+  it('requires the complete Rendition manifest before storing ready metadata', async () => {
+    const intent = await repository.createUploadIntent(intentInput)
+    const now = new Date('2026-07-15T01:00:00.000Z')
+    const asset = await repository.createVerifiedMediaAsset({
+      uploadIntent: intent,
+      completedAt: now,
+    })
+    await repository.claimProcessing({
+      mediaAssetId: asset.id,
+      claimedAt: now,
+      staleBefore: new Date('2026-07-15T00:55:00.000Z'),
+    })
+
+    const rendition = (profileWidth: 640 | 1024 | 1600) => ({
+      mediaAssetId: asset.id,
+      profileWidth,
+      objectKey: `renditions/${asset.id}/${profileWidth}-${String(profileWidth).padStart(64, '0')}.jpg`,
+      checksumSha256: String(profileWidth).padStart(64, '0'),
+      byteSize: profileWidth,
+      width: profileWidth,
+      height: Math.round(profileWidth * 0.75),
+      contentType: 'image/jpeg' as const,
+      colorSpace: 'srgb' as const,
+      progressive: true as const,
+      metadataStripped: true as const,
+    })
+    await repository.recordRendition(rendition(640))
+
+    const readyInput = {
+      mediaAssetId: asset.id,
+      metadata: {
+        width: 4032,
+        height: 3024,
+        capturedAt: new Date('2025-05-08T07:31:34.000Z'),
+        cameraMake: 'Apple',
+        cameraModel: 'iPhone',
+        lens: 'Main Camera',
+        focalLengthMillimeters: 6.8,
+        aperture: 1.78,
+        shutterSpeedSeconds: 0.008,
+        iso: 80,
+        captureLocationEnvelope: {
+          version: 1,
+          ciphertext: 'encrypted-location',
+        },
+      },
+      completedAt: now,
+    }
+    await expect(repository.markReady(readyInput)).rejects.toThrow(
+      'Rendition manifest is incomplete',
+    )
+
+    await repository.recordRendition(rendition(1024))
+    await repository.recordRendition(rendition(1600))
+    const ready = await repository.markReady(readyInput)
+
+    const staleFailure = await repository.markFailure({
+      mediaAssetId: asset.id,
+      processingState: 'retryable_failure',
+      processingErrorCode: 'stale_worker_failure',
+      failedAt: new Date('2026-07-15T01:01:00.000Z'),
+    })
+
+    expect(ready).toMatchObject({
+      processingState: 'ready',
+      width: 4032,
+      height: 3024,
+      captureLocationEnvelope: {
+        version: 1,
+        ciphertext: 'encrypted-location',
+      },
+    })
+    expect(staleFailure).toMatchObject({
+      processingState: 'ready',
+      processingErrorCode: null,
+    })
+    expect(JSON.stringify(ready)).not.toContain('37.7749')
+  })
+})

--- a/lib/media/ingestion/repository.ts
+++ b/lib/media/ingestion/repository.ts
@@ -1,0 +1,323 @@
+import 'server-only'
+
+import { and, eq, inArray, lt, ne, or, sql } from 'drizzle-orm'
+
+import type { getDatabase } from '~/db'
+import {
+  mediaAssets,
+  mediaRenditions,
+  mediaUploadIntents,
+} from '~/db/schema'
+
+import type {
+  MediaAssetRecord,
+  MediaIngestionRepository,
+  OriginalContentType,
+  RenditionRecord,
+  UploadIntentRecord,
+} from './service'
+
+export type MediaIngestionDatabase = ReturnType<typeof getDatabase>
+
+function uploadIntentRecord(
+  row: typeof mediaUploadIntents.$inferSelect,
+): UploadIntentRecord {
+  return {
+    id: row.id,
+    ownerUserId: row.ownerUserId,
+    idempotencyKey: row.idempotencyKey,
+    originalKey: row.originalKey,
+    contentType: row.contentType as OriginalContentType,
+    byteSize: row.byteSize,
+    checksumSha256: row.checksumSha256,
+    expiresAt: row.expiresAt,
+    completedAt: row.completedAt,
+    createdAt: row.createdAt,
+  }
+}
+
+function optionalNumber(value: string | null) {
+  return value === null ? null : Number(value)
+}
+
+function mediaAssetRecord(
+  row: typeof mediaAssets.$inferSelect,
+): MediaAssetRecord {
+  return {
+    id: row.id,
+    uploadIntentId: row.uploadIntentId,
+    processingState: row.processingState as MediaAssetRecord['processingState'],
+    processingErrorCode: row.processingErrorCode,
+    originalKey: row.originalKey,
+    originalContentType: row.originalContentType as OriginalContentType,
+    originalByteSize: row.originalByteSize,
+    originalChecksumSha256: row.originalChecksumSha256,
+    width: row.width,
+    height: row.height,
+    capturedAt: row.capturedAt,
+    cameraMake: row.cameraMake,
+    cameraModel: row.cameraModel,
+    lens: row.lens,
+    focalLengthMillimeters: optionalNumber(row.focalLengthMillimeters),
+    aperture: optionalNumber(row.aperture),
+    shutterSpeedSeconds: optionalNumber(row.shutterSpeedSeconds),
+    iso: row.iso,
+    captureLocationEnvelope: row.captureLocationEnvelope,
+  }
+}
+
+function renditionRecord(
+  row: typeof mediaRenditions.$inferSelect,
+): RenditionRecord {
+  return {
+    mediaAssetId: row.mediaAssetId,
+    profileWidth: row.profileWidth,
+    objectKey: row.objectKey,
+    checksumSha256: row.checksumSha256,
+    byteSize: row.byteSize,
+    width: row.width,
+    height: row.height,
+    contentType: row.contentType as 'image/jpeg',
+    colorSpace: row.colorSpace as 'srgb',
+    progressive: row.progressive as true,
+    metadataStripped: row.metadataStripped as true,
+  }
+}
+
+function numericValue(value: number | null) {
+  return value === null ? null : String(value)
+}
+
+export function createMediaIngestionRepository(
+  database: () => MediaIngestionDatabase,
+): MediaIngestionRepository {
+  async function findAssetBy(
+    field: typeof mediaAssets.id | typeof mediaAssets.uploadIntentId,
+    value: string,
+  ) {
+    const [row] = await database()
+      .select()
+      .from(mediaAssets)
+      .where(eq(field, value))
+      .limit(1)
+    return row ? mediaAssetRecord(row) : null
+  }
+
+  return {
+    async createUploadIntent(input) {
+      const [created] = await database()
+        .insert(mediaUploadIntents)
+        .values(input)
+        .onConflictDoNothing({
+          target: [
+            mediaUploadIntents.ownerUserId,
+            mediaUploadIntents.idempotencyKey,
+          ],
+        })
+        .returning()
+      if (created) return uploadIntentRecord(created)
+
+      const [existing] = await database()
+        .select()
+        .from(mediaUploadIntents)
+        .where(
+          and(
+            eq(mediaUploadIntents.ownerUserId, input.ownerUserId),
+            eq(mediaUploadIntents.idempotencyKey, input.idempotencyKey),
+          ),
+        )
+        .limit(1)
+      if (!existing) throw new Error('Upload Intent conflict was not readable')
+      return uploadIntentRecord(existing)
+    },
+
+    async findUploadIntent(ownerUserId, id) {
+      const [row] = await database()
+        .select()
+        .from(mediaUploadIntents)
+        .where(
+          and(
+            eq(mediaUploadIntents.id, id),
+            eq(mediaUploadIntents.ownerUserId, ownerUserId),
+          ),
+        )
+        .limit(1)
+      return row ? uploadIntentRecord(row) : null
+    },
+
+    findMediaAsset(uploadIntentId) {
+      return findAssetBy(mediaAssets.uploadIntentId, uploadIntentId)
+    },
+
+    async createVerifiedMediaAsset({ uploadIntent, completedAt }) {
+      await database().execute(sql`
+        WITH completed_intent AS (
+          UPDATE ${mediaUploadIntents}
+          SET
+            completed_at = COALESCE(completed_at, ${completedAt}),
+            updated_at = ${completedAt}
+          WHERE id = ${uploadIntent.id}
+          RETURNING id
+        )
+        INSERT INTO ${mediaAssets} (
+          upload_intent_id,
+          processing_state,
+          original_key,
+          original_content_type,
+          original_byte_size,
+          original_checksum_sha256,
+          created_at,
+          updated_at
+        )
+        SELECT
+          completed_intent.id,
+          'original_verified',
+          ${uploadIntent.originalKey},
+          ${uploadIntent.contentType},
+          ${uploadIntent.byteSize},
+          ${uploadIntent.checksumSha256},
+          ${completedAt},
+          ${completedAt}
+        FROM completed_intent
+        ON CONFLICT (upload_intent_id) DO NOTHING
+      `)
+      const asset = await findAssetBy(mediaAssets.uploadIntentId, uploadIntent.id)
+      if (!asset) throw new Error('Verified Media Asset was not readable')
+      return asset
+    },
+
+    async claimProcessing({ mediaAssetId, claimedAt, staleBefore }) {
+      const [claimed] = await database()
+        .update(mediaAssets)
+        .set({
+          processingState: 'processing',
+          processingErrorCode: null,
+          updatedAt: claimedAt,
+        })
+        .where(
+          and(
+            eq(mediaAssets.id, mediaAssetId),
+            or(
+              inArray(mediaAssets.processingState, [
+                'original_verified',
+                'retryable_failure',
+              ]),
+              and(
+                eq(mediaAssets.processingState, 'processing'),
+                lt(mediaAssets.updatedAt, staleBefore),
+              ),
+            ),
+          ),
+        )
+        .returning({ id: mediaAssets.id })
+      return claimed !== undefined
+    },
+
+    getMediaAsset(id) {
+      return findAssetBy(mediaAssets.id, id)
+    },
+
+    async findRendition(mediaAssetId, profileWidth) {
+      const [row] = await database()
+        .select()
+        .from(mediaRenditions)
+        .where(
+          and(
+            eq(mediaRenditions.mediaAssetId, mediaAssetId),
+            eq(mediaRenditions.profileWidth, profileWidth),
+          ),
+        )
+        .limit(1)
+      return row ? renditionRecord(row) : null
+    },
+
+    async recordRendition(input) {
+      const [created] = await database()
+        .insert(mediaRenditions)
+        .values(input)
+        .onConflictDoNothing({
+          target: [mediaRenditions.mediaAssetId, mediaRenditions.profileWidth],
+        })
+        .returning()
+      if (created) return renditionRecord(created)
+
+      const [existing] = await database()
+        .select()
+        .from(mediaRenditions)
+        .where(
+          and(
+            eq(mediaRenditions.mediaAssetId, input.mediaAssetId),
+            eq(mediaRenditions.profileWidth, input.profileWidth),
+          ),
+        )
+        .limit(1)
+      if (!existing) throw new Error('Rendition conflict was not readable')
+      return renditionRecord(existing)
+    },
+
+    async markReady({ mediaAssetId, metadata, completedAt }) {
+      const [ready] = await database()
+        .update(mediaAssets)
+        .set({
+          processingState: 'ready',
+          processingErrorCode: null,
+          width: metadata.width,
+          height: metadata.height,
+          capturedAt: metadata.capturedAt,
+          cameraMake: metadata.cameraMake,
+          cameraModel: metadata.cameraModel,
+          lens: metadata.lens,
+          focalLengthMillimeters: numericValue(
+            metadata.focalLengthMillimeters,
+          ),
+          aperture: numericValue(metadata.aperture),
+          shutterSpeedSeconds: numericValue(metadata.shutterSpeedSeconds),
+          iso: metadata.iso,
+          captureLocationEnvelope: metadata.captureLocationEnvelope,
+          updatedAt: completedAt,
+        })
+        .where(
+          and(
+            eq(mediaAssets.id, mediaAssetId),
+            eq(mediaAssets.processingState, 'processing'),
+            sql`(
+              SELECT count(*)
+              FROM ${mediaRenditions}
+              WHERE ${mediaRenditions.mediaAssetId} = ${mediaAssetId}
+            ) = 3`,
+          ),
+        )
+        .returning()
+      if (!ready) throw new Error('Media Asset Rendition manifest is incomplete')
+      return mediaAssetRecord(ready)
+    },
+
+    async markFailure({
+      mediaAssetId,
+      processingState,
+      processingErrorCode,
+      failedAt,
+    }) {
+      const [failed] = await database()
+        .update(mediaAssets)
+        .set({
+          processingState,
+          processingErrorCode,
+          updatedAt: failedAt,
+        })
+        .where(
+          and(
+            eq(mediaAssets.id, mediaAssetId),
+            ne(mediaAssets.processingState, 'ready'),
+          ),
+        )
+        .returning()
+      if (!failed) {
+        const current = await findAssetBy(mediaAssets.id, mediaAssetId)
+        if (current?.processingState === 'ready') return current
+        throw new Error('Media Asset failure was not recorded')
+      }
+      return mediaAssetRecord(failed)
+    },
+  }
+}

--- a/lib/media/ingestion/repository.ts
+++ b/lib/media/ingestion/repository.ts
@@ -255,7 +255,12 @@ export function createMediaIngestionRepository(
       return renditionRecord(existing)
     },
 
-    async markReady({ mediaAssetId, metadata, completedAt }) {
+    async markReady({
+      mediaAssetId,
+      metadata,
+      completedAt,
+      requiredRenditionCount,
+    }) {
       const [ready] = await database()
         .update(mediaAssets)
         .set({
@@ -284,7 +289,7 @@ export function createMediaIngestionRepository(
               SELECT count(*)
               FROM ${mediaRenditions}
               WHERE ${mediaRenditions.mediaAssetId} = ${mediaAssetId}
-            ) = 3`,
+            ) = ${requiredRenditionCount}`,
           ),
         )
         .returning()

--- a/lib/media/ingestion/service.test.ts
+++ b/lib/media/ingestion/service.test.ts
@@ -13,6 +13,7 @@ import {
   type UploadIntentRecord,
 } from './service'
 import { MediaImageError } from '../processing/image'
+import { CaptureLocationError } from '../privacy/capture-location'
 import { BunnyStorageError } from '../storage/bunny'
 
 const originalBytes = new TextEncoder().encode('approved original bytes')
@@ -434,6 +435,30 @@ describe('Media Library ingestion service', () => {
       processingErrorCode: 'image_unsupported_format',
     })
     expect(f.storage.storeRendition).not.toHaveBeenCalled()
+  })
+
+  it('marks an invalid Capture Location as repair required', async () => {
+    const f = fixture()
+    const intent = await f.service.createUploadIntent({
+      ownerUserId: 'owner_01',
+      idempotencyKey: 'upload_01',
+      contentType: 'image/jpeg',
+      byteSize: originalBytes.byteLength,
+      checksumSha256: originalChecksum,
+    })
+    f.captureLocationVault.seal.mockImplementationOnce(() => {
+      throw new CaptureLocationError('invalid_location')
+    })
+
+    await expect(
+      f.service.completeUploadIntent({
+        ownerUserId: 'owner_01',
+        uploadIntentId: intent.id,
+      }),
+    ).resolves.toMatchObject({
+      processingState: 'repair_required',
+      processingErrorCode: 'capture_location_invalid',
+    })
   })
 
   it('resumes after a partial Rendition failure without rewriting confirmed output', async () => {

--- a/lib/media/ingestion/service.test.ts
+++ b/lib/media/ingestion/service.test.ts
@@ -1,0 +1,507 @@
+import { createHash } from 'node:crypto'
+
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import {
+  createMediaIngestionService,
+  type MediaAssetRecord,
+  MediaIngestionError,
+  type MediaIngestionRepository,
+  type RenditionRecord,
+  type UploadIntentRecord,
+} from './service'
+import { MediaImageError } from '../processing/image'
+import { BunnyStorageError } from '../storage/bunny'
+
+const originalBytes = new TextEncoder().encode('approved original bytes')
+const originalChecksum = createHash('sha256').update(originalBytes).digest('hex')
+
+function processedImage() {
+  const rendition = (profileWidth: 640 | 1024 | 1600) => {
+    const bytes = new TextEncoder().encode(`rendition:${profileWidth}`)
+    return {
+      profileWidth,
+      bytes,
+      checksumSha256: createHash('sha256').update(bytes).digest('hex'),
+      byteSize: bytes.byteLength,
+      width: profileWidth,
+      height: Math.round(profileWidth * 0.75),
+      contentType: 'image/jpeg' as const,
+      colorSpace: 'srgb' as const,
+      progressive: true as const,
+      metadataStripped: true as const,
+    }
+  }
+  return {
+    original: {
+      format: 'jpeg' as const,
+      width: 4032,
+      height: 3024,
+      capturedAt: new Date('2025-05-08T07:31:34.000Z'),
+      cameraMake: 'Apple',
+      cameraModel: 'iPhone',
+      lens: 'Main Camera',
+      focalLengthMillimeters: 6.8,
+      aperture: 1.78,
+      shutterSpeedSeconds: 0.008,
+      iso: 80,
+      captureLocation: { latitude: 37.7749, longitude: -122.4194 },
+    },
+    renditions: [rendition(640), rendition(1024), rendition(1600)],
+  }
+}
+
+function fixture() {
+  const intents = new Map<string, UploadIntentRecord>()
+  const assets = new Map<string, MediaAssetRecord>()
+  const assetsByIntent = new Map<string, string>()
+  const renditions = new Map<string, RenditionRecord>()
+  const storedRenditions = new Map<
+    string,
+    { bytes: Uint8Array; byteSize: number; contentType: string }
+  >()
+  const events: string[] = []
+  let now = new Date('2026-07-15T00:00:00.000Z')
+  let readableOriginal: Uint8Array = originalBytes
+  let originalContentType = 'image/jpeg'
+  let originalReportedByteSize: number | null = null
+  let originalMissing = false
+  let failingRenditionProfile: number | null = null
+  const repository: MediaIngestionRepository = {
+    async createUploadIntent(input) {
+      const key = `${input.ownerUserId}:${input.idempotencyKey}`
+      const existing = intents.get(key)
+      if (existing) return existing
+      const created = { ...input, completedAt: null }
+      intents.set(key, created)
+      return created
+    },
+    async findUploadIntent(ownerUserId, id) {
+      return (
+        [...intents.values()].find(
+          (intent) => intent.ownerUserId === ownerUserId && intent.id === id,
+        ) ?? null
+      )
+    },
+    async findMediaAsset(uploadIntentId) {
+      const id = assetsByIntent.get(uploadIntentId)
+      return id ? assets.get(id) ?? null : null
+    },
+    async createVerifiedMediaAsset({ uploadIntent, completedAt }) {
+      const existingId = assetsByIntent.get(uploadIntent.id)
+      if (existingId) return assets.get(existingId)!
+      const asset: MediaAssetRecord = {
+        id: '22222222-2222-4222-8222-222222222222',
+        uploadIntentId: uploadIntent.id,
+        processingState: 'original_verified',
+        processingErrorCode: null,
+        originalKey: uploadIntent.originalKey,
+        originalContentType: uploadIntent.contentType,
+        originalByteSize: uploadIntent.byteSize,
+        originalChecksumSha256: uploadIntent.checksumSha256,
+        width: null,
+        height: null,
+        capturedAt: null,
+        cameraMake: null,
+        cameraModel: null,
+        lens: null,
+        focalLengthMillimeters: null,
+        aperture: null,
+        shutterSpeedSeconds: null,
+        iso: null,
+        captureLocationEnvelope: null,
+      }
+      uploadIntent.completedAt = completedAt
+      assets.set(asset.id, asset)
+      assetsByIntent.set(uploadIntent.id, asset.id)
+      events.push('asset:original_verified')
+      return asset
+    },
+    async claimProcessing({ mediaAssetId }) {
+      const asset = assets.get(mediaAssetId)!
+      if (asset.processingState === 'ready') return false
+      asset.processingState = 'processing'
+      asset.processingErrorCode = null
+      events.push('asset:processing')
+      return true
+    },
+    async getMediaAsset(id) {
+      return assets.get(id) ?? null
+    },
+    async findRendition(mediaAssetId, profileWidth) {
+      return renditions.get(`${mediaAssetId}:${profileWidth}`) ?? null
+    },
+    async recordRendition(input) {
+      renditions.set(`${input.mediaAssetId}:${input.profileWidth}`, input)
+      events.push(`rendition:record:${input.profileWidth}`)
+      return input
+    },
+    async markReady({ mediaAssetId, metadata }) {
+      const asset = assets.get(mediaAssetId)!
+      Object.assign(asset, metadata, {
+        processingState: 'ready',
+        processingErrorCode: null,
+      })
+      events.push('asset:ready')
+      return asset
+    },
+    async markFailure({
+      mediaAssetId,
+      processingState,
+      processingErrorCode,
+    }) {
+      const asset = assets.get(mediaAssetId)!
+      Object.assign(asset, { processingState, processingErrorCode })
+      events.push(`asset:${processingState}`)
+      return asset
+    },
+  }
+  const storage = {
+    inspectOriginal: vi.fn(async () => {
+      if (originalMissing) throw new BunnyStorageError('not_found')
+      return {
+        byteSize: originalReportedByteSize ?? readableOriginal.byteLength,
+        contentType: originalContentType,
+      }
+    }),
+    readOriginal: vi.fn(async () => readableOriginal),
+    storeRendition: vi.fn(async (input: {
+      key: string
+      bytes: Uint8Array
+      contentType: 'image/jpeg'
+    }) => {
+      const profileWidth = Number(input.key.split('/').at(-1)?.split('-')[0])
+      events.push(`rendition:store:${profileWidth}`)
+      if (profileWidth === failingRenditionProfile) {
+        throw new Error('provider response with private details')
+      }
+      storedRenditions.set(input.key, {
+        bytes: input.bytes,
+        byteSize: input.bytes.byteLength,
+        contentType: input.contentType,
+      })
+      return `https://media-preview.cali.so/${input.key}`
+    }),
+    inspectRendition: vi.fn(async (key: string) => {
+      const stored = storedRenditions.get(key)
+      if (!stored) throw new BunnyStorageError('not_found')
+      return stored
+    }),
+    readRendition: vi.fn(async (key: string) => {
+      const stored = storedRenditions.get(key)
+      if (!stored) throw new BunnyStorageError('not_found')
+      return stored.bytes
+    }),
+  }
+  const processor = vi.fn(async (_bytes: Uint8Array) => {
+    events.push('image:process')
+    return processedImage()
+  })
+  const captureLocationVault = {
+    seal: vi.fn((_location: { latitude: number; longitude: number }) => {
+      events.push('location:seal')
+      return { version: 1, ciphertext: 'sealed-location' }
+    }),
+  }
+  const service = createMediaIngestionService({
+    repository,
+    storage,
+    captureLocationVault,
+    processor,
+    clock: { now: () => now },
+    idGenerator: () => '11111111-1111-4111-8111-111111111111',
+  })
+  return {
+    service,
+    intents,
+    assets,
+    renditions,
+    events,
+    storage,
+    processor,
+    captureLocationVault,
+    setNow(value: Date) {
+      now = value
+    },
+    setOriginal(value: Uint8Array, contentType = 'image/jpeg') {
+      readableOriginal = value
+      originalContentType = contentType
+    },
+    setOriginalReportedByteSize(value: number | null) {
+      originalReportedByteSize = value
+    },
+    setOriginalMissing(value: boolean) {
+      originalMissing = value
+    },
+    seedRendition(profileWidth: 640 | 1024 | 1600) {
+      const rendition = processedImage().renditions.find(
+        (candidate) => candidate.profileWidth === profileWidth,
+      )!
+      const key =
+        `renditions/22222222-2222-4222-8222-222222222222/${profileWidth}-${rendition.checksumSha256}.jpg`
+      storedRenditions.set(key, {
+        bytes: rendition.bytes,
+        byteSize: rendition.byteSize,
+        contentType: rendition.contentType,
+      })
+    },
+    failRendition(profileWidth: number | null) {
+      failingRenditionProfile = profileWidth
+    },
+  }
+}
+
+describe('Media Library ingestion service', () => {
+  it('creates one idempotent 24-hour Upload Intent with an opaque Original key', async () => {
+    const f = fixture()
+    const input = {
+      ownerUserId: 'owner_01',
+      idempotencyKey: 'upload_01',
+      contentType: 'image/heic' as const,
+      byteSize: 2_660_052,
+      checksumSha256:
+        '88a49da230bb852105ed25e9135cd076d2d515810767a57f79839c6933fe4f49',
+    }
+
+    const first = await f.service.createUploadIntent(input)
+    const replay = await f.service.createUploadIntent(input)
+
+    expect(replay).toEqual(first)
+    expect(first).toMatchObject({
+      id: '11111111-1111-4111-8111-111111111111',
+      originalKey: 'originals/11111111-1111-4111-8111-111111111111.heic',
+      createdAt: new Date('2026-07-15T00:00:00.000Z'),
+      expiresAt: new Date('2026-07-16T00:00:00.000Z'),
+      completedAt: null,
+    })
+    expect(first.originalKey).not.toContain(input.idempotencyKey)
+    expect(f.intents).toHaveLength(1)
+  })
+
+  it('rejects an idempotency replay with different transfer expectations', async () => {
+    const f = fixture()
+    const input = {
+      ownerUserId: 'owner_01',
+      idempotencyKey: 'upload_01',
+      contentType: 'image/jpeg' as const,
+      byteSize: 1024,
+      checksumSha256: 'a'.repeat(64),
+    }
+    await f.service.createUploadIntent(input)
+
+    await expect(
+      f.service.createUploadIntent({ ...input, checksumSha256: 'b'.repeat(64) }),
+    ).rejects.toEqual(new MediaIngestionError('idempotency_conflict'))
+  })
+
+  it('completes an expired Upload Intent through durable processing states', async () => {
+    const f = fixture()
+    const intent = await f.service.createUploadIntent({
+      ownerUserId: 'owner_01',
+      idempotencyKey: 'upload_01',
+      contentType: 'image/jpeg',
+      byteSize: originalBytes.byteLength,
+      checksumSha256: originalChecksum,
+    })
+    f.setNow(new Date('2026-07-17T00:00:00.000Z'))
+
+    const asset = await f.service.completeUploadIntent({
+      ownerUserId: 'owner_01',
+      uploadIntentId: intent.id,
+    })
+
+    expect(asset).toMatchObject({
+      processingState: 'ready',
+      width: 4032,
+      height: 3024,
+      cameraMake: 'Apple',
+      iso: 80,
+      captureLocationEnvelope: {
+        version: 1,
+        ciphertext: 'sealed-location',
+      },
+    })
+    expect(intent.completedAt).toEqual(new Date('2026-07-17T00:00:00.000Z'))
+    expect(f.renditions).toHaveLength(3)
+    expect(f.events).toEqual([
+      'asset:original_verified',
+      'asset:processing',
+      'image:process',
+      'rendition:store:640',
+      'rendition:record:640',
+      'rendition:store:1024',
+      'rendition:record:1024',
+      'rendition:store:1600',
+      'rendition:record:1600',
+      'location:seal',
+      'asset:ready',
+    ])
+    expect(f.captureLocationVault.seal).toHaveBeenCalledWith({
+      latitude: 37.7749,
+      longitude: -122.4194,
+    })
+  })
+
+  it('returns a ready Media Asset idempotently without repeating side effects', async () => {
+    const f = fixture()
+    const intent = await f.service.createUploadIntent({
+      ownerUserId: 'owner_01',
+      idempotencyKey: 'upload_01',
+      contentType: 'image/jpeg',
+      byteSize: originalBytes.byteLength,
+      checksumSha256: originalChecksum,
+    })
+    const input = { ownerUserId: 'owner_01', uploadIntentId: intent.id }
+    const first = await f.service.completeUploadIntent(input)
+    const eventCount = f.events.length
+
+    const replay = await f.service.completeUploadIntent(input)
+
+    expect(replay).toBe(first)
+    expect(f.events).toHaveLength(eventCount)
+    expect(f.processor).toHaveBeenCalledTimes(1)
+    expect(f.storage.storeRendition).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not register a Media Asset when the Original bytes do not match', async () => {
+    const f = fixture()
+    const intent = await f.service.createUploadIntent({
+      ownerUserId: 'owner_01',
+      idempotencyKey: 'upload_01',
+      contentType: 'image/jpeg',
+      byteSize: originalBytes.byteLength,
+      checksumSha256: originalChecksum,
+    })
+    f.setOriginal(new TextEncoder().encode('tampered original bytes'))
+
+    await expect(
+      f.service.completeUploadIntent({
+        ownerUserId: 'owner_01',
+        uploadIntentId: intent.id,
+      }),
+    ).rejects.toEqual(new MediaIngestionError('original_mismatch'))
+    expect(f.assets).toHaveLength(0)
+    expect(f.processor).not.toHaveBeenCalled()
+  })
+
+  it('does not read an Original after its stored size fails verification', async () => {
+    const f = fixture()
+    const intent = await f.service.createUploadIntent({
+      ownerUserId: 'owner_01',
+      idempotencyKey: 'upload_01',
+      contentType: 'image/jpeg',
+      byteSize: originalBytes.byteLength,
+      checksumSha256: originalChecksum,
+    })
+    f.setOriginalReportedByteSize(originalBytes.byteLength + 1)
+
+    await expect(
+      f.service.completeUploadIntent({
+        ownerUserId: 'owner_01',
+        uploadIntentId: intent.id,
+      }),
+    ).rejects.toEqual(new MediaIngestionError('original_mismatch'))
+    expect(f.storage.readOriginal).not.toHaveBeenCalled()
+  })
+
+  it('marks invalid image processing as repair required without leaking errors', async () => {
+    const f = fixture()
+    const intent = await f.service.createUploadIntent({
+      ownerUserId: 'owner_01',
+      idempotencyKey: 'upload_01',
+      contentType: 'image/jpeg',
+      byteSize: originalBytes.byteLength,
+      checksumSha256: originalChecksum,
+    })
+    f.processor.mockRejectedValueOnce(new MediaImageError('unsupported_format'))
+
+    const asset = await f.service.completeUploadIntent({
+      ownerUserId: 'owner_01',
+      uploadIntentId: intent.id,
+    })
+
+    expect(asset).toMatchObject({
+      processingState: 'repair_required',
+      processingErrorCode: 'image_unsupported_format',
+    })
+    expect(f.storage.storeRendition).not.toHaveBeenCalled()
+  })
+
+  it('resumes after a partial Rendition failure without rewriting confirmed output', async () => {
+    const f = fixture()
+    const intent = await f.service.createUploadIntent({
+      ownerUserId: 'owner_01',
+      idempotencyKey: 'upload_01',
+      contentType: 'image/jpeg',
+      byteSize: originalBytes.byteLength,
+      checksumSha256: originalChecksum,
+    })
+    const input = { ownerUserId: 'owner_01', uploadIntentId: intent.id }
+    f.failRendition(1024)
+
+    await expect(f.service.completeUploadIntent(input)).resolves.toMatchObject({
+      processingState: 'retryable_failure',
+      processingErrorCode: 'dependency_unavailable',
+    })
+    expect(f.renditions).toHaveLength(1)
+
+    f.failRendition(null)
+    await expect(f.service.completeUploadIntent(input)).resolves.toMatchObject({
+      processingState: 'ready',
+      processingErrorCode: null,
+    })
+    expect(f.renditions).toHaveLength(3)
+    expect(
+      f.storage.storeRendition.mock.calls.filter(([call]) =>
+        call.key.includes('/640-'),
+      ),
+    ).toHaveLength(1)
+  })
+
+  it('adopts a verified orphan Rendition after an interrupted catalog write', async () => {
+    const f = fixture()
+    const intent = await f.service.createUploadIntent({
+      ownerUserId: 'owner_01',
+      idempotencyKey: 'upload_01',
+      contentType: 'image/jpeg',
+      byteSize: originalBytes.byteLength,
+      checksumSha256: originalChecksum,
+    })
+    f.seedRendition(640)
+
+    await expect(
+      f.service.completeUploadIntent({
+        ownerUserId: 'owner_01',
+        uploadIntentId: intent.id,
+      }),
+    ).resolves.toMatchObject({ processingState: 'ready' })
+    expect(
+      f.storage.storeRendition.mock.calls.filter(([call]) =>
+        call.key.includes('/640-'),
+      ),
+    ).toHaveLength(0)
+    expect(f.renditions).toHaveLength(3)
+  })
+
+  it('marks a missing verified Original as repair required', async () => {
+    const f = fixture()
+    const intent = await f.service.createUploadIntent({
+      ownerUserId: 'owner_01',
+      idempotencyKey: 'upload_01',
+      contentType: 'image/jpeg',
+      byteSize: originalBytes.byteLength,
+      checksumSha256: originalChecksum,
+    })
+    const input = { ownerUserId: 'owner_01', uploadIntentId: intent.id }
+    f.failRendition(640)
+    await f.service.completeUploadIntent(input)
+    f.setOriginalMissing(true)
+
+    await expect(f.service.completeUploadIntent(input)).resolves.toMatchObject({
+      processingState: 'repair_required',
+      processingErrorCode: 'storage_not_found',
+    })
+  })
+})

--- a/lib/media/ingestion/service.test.ts
+++ b/lib/media/ingestion/service.test.ts
@@ -138,7 +138,14 @@ function fixture() {
       events.push(`rendition:record:${input.profileWidth}`)
       return input
     },
-    async markReady({ mediaAssetId, metadata }) {
+    async markReady({
+      mediaAssetId,
+      metadata,
+      requiredRenditionCount,
+    }) {
+      if (renditions.size !== requiredRenditionCount) {
+        throw new Error('Rendition manifest is incomplete')
+      }
       const asset = assets.get(mediaAssetId)!
       Object.assign(asset, metadata, {
         processingState: 'ready',
@@ -446,6 +453,10 @@ describe('Media Library ingestion service', () => {
       processingErrorCode: 'dependency_unavailable',
     })
     expect(f.renditions).toHaveLength(1)
+    const confirmedKey = [...f.renditions.values()][0]!.objectKey
+    const confirmedInspections = f.storage.inspectRendition.mock.calls.filter(
+      ([key]) => key === confirmedKey,
+    ).length
 
     f.failRendition(null)
     await expect(f.service.completeUploadIntent(input)).resolves.toMatchObject({
@@ -458,6 +469,14 @@ describe('Media Library ingestion service', () => {
         call.key.includes('/640-'),
       ),
     ).toHaveLength(1)
+    expect(
+      f.storage.inspectRendition.mock.calls.filter(
+        ([key]) => key === confirmedKey,
+      ),
+    ).toHaveLength(confirmedInspections)
+    expect(
+      f.storage.readRendition.mock.calls.filter(([key]) => key === confirmedKey),
+    ).toHaveLength(2)
   })
 
   it('adopts a verified orphan Rendition after an interrupted catalog write', async () => {

--- a/lib/media/ingestion/service.ts
+++ b/lib/media/ingestion/service.ts
@@ -7,6 +7,7 @@ import {
   processOriginalImage,
   RENDITION_PROFILE_WIDTHS,
 } from '../processing/image'
+import { CaptureLocationError } from '../privacy/capture-location'
 import { BunnyStorageError } from '../storage/bunny'
 import { MAX_ORIGINAL_UPLOAD_BYTES } from '../storage/upload'
 
@@ -303,6 +304,12 @@ function safeFailure(error: unknown) {
     return {
       processingState: 'repair_required' as const,
       processingErrorCode: `ingestion_${error.code}`,
+    }
+  }
+  if (error instanceof CaptureLocationError) {
+    return {
+      processingState: 'repair_required' as const,
+      processingErrorCode: 'capture_location_invalid',
     }
   }
   if (error instanceof BunnyStorageError) {

--- a/lib/media/ingestion/service.ts
+++ b/lib/media/ingestion/service.ts
@@ -1,0 +1,509 @@
+import 'server-only'
+
+import { createHash, randomUUID } from 'node:crypto'
+
+import {
+  MediaImageError,
+  processOriginalImage,
+  RENDITION_PROFILE_WIDTHS,
+} from '../processing/image'
+import { BunnyStorageError } from '../storage/bunny'
+import { MAX_ORIGINAL_UPLOAD_BYTES } from '../storage/upload'
+
+export const UPLOAD_INTENT_LIFETIME_MS = 24 * 60 * 60 * 1000
+
+export type OriginalContentType =
+  | 'image/heic'
+  | 'image/heif'
+  | 'image/jpeg'
+  | 'image/png'
+
+export type UploadIntentRecord = {
+  id: string
+  ownerUserId: string
+  idempotencyKey: string
+  originalKey: string
+  contentType: OriginalContentType
+  byteSize: number
+  checksumSha256: string
+  expiresAt: Date
+  completedAt: Date | null
+  createdAt: Date
+}
+
+export type MediaAssetProcessingState =
+  | 'original_verified'
+  | 'processing'
+  | 'ready'
+  | 'retryable_failure'
+  | 'repair_required'
+
+export type MediaAssetRecord = {
+  id: string
+  uploadIntentId: string
+  processingState: MediaAssetProcessingState
+  processingErrorCode: string | null
+  originalKey: string
+  originalContentType: OriginalContentType
+  originalByteSize: number
+  originalChecksumSha256: string
+  width: number | null
+  height: number | null
+  capturedAt: Date | null
+  cameraMake: string | null
+  cameraModel: string | null
+  lens: string | null
+  focalLengthMillimeters: number | null
+  aperture: number | null
+  shutterSpeedSeconds: number | null
+  iso: number | null
+  captureLocationEnvelope: unknown | null
+}
+
+export type RenditionRecord = {
+  mediaAssetId: string
+  profileWidth: number
+  objectKey: string
+  checksumSha256: string
+  byteSize: number
+  width: number
+  height: number
+  contentType: 'image/jpeg'
+  colorSpace: 'srgb'
+  progressive: true
+  metadataStripped: true
+}
+
+export interface MediaIngestionRepository {
+  createUploadIntent(
+    input: Omit<UploadIntentRecord, 'completedAt'>,
+  ): Promise<UploadIntentRecord>
+  findUploadIntent(ownerUserId: string, id: string): Promise<UploadIntentRecord | null>
+  findMediaAsset(uploadIntentId: string): Promise<MediaAssetRecord | null>
+  createVerifiedMediaAsset(input: {
+    uploadIntent: UploadIntentRecord
+    completedAt: Date
+  }): Promise<MediaAssetRecord>
+  claimProcessing(input: {
+    mediaAssetId: string
+    claimedAt: Date
+    staleBefore: Date
+  }): Promise<boolean>
+  getMediaAsset(id: string): Promise<MediaAssetRecord | null>
+  findRendition(
+    mediaAssetId: string,
+    profileWidth: number,
+  ): Promise<RenditionRecord | null>
+  recordRendition(input: RenditionRecord): Promise<RenditionRecord>
+  markReady(input: {
+    mediaAssetId: string
+    metadata: Omit<
+      MediaAssetRecord,
+      | 'id'
+      | 'uploadIntentId'
+      | 'processingState'
+      | 'processingErrorCode'
+      | 'originalKey'
+      | 'originalContentType'
+      | 'originalByteSize'
+      | 'originalChecksumSha256'
+    >
+    completedAt: Date
+  }): Promise<MediaAssetRecord>
+  markFailure(input: {
+    mediaAssetId: string
+    processingState: 'retryable_failure' | 'repair_required'
+    processingErrorCode: string
+    failedAt: Date
+  }): Promise<MediaAssetRecord>
+}
+
+export type MediaIngestionErrorCode =
+  | 'idempotency_conflict'
+  | 'invalid_request'
+  | 'not_found'
+  | 'original_mismatch'
+  | 'rendition_mismatch'
+
+export class MediaIngestionError extends Error {
+  constructor(readonly code: MediaIngestionErrorCode) {
+    super(`Media ingestion failed: ${code}`)
+    this.name = 'MediaIngestionError'
+  }
+}
+
+type MediaIngestionDependencies = {
+  repository: MediaIngestionRepository
+  storage: {
+    inspectOriginal(key: string): Promise<{
+      byteSize: number
+      contentType: string
+    }>
+    readOriginal(key: string): Promise<Uint8Array>
+    storeRendition(input: {
+      key: string
+      bytes: Uint8Array
+      checksumSha256: string
+      contentType: 'image/jpeg'
+    }): Promise<string>
+    inspectRendition(key: string): Promise<{
+      byteSize: number
+      contentType: string
+    }>
+    readRendition(key: string): Promise<Uint8Array>
+  }
+  captureLocationVault: {
+    seal(location: { latitude: number; longitude: number }): unknown
+  }
+  processor?: typeof processOriginalImage
+  clock?: { now(): Date }
+  idGenerator?: () => string
+}
+
+const contentTypeExtensions: Record<OriginalContentType, string> = {
+  'image/heic': 'heic',
+  'image/heif': 'heif',
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+}
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function validText(value: string, maximumLength: number) {
+  return value === value.trim() && value.length > 0 && value.length <= maximumLength
+}
+
+function assertUploadIntentInput(input: {
+  ownerUserId: string
+  idempotencyKey: string
+  contentType: string
+  byteSize: number
+  checksumSha256: string
+}): asserts input is typeof input & { contentType: OriginalContentType } {
+  if (
+    !validText(input.ownerUserId, 255) ||
+    !validText(input.idempotencyKey, 128) ||
+    !(input.contentType in contentTypeExtensions) ||
+    !Number.isSafeInteger(input.byteSize) ||
+    input.byteSize <= 0 ||
+    input.byteSize > MAX_ORIGINAL_UPLOAD_BYTES ||
+    !/^[a-f0-9]{64}$/.test(input.checksumSha256)
+  ) {
+    throw new MediaIngestionError('invalid_request')
+  }
+}
+
+function sameTransferExpectation(
+  intent: UploadIntentRecord,
+  input: {
+    ownerUserId: string
+    idempotencyKey: string
+    contentType: OriginalContentType
+    byteSize: number
+    checksumSha256: string
+  },
+) {
+  return (
+    intent.ownerUserId === input.ownerUserId &&
+    intent.idempotencyKey === input.idempotencyKey &&
+    intent.originalKey ===
+      `originals/${intent.id}.${contentTypeExtensions[input.contentType]}` &&
+    intent.contentType === input.contentType &&
+    intent.byteSize === input.byteSize &&
+    intent.checksumSha256 === input.checksumSha256
+  )
+}
+
+const PROCESSING_STALE_AFTER_MS = 5 * 60 * 1000
+
+async function verifyOriginal(
+  storage: MediaIngestionDependencies['storage'],
+  intent: UploadIntentRecord,
+) {
+  const object = await storage.inspectOriginal(intent.originalKey)
+  if (
+    object.byteSize !== intent.byteSize ||
+    object.contentType !== intent.contentType
+  ) {
+    throw new MediaIngestionError('original_mismatch')
+  }
+  const bytes = await storage.readOriginal(intent.originalKey)
+  const checksumSha256 = createHash('sha256').update(bytes).digest('hex')
+  if (
+    bytes.byteLength !== intent.byteSize ||
+    checksumSha256 !== intent.checksumSha256
+  ) {
+    throw new MediaIngestionError('original_mismatch')
+  }
+  return bytes
+}
+
+async function inspectOptionalRendition(
+  storage: MediaIngestionDependencies['storage'],
+  key: string,
+) {
+  try {
+    return await storage.inspectRendition(key)
+  } catch (error) {
+    if (error instanceof BunnyStorageError && error.code === 'not_found') {
+      return null
+    }
+    throw error
+  }
+}
+
+async function verifyRendition(
+  storage: MediaIngestionDependencies['storage'],
+  key: string,
+  expected: { byteSize: number; contentType: string; checksumSha256: string },
+  inspected?: { byteSize: number; contentType: string },
+) {
+  const object = inspected ?? (await storage.inspectRendition(key))
+  if (
+    object.byteSize !== expected.byteSize ||
+    object.contentType !== expected.contentType
+  ) {
+    throw new MediaIngestionError('rendition_mismatch')
+  }
+  const bytes = await storage.readRendition(key)
+  if (
+    bytes.byteLength !== expected.byteSize ||
+    createHash('sha256').update(bytes).digest('hex') !== expected.checksumSha256
+  ) {
+    throw new MediaIngestionError('rendition_mismatch')
+  }
+}
+
+function renditionMatches(
+  record: RenditionRecord,
+  expected: Omit<RenditionRecord, 'mediaAssetId' | 'objectKey'>,
+) {
+  return (
+    record.profileWidth === expected.profileWidth &&
+    record.checksumSha256 === expected.checksumSha256 &&
+    record.byteSize === expected.byteSize &&
+    record.width === expected.width &&
+    record.height === expected.height &&
+    record.contentType === expected.contentType &&
+    record.colorSpace === expected.colorSpace &&
+    record.progressive === expected.progressive &&
+    record.metadataStripped === expected.metadataStripped
+  )
+}
+
+function safeFailure(error: unknown) {
+  if (error instanceof MediaImageError) {
+    return {
+      processingState: 'repair_required' as const,
+      processingErrorCode: `image_${error.code}`,
+    }
+  }
+  if (error instanceof MediaIngestionError) {
+    return {
+      processingState: 'repair_required' as const,
+      processingErrorCode: `ingestion_${error.code}`,
+    }
+  }
+  if (error instanceof BunnyStorageError) {
+    if (error.code === 'not_found') {
+      return {
+        processingState: 'repair_required' as const,
+        processingErrorCode: 'storage_not_found',
+      }
+    }
+    return {
+      processingState: 'retryable_failure' as const,
+      processingErrorCode: `storage_${error.code}`,
+    }
+  }
+  return {
+    processingState: 'retryable_failure' as const,
+    processingErrorCode: 'dependency_unavailable',
+  }
+}
+
+export function createMediaIngestionService({
+  repository,
+  storage,
+  captureLocationVault,
+  processor = processOriginalImage,
+  clock = { now: () => new Date() },
+  idGenerator = randomUUID,
+}: MediaIngestionDependencies) {
+  return {
+    async createUploadIntent(input: {
+      ownerUserId: string
+      idempotencyKey: string
+      contentType: OriginalContentType
+      byteSize: number
+      checksumSha256: string
+    }) {
+      assertUploadIntentInput(input)
+      const now = clock.now()
+      const id = idGenerator()
+      if (!uuidPattern.test(id)) {
+        throw new MediaIngestionError('invalid_request')
+      }
+      const intent = await repository.createUploadIntent({
+        ...input,
+        id,
+        originalKey: `originals/${id}.${contentTypeExtensions[input.contentType]}`,
+        createdAt: now,
+        expiresAt: new Date(now.getTime() + UPLOAD_INTENT_LIFETIME_MS),
+      })
+      if (!sameTransferExpectation(intent, input)) {
+        throw new MediaIngestionError('idempotency_conflict')
+      }
+      return intent
+    },
+
+    async completeUploadIntent(input: {
+      ownerUserId: string
+      uploadIntentId: string
+    }) {
+      if (
+        !validText(input.ownerUserId, 255) ||
+        !validText(input.uploadIntentId, 64)
+      ) {
+        throw new MediaIngestionError('invalid_request')
+      }
+      const intent = await repository.findUploadIntent(
+        input.ownerUserId,
+        input.uploadIntentId,
+      )
+      if (!intent) throw new MediaIngestionError('not_found')
+
+      let asset = await repository.findMediaAsset(intent.id)
+      if (asset?.processingState === 'ready') return asset
+
+      let bytes: Uint8Array
+      try {
+        bytes = await verifyOriginal(storage, intent)
+      } catch (error) {
+        if (!asset) throw error
+        const failure = safeFailure(error)
+        return repository.markFailure({
+          mediaAssetId: asset.id,
+          ...failure,
+          failedAt: clock.now(),
+        })
+      }
+
+      const now = clock.now()
+      asset ??= await repository.createVerifiedMediaAsset({
+        uploadIntent: intent,
+        completedAt: now,
+      })
+      const claimed = await repository.claimProcessing({
+        mediaAssetId: asset.id,
+        claimedAt: now,
+        staleBefore: new Date(now.getTime() - PROCESSING_STALE_AFTER_MS),
+      })
+      if (!claimed) return (await repository.getMediaAsset(asset.id)) ?? asset
+
+      try {
+        const processed = await processor(bytes)
+        const byProfile = new Map(
+          processed.renditions.map((rendition) => [
+            rendition.profileWidth,
+            rendition,
+          ]),
+        )
+        if (
+          processed.renditions.length !== RENDITION_PROFILE_WIDTHS.length ||
+          byProfile.size !== RENDITION_PROFILE_WIDTHS.length ||
+          RENDITION_PROFILE_WIDTHS.some((width) => !byProfile.has(width))
+        ) {
+          throw new MediaIngestionError('rendition_mismatch')
+        }
+
+        for (const profileWidth of RENDITION_PROFILE_WIDTHS) {
+          const rendition = byProfile.get(profileWidth)!
+          const objectKey =
+            `renditions/${asset.id}/${profileWidth}-${rendition.checksumSha256}.jpg`
+          const expected = {
+            profileWidth,
+            checksumSha256: rendition.checksumSha256,
+            byteSize: rendition.byteSize,
+            width: rendition.width,
+            height: rendition.height,
+            contentType: rendition.contentType,
+            colorSpace: rendition.colorSpace,
+            progressive: rendition.progressive,
+            metadataStripped: rendition.metadataStripped,
+          }
+          const existing = await repository.findRendition(asset.id, profileWidth)
+          if (existing) {
+            if (!renditionMatches(existing, expected)) {
+              throw new MediaIngestionError('rendition_mismatch')
+            }
+            await verifyRendition(storage, existing.objectKey, existing)
+            continue
+          }
+
+          let stored = await inspectOptionalRendition(storage, objectKey)
+          if (!stored) {
+            await storage.storeRendition({
+              key: objectKey,
+              bytes: rendition.bytes,
+              checksumSha256: rendition.checksumSha256,
+              contentType: rendition.contentType,
+            })
+            stored = await storage.inspectRendition(objectKey)
+          }
+          if (
+            stored.byteSize !== rendition.byteSize ||
+            stored.contentType !== rendition.contentType
+          ) {
+            throw new MediaIngestionError('rendition_mismatch')
+          }
+          await verifyRendition(storage, objectKey, expected, stored)
+          const recorded = await repository.recordRendition({
+            mediaAssetId: asset.id,
+            objectKey,
+            ...expected,
+          })
+          if (
+            recorded.objectKey !== objectKey ||
+            !renditionMatches(recorded, expected)
+          ) {
+            throw new MediaIngestionError('rendition_mismatch')
+          }
+        }
+
+        const captureLocationEnvelope = processed.original.captureLocation
+          ? captureLocationVault.seal(processed.original.captureLocation)
+          : null
+        return repository.markReady({
+          mediaAssetId: asset.id,
+          metadata: {
+            width: processed.original.width,
+            height: processed.original.height,
+            capturedAt: processed.original.capturedAt,
+            cameraMake: processed.original.cameraMake,
+            cameraModel: processed.original.cameraModel,
+            lens: processed.original.lens,
+            focalLengthMillimeters:
+              processed.original.focalLengthMillimeters,
+            aperture: processed.original.aperture,
+            shutterSpeedSeconds: processed.original.shutterSpeedSeconds,
+            iso:
+              processed.original.iso !== null &&
+              Number.isSafeInteger(processed.original.iso)
+                ? processed.original.iso
+                : null,
+            captureLocationEnvelope,
+          },
+          completedAt: clock.now(),
+        })
+      } catch (error) {
+        const failure = safeFailure(error)
+        return repository.markFailure({
+          mediaAssetId: asset.id,
+          ...failure,
+          failedAt: clock.now(),
+        })
+      }
+    },
+  }
+}

--- a/lib/media/ingestion/service.ts
+++ b/lib/media/ingestion/service.ts
@@ -109,6 +109,7 @@ export interface MediaIngestionRepository {
       | 'originalChecksumSha256'
     >
     completedAt: Date
+    requiredRenditionCount: number
   }): Promise<MediaAssetRecord>
   markFailure(input: {
     mediaAssetId: string
@@ -437,7 +438,12 @@ export function createMediaIngestionService({
             if (!renditionMatches(existing, expected)) {
               throw new MediaIngestionError('rendition_mismatch')
             }
-            await verifyRendition(storage, existing.objectKey, existing)
+            await verifyRendition(
+              storage,
+              existing.objectKey,
+              existing,
+              existing,
+            )
             continue
           }
 
@@ -495,6 +501,7 @@ export function createMediaIngestionService({
             captureLocationEnvelope,
           },
           completedAt: clock.now(),
+          requiredRenditionCount: RENDITION_PROFILE_WIDTHS.length,
         })
       } catch (error) {
         const failure = safeFailure(error)

--- a/lib/media/privacy/capture-location.test.ts
+++ b/lib/media/privacy/capture-location.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import { createCaptureLocationVault } from './capture-location'
+
+describe('Media Library Capture Location vault', () => {
+  it('stores coordinates only inside a media-specific encrypted envelope', () => {
+    const vault = createCaptureLocationVault(
+      Buffer.alloc(32, 7).toString('base64'),
+    )
+    const location = { latitude: 37.7749, longitude: -122.4194 }
+
+    const envelope = vault.seal(location)
+
+    expect(vault.open(envelope)).toEqual(location)
+    expect(envelope).toMatchObject({
+      version: 1,
+      algorithm: 'aes-256-gcm',
+    })
+    expect(JSON.stringify(envelope)).not.toContain('37.7749')
+    expect(JSON.stringify(envelope)).not.toContain('-122.4194')
+  })
+
+  it('fails closed with a safe error for a different media key', () => {
+    const envelope = createCaptureLocationVault(
+      Buffer.alloc(32, 3).toString('base64'),
+    ).seal({ latitude: 25.033, longitude: 121.5654 })
+    const otherVault = createCaptureLocationVault(
+      Buffer.alloc(32, 4).toString('base64'),
+    )
+
+    expect(() => otherVault.open(envelope)).toThrow(
+      'Unable to open Capture Location',
+    )
+    expect(() => otherVault.open(envelope)).not.toThrow(/25\.033|121\.5654/)
+  })
+
+  it('rejects malformed keys and out-of-range coordinates', () => {
+    expect(() => createCaptureLocationVault('not-a-key')).toThrow(
+      'Invalid Media encryption key',
+    )
+    const vault = createCaptureLocationVault(
+      Buffer.alloc(32, 5).toString('base64'),
+    )
+    expect(() => vault.seal({ latitude: 91, longitude: 0 })).toThrow(
+      'Invalid Capture Location',
+    )
+  })
+})

--- a/lib/media/privacy/capture-location.ts
+++ b/lib/media/privacy/capture-location.ts
@@ -1,0 +1,94 @@
+import 'server-only'
+
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto'
+
+export type CaptureLocation = {
+  latitude: number
+  longitude: number
+}
+
+export type CaptureLocationEnvelope = {
+  version: 1
+  algorithm: 'aes-256-gcm'
+  iv: string
+  ciphertext: string
+  tag: string
+}
+
+const additionalData = Buffer.from('cali.so:media:capture-location:v1', 'utf8')
+const openError = 'Unable to open Capture Location'
+
+function decodeKey(value: string) {
+  const normalized = value.trim()
+  const key = Buffer.from(normalized, 'base64')
+  const canonical = key.toString('base64').replace(/=+$/, '')
+  if (key.length !== 32 || canonical !== normalized.replace(/=+$/, '')) {
+    throw new Error('Invalid Media encryption key')
+  }
+  return key
+}
+
+function assertCaptureLocation(value: unknown): asserts value is CaptureLocation {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    typeof Reflect.get(value, 'latitude') !== 'number' ||
+    !Number.isFinite(Reflect.get(value, 'latitude')) ||
+    Reflect.get(value, 'latitude') < -90 ||
+    Reflect.get(value, 'latitude') > 90 ||
+    typeof Reflect.get(value, 'longitude') !== 'number' ||
+    !Number.isFinite(Reflect.get(value, 'longitude')) ||
+    Reflect.get(value, 'longitude') < -180 ||
+    Reflect.get(value, 'longitude') > 180
+  ) {
+    throw new Error('Invalid Capture Location')
+  }
+}
+
+export function createCaptureLocationVault(encodedKey: string) {
+  const key = decodeKey(encodedKey)
+
+  return {
+    seal(location: CaptureLocation): CaptureLocationEnvelope {
+      assertCaptureLocation(location)
+      const iv = randomBytes(12)
+      const cipher = createCipheriv('aes-256-gcm', key, iv)
+      cipher.setAAD(additionalData)
+      const ciphertext = Buffer.concat([
+        cipher.update(JSON.stringify(location), 'utf8'),
+        cipher.final(),
+      ])
+      return {
+        version: 1,
+        algorithm: 'aes-256-gcm',
+        iv: iv.toString('base64url'),
+        ciphertext: ciphertext.toString('base64url'),
+        tag: cipher.getAuthTag().toString('base64url'),
+      }
+    },
+
+    open(envelope: CaptureLocationEnvelope): CaptureLocation {
+      try {
+        if (envelope.version !== 1 || envelope.algorithm !== 'aes-256-gcm') {
+          throw new Error(openError)
+        }
+        const decipher = createDecipheriv(
+          'aes-256-gcm',
+          key,
+          Buffer.from(envelope.iv, 'base64url'),
+        )
+        decipher.setAAD(additionalData)
+        decipher.setAuthTag(Buffer.from(envelope.tag, 'base64url'))
+        const plaintext = Buffer.concat([
+          decipher.update(Buffer.from(envelope.ciphertext, 'base64url')),
+          decipher.final(),
+        ]).toString('utf8')
+        const location: unknown = JSON.parse(plaintext)
+        assertCaptureLocation(location)
+        return location
+      } catch {
+        throw new Error(openError)
+      }
+    },
+  }
+}

--- a/lib/media/privacy/capture-location.ts
+++ b/lib/media/privacy/capture-location.ts
@@ -15,6 +15,13 @@ export type CaptureLocationEnvelope = {
   tag: string
 }
 
+export class CaptureLocationError extends Error {
+  constructor(readonly code: 'invalid_location') {
+    super('Invalid Capture Location')
+    this.name = 'CaptureLocationError'
+  }
+}
+
 const additionalData = Buffer.from('cali.so:media:capture-location:v1', 'utf8')
 const openError = 'Unable to open Capture Location'
 
@@ -41,7 +48,7 @@ function assertCaptureLocation(value: unknown): asserts value is CaptureLocation
     Reflect.get(value, 'longitude') < -180 ||
     Reflect.get(value, 'longitude') > 180
   ) {
-    throw new Error('Invalid Capture Location')
+    throw new CaptureLocationError('invalid_location')
   }
 }
 

--- a/lib/media/storage/bunny.test.ts
+++ b/lib/media/storage/bunny.test.ts
@@ -252,6 +252,31 @@ describe('Bunny Media Storage', () => {
     expect(original).toEqual(bytes)
   })
 
+  it('reads Rendition bytes through the authenticated storage client', async () => {
+    const bytes = new TextEncoder().encode('public jpeg bytes')
+    const send = vi.fn(async (_command: unknown) => ({
+      Body: {
+        transformToByteArray: async () => bytes,
+      },
+    }))
+    const storage = createBunnyStorage(config, {
+      renditionsClient: { send } as never,
+    })
+    const key = 'renditions/asset_01/photo-1600-v1.jpg'
+
+    await expect(storage.readRendition(key)).resolves.toEqual(bytes)
+
+    const command = send.mock.calls[0]?.[0]
+    expect(command).toBeInstanceOf(GetObjectCommand)
+    if (!(command instanceof GetObjectCommand)) {
+      throw new TypeError('Expected GetObject')
+    }
+    expect(command.input).toEqual({
+      Bucket: 'cali-media-renditions-preview',
+      Key: key,
+    })
+  })
+
   it('deletes Originals and Renditions individually from their own zones', async () => {
     const originalsSend = vi.fn(async (_command: unknown) => ({}))
     const renditionsSend = vi.fn(async (_command: unknown) => ({}))

--- a/lib/media/storage/bunny.ts
+++ b/lib/media/storage/bunny.ts
@@ -170,6 +170,24 @@ export function createBunnyStorage(
     }
   }
 
+  async function readObject(client: S3Client, bucket: string, key: string) {
+    assertObjectKey(key)
+    let output
+    try {
+      output = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }))
+    } catch (error) {
+      throw new BunnyStorageError(
+        providerStatus(error) === 404 ? 'not_found' : 'provider_unavailable',
+      )
+    }
+    if (!output.Body) throw new BunnyStorageError('invalid_response')
+    try {
+      return await output.Body.transformToByteArray()
+    } catch {
+      throw new BunnyStorageError('provider_unavailable')
+    }
+  }
+
   return {
     async storeOriginal(input: {
       key: string
@@ -200,26 +218,7 @@ export function createBunnyStorage(
     },
 
     async readOriginal(key: string) {
-      assertObjectKey(key)
-      let output
-      try {
-        output = await originals.send(
-          new GetObjectCommand({
-            Bucket: config.originals.zone,
-            Key: key,
-          }),
-        )
-      } catch (error) {
-        throw new BunnyStorageError(
-          providerStatus(error) === 404 ? 'not_found' : 'provider_unavailable',
-        )
-      }
-      if (!output.Body) throw new BunnyStorageError('invalid_response')
-      try {
-        return await output.Body.transformToByteArray()
-      } catch {
-        throw new BunnyStorageError('provider_unavailable')
-      }
+      return readObject(originals, config.originals.zone, key)
     },
 
     async storeRendition(input: {
@@ -252,6 +251,10 @@ export function createBunnyStorage(
 
     async inspectRendition(key: string) {
       return inspectObject(renditions, config.renditions.zone, key)
+    },
+
+    async readRendition(key: string) {
+      return readObject(renditions, config.renditions.zone, key)
     },
 
     deleteOriginal(key: string) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:security": "vitest run lib/security",
     "test:localization": "node --test scripts/localization.test.mjs",
     "test:media:catalog": "vitest run lib/media/catalog",
+    "test:media:ingestion": "vitest run lib/media/ingestion lib/media/privacy",
     "test:media:processing": "vitest run lib/media/processing --exclude='**/*.live.test.ts'",
     "test:media:storage": "vitest run lib/media/storage --exclude='**/*.live.test.ts'",
     "test:media:storage:live": "pnpm test:media:storage:live:server && pnpm test:media:storage:live:browser",


### PR DESCRIPTION
Part of #96.

Stacked on #118.

## Summary

- add idempotent 24-hour Upload Intents and verified completion
- persist resumable image processing with stale-worker recovery
- verify all three Renditions before readiness and recover partial writes
- encrypt private Capture Location with Media Library scoped key material

## Verification

- `pnpm test:media:ingestion`
- `pnpm test:media:storage`
- `pnpm test:media:processing`
- `pnpm test:media:catalog`
- `pnpm typecheck`
- `pnpm build`