### PR TITLE
refactor(media): align catalog state with the glossary

### DIFF
--- a/app/admin/(protected)/media/MediaLibrary.tsx
+++ b/app/admin/(protected)/media/MediaLibrary.tsx
@@ -105,8 +105,8 @@ async function responseJson(response: Response) {
 }
 
 function processingLabel(asset: MediaAssetReviewRecord) {
-  if (asset.lifecycle === 'purging') return { zh: '正在永久清除', en: 'Purging' }
-  if (asset.lifecycle === 'archived') return { zh: '已归档', en: 'Archived' }
+  if (asset.catalogState === 'purging') return { zh: '正在永久清除', en: 'Purging' }
+  if (asset.catalogState === 'archived') return { zh: '已归档', en: 'Archived' }
   const labels = {
     upload_initiated: { zh: '等待上传', en: 'Upload initiated' },
     original_verified: { zh: '原片已验证', en: 'Original verified' },
@@ -496,7 +496,7 @@ function Inspector({
     }
   }
 
-  async function changeLifecycle(intent: 'archive' | 'restore') {
+  async function changeCatalogState(intent: 'archive' | 'restore') {
     if (
       intent === 'archive' &&
       !globalThis.confirm(
@@ -634,7 +634,7 @@ function Inspector({
       ) && (
         <button
           type="button"
-          disabled={pending !== null || asset.lifecycle !== 'active'}
+          disabled={pending !== null || asset.catalogState !== 'active'}
           onClick={resumeProcessing}
           className="mt-4 min-h-11 rounded-md border border-border px-4 text-sm font-medium outline-none disabled:opacity-50 focus-visible:border-foreground"
         >
@@ -649,7 +649,7 @@ function Inspector({
       {asset.previewRendition && (
         <button
           type="button"
-          disabled={asset.lifecycle !== 'active'}
+          disabled={asset.catalogState !== 'active'}
           onClick={chooseFocalPoint}
           onKeyDown={moveFocalPoint}
           aria-label={localize(locale, '设置焦点', 'Set Focal Point')}
@@ -691,7 +691,7 @@ function Inspector({
           </h3>
           <button
             type="button"
-            disabled={pending !== null || asset.lifecycle !== 'active'}
+            disabled={pending !== null || asset.catalogState !== 'active'}
             onClick={suggestLocationLabel}
             className="min-h-11 px-2 text-sm font-medium text-muted-foreground outline-none disabled:opacity-50 focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
           >
@@ -714,7 +714,7 @@ function Inspector({
         />
         <button
           type="button"
-          disabled={pending !== null || asset.lifecycle !== 'active'}
+          disabled={pending !== null || asset.catalogState !== 'active'}
           onClick={saveMetadata}
           className="min-h-11 rounded-md border border-border px-4 text-sm font-medium outline-none disabled:opacity-50 focus-visible:border-foreground"
         >
@@ -729,7 +729,7 @@ function Inspector({
           </h3>
           <button
             type="button"
-            disabled={pending !== null || asset.lifecycle !== 'active'}
+            disabled={pending !== null || asset.catalogState !== 'active'}
             onClick={regenerate}
             className="min-h-11 px-2 text-sm font-medium text-muted-foreground outline-none disabled:opacity-50 focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
           >
@@ -755,7 +755,7 @@ function Inspector({
           />
           <button
             type="button"
-            disabled={pending !== null || asset.lifecycle !== 'active'}
+            disabled={pending !== null || asset.catalogState !== 'active'}
             onClick={approveAltText}
             className="min-h-11 rounded-md bg-foreground px-4 text-sm font-medium text-background outline-none disabled:opacity-50 focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-2"
           >
@@ -776,21 +776,21 @@ function Inspector({
       )}
 
       <div className="mt-7 flex flex-wrap gap-2 border-t border-dashed border-border pt-5">
-        {asset.lifecycle === 'active' ? (
+        {asset.catalogState === 'active' ? (
           <button
             type="button"
             disabled={pending !== null}
-            onClick={() => changeLifecycle('archive')}
+            onClick={() => changeCatalogState('archive')}
             className="min-h-11 px-3 text-sm text-muted-foreground outline-none disabled:opacity-50 focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
           >
             <T zh="归档" en="Archive" />
           </button>
-        ) : asset.lifecycle === 'archived' ? (
+        ) : asset.catalogState === 'archived' ? (
           <>
             <button
               type="button"
               disabled={pending !== null}
-              onClick={() => changeLifecycle('restore')}
+              onClick={() => changeCatalogState('restore')}
               className="min-h-11 rounded-md border border-border px-4 text-sm font-medium outline-none disabled:opacity-50 focus-visible:border-foreground"
             >
               <T zh="恢复" en="Restore" />
@@ -815,7 +815,7 @@ function Inspector({
           </button>
         )}
       </div>
-      {asset.lifecycle !== 'active' && (
+      {asset.catalogState !== 'active' && (
         <p className="mt-3 text-sm leading-5 text-muted-foreground">
           <T
             zh="归档不会撤销已经知道的成品 URL；只有永久清除完成后才会删除文件和 CDN 缓存。"
@@ -992,14 +992,14 @@ export function MediaLibrary({
     }
     setActive((items) => {
       const without = items.filter((item) => item.id !== asset.id)
-      return asset.lifecycle === 'active' ? [asset, ...without] : without
+      return asset.catalogState === 'active' ? [asset, ...without] : without
     })
     setArchived((items) => {
       const without = items.filter((item) => item.id !== asset.id)
-      return asset.lifecycle === 'active' ? without : [asset, ...without]
+      return asset.catalogState === 'active' ? without : [asset, ...without]
     })
-    if (asset.lifecycle === 'active' && view === 'archived') setSelectedId(null)
-    if (asset.lifecycle !== 'active' && view === 'active') setSelectedId(null)
+    if (asset.catalogState === 'active' && view === 'archived') setSelectedId(null)
+    if (asset.catalogState !== 'active' && view === 'active') setSelectedId(null)
   }
 
   function chooseView(next: LibraryView) {

--- a/app/admin/(protected)/photos/PhotoSelectionEditor.tsx
+++ b/app/admin/(protected)/photos/PhotoSelectionEditor.tsx
@@ -25,7 +25,7 @@ async function responseJson(response: Response) {
 
 function eligible(asset: MediaAssetReviewRecord) {
   return (
-    asset.lifecycle === 'active' &&
+    asset.catalogState === 'active' &&
     asset.processingState === 'ready' &&
     asset.previewRendition !== null &&
     asset.altTextApprovedAt !== null &&

--- a/db/migrations/0009_media_catalog_state.sql
+++ b/db/migrations/0009_media_catalog_state.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "media_assets" RENAME COLUMN "lifecycle" TO "catalog_state";--> statement-breakpoint
+ALTER TABLE "media_assets" RENAME CONSTRAINT "media_assets_lifecycle_check" TO "media_assets_catalog_state_check";

--- a/db/migrations/meta/0009_snapshot.json
+++ b/db/migrations/meta/0009_snapshot.json
@@ -1,0 +1,2129 @@
+{
+  "id": "255192c2-5fad-453b-9433-9ee567ec62fe",
+  "prevId": "3f238545-4f05-47f7-9cdc-d880ce9b9c6f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ama_admin_sessions": {
+      "name": "ama_admin_sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_admin_sessions_expires_at_idx": {
+          "name": "ama_admin_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ama_auth_tokens": {
+      "name": "ama_auth_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_auth_tokens_expires_at_idx": {
+          "name": "ama_auth_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ama_availability_windows": {
+      "name": "ama_availability_windows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "iso_weekday": {
+          "name": "iso_weekday",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_minute": {
+          "name": "start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_minute": {
+          "name": "end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_availability_windows_order_idx": {
+          "name": "ama_availability_windows_order_idx",
+          "columns": [
+            {
+              "expression": "iso_weekday",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_minute",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_minute",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_availability_windows_iso_weekday_check": {
+          "name": "ama_availability_windows_iso_weekday_check",
+          "value": "\"ama_availability_windows\".\"iso_weekday\" BETWEEN 1 AND 7"
+        },
+        "ama_availability_windows_start_minute_check": {
+          "name": "ama_availability_windows_start_minute_check",
+          "value": "\"ama_availability_windows\".\"start_minute\" BETWEEN 0 AND 1439"
+        },
+        "ama_availability_windows_end_minute_check": {
+          "name": "ama_availability_windows_end_minute_check",
+          "value": "\"ama_availability_windows\".\"end_minute\" BETWEEN 1 AND 1440"
+        },
+        "ama_availability_windows_same_day_check": {
+          "name": "ama_availability_windows_same_day_check",
+          "value": "\"ama_availability_windows\".\"start_minute\" < \"ama_availability_windows\".\"end_minute\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_google_calendar_connections": {
+      "name": "ama_google_calendar_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_email": {
+          "name": "calendar_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_summary": {
+          "name": "calendar_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_scopes": {
+          "name": "granted_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "refresh_token_envelope": {
+          "name": "refresh_token_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_google_calendar_connections_singleton_check": {
+          "name": "ama_google_calendar_connections_singleton_check",
+          "value": "\"ama_google_calendar_connections\".\"id\" = 1"
+        },
+        "ama_google_calendar_connections_status_check": {
+          "name": "ama_google_calendar_connections_status_check",
+          "value": "\"ama_google_calendar_connections\".\"status\" IN ('disconnected', 'connected', 'expired', 'revoked', 'denied_scope', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_google_oauth_attempts": {
+      "name": "ama_google_oauth_attempts",
+      "schema": "",
+      "columns": {
+        "state_hash": {
+          "name": "state_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pkce_verifier_envelope": {
+          "name": "pkce_verifier_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_google_oauth_attempts_expires_at_idx": {
+          "name": "ama_google_oauth_attempts_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_active_photo_publication": {
+      "name": "media_active_photo_publication",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "published_selection_id": {
+          "name": "published_selection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_active_photo_publication_selection_uidx": {
+          "name": "media_active_photo_publication_selection_uidx",
+          "columns": [
+            {
+              "expression": "published_selection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_active_photo_publication_published_selection_id_media_published_photo_selections_id_fk": {
+          "name": "media_active_photo_publication_published_selection_id_media_published_photo_selections_id_fk",
+          "tableFrom": "media_active_photo_publication",
+          "tableTo": "media_published_photo_selections",
+          "columnsFrom": [
+            "published_selection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_active_photo_publication_singleton_check": {
+          "name": "media_active_photo_publication_singleton_check",
+          "value": "\"media_active_photo_publication\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_asset_purge_jobs": {
+      "name": "media_asset_purge_jobs",
+      "schema": "",
+      "columns": {
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_deleted_at": {
+          "name": "original_deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "media_asset_purge_jobs_owner_idx": {
+          "name": "media_asset_purge_jobs_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_asset_purge_jobs_owner_check": {
+          "name": "media_asset_purge_jobs_owner_check",
+          "value": "length(btrim(\"media_asset_purge_jobs\".\"owner_user_id\")) > 0"
+        },
+        "media_asset_purge_jobs_claim_check": {
+          "name": "media_asset_purge_jobs_claim_check",
+          "value": "num_nonnulls(\"media_asset_purge_jobs\".\"claim_token\", \"media_asset_purge_jobs\".\"claim_expires_at\") IN (0, 2)"
+        },
+        "media_asset_purge_jobs_error_check": {
+          "name": "media_asset_purge_jobs_error_check",
+          "value": "\"media_asset_purge_jobs\".\"last_error_code\" IS NULL OR length(btrim(\"media_asset_purge_jobs\".\"last_error_code\")) > 0"
+        },
+        "media_asset_purge_jobs_completion_check": {
+          "name": "media_asset_purge_jobs_completion_check",
+          "value": "(\"media_asset_purge_jobs\".\"completed_at\" IS NULL AND \"media_asset_purge_jobs\".\"original_key\" IS NOT NULL) OR (\"media_asset_purge_jobs\".\"completed_at\" IS NOT NULL AND \"media_asset_purge_jobs\".\"original_key\" IS NULL AND \"media_asset_purge_jobs\".\"original_deleted_at\" IS NOT NULL AND \"media_asset_purge_jobs\".\"claim_token\" IS NULL AND \"media_asset_purge_jobs\".\"claim_expires_at\" IS NULL AND \"media_asset_purge_jobs\".\"last_error_code\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_asset_purge_renditions": {
+      "name": "media_asset_purge_renditions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_deleted_at": {
+          "name": "object_deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cdn_purged_at": {
+          "name": "cdn_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "media_asset_purge_renditions_object_uidx": {
+          "name": "media_asset_purge_renditions_object_uidx",
+          "columns": [
+            {
+              "expression": "media_asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_asset_purge_renditions_media_asset_id_media_asset_purge_jobs_media_asset_id_fk": {
+          "name": "media_asset_purge_renditions_media_asset_id_media_asset_purge_jobs_media_asset_id_fk",
+          "tableFrom": "media_asset_purge_renditions",
+          "tableTo": "media_asset_purge_jobs",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "media_asset_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_asset_purge_renditions_object_key_check": {
+          "name": "media_asset_purge_renditions_object_key_check",
+          "value": "length(btrim(\"media_asset_purge_renditions\".\"object_key\")) > 0"
+        },
+        "media_asset_purge_renditions_progress_check": {
+          "name": "media_asset_purge_renditions_progress_check",
+          "value": "\"media_asset_purge_renditions\".\"cdn_purged_at\" IS NULL OR \"media_asset_purge_renditions\".\"object_deleted_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_assets": {
+      "name": "media_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "upload_intent_id": {
+          "name": "upload_intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'image'"
+        },
+        "catalog_state": {
+          "name": "catalog_state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "processing_state": {
+          "name": "processing_state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upload_initiated'"
+        },
+        "processing_error_code": {
+          "name": "processing_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_content_type": {
+          "name": "original_content_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_byte_size": {
+          "name": "original_byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_checksum_sha256": {
+          "name": "original_checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera_make": {
+          "name": "camera_make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera_model": {
+          "name": "camera_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lens": {
+          "name": "lens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_length_millimeters": {
+          "name": "focal_length_millimeters",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aperture": {
+          "name": "aperture",
+          "type": "numeric(6, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutter_speed_seconds": {
+          "name": "shutter_speed_seconds",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iso": {
+          "name": "iso",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_point_x": {
+          "name": "focal_point_x",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_point_y": {
+          "name": "focal_point_y",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_location_envelope": {
+          "name": "capture_location_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_label_zh_hans": {
+          "name": "location_label_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_label_en": {
+          "name": "location_label_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_suggestion_zh_hans": {
+          "name": "alt_text_suggestion_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_suggestion_en": {
+          "name": "alt_text_suggestion_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_suggestion_model": {
+          "name": "alt_text_suggestion_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_suggested_at": {
+          "name": "alt_text_suggested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_zh_hans": {
+          "name": "alt_text_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_en": {
+          "name": "alt_text_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_approved_at": {
+          "name": "alt_text_approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purge_started_at": {
+          "name": "purge_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_assets_upload_intent_uidx": {
+          "name": "media_assets_upload_intent_uidx",
+          "columns": [
+            {
+              "expression": "upload_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_assets_original_key_uidx": {
+          "name": "media_assets_original_key_uidx",
+          "columns": [
+            {
+              "expression": "original_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_assets_library_idx": {
+          "name": "media_assets_library_idx",
+          "columns": [
+            {
+              "expression": "catalog_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processing_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_assets_upload_intent_id_media_upload_intents_id_fk": {
+          "name": "media_assets_upload_intent_id_media_upload_intents_id_fk",
+          "tableFrom": "media_assets",
+          "tableTo": "media_upload_intents",
+          "columnsFrom": [
+            "upload_intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_assets_kind_check": {
+          "name": "media_assets_kind_check",
+          "value": "\"media_assets\".\"kind\" = 'image'"
+        },
+        "media_assets_catalog_state_check": {
+          "name": "media_assets_catalog_state_check",
+          "value": "\"media_assets\".\"catalog_state\" IN ('active', 'archived', 'purging')"
+        },
+        "media_assets_processing_state_check": {
+          "name": "media_assets_processing_state_check",
+          "value": "\"media_assets\".\"processing_state\" IN ('upload_initiated', 'original_verified', 'processing', 'ready', 'retryable_failure', 'repair_required')"
+        },
+        "media_assets_processing_error_check": {
+          "name": "media_assets_processing_error_check",
+          "value": "(\"media_assets\".\"processing_state\" IN ('retryable_failure', 'repair_required')) = (\"media_assets\".\"processing_error_code\" IS NOT NULL AND length(btrim(\"media_assets\".\"processing_error_code\")) > 0)"
+        },
+        "media_assets_original_key_check": {
+          "name": "media_assets_original_key_check",
+          "value": "length(btrim(\"media_assets\".\"original_key\")) > 0"
+        },
+        "media_assets_original_content_type_check": {
+          "name": "media_assets_original_content_type_check",
+          "value": "\"media_assets\".\"original_content_type\" IN ('image/jpeg', 'image/png', 'image/heic', 'image/heif')"
+        },
+        "media_assets_original_byte_size_check": {
+          "name": "media_assets_original_byte_size_check",
+          "value": "\"media_assets\".\"original_byte_size\" BETWEEN 1 AND 52428800"
+        },
+        "media_assets_original_checksum_check": {
+          "name": "media_assets_original_checksum_check",
+          "value": "\"media_assets\".\"original_checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "media_assets_dimensions_check": {
+          "name": "media_assets_dimensions_check",
+          "value": "num_nonnulls(\"media_assets\".\"width\", \"media_assets\".\"height\") IN (0, 2) AND (\"media_assets\".\"width\" IS NULL OR (\"media_assets\".\"width\" > 0 AND \"media_assets\".\"height\" > 0 AND (\"media_assets\".\"width\"::bigint * \"media_assets\".\"height\"::bigint) <= 100000000))"
+        },
+        "media_assets_focal_point_check": {
+          "name": "media_assets_focal_point_check",
+          "value": "num_nonnulls(\"media_assets\".\"focal_point_x\", \"media_assets\".\"focal_point_y\") IN (0, 2) AND (\"media_assets\".\"focal_point_x\" IS NULL OR (\"media_assets\".\"focal_point_x\" BETWEEN 0 AND 1 AND \"media_assets\".\"focal_point_y\" BETWEEN 0 AND 1))"
+        },
+        "media_assets_camera_values_check": {
+          "name": "media_assets_camera_values_check",
+          "value": "(\"media_assets\".\"focal_length_millimeters\" IS NULL OR \"media_assets\".\"focal_length_millimeters\" > 0) AND (\"media_assets\".\"aperture\" IS NULL OR \"media_assets\".\"aperture\" > 0) AND (\"media_assets\".\"shutter_speed_seconds\" IS NULL OR \"media_assets\".\"shutter_speed_seconds\" > 0) AND (\"media_assets\".\"iso\" IS NULL OR \"media_assets\".\"iso\" > 0)"
+        },
+        "media_assets_alt_suggestion_check": {
+          "name": "media_assets_alt_suggestion_check",
+          "value": "num_nonnulls(\"media_assets\".\"alt_text_suggestion_zh_hans\", \"media_assets\".\"alt_text_suggestion_en\", \"media_assets\".\"alt_text_suggestion_model\", \"media_assets\".\"alt_text_suggested_at\") IN (0, 4) AND (\"media_assets\".\"alt_text_suggestion_zh_hans\" IS NULL OR (length(btrim(\"media_assets\".\"alt_text_suggestion_zh_hans\")) > 0 AND length(btrim(\"media_assets\".\"alt_text_suggestion_en\")) > 0 AND length(btrim(\"media_assets\".\"alt_text_suggestion_model\")) > 0))"
+        },
+        "media_assets_alt_text_check": {
+          "name": "media_assets_alt_text_check",
+          "value": "num_nonnulls(\"media_assets\".\"alt_text_zh_hans\", \"media_assets\".\"alt_text_en\", \"media_assets\".\"alt_text_approved_at\") IN (0, 3) AND (\"media_assets\".\"alt_text_zh_hans\" IS NULL OR (length(btrim(\"media_assets\".\"alt_text_zh_hans\")) > 0 AND length(btrim(\"media_assets\".\"alt_text_en\")) > 0))"
+        },
+        "media_assets_archive_check": {
+          "name": "media_assets_archive_check",
+          "value": "(\"media_assets\".\"catalog_state\" = 'active' AND \"media_assets\".\"archived_at\" IS NULL AND \"media_assets\".\"purge_started_at\" IS NULL) OR (\"media_assets\".\"catalog_state\" = 'archived' AND \"media_assets\".\"archived_at\" IS NOT NULL AND \"media_assets\".\"purge_started_at\" IS NULL) OR (\"media_assets\".\"catalog_state\" = 'purging' AND \"media_assets\".\"archived_at\" IS NOT NULL AND \"media_assets\".\"purge_started_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_photo_selection_draft_entries": {
+      "name": "media_photo_selection_draft_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_photo_selection_draft_entries_asset_uidx": {
+          "name": "media_photo_selection_draft_entries_asset_uidx",
+          "columns": [
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_photo_selection_draft_entries_position_uidx": {
+          "name": "media_photo_selection_draft_entries_position_uidx",
+          "columns": [
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_photo_selection_draft_entries_draft_id_media_photo_selection_drafts_id_fk": {
+          "name": "media_photo_selection_draft_entries_draft_id_media_photo_selection_drafts_id_fk",
+          "tableFrom": "media_photo_selection_draft_entries",
+          "tableTo": "media_photo_selection_drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_photo_selection_draft_entries_media_asset_id_media_assets_id_fk": {
+          "name": "media_photo_selection_draft_entries_media_asset_id_media_assets_id_fk",
+          "tableFrom": "media_photo_selection_draft_entries",
+          "tableTo": "media_assets",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_photo_selection_draft_entries_position_check": {
+          "name": "media_photo_selection_draft_entries_position_check",
+          "value": "\"media_photo_selection_draft_entries\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_photo_selection_drafts": {
+      "name": "media_photo_selection_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_photo_selection_drafts_owner_uidx": {
+          "name": "media_photo_selection_drafts_owner_uidx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_photo_selection_drafts_owner_check": {
+          "name": "media_photo_selection_drafts_owner_check",
+          "value": "length(btrim(\"media_photo_selection_drafts\".\"owner_user_id\")) > 0"
+        },
+        "media_photo_selection_drafts_revision_check": {
+          "name": "media_photo_selection_drafts_revision_check",
+          "value": "\"media_photo_selection_drafts\".\"revision\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_published_photo_selection_entries": {
+      "name": "media_published_photo_selection_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "published_selection_id": {
+          "name": "published_selection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_media_asset_id": {
+          "name": "source_media_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "focal_point_x": {
+          "name": "focal_point_x",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_point_y": {
+          "name": "focal_point_y",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_zh_hans": {
+          "name": "alt_text_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt_text_en": {
+          "name": "alt_text_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_label_zh_hans": {
+          "name": "location_label_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_label_en": {
+          "name": "location_label_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera_make": {
+          "name": "camera_make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera_model": {
+          "name": "camera_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lens": {
+          "name": "lens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_length_millimeters": {
+          "name": "focal_length_millimeters",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aperture": {
+          "name": "aperture",
+          "type": "numeric(6, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutter_speed_seconds": {
+          "name": "shutter_speed_seconds",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iso": {
+          "name": "iso",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_published_photo_selection_entries_asset_uidx": {
+          "name": "media_published_photo_selection_entries_asset_uidx",
+          "columns": [
+            {
+              "expression": "published_selection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_media_asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_published_photo_selection_entries_position_uidx": {
+          "name": "media_published_photo_selection_entries_position_uidx",
+          "columns": [
+            {
+              "expression": "published_selection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_published_photo_selection_entries_published_selection_id_media_published_photo_selections_id_fk": {
+          "name": "media_published_photo_selection_entries_published_selection_id_media_published_photo_selections_id_fk",
+          "tableFrom": "media_published_photo_selection_entries",
+          "tableTo": "media_published_photo_selections",
+          "columnsFrom": [
+            "published_selection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_published_photo_selection_entries_position_check": {
+          "name": "media_published_photo_selection_entries_position_check",
+          "value": "\"media_published_photo_selection_entries\".\"position\" >= 0"
+        },
+        "media_published_photo_selection_entries_dimensions_check": {
+          "name": "media_published_photo_selection_entries_dimensions_check",
+          "value": "\"media_published_photo_selection_entries\".\"width\" > 0 AND \"media_published_photo_selection_entries\".\"height\" > 0 AND (\"media_published_photo_selection_entries\".\"width\"::bigint * \"media_published_photo_selection_entries\".\"height\"::bigint) <= 100000000"
+        },
+        "media_published_photo_selection_entries_focal_point_check": {
+          "name": "media_published_photo_selection_entries_focal_point_check",
+          "value": "num_nonnulls(\"media_published_photo_selection_entries\".\"focal_point_x\", \"media_published_photo_selection_entries\".\"focal_point_y\") IN (0, 2) AND (\"media_published_photo_selection_entries\".\"focal_point_x\" IS NULL OR (\"media_published_photo_selection_entries\".\"focal_point_x\" BETWEEN 0 AND 1 AND \"media_published_photo_selection_entries\".\"focal_point_y\" BETWEEN 0 AND 1))"
+        },
+        "media_published_photo_selection_entries_alt_text_check": {
+          "name": "media_published_photo_selection_entries_alt_text_check",
+          "value": "length(btrim(\"media_published_photo_selection_entries\".\"alt_text_zh_hans\")) > 0 AND length(btrim(\"media_published_photo_selection_entries\".\"alt_text_en\")) > 0"
+        },
+        "media_published_photo_selection_entries_camera_values_check": {
+          "name": "media_published_photo_selection_entries_camera_values_check",
+          "value": "(\"media_published_photo_selection_entries\".\"focal_length_millimeters\" IS NULL OR \"media_published_photo_selection_entries\".\"focal_length_millimeters\" > 0) AND (\"media_published_photo_selection_entries\".\"aperture\" IS NULL OR \"media_published_photo_selection_entries\".\"aperture\" > 0) AND (\"media_published_photo_selection_entries\".\"shutter_speed_seconds\" IS NULL OR \"media_published_photo_selection_entries\".\"shutter_speed_seconds\" > 0) AND (\"media_published_photo_selection_entries\".\"iso\" IS NULL OR \"media_published_photo_selection_entries\".\"iso\" > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_published_photo_selection_renditions": {
+      "name": "media_published_photo_selection_renditions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "published_entry_id": {
+          "name": "published_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_width": {
+          "name": "profile_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_published_photo_selection_renditions_profile_uidx": {
+          "name": "media_published_photo_selection_renditions_profile_uidx",
+          "columns": [
+            {
+              "expression": "published_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_width",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_published_photo_selection_renditions_published_entry_id_media_published_photo_selection_entries_id_fk": {
+          "name": "media_published_photo_selection_renditions_published_entry_id_media_published_photo_selection_entries_id_fk",
+          "tableFrom": "media_published_photo_selection_renditions",
+          "tableTo": "media_published_photo_selection_entries",
+          "columnsFrom": [
+            "published_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_published_photo_selection_renditions_profile_check": {
+          "name": "media_published_photo_selection_renditions_profile_check",
+          "value": "\"media_published_photo_selection_renditions\".\"profile_width\" IN (640, 1024, 1600)"
+        },
+        "media_published_photo_selection_renditions_object_key_check": {
+          "name": "media_published_photo_selection_renditions_object_key_check",
+          "value": "length(btrim(\"media_published_photo_selection_renditions\".\"object_key\")) > 0"
+        },
+        "media_published_photo_selection_renditions_dimensions_check": {
+          "name": "media_published_photo_selection_renditions_dimensions_check",
+          "value": "\"media_published_photo_selection_renditions\".\"width\" BETWEEN 1 AND \"media_published_photo_selection_renditions\".\"profile_width\" AND \"media_published_photo_selection_renditions\".\"height\" > 0 AND (\"media_published_photo_selection_renditions\".\"width\"::bigint * \"media_published_photo_selection_renditions\".\"height\"::bigint) <= 100000000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_published_photo_selections": {
+      "name": "media_published_photo_selections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_revision": {
+          "name": "draft_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_count": {
+          "name": "item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "media_published_photo_selections_idempotency_uidx": {
+          "name": "media_published_photo_selections_idempotency_uidx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_published_photo_selections_draft_revision_uidx": {
+          "name": "media_published_photo_selections_draft_revision_uidx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "draft_revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_published_photo_selections_identity_check": {
+          "name": "media_published_photo_selections_identity_check",
+          "value": "length(btrim(\"media_published_photo_selections\".\"owner_user_id\")) > 0 AND length(btrim(\"media_published_photo_selections\".\"idempotency_key\")) > 0"
+        },
+        "media_published_photo_selections_revision_check": {
+          "name": "media_published_photo_selections_revision_check",
+          "value": "\"media_published_photo_selections\".\"draft_revision\" >= 0"
+        },
+        "media_published_photo_selections_item_count_check": {
+          "name": "media_published_photo_selections_item_count_check",
+          "value": "\"media_published_photo_selections\".\"item_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_renditions": {
+      "name": "media_renditions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_width": {
+          "name": "profile_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum_sha256": {
+          "name": "checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'image/jpeg'"
+        },
+        "color_space": {
+          "name": "color_space",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'srgb'"
+        },
+        "progressive": {
+          "name": "progressive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata_stripped": {
+          "name": "metadata_stripped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_renditions_asset_profile_uidx": {
+          "name": "media_renditions_asset_profile_uidx",
+          "columns": [
+            {
+              "expression": "media_asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_width",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_renditions_object_key_uidx": {
+          "name": "media_renditions_object_key_uidx",
+          "columns": [
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_renditions_media_asset_id_media_assets_id_fk": {
+          "name": "media_renditions_media_asset_id_media_assets_id_fk",
+          "tableFrom": "media_renditions",
+          "tableTo": "media_assets",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_renditions_object_key_check": {
+          "name": "media_renditions_object_key_check",
+          "value": "length(btrim(\"media_renditions\".\"object_key\")) > 0"
+        },
+        "media_renditions_profile_check": {
+          "name": "media_renditions_profile_check",
+          "value": "\"media_renditions\".\"profile_width\" IN (640, 1024, 1600)"
+        },
+        "media_renditions_checksum_check": {
+          "name": "media_renditions_checksum_check",
+          "value": "\"media_renditions\".\"checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "media_renditions_dimensions_check": {
+          "name": "media_renditions_dimensions_check",
+          "value": "\"media_renditions\".\"width\" BETWEEN 1 AND \"media_renditions\".\"profile_width\" AND \"media_renditions\".\"height\" > 0 AND (\"media_renditions\".\"width\"::bigint * \"media_renditions\".\"height\"::bigint) <= 100000000"
+        },
+        "media_renditions_byte_size_check": {
+          "name": "media_renditions_byte_size_check",
+          "value": "\"media_renditions\".\"byte_size\" > 0"
+        },
+        "media_renditions_content_type_check": {
+          "name": "media_renditions_content_type_check",
+          "value": "\"media_renditions\".\"content_type\" = 'image/jpeg'"
+        },
+        "media_renditions_color_space_check": {
+          "name": "media_renditions_color_space_check",
+          "value": "\"media_renditions\".\"color_space\" = 'srgb'"
+        },
+        "media_renditions_progressive_check": {
+          "name": "media_renditions_progressive_check",
+          "value": "\"media_renditions\".\"progressive\" = true"
+        },
+        "media_renditions_metadata_stripped_check": {
+          "name": "media_renditions_metadata_stripped_check",
+          "value": "\"media_renditions\".\"metadata_stripped\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_upload_intents": {
+      "name": "media_upload_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum_sha256": {
+          "name": "checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_upload_intents_owner_idempotency_uidx": {
+          "name": "media_upload_intents_owner_idempotency_uidx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_upload_intents_original_key_uidx": {
+          "name": "media_upload_intents_original_key_uidx",
+          "columns": [
+            {
+              "expression": "original_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_upload_intents_expiry_idx": {
+          "name": "media_upload_intents_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_upload_intents_identity_check": {
+          "name": "media_upload_intents_identity_check",
+          "value": "length(btrim(\"media_upload_intents\".\"owner_user_id\")) > 0 AND length(btrim(\"media_upload_intents\".\"idempotency_key\")) > 0"
+        },
+        "media_upload_intents_original_key_check": {
+          "name": "media_upload_intents_original_key_check",
+          "value": "length(btrim(\"media_upload_intents\".\"original_key\")) > 0"
+        },
+        "media_upload_intents_content_type_check": {
+          "name": "media_upload_intents_content_type_check",
+          "value": "\"media_upload_intents\".\"content_type\" IN ('image/jpeg', 'image/png', 'image/heic', 'image/heif')"
+        },
+        "media_upload_intents_byte_size_check": {
+          "name": "media_upload_intents_byte_size_check",
+          "value": "\"media_upload_intents\".\"byte_size\" BETWEEN 1 AND 52428800"
+        },
+        "media_upload_intents_checksum_check": {
+          "name": "media_upload_intents_checksum_check",
+          "value": "\"media_upload_intents\".\"checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "media_upload_intents_expiry_check": {
+          "name": "media_upload_intents_expiry_check",
+          "value": "\"media_upload_intents\".\"expires_at\" > \"media_upload_intents\".\"created_at\""
+        },
+        "media_upload_intents_completion_check": {
+          "name": "media_upload_intents_completion_check",
+          "value": "\"media_upload_intents\".\"completed_at\" IS NULL OR \"media_upload_intents\".\"completed_at\" >= \"media_upload_intents\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.newsletters": {
+      "name": "newsletters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscribers": {
+      "name": "subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1784104946550,
       "tag": "0008_media_purge_progress",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1784261629000,
+      "tag": "0009_media_catalog_state",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -187,7 +187,7 @@ export const mediaAssets = pgTable(
       .notNull()
       .references(() => mediaUploadIntents.id, { onDelete: 'restrict' }),
     kind: varchar('kind', { length: 16 }).default('image').notNull(),
-    lifecycle: varchar('lifecycle', { length: 16 })
+    catalogState: varchar('catalog_state', { length: 16 })
       .$type<'active' | 'archived' | 'purging'>()
       .default('active')
       .notNull(),
@@ -246,14 +246,14 @@ export const mediaAssets = pgTable(
     uniqueIndex('media_assets_upload_intent_uidx').on(table.uploadIntentId),
     uniqueIndex('media_assets_original_key_uidx').on(table.originalKey),
     index('media_assets_library_idx').on(
-      table.lifecycle,
+      table.catalogState,
       table.processingState,
       table.createdAt,
     ),
     check('media_assets_kind_check', sql`${table.kind} = 'image'`),
     check(
-      'media_assets_lifecycle_check',
-      sql`${table.lifecycle} IN ('active', 'archived', 'purging')`,
+      'media_assets_catalog_state_check',
+      sql`${table.catalogState} IN ('active', 'archived', 'purging')`,
     ),
     check(
       'media_assets_processing_state_check',
@@ -301,7 +301,7 @@ export const mediaAssets = pgTable(
     ),
     check(
       'media_assets_archive_check',
-      sql`(${table.lifecycle} = 'active' AND ${table.archivedAt} IS NULL AND ${table.purgeStartedAt} IS NULL) OR (${table.lifecycle} = 'archived' AND ${table.archivedAt} IS NOT NULL AND ${table.purgeStartedAt} IS NULL) OR (${table.lifecycle} = 'purging' AND ${table.archivedAt} IS NOT NULL AND ${table.purgeStartedAt} IS NOT NULL)`,
+      sql`(${table.catalogState} = 'active' AND ${table.archivedAt} IS NULL AND ${table.purgeStartedAt} IS NULL) OR (${table.catalogState} = 'archived' AND ${table.archivedAt} IS NOT NULL AND ${table.purgeStartedAt} IS NULL) OR (${table.catalogState} = 'purging' AND ${table.archivedAt} IS NOT NULL AND ${table.purgeStartedAt} IS NOT NULL)`,
     ),
   ],
 )

--- a/lib/media/CONTEXT.md
+++ b/lib/media/CONTEXT.md
@@ -62,11 +62,16 @@ The owner-approved Chinese and English visual descriptions required before a
 Media Asset may join a Published Photo Selection.
 _Avoid_: Caption, Alt Text Suggestion
 
+**Catalog State**:
+Whether a Media Asset is active, Archived, or being purged. It records the
+asset's standing in the catalog and is separate from Processing State, which
+tracks derivation progress.
+_Avoid_: Lifecycle, status
+
 **Processing State**:
 The durable progress of registering and deriving a Media Asset, including
 Original verification, Rendition processing, readiness, retryable failure, and
-repair required. It is separate from whether the Media Asset is active,
-Archived, or being purged.
+repair required. It is separate from Catalog State.
 _Avoid_: Lifecycle, upload status
 
 **Archived Media Asset**:

--- a/lib/media/admin/photo-selection-ui.test.tsx
+++ b/lib/media/admin/photo-selection-ui.test.tsx
@@ -11,7 +11,7 @@ function asset(id: string, name: string): MediaAssetReviewRecord {
   return {
     id,
     createdAt: new Date('2026-07-15T12:00:00.000Z'),
-    lifecycle: 'active',
+    catalogState: 'active',
     processingState: 'ready',
     width: 1600,
     height: 1200,

--- a/lib/media/admin/ui.test.tsx
+++ b/lib/media/admin/ui.test.tsx
@@ -10,7 +10,7 @@ import type { MediaAssetReviewRecord } from '../asset-review/service'
 const activeAsset: MediaAssetReviewRecord = {
   id: '11111111-1111-4111-8111-111111111111',
   createdAt: new Date('2026-07-15T12:00:00.000Z'),
-  lifecycle: 'active',
+  catalogState: 'active',
   processingState: 'ready',
   width: 4032,
   height: 3024,

--- a/lib/media/alt-text/repository.test.ts
+++ b/lib/media/alt-text/repository.test.ts
@@ -11,10 +11,13 @@ import {
   type MediaAltTextDatabase,
 } from './repository'
 
-const migrationUrl = new URL(
-  '../../../db/migrations/0005_media_catalog.sql',
-  import.meta.url,
-)
+const migrations = [
+  new URL('../../../db/migrations/0005_media_catalog.sql', import.meta.url),
+  new URL(
+    '../../../db/migrations/0009_media_catalog_state.sql',
+    import.meta.url,
+  ),
+]
 const mediaAssetId = '11111111-1111-4111-8111-111111111111'
 const uploadIntentId = '22222222-2222-4222-8222-222222222222'
 const checksum = 'a'.repeat(64)
@@ -26,8 +29,10 @@ describe('Media Library Alt Text Suggestion repository', () => {
 
   beforeEach(async () => {
     client = new PGlite()
-    const migration = await readFile(migrationUrl, 'utf8')
-    await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
+    for (const url of migrations) {
+      const migration = await readFile(url, 'utf8')
+      await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
+    }
     const database = drizzle(client)
     repository = createMediaAltTextRepository(
       () => database as unknown as MediaAltTextDatabase,
@@ -79,7 +84,7 @@ describe('Media Library Alt Text Suggestion repository', () => {
       }),
     ).resolves.toEqual({
       mediaAssetId,
-      lifecycle: 'active',
+      catalogState: 'active',
       processingState: 'ready',
       rendition: {
         objectKey: `renditions/${mediaAssetId}/640-${checksum}.jpg`,
@@ -144,7 +149,7 @@ describe('Media Library Alt Text Suggestion repository', () => {
     await repository.saveSuggestion(first)
     await client.query(
       `UPDATE media_assets
-       SET lifecycle = 'archived', archived_at = now()
+       SET catalog_state = 'archived', archived_at = now()
        WHERE id = $1`,
       [mediaAssetId],
     )

--- a/lib/media/alt-text/repository.ts
+++ b/lib/media/alt-text/repository.ts
@@ -22,7 +22,7 @@ export function createMediaAltTextRepository(
       const [row] = await database()
         .select({
           mediaAssetId: mediaAssets.id,
-          lifecycle: mediaAssets.lifecycle,
+          catalogState: mediaAssets.catalogState,
           processingState: mediaAssets.processingState,
           renditionObjectKey: mediaRenditions.objectKey,
           renditionProfileWidth: mediaRenditions.profileWidth,
@@ -55,7 +55,7 @@ export function createMediaAltTextRepository(
 
       return {
         mediaAssetId: row.mediaAssetId,
-        lifecycle: row.lifecycle,
+        catalogState: row.catalogState,
         processingState: row.processingState,
         rendition:
           row.renditionObjectKey === null
@@ -84,7 +84,7 @@ export function createMediaAltTextRepository(
         .where(
           and(
             eq(mediaAssets.id, input.mediaAssetId),
-            eq(mediaAssets.lifecycle, 'active'),
+            eq(mediaAssets.catalogState, 'active'),
             eq(mediaAssets.processingState, 'ready'),
             sql`EXISTS (
               SELECT 1

--- a/lib/media/alt-text/service.test.ts
+++ b/lib/media/alt-text/service.test.ts
@@ -18,7 +18,7 @@ const now = new Date('2026-07-15T10:00:00.000Z')
 
 const eligibleTarget: AltTextGenerationTarget = {
   mediaAssetId,
-  lifecycle: 'active',
+  catalogState: 'active',
   processingState: 'ready',
   rendition: {
     objectKey: `renditions/${mediaAssetId}/640-${checksumSha256}.jpg`,
@@ -122,7 +122,7 @@ describe('Media Library Alt Text Suggestion service', () => {
 
   it('rejects a non-ready or Archived Media Asset', async () => {
     const harness = createHarness({
-      target: { ...eligibleTarget, lifecycle: 'archived' },
+      target: { ...eligibleTarget, catalogState: 'archived' },
     })
 
     await expect(

--- a/lib/media/alt-text/service.ts
+++ b/lib/media/alt-text/service.ts
@@ -17,7 +17,7 @@ export type AltTextRendition = {
 
 export type AltTextGenerationTarget = {
   mediaAssetId: string
-  lifecycle: 'active' | 'archived' | 'purging'
+  catalogState: 'active' | 'archived' | 'purging'
   processingState:
     | 'upload_initiated'
     | 'original_verified'
@@ -101,7 +101,7 @@ function validSuggestion(value: string) {
 function assertEligible(target: AltTextGenerationTarget) {
   const rendition = target.rendition
   if (
-    target.lifecycle !== 'active' ||
+    target.catalogState !== 'active' ||
     target.processingState !== 'ready' ||
     !rendition
   ) {

--- a/lib/media/asset-review/repository.test.ts
+++ b/lib/media/asset-review/repository.test.ts
@@ -18,6 +18,10 @@ const migrations = [
     '../../../db/migrations/0007_photo_publication_revision.sql',
     import.meta.url,
   ),
+  new URL(
+    '../../../db/migrations/0009_media_catalog_state.sql',
+    import.meta.url,
+  ),
 ]
 const assetId = '11111111-1111-4111-8111-111111111111'
 const intentId = '22222222-2222-4222-8222-222222222222'
@@ -36,9 +40,9 @@ describe('Media Asset review repository', () => {
     await client.query(
       `INSERT INTO media_upload_intents
         (id, owner_user_id, idempotency_key, original_key, content_type,
-         byte_size, checksum_sha256, expires_at)
+         byte_size, checksum_sha256, expires_at, created_at)
        VALUES ($1, 'owner_01', 'upload_01', 'originals/photo.jpg',
-               'image/jpeg', 1000, $2, '2026-07-16T00:00:00Z')`,
+               'image/jpeg', 1000, $2, '2026-07-16T00:00:00Z', '2026-07-15T00:00:00Z')`,
       [intentId, 'a'.repeat(64)],
     )
     await client.query(
@@ -68,7 +72,7 @@ describe('Media Asset review repository', () => {
 
   afterEach(async () => client.close())
 
-  it('lists only owned lifecycle views with public 640-pixel previews', async () => {
+  it('lists only owned catalogState views with public 640-pixel previews', async () => {
     await expect(
       repository.listOwnedAssets({ ownerUserId: 'owner_02', view: 'active' }),
     ).resolves.toEqual([])
@@ -77,7 +81,7 @@ describe('Media Asset review repository', () => {
     ).resolves.toMatchObject([
       {
         id: assetId,
-        lifecycle: 'active',
+        catalogState: 'active',
         previewRendition: {
           src: 'https://media.example.com/renditions/photo-640.jpg',
           width: 640,
@@ -87,7 +91,7 @@ describe('Media Asset review repository', () => {
     ])
 
     await client.query(
-      `UPDATE media_assets SET lifecycle = 'archived', archived_at = now()
+      `UPDATE media_assets SET catalog_state = 'archived', archived_at = now()
        WHERE id = $1`,
       [assetId],
     )
@@ -266,7 +270,7 @@ describe('Media Asset review repository', () => {
     expect(archived).toMatchObject({
       status: 'updated',
       asset: {
-        lifecycle: 'archived',
+        catalogState: 'archived',
         previewRendition: {
           src: 'https://media.example.com/renditions/photo-640.jpg',
         },
@@ -275,7 +279,7 @@ describe('Media Asset review repository', () => {
     expect(restored).toMatchObject({
       status: 'updated',
       asset: {
-        lifecycle: 'active',
+        catalogState: 'active',
         archivedAt: null,
         previewRendition: {
           src: 'https://media.example.com/renditions/photo-640.jpg',

--- a/lib/media/asset-review/repository.ts
+++ b/lib/media/asset-review/repository.ts
@@ -23,7 +23,7 @@ export type MediaAssetReviewDatabase = ReturnType<typeof getDatabase>
 const reviewAssetColumns = {
   id: mediaAssets.id,
   createdAt: mediaAssets.createdAt,
-  lifecycle: mediaAssets.lifecycle,
+  catalogState: mediaAssets.catalogState,
   processingState: mediaAssets.processingState,
   width: mediaAssets.width,
   height: mediaAssets.height,
@@ -76,7 +76,7 @@ function record(
   return {
     id: row.id,
     createdAt: row.createdAt,
-    lifecycle: row.lifecycle,
+    catalogState: row.catalogState,
     processingState: row.processingState,
     width: row.width,
     height: row.height,
@@ -190,8 +190,8 @@ export function createMediaAssetReviewRepository(
         )
         .where(
           input.view === 'active'
-            ? eq(mediaAssets.lifecycle, 'active')
-            : inArray(mediaAssets.lifecycle, ['archived', 'purging']),
+            ? eq(mediaAssets.catalogState, 'active')
+            : inArray(mediaAssets.catalogState, ['archived', 'purging']),
         )
         .orderBy(desc(mediaAssets.createdAt))
       return rows.map(
@@ -228,7 +228,7 @@ export function createMediaAssetReviewRepository(
         .where(
           and(
             ownedAssetCondition(input.ownerUserId, input.mediaAssetId),
-            eq(mediaAssets.lifecycle, 'active'),
+            eq(mediaAssets.catalogState, 'active'),
             eq(mediaAssets.processingState, 'ready'),
           ),
         )
@@ -251,7 +251,7 @@ export function createMediaAssetReviewRepository(
         .where(
           and(
             ownedAssetCondition(input.ownerUserId, input.mediaAssetId),
-            eq(mediaAssets.lifecycle, 'active'),
+            eq(mediaAssets.catalogState, 'active'),
             eq(mediaAssets.processingState, 'ready'),
           ),
         )
@@ -264,13 +264,13 @@ export function createMediaAssetReviewRepository(
     async archive(input) {
       return database().transaction(async (transaction) => {
         const [current] = await transaction
-          .select({ id: mediaAssets.id, lifecycle: mediaAssets.lifecycle })
+          .select({ id: mediaAssets.id, catalogState: mediaAssets.catalogState })
           .from(mediaAssets)
           .where(ownedAssetCondition(input.ownerUserId, input.mediaAssetId))
           .limit(1)
           .for('update')
         if (!current) return { status: 'not_found' }
-        if (current.lifecycle !== 'active') return { status: 'invalid_state' }
+        if (current.catalogState !== 'active') return { status: 'invalid_state' }
 
         const [selection] = await transaction
           .select({ id: mediaAssets.id })
@@ -305,14 +305,14 @@ export function createMediaAssetReviewRepository(
         const [asset] = await transaction
           .update(mediaAssets)
           .set({
-            lifecycle: 'archived',
+            catalogState: 'archived',
             archivedAt: input.archivedAt,
             updatedAt: input.archivedAt,
           })
           .where(
             and(
               eq(mediaAssets.id, current.id),
-              eq(mediaAssets.lifecycle, 'active'),
+              eq(mediaAssets.catalogState, 'active'),
             ),
           )
           .returning(reviewAssetColumns)
@@ -333,14 +333,14 @@ export function createMediaAssetReviewRepository(
       const [asset] = await client
         .update(mediaAssets)
         .set({
-          lifecycle: 'active',
+          catalogState: 'active',
           archivedAt: null,
           updatedAt: input.restoredAt,
         })
         .where(
           and(
             ownedAssetCondition(input.ownerUserId, input.mediaAssetId),
-            eq(mediaAssets.lifecycle, 'archived'),
+            eq(mediaAssets.catalogState, 'archived'),
           ),
         )
         .returning(reviewAssetColumns)

--- a/lib/media/asset-review/service.test.ts
+++ b/lib/media/asset-review/service.test.ts
@@ -15,7 +15,7 @@ function fixture() {
   let record: MediaAssetReviewRecord = {
     id: mediaAssetId,
     createdAt: new Date('2025-05-08T00:31:34.000Z'),
-    lifecycle: 'active',
+    catalogState: 'active',
     processingState: 'ready',
     width: 4032,
     height: 3024,
@@ -50,7 +50,7 @@ function fixture() {
       return id === record.id ? record : null
     },
     async updateDisplayMetadata(input) {
-      if (record.lifecycle !== 'active') return null
+      if (record.catalogState !== 'active') return null
       record = {
         ...record,
         locationLabelZhHans: input.locationLabelZhHans,
@@ -60,7 +60,7 @@ function fixture() {
       return record
     },
     async approveAltText(input) {
-      if (record.lifecycle !== 'active') return null
+      if (record.catalogState !== 'active') return null
       record = {
         ...record,
         altTextZhHans: input.zhHans,
@@ -71,17 +71,17 @@ function fixture() {
     },
     async archive(input) {
       if (selectionConflict) return { status: 'selection_conflict' }
-      if (record.lifecycle !== 'active') return { status: 'invalid_state' }
+      if (record.catalogState !== 'active') return { status: 'invalid_state' }
       record = {
         ...record,
-        lifecycle: 'archived',
+        catalogState: 'archived',
         archivedAt: input.archivedAt,
       }
       return { status: 'updated', asset: record }
     },
     async restore() {
-      if (record.lifecycle !== 'archived') return { status: 'invalid_state' }
-      record = { ...record, lifecycle: 'active', archivedAt: null }
+      if (record.catalogState !== 'archived') return { status: 'invalid_state' }
+      record = { ...record, catalogState: 'active', archivedAt: null }
       return { status: 'updated', asset: record }
     },
   }
@@ -173,14 +173,14 @@ describe('Media Asset review service', () => {
     await expect(
       service.archive({ ownerUserId: 'owner_01', mediaAssetId }),
     ).resolves.toMatchObject({
-      lifecycle: 'archived',
+      catalogState: 'archived',
       altTextEn: 'A cable car.',
       archivedAt: new Date('2026-07-15T12:00:00.000Z'),
     })
     await expect(
       service.restore({ ownerUserId: 'owner_01', mediaAssetId }),
     ).resolves.toMatchObject({
-      lifecycle: 'active',
+      catalogState: 'active',
       altTextEn: 'A cable car.',
       archivedAt: null,
     })

--- a/lib/media/asset-review/service.ts
+++ b/lib/media/asset-review/service.ts
@@ -3,7 +3,7 @@ import 'server-only'
 export type MediaAssetReviewRecord = {
   id: string
   createdAt: Date
-  lifecycle: 'active' | 'archived' | 'purging'
+  catalogState: 'active' | 'archived' | 'purging'
   processingState:
     | 'upload_initiated'
     | 'original_verified'
@@ -41,7 +41,7 @@ export type MediaAssetReviewRecord = {
   } | null
 }
 
-type LifecycleResult =
+type CatalogStateResult =
   | { status: 'updated'; asset: MediaAssetReviewRecord }
   | { status: 'invalid_state' }
   | { status: 'not_found' }
@@ -75,12 +75,12 @@ export interface MediaAssetReviewRepository {
     ownerUserId: string
     mediaAssetId: string
     archivedAt: Date
-  }): Promise<LifecycleResult>
+  }): Promise<CatalogStateResult>
   restore(input: {
     ownerUserId: string
     mediaAssetId: string
     restoredAt: Date
-  }): Promise<LifecycleResult>
+  }): Promise<CatalogStateResult>
 }
 
 export type MediaAssetReviewErrorCode =
@@ -134,7 +134,7 @@ function validFocalPoint(value: { x: number; y: number } | null) {
   )
 }
 
-function unwrapLifecycle(result: LifecycleResult) {
+function unwrapCatalogState(result: CatalogStateResult) {
   if (result.status === 'updated') return result.asset
   throw new MediaAssetReviewError(result.status)
 }
@@ -244,7 +244,7 @@ export function createMediaAssetReviewService({
         throw new MediaAssetReviewError('invalid_request')
       }
       try {
-        return unwrapLifecycle(
+        return unwrapCatalogState(
           await repository.archive({ ...input, archivedAt: clock.now() }),
         )
       } catch (error) {
@@ -258,7 +258,7 @@ export function createMediaAssetReviewService({
         throw new MediaAssetReviewError('invalid_request')
       }
       try {
-        return unwrapLifecycle(
+        return unwrapCatalogState(
           await repository.restore({ ...input, restoredAt: clock.now() }),
         )
       } catch (error) {

--- a/lib/media/catalog/schema.test.ts
+++ b/lib/media/catalog/schema.test.ts
@@ -15,6 +15,10 @@ const migrations = [
     import.meta.url,
   ),
   new URL('../../../db/migrations/0008_media_purge_progress.sql', import.meta.url),
+  new URL(
+    '../../../db/migrations/0009_media_catalog_state.sql',
+    import.meta.url,
+  ),
 ]
 
 const checksum = 'a'.repeat(64)
@@ -270,14 +274,14 @@ describe('Media Library catalog migration', () => {
     ).rejects.toThrow()
   })
 
-  it('enforces lifecycle timestamps and retryable processing failures', async () => {
+  it('enforces catalog state timestamps and retryable processing failures', async () => {
     const intent = await createUploadIntent()
     const asset = await createMediaAsset(intent.id, {
       originalKey: intent.originalKey,
     })
 
     await expect(
-      client.query(`UPDATE media_assets SET lifecycle = 'archived' WHERE id = $1`, [
+      client.query(`UPDATE media_assets SET catalog_state = 'archived' WHERE id = $1`, [
         asset.id,
       ]),
     ).rejects.toThrow()
@@ -292,7 +296,7 @@ describe('Media Library catalog migration', () => {
     await expect(
       client.query(
         `UPDATE media_assets
-         SET lifecycle = 'archived', archived_at = now()
+         SET catalog_state = 'archived', archived_at = now()
          WHERE id = $1`,
         [asset.id],
       ),

--- a/lib/media/geocoding/repository.test.ts
+++ b/lib/media/geocoding/repository.test.ts
@@ -11,10 +11,13 @@ import {
   type MediaGeocodingDatabase,
 } from './repository'
 
-const migrationUrl = new URL(
-  '../../../db/migrations/0005_media_catalog.sql',
-  import.meta.url,
-)
+const migrations = [
+  new URL('../../../db/migrations/0005_media_catalog.sql', import.meta.url),
+  new URL(
+    '../../../db/migrations/0009_media_catalog_state.sql',
+    import.meta.url,
+  ),
+]
 const mediaAssetId = '11111111-1111-4111-8111-111111111111'
 const uploadIntentId = '22222222-2222-4222-8222-222222222222'
 const checksum = 'a'.repeat(64)
@@ -32,8 +35,10 @@ describe('Media Geocoding repository', () => {
 
   beforeEach(async () => {
     client = new PGlite()
-    const migration = await readFile(migrationUrl, 'utf8')
-    await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
+    for (const url of migrations) {
+      const migration = await readFile(url, 'utf8')
+      await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
+    }
     const database = drizzle(client)
     repository = createMediaGeocodingRepository(
       () => database as unknown as MediaGeocodingDatabase,

--- a/lib/media/ingestion/repository.test.ts
+++ b/lib/media/ingestion/repository.test.ts
@@ -11,10 +11,13 @@ import {
   type MediaIngestionDatabase,
 } from './repository'
 
-const migrationUrl = new URL(
-  '../../../db/migrations/0005_media_catalog.sql',
-  import.meta.url,
-)
+const migrations = [
+  new URL('../../../db/migrations/0005_media_catalog.sql', import.meta.url),
+  new URL(
+    '../../../db/migrations/0009_media_catalog_state.sql',
+    import.meta.url,
+  ),
+]
 const intentInput = {
   id: '11111111-1111-4111-8111-111111111111',
   ownerUserId: 'owner_01',
@@ -34,8 +37,10 @@ describe('Media Library ingestion repository', () => {
 
   beforeEach(async () => {
     client = new PGlite()
-    const migration = await readFile(migrationUrl, 'utf8')
-    await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
+    for (const url of migrations) {
+      const migration = await readFile(url, 'utf8')
+      await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
+    }
     const database = drizzle(client)
     repository = createMediaIngestionRepository(
       () => database as unknown as MediaIngestionDatabase,

--- a/lib/media/photo-selection/repository.test.ts
+++ b/lib/media/photo-selection/repository.test.ts
@@ -20,6 +20,10 @@ const migrationUrls = [
     '../../../db/migrations/0007_photo_publication_revision.sql',
     import.meta.url,
   ),
+  new URL(
+    '../../../db/migrations/0009_media_catalog_state.sql',
+    import.meta.url,
+  ),
 ]
 const checksum = 'a'.repeat(64)
 
@@ -50,7 +54,7 @@ describe('Photo Selection repository', () => {
     ownerUserId: string,
     overrides: {
       id?: string
-      lifecycle?: 'active' | 'archived'
+      catalogState?: 'active' | 'archived'
       processingState?: 'ready' | 'retryable_failure'
       altTextZhHans?: string | null
       altTextEn?: string | null
@@ -59,9 +63,9 @@ describe('Photo Selection repository', () => {
   ) {
     const id = overrides.id ?? crypto.randomUUID()
     const uploadIntentId = crypto.randomUUID()
-    const lifecycle = overrides.lifecycle ?? 'active'
+    const catalogState = overrides.catalogState ?? 'active'
     const processingState = overrides.processingState ?? 'ready'
-    const archivedAt = lifecycle === 'archived' ? '2026-07-15T01:00:00.000Z' : null
+    const archivedAt = catalogState === 'archived' ? '2026-07-15T01:00:00.000Z' : null
     const processingErrorCode =
       processingState === 'retryable_failure' ? 'processing_failed' : null
     const altTextZhHans =
@@ -75,9 +79,9 @@ describe('Photo Selection repository', () => {
     await client.query(
       `INSERT INTO media_upload_intents
         (id, owner_user_id, idempotency_key, original_key, content_type,
-         byte_size, checksum_sha256, expires_at)
+         byte_size, checksum_sha256, expires_at, created_at)
        VALUES ($1, $2, $3, $4, 'image/jpeg', 1000, $5,
-               '2026-07-16T00:00:00.000Z')`,
+               '2026-07-16T00:00:00.000Z', '2026-07-15T00:00:00.000Z')`,
       [
         uploadIntentId,
         ownerUserId,
@@ -88,7 +92,7 @@ describe('Photo Selection repository', () => {
     )
     await client.query(
       `INSERT INTO media_assets
-        (id, upload_intent_id, lifecycle, processing_state,
+        (id, upload_intent_id, catalog_state, processing_state,
          processing_error_code, original_key, original_content_type,
          original_byte_size, original_checksum_sha256, width, height,
          captured_at, camera_make, camera_model, lens,
@@ -104,7 +108,7 @@ describe('Photo Selection repository', () => {
       [
         id,
         uploadIntentId,
-        lifecycle,
+        catalogState,
         processingState,
         processingErrorCode,
         `originals/${id}/photo.jpg`,
@@ -174,7 +178,7 @@ describe('Photo Selection repository', () => {
   it('requires owned, active, ready Media Assets with Alt Text and all Renditions', async () => {
     const eligible = await createAsset('owner_01')
     const wrongOwner = await createAsset('owner_02')
-    const archived = await createAsset('owner_01', { lifecycle: 'archived' })
+    const archived = await createAsset('owner_01', { catalogState: 'archived' })
     const failed = await createAsset('owner_01', {
       processingState: 'retryable_failure',
     })
@@ -317,11 +321,11 @@ describe('Photo Selection repository', () => {
     )
     await expect(
       client.query(
-        `SELECT lifecycle, processing_state FROM media_assets WHERE id = $1`,
+        `SELECT catalog_state, processing_state FROM media_assets WHERE id = $1`,
         [unrelated],
       ),
     ).resolves.toMatchObject({
-      rows: [{ lifecycle: 'active', processing_state: 'ready' }],
+      rows: [{ catalog_state: 'active', processing_state: 'ready' }],
     })
   })
 

--- a/lib/media/photo-selection/repository.ts
+++ b/lib/media/photo-selection/repository.ts
@@ -32,7 +32,7 @@ export const PUBLIC_PHOTO_SELECTION_CACHE_TAG = 'media:published-photo-selection
 
 type CandidateRow = {
   id: string
-  lifecycle: 'active' | 'archived' | 'purging'
+  catalogState: 'active' | 'archived' | 'purging'
   processingState:
     | 'upload_initiated'
     | 'original_verified'
@@ -121,7 +121,7 @@ function collectCandidates(rows: CandidateRow[]) {
 function candidateIsEligible(candidate: Candidate | undefined) {
   if (
     !candidate ||
-    candidate.lifecycle !== 'active' ||
+    candidate.catalogState !== 'active' ||
     candidate.processingState !== 'ready' ||
     candidate.width === null ||
     candidate.height === null ||
@@ -149,7 +149,7 @@ async function loadCandidates(
   const rows = await transaction
     .select({
       id: mediaAssets.id,
-      lifecycle: mediaAssets.lifecycle,
+      catalogState: mediaAssets.catalogState,
       processingState: mediaAssets.processingState,
       width: mediaAssets.width,
       height: mediaAssets.height,

--- a/lib/media/purge/repository.test.ts
+++ b/lib/media/purge/repository.test.ts
@@ -19,6 +19,10 @@ const migrations = [
     import.meta.url,
   ),
   new URL('../../../db/migrations/0008_media_purge_progress.sql', import.meta.url),
+  new URL(
+    '../../../db/migrations/0009_media_catalog_state.sql',
+    import.meta.url,
+  ),
 ]
 const assetId = '11111111-1111-4111-8111-111111111111'
 const intentId = '22222222-2222-4222-8222-222222222222'
@@ -38,14 +42,14 @@ describe('Media Asset Purge repository', () => {
     await client.query(
       `INSERT INTO media_upload_intents
         (id, owner_user_id, idempotency_key, original_key, content_type,
-         byte_size, checksum_sha256, expires_at)
+         byte_size, checksum_sha256, expires_at, created_at)
        VALUES ($1, 'owner_01', 'upload_01', 'originals/photo.jpg',
-               'image/jpeg', 1000, $2, '2026-07-16T00:00:00Z')`,
+               'image/jpeg', 1000, $2, '2026-07-16T00:00:00Z', '2026-07-15T00:00:00Z')`,
       [intentId, 'a'.repeat(64)],
     )
     await client.query(
       `INSERT INTO media_assets
-        (id, upload_intent_id, lifecycle, archived_at, processing_state,
+        (id, upload_intent_id, catalog_state, archived_at, processing_state,
          original_key, original_content_type, original_byte_size,
          original_checksum_sha256, width, height)
        VALUES ($1, $2, 'archived', '2026-07-15T10:00:00Z', 'ready',
@@ -116,12 +120,12 @@ describe('Media Asset Purge repository', () => {
       lastErrorCode: null,
     })
     const asset = await client.query<{
-      lifecycle: string
+      catalog_state: string
       purge_started_at: Date
-    }>('SELECT lifecycle, purge_started_at FROM media_assets WHERE id = $1', [
+    }>('SELECT catalog_state, purge_started_at FROM media_assets WHERE id = $1', [
       assetId,
     ])
-    expect(asset.rows[0]).toMatchObject({ lifecycle: 'purging' })
+    expect(asset.rows[0]).toMatchObject({ catalog_state: 'purging' })
   })
 
   it('enforces ownership, Archived state, selection safety, and claim leases', async () => {
@@ -131,7 +135,7 @@ describe('Media Asset Purge repository', () => {
 
     await client.query(
       `UPDATE media_assets
-       SET lifecycle = 'active', archived_at = NULL
+       SET catalog_state = 'active', archived_at = NULL
        WHERE id = $1`,
       [assetId],
     )
@@ -140,7 +144,7 @@ describe('Media Asset Purge repository', () => {
     })
     await client.query(
       `UPDATE media_assets
-       SET lifecycle = 'archived', archived_at = '2026-07-15T10:00:00Z'
+       SET catalog_state = 'archived', archived_at = '2026-07-15T10:00:00Z'
        WHERE id = $1`,
       [assetId],
     )

--- a/lib/media/purge/repository.ts
+++ b/lib/media/purge/repository.ts
@@ -153,7 +153,7 @@ export function createMediaPurgeRepository(
           ) {
             return { status: 'busy' }
           }
-          if (asset.lifecycle !== 'purging' || existingJob.originalKey === null) {
+          if (asset.catalogState !== 'purging' || existingJob.originalKey === null) {
             return { status: 'invalid_state' }
           }
           originalKey = existingJob.originalKey
@@ -167,7 +167,7 @@ export function createMediaPurgeRepository(
             })
             .where(eq(mediaAssetPurgeJobs.mediaAssetId, input.mediaAssetId))
         } else {
-          if (asset.lifecycle !== 'archived') return { status: 'invalid_state' }
+          if (asset.catalogState !== 'archived') return { status: 'invalid_state' }
           const [selection] = await transaction
             .select({ id: mediaAssets.id })
             .from(mediaAssets)
@@ -207,7 +207,7 @@ export function createMediaPurgeRepository(
           await transaction
             .update(mediaAssets)
             .set({
-              lifecycle: 'purging',
+              catalogState: 'purging',
               purgeStartedAt: input.claimedAt,
               updatedAt: input.claimedAt,
             })

--- a/lib/media/reconciliation/repository.test.ts
+++ b/lib/media/reconciliation/repository.test.ts
@@ -11,10 +11,13 @@ import {
   type MediaReconciliationDatabase,
 } from './repository'
 
-const migrationUrl = new URL(
-  '../../../db/migrations/0005_media_catalog.sql',
-  import.meta.url,
-)
+const migrations = [
+  new URL('../../../db/migrations/0005_media_catalog.sql', import.meta.url),
+  new URL(
+    '../../../db/migrations/0009_media_catalog_state.sql',
+    import.meta.url,
+  ),
+]
 const abandonedIntentId = '11111111-1111-4111-8111-111111111111'
 const retryIntentId = '22222222-2222-4222-8222-222222222222'
 const retryAssetId = '33333333-3333-4333-8333-333333333333'
@@ -30,8 +33,10 @@ describe('Media reconciliation repository', () => {
 
   beforeEach(async () => {
     client = new PGlite()
-    const migration = await readFile(migrationUrl, 'utf8')
-    await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
+    for (const url of migrations) {
+      const migration = await readFile(url, 'utf8')
+      await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
+    }
     const database = drizzle(client)
     repository = createMediaReconciliationRepository(
       () => database as unknown as MediaReconciliationDatabase,
@@ -208,15 +213,15 @@ describe('Media reconciliation repository', () => {
 
   it.each(['archived', 'purging'] as const)(
     'does not recover %s assets',
-    async (lifecycle) => {
+    async (catalogState) => {
       await client.query(
         `UPDATE media_assets
-         SET lifecycle = $1, archived_at = $2, purge_started_at = $3
+         SET catalog_state = $1, archived_at = $2, purge_started_at = $3
          WHERE id = $4`,
         [
-          lifecycle,
+          catalogState,
           '2026-07-15T11:00:00.000Z',
-          lifecycle === 'purging' ? '2026-07-15T11:30:00.000Z' : null,
+          catalogState === 'purging' ? '2026-07-15T11:30:00.000Z' : null,
           retryAssetId,
         ],
       )

--- a/lib/media/reconciliation/repository.ts
+++ b/lib/media/reconciliation/repository.ts
@@ -44,14 +44,14 @@ export function createMediaReconciliationRepository(
               lt(mediaUploadIntents.createdAt, input.createdBefore),
             ),
             and(
-              eq(mediaAssets.lifecycle, 'active'),
+              eq(mediaAssets.catalogState, 'active'),
               inArray(mediaAssets.processingState, [
                 'original_verified',
                 'retryable_failure',
               ]),
             ),
             and(
-              eq(mediaAssets.lifecycle, 'active'),
+              eq(mediaAssets.catalogState, 'active'),
               eq(mediaAssets.processingState, 'processing'),
               lt(mediaAssets.updatedAt, input.processingStaleBefore),
             ),
@@ -107,7 +107,7 @@ export function createMediaReconciliationRepository(
         )
         .where(
           and(
-            eq(mediaAssets.lifecycle, 'active'),
+            eq(mediaAssets.catalogState, 'active'),
             eq(mediaAssets.processingState, 'ready'),
             isNull(mediaAssets.altTextSuggestedAt),
           ),
@@ -143,7 +143,7 @@ export function createMediaReconciliationRepository(
         .where(
           and(
             eq(mediaAssets.id, input.mediaAssetId),
-            eq(mediaAssets.lifecycle, 'active'),
+            eq(mediaAssets.catalogState, 'active'),
             inArray(mediaAssets.processingState, [
               'original_verified',
               'processing',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   resolve: { tsconfigPaths: true },
   test: {
     environment: 'node',
-    exclude: [...configDefaults.exclude, 'e2e/**'],
+    exclude: [...configDefaults.exclude, 'e2e/**', '.claude/**'],
   },
 })


### PR DESCRIPTION
Closes #134

The Media glossary reserves *lifecycle* as an avoided synonym for Processing State, so the merged catalog schema conflicted with the domain language. **Catalog State** is now the umbrella term for the active, Archived, and purging standing of a Media Asset.

## Changes

- Additive migration `0009` renames `media_assets.lifecycle` to `catalog_state` and the `media_assets_lifecycle_check` constraint to `media_assets_catalog_state_check`. Merged migration `0005` stays immutable; Postgres rewrites the dependent `media_assets_archive_check` expression and `media_assets_library_idx` definition automatically, and every state transition and row is preserved.
- The Drizzle schema, repositories, services, admin surfaces, and tests use `catalogState`; raw-SQL test fixtures use `catalog_state`.
- `lib/media/CONTEXT.md` gains a **Catalog State** glossary entry, and Processing State's distinction now points at it. Remaining *lifecycle* mentions in the repo are Bunny S3 lifecycle rules and the AMA booking lifecycle — different concepts, deliberately untouched.
- Upload-intent test fixtures that relied on the database clock for `created_at` now pin it explicitly; their hard-coded expiries began failing once the wall clock passed 2026-07-16.
- Local vitest runs no longer pick up stale session worktrees under `.claude/worktrees/`, which double-ran every suite.

## Verification

- `pnpm typecheck`
- `pnpm db:validate` (5 checks)
- `pnpm test:unit` — 385 tests
- All 11 `pnpm test:media:*` suites, matching the readiness-report baseline counts exactly (19 catalog, 17 ingestion, 9 processing, 41 storage, 7 geocoding, 18 alt-text, 26 admin, 12 asset-review, 27 photo-selection, 8 purge, 11 reconciliation)

## Release note

This resolves the Standards-review breach recorded in `docs/v3-cutover-readiness.md`; the report itself is refreshed by the next #107 readiness pass rather than edited here.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames the `lifecycle` column on `media_assets` to `catalog_state` (and its associated check constraint), aligning the codebase with the domain glossary in `lib/media/CONTEXT.md`. Every layer — migration, Drizzle schema, repositories, services, admin UI components, and tests — is updated consistently.

- **Migration 0009** issues two safe DDL statements (`RENAME COLUMN`, `RENAME CONSTRAINT`) that preserve all data; Postgres automatically rewrites dependent index and check-constraint expressions.
- **All test suites** now apply migration 0009 after 0005, raw SQL fixtures use `catalog_state`, and three test fixtures that used the database clock for `created_at` now pin it explicitly to avoid wall-clock failures past 2026-07-16.
- **`vitest.config.ts`** excludes `.claude/**` to prevent stale worktrees from double-running suites.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the rename is purely mechanical, all data is preserved, and the migration has no destructive steps.

The change touches 27 files but is entirely a controlled rename of one column and one constraint name. The two-statement migration is idempotent-safe, Postgres handles dependent objects automatically, every repository and service file is updated in lock-step, raw SQL test fixtures use the new snake_case name, and the three fixtures with wall-clock-sensitive expiries now pin `created_at`. No logic changes, no schema shape changes, and no missed references were found anywhere in the diff.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| db/migrations/0009_media_catalog_state.sql | Two-statement additive migration: renames the column and the named check constraint. Postgres automatically rewrites dependent index and check expressions; no data is touched. |
| db/schema.ts | Drizzle column renamed from `lifecycle` to `catalogState` (maps to `catalog_state`); index and both check constraints that reference it updated correctly. |
| lib/media/asset-review/service.ts | Public type `MediaAssetReviewRecord` field renamed to `catalogState`; internal `LifecycleResult`→`CatalogStateResult` and `unwrapLifecycle`→`unwrapCatalogState` renamed consistently. |
| lib/media/asset-review/repository.ts | All select projections, filter conditions, and update payloads switch from `lifecycle` to `catalogState`; archive/restore transactions use the new column name in both optimistic filter and SET clause. |
| lib/media/purge/repository.ts | State guard checks (`asset.catalogState !== 'purging'` and `!== 'archived'`) and the SET clause that writes `'purging'` all updated; no missed references. |
| lib/media/reconciliation/repository.ts | All four `eq(mediaAssets.lifecycle, …)` filter clauses updated to `catalogState`. |
| app/admin/(protected)/media/MediaLibrary.tsx | All `asset.lifecycle` reads (guards, list partition, label lookup) and the `changeLifecycle` function renamed to `changeCatalogState`; no missed references. |
| vitest.config.ts | Adds `.claude/**` to the excluded glob list so stale session worktrees don't double-run every suite. |
| lib/media/purge/repository.test.ts | Migration 0009 added to chain; raw SQL fixture columns renamed to `catalog_state`; `created_at` pinned on upload-intent insert to avoid wall-clock failures. |
| lib/media/asset-review/repository.test.ts | Migration 0009 added; `created_at` pinned on upload-intent insert; all `lifecycle` fixture references updated to `catalog_state`/`catalogState`. |
| lib/media/catalog/schema.test.ts | Migration 0009 added to the full chain; raw SQL constraint test updated to use `catalog_state`. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([active]) -->|archive| B([archived])
    B -->|restore| A
    B -->|claim purge| C([purging])
    C -->|complete| D([deleted])

    subgraph Catalog State Values
        A
        B
        C
    end

    subgraph DB Column
        E["media_assets.catalog_state\n(was: lifecycle)"]
    end

    subgraph Constraints
        F["media_assets_catalog_state_check\n(was: media_assets_lifecycle_check)"]
        G["media_assets_archive_check\n(auto-updated by Postgres)"]
        H["media_assets_library_idx\n(auto-updated by Postgres)"]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([active]) -->|archive| B([archived])
    B -->|restore| A
    B -->|claim purge| C([purging])
    C -->|complete| D([deleted])

    subgraph Catalog State Values
        A
        B
        C
    end

    subgraph DB Column
        E["media_assets.catalog_state\n(was: lifecycle)"]
    end

    subgraph Constraints
        F["media_assets_catalog_state_check\n(was: media_assets_lifecycle_check)"]
        G["media_assets_archive_check\n(auto-updated by Postgres)"]
        H["media_assets_library_idx\n(auto-updated by Postgres)"]
    end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["refactor(media): rename lifecycle to Cat..."](https://github.com/calicastle/cali.so/commit/dc0bdbd087e95ef580b8ca69d86b6b409425236c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44682417)</sub>

<!-- /greptile_comment -->