### PR TITLE
docs(release): refresh hosted readiness evidence

### DIFF
--- a/docs/v3-cutover-ops-runbook.md
+++ b/docs/v3-cutover-ops-runbook.md
@@ -1,0 +1,159 @@
+# v3 cutover ops runbook
+
+Maintainer-operated commands for the hosted blockers in
+`docs/v3-cutover-readiness.md`. Every step here changes production-adjacent
+state and is intentionally left to a human operator. Nothing in this file
+contains a secret; commands that need one prompt for it interactively.
+
+## Vercel CLI scope
+
+The team slug `cali` collides with the personal account, so slug-based scope
+resolution returns `Not authorized`. Always pass the team ID:
+
+```bash
+SCOPE=--scope=team_r1Mln12TRfgnkYJwXd62uJJ5
+npx vercel project inspect cali-so $SCOPE
+```
+
+## 1. Require Quality and CodeQL on both branches
+
+The `v2` ruleset (`18920686`) has deletion, non-fast-forward, and PR rules but
+no required checks; `main` classic protection has none. Add the rule to the
+ruleset by round-tripping it:
+
+```bash
+gh api repos/CaliCastle/cali.so/rulesets/18920686 > /tmp/ruleset.json
+jq '{name, target, enforcement, conditions, rules: (.rules + [{
+  "type": "required_status_checks",
+  "parameters": {
+    "strict_required_status_checks_policy": false,
+    "required_status_checks": [{"context": "Quality"}, {"context": "CodeQL"}]
+  }
+}])}' /tmp/ruleset.json > /tmp/ruleset-update.json
+gh api -X PUT repos/CaliCastle/cali.so/rulesets/18920686 \
+  --input /tmp/ruleset-update.json
+```
+
+Then protect `main` (PUT replaces the whole protection object; force pushes
+and deletions stay disabled by default):
+
+```bash
+gh api -X PUT repos/CaliCastle/cali.so/branches/main/protection --input - <<'JSON'
+{
+  "required_status_checks": { "strict": false, "contexts": ["Quality", "CodeQL"] },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}
+JSON
+```
+
+## 2. Isolate Preview and Production credentials
+
+- `RESEND_API_KEY` is a single variable targeting both environments. Create a
+  second Resend key for Preview, then rescope: in the dashboard, edit the
+  existing variable to Production only and add a Preview-only variable with
+  the new key. CLI equivalent (each `env add` prompts for the value):
+
+  ```bash
+  npx vercel env rm RESEND_API_KEY preview $SCOPE
+  npx vercel env add RESEND_API_KEY preview $SCOPE
+  ```
+
+- The `KV_URL`, `KV_REST_API_*`, and `REDIS_URL` group comes from one storage
+  integration connected to both environments. Isolation happens in the
+  dashboard's Storage tab: connect a separate store (or database) for Preview
+  so Production traffic and Preview experiments never share data.
+
+- Remove the dead capability switch left behind by ADR-0008:
+
+  ```bash
+  npx vercel env rm AMA_ADMIN_ENABLED preview $SCOPE
+  ```
+
+## 3. Provision the Production environment
+
+Production currently satisfies none of the v3 contract in `.env.example`.
+Each `env add` prompts for its value; generate fresh secrets rather than
+copying Preview's, and never add `MIGRATION_DATABASE_URL` to any Vercel
+environment.
+
+```bash
+add() { npx vercel env add "$1" production $SCOPE; }
+
+# Runtime database: the CRUD-only Neon role, replacing the legacy value.
+npx vercel env rm DATABASE_URL production $SCOPE
+add DATABASE_URL
+
+# Identity and delivery.
+add SITE_URL                 # https://cali.so
+add ADMIN_EMAIL
+add RESEND_FROM_EMAIL
+add CRON_SECRET              # openssl rand -hex 32
+
+# Server-only key material — generate per environment, never reuse Preview's.
+add SESSION_SECRET           # openssl rand -hex 32
+add AMA_ENCRYPTION_KEY       # openssl rand -hex 32
+add RATE_LIMIT_HASH_KEY      # openssl rand -hex 32
+add MEDIA_ENCRYPTION_KEY     # openssl rand -hex 32
+
+# Rate limits (values from .env.example defaults unless tuned).
+add AUTH_RATE_LIMIT_MAX_REQUESTS
+add AUTH_RATE_LIMIT_WINDOW_SECONDS
+add ADMIN_MUTATION_RATE_LIMIT_MAX_REQUESTS
+add ADMIN_MUTATION_RATE_LIMIT_WINDOW_SECONDS
+
+# Capability switches — explicitly false for launch.
+add AMA_PUBLIC_MUTATIONS_ENABLED
+add AMA_PAYMENTS_ENABLED
+add AMA_BOOKING_FINALIZATION_ENABLED
+add AMA_GOOGLE_INTEGRATION_ENABLED
+add AMA_TENCENT_INTEGRATION_ENABLED
+
+# Bunny media storage (production zones, not the preview zones).
+add BUNNY_MEDIA_REGION
+add BUNNY_ORIGINALS_ZONE
+add BUNNY_ORIGINALS_PASSWORD
+add BUNNY_RENDITIONS_ZONE
+add BUNNY_RENDITIONS_PASSWORD
+add BUNNY_RENDITIONS_CDN_URL
+add BUNNY_CDN_API_KEY
+
+# Media enrichment — leave disabled until provider policy is approved.
+add MEDIA_GEOCODING_ENABLED
+add MEDIA_ALT_TEXT_ENABLED
+```
+
+The remaining `MEDIA_ALT_TEXT_*` and `BUNNY_STORAGE_CONTRACT_*` values are
+needed only when Alt Text generation and the live storage contract are turned
+on; consult `.env.example` and `docs/media/ai-provider-policy.md` first.
+
+## 4. Dashboard-only checks
+
+The CLI does not expose these; verify in the Vercel dashboard and record the
+results in the readiness report:
+
+- Log access, retention, and any drains against the privacy allowlist.
+- Firewall and Attack Challenge configuration.
+- Git production-branch mapping (`main`) and the `cali.so` certificate.
+
+## 5. Production database and migrations
+
+Gated by two fresh explicit confirmations immediately before access. Verify
+the runtime role has only CRUD grants, then apply the nine additive
+migrations with the separately held credential:
+
+```bash
+MIGRATION_DATABASE_URL=postgresql://... pnpm db:migrate
+```
+
+## 6. Rollback anchor
+
+The last known-good production deployment is
+`dpl_BV7cKxGmfTAa1tUr2SScR6p9Uco8` (2024-03-10, Ready). Rollback prefers
+promoting it or reverting the cutover merge; additive migrations stay in
+place:
+
+```bash
+npx vercel promote dpl_BV7cKxGmfTAa1tUr2SScR6p9Uco8 $SCOPE
+```

--- a/docs/v3-cutover-ops-runbook.md
+++ b/docs/v3-cutover-ops-runbook.md
@@ -154,13 +154,13 @@ MIGRATION_DATABASE_URL=postgresql://... pnpm db:migrate
 ## 6. Rollback anchor
 
 The last known-good production deployment is recorded in the readiness
-report's audit baseline (created 2024-03-10, status Ready at inventory time).
-Because a deployment that old can age out of plan retention, verify it still
-exists immediately before cutover and re-record a newer known-good ID if it
-does not:
+report's audit baseline. Deployments can age out of plan retention, so
+resolve and verify the current one immediately before cutover and re-record
+the ID:
 
 ```bash
-DPL=$(npx vercel ls cali-so --prod $SCOPE 2>/dev/null | head -1)
+DPL=$(npx vercel ls cali-so --prod $SCOPE 2>/dev/null \
+  | grep -m1 -oE 'https://[a-z0-9-]+\.vercel\.app')
 npx vercel inspect "$DPL" $SCOPE
 ```
 

--- a/docs/v3-cutover-ops-runbook.md
+++ b/docs/v3-cutover-ops-runbook.md
@@ -8,12 +8,16 @@ contains a secret; commands that need one prompt for it interactively.
 ## Vercel CLI scope
 
 The team slug `cali` collides with the personal account, so slug-based scope
-resolution returns `Not authorized`. Always pass the team ID:
+resolution returns `Not authorized`. Always pass the team ID, read from the
+local link state so the ID itself stays out of the public repo:
 
 ```bash
-SCOPE=--scope=team_r1Mln12TRfgnkYJwXd62uJJ5
+SCOPE=--scope=$(jq -r .orgId .vercel/project.json)
 npx vercel project inspect cali-so $SCOPE
 ```
+
+If the repo is not yet linked, run `npx vercel link` once and pick the team
+and the `cali-so` project.
 
 ## 1. Require Quality and CodeQL on both branches
 
@@ -23,7 +27,7 @@ ruleset by round-tripping it:
 
 ```bash
 gh api repos/CaliCastle/cali.so/rulesets/18920686 > /tmp/ruleset.json
-jq '{name, target, enforcement, conditions, rules: (.rules + [{
+jq '{name, target, enforcement, conditions, bypass_actors, rules: (.rules + [{
   "type": "required_status_checks",
   "parameters": {
     "strict_required_status_checks_policy": false,
@@ -149,11 +153,20 @@ MIGRATION_DATABASE_URL=postgresql://... pnpm db:migrate
 
 ## 6. Rollback anchor
 
-The last known-good production deployment is
-`dpl_BV7cKxGmfTAa1tUr2SScR6p9Uco8` (2024-03-10, Ready). Rollback prefers
-promoting it or reverting the cutover merge; additive migrations stay in
-place:
+The last known-good production deployment is recorded in the readiness
+report's audit baseline (created 2024-03-10, status Ready at inventory time).
+Because a deployment that old can age out of plan retention, verify it still
+exists immediately before cutover and re-record a newer known-good ID if it
+does not:
 
 ```bash
-npx vercel promote dpl_BV7cKxGmfTAa1tUr2SScR6p9Uco8 $SCOPE
+DPL=$(npx vercel ls cali-so --prod $SCOPE 2>/dev/null | head -1)
+npx vercel inspect "$DPL" $SCOPE
+```
+
+Rollback prefers promoting that verified deployment or reverting the cutover
+merge; additive migrations stay in place:
+
+```bash
+npx vercel promote "$DPL" $SCOPE
 ```

--- a/docs/v3-cutover-ops-runbook.md
+++ b/docs/v3-cutover-ops-runbook.md
@@ -159,10 +159,17 @@ resolve and verify the current one immediately before cutover and re-record
 the ID:
 
 ```bash
-DPL=$(npx vercel ls cali-so --prod $SCOPE 2>/dev/null \
+DPL=$(npx vercel ls cali-so --prod $SCOPE \
   | grep -m1 -oE 'https://[a-z0-9-]+\.vercel\.app')
-npx vercel inspect "$DPL" $SCOPE
+if [ -z "$DPL" ]; then
+  echo 'ERROR: no production deployment resolved — STOP; do not run inspect or promote' >&2
+else
+  npx vercel inspect "$DPL" $SCOPE
+fi
 ```
+
+Only continue past this point when the inspect output shows the expected
+deployment with `target production` and `status Ready`.
 
 Rollback prefers promoting that verified deployment or reverting the cutover
 merge; additive migrations stay in place:

--- a/docs/v3-cutover-readiness.md
+++ b/docs/v3-cutover-readiness.md
@@ -24,7 +24,7 @@ running production migrations.
 | Production branch | `main` at `8c258834af538dd501486a5fd319b3e96a2ff5bc` |
 | Integration branch | `v2` at `12fb6df` (post `#136` and `#138`) |
 | Vercel project | `cali-so` (`prj_oIl5…`) on team `team_r1Mln…`; full IDs live in the local `.vercel/project.json` link state |
-| Production deployment | `dpl_BV7cK…`, created 2024-03-10, status Ready at inventory time |
+| Production deployment | `dpl_A29CV…`, created 2026-07-11, status Ready at inventory time |
 | Release issue | [#98](https://github.com/CaliCastle/cali.so/issues/98) |
 | Readiness issue | [#107](https://github.com/CaliCastle/cali.so/issues/107) |
 | Framework pin | `next@16.3.0-preview.6` |

--- a/docs/v3-cutover-readiness.md
+++ b/docs/v3-cutover-readiness.md
@@ -1,15 +1,17 @@
 # v3 cutover readiness
 
-Last checked: 2026-07-16.
+Last checked: 2026-07-16 (hosted-control inventory refreshed the same day).
 
 ## Verdict
 
 **NOT READY.** The merged `v2` integration branch is green under the complete
-local release suite, and the browser and standards reviews found and fixed the
-remaining motion and typography regressions. The production cutover must still
-wait for current Vercel evidence, production credential and database-role
-confirmation, required GitHub checks, and a final review of this branch's
-Vercel Preview.
+local release suite, the Standards vocabulary breach is resolved, and the
+hosted-control inventory now has current evidence. The decisive blocker is
+that the Production environment is not yet provisioned for v3: its runtime
+database credential predates the rewrite and the v3 server-environment
+contract — including every media provider value — is unmet. Required GitHub
+checks, credential isolation, and the production database and media
+verifications also remain open.
 
 Unknown hosted state is not counted as passed. This report does not authorize
 merging to `main`, changing production settings, accessing production data, or
@@ -20,7 +22,9 @@ running production migrations.
 | Item | Value |
 | --- | --- |
 | Production branch | `main` at `8c258834af538dd501486a5fd319b3e96a2ff5bc` |
-| Integration branch | `v2` at `1fbaef5c4a8b7874786033a0538487c2b73fffe7` |
+| Integration branch | `v2` at `12fb6df` (post `#136` and `#138`) |
+| Vercel project | `cali-so` (`prj_oIl5MLjdm44QGv4v7ywZsPegtFoH`) on team `team_r1Mln12TRfgnkYJwXd62uJJ5` |
+| Production deployment | `dpl_BV7cKxGmfTAa1tUr2SScR6p9Uco8`, created 2024-03-10, status Ready |
 | Release issue | [#98](https://github.com/CaliCastle/cali.so/issues/98) |
 | Readiness issue | [#107](https://github.com/CaliCastle/cali.so/issues/107) |
 | Framework pin | `next@16.3.0-preview.6` |
@@ -41,22 +45,23 @@ Renditions. The retired static photo fallback has been removed.
 | Repository validation | PASS | Every command and count in the automated evidence section passed. |
 | Public browser behavior | PASS | Desktop, mobile, both locales, light and dark appearance, reduced motion, metadata, overflow, accessibility tree, and dock targets were reviewed locally. |
 | Owner admin boundary | PASS | Admin login remains reachable without a feature flag; protected pages and APIs enforce owner authentication, same-origin mutations, rate limits, audit events, and the strict admin CSP. |
-| Complete diff Standards review | FAIL | Portal layering and admin typography findings were fixed. The Media `lifecycle` vocabulary breach remains tracked in #134 and needs resolution or an explicit maintainer exception. |
+| Complete diff Standards review | PASS | Portal layering and admin typography findings were fixed. The Media `lifecycle` vocabulary breach was resolved by PR #138 (issue #134 closed): Catalog State is the glossary term, and additive migration `0009` renames the column. |
 | Complete diff Spec review | PASS | No scope creep, incorrect PASS treatment, or missing local evidence was found; the unresolved hosted and production requirements below correctly keep the verdict at NOT READY. |
-| Production-like PR Preview | AWAITING CONFIRMATION | Review the public Preview created by the #107 PR after Vercel finishes. |
+| Production-like PR Preview | AWAITING CONFIRMATION | The #107 PR is merged; review a current `v2` Preview across the full release matrix once Production provisioning lands, and record its URL here. |
 | GitHub security settings | PASS | Secret scanning, push protection, Dependabot security updates, read-only Actions defaults, and full-SHA action policy are enabled. |
-| Required GitHub checks | FAIL | Neither the `v2` ruleset nor `main` branch protection requires `Quality` and `CodeQL`. Changing protection requires separate maintainer authorization. |
-| Current Vercel project settings | UNKNOWN | The authenticated CLI user is `cali`, but project inspection returns `Not authorized`. Historical evidence cannot replace a current check. |
-| Production capability switches | UNKNOWN | Confirm all five optional `AMA_*_ENABLED` values are explicitly `false` in Production. Owner admin has no capability switch. |
-| Preview and Production secret isolation | UNKNOWN | The last verified state shared one Resend key across environments; current Vercel state is inaccessible. |
+| Required GitHub checks | FAIL | Neither the `v2` ruleset nor `main` branch protection requires `Quality` and `CodeQL`. The maintainer-operated commands are in `docs/v3-cutover-ops-runbook.md`. |
+| Current Vercel project settings | PASS | Project inspection succeeds with the explicit team scope. The earlier `Not authorized` was a CLI quirk: the team slug `cali` resolves to the personal account, so commands must pass `--scope=team_r1Mln12TRfgnkYJwXd62uJJ5`. |
+| Production capability switches | PASS | All five optional `AMA_*_ENABLED` variables are absent from Production and therefore fail closed. Setting them explicitly `false` remains recommended during provisioning. `AMA_ADMIN_ENABLED` survives in Preview as dead configuration after ADR-0008 and should be removed. |
+| Preview and Production secret isolation | FAIL | `RESEND_API_KEY` is one variable targeting both Production and Preview, and the `KV_*`/`REDIS_URL` group added with the Preview provisioning also targets both environments. |
+| Production runtime environment | FAIL | Production `DATABASE_URL` predates the rewrite by over three years, and the v3 server-environment contract is otherwise unmet: no `SESSION_SECRET`, `AMA_ENCRYPTION_KEY`, `RATE_LIMIT_HASH_KEY`, `SITE_URL`, `RESEND_FROM_EMAIL`, rate-limit values, `CRON_SECRET`, or any `BUNNY_*`/`MEDIA_*` variable. The first v3 production build would fail environment validation. |
 | Production runtime database grants | AWAITING CONFIRMATION | Requires two fresh confirmations before inspecting the production role or sensitive cloud state. |
-| Production migration credential | AWAITING CONFIRMATION | Confirm `MIGRATION_DATABASE_URL` is absent from Vercel and available only to the controlled migration operation. |
-| Production migrations | AWAITING CONFIRMATION | Eight additive migrations validate locally. Media migrations `0005` through `0008` are required for the v3 photo surface; execution and schema state require a separately authorized cutover step. |
-| Media provider and publication | AWAITING CONFIRMATION | Verify the production Bunny zones and CDN, private Original boundary, required Renditions, live storage contract evidence, and the active two-photo Published Photo Selection. |
-| Other external providers | UNKNOWN | Google, Tencent, payment, booking finalization, and public AMA mutation capabilities must remain disabled. Confirm production credentials are absent or isolated. |
-| Logs and drains | UNKNOWN | Verify access, retention, drains, and the privacy allowlist against the current Vercel project. |
-| Domain cutover | UNKNOWN | `cali.so` currently serves `main`; verify the current Vercel project, production-branch mapping, aliases, and certificate before merge. |
-| Rollback | AWAITING CONFIRMATION | Confirm an operator can promote the last known-good Vercel deployment or revert the cutover merge without reversing additive database migrations. |
+| Production migration credential | PASS (name level) | `MIGRATION_DATABASE_URL` is absent from every Vercel environment. Its availability to the controlled migration operation is confirmed at cutover time. |
+| Production migrations | AWAITING CONFIRMATION | Nine additive migrations validate locally. Media migrations `0005` through `0009` are required for the v3 photo surface; execution and schema state require a separately authorized cutover step. |
+| Media provider and publication | FAIL | Production has no Bunny or media configuration at all, so the provider boundary, live storage contract, and the two-photo Published Photo Selection cannot exist yet. Provisioning precedes verification. |
+| Other external providers | PASS (name level) | No Google, Tencent, payment, or booking-finalization credentials exist in Production. Legacy-era variables (Clerk, Sanity, Edge Config, a three-year-old Upstash pair) remain for the current `main` site and need pruning or rotation at cutover. |
+| Logs and drains | UNKNOWN | Not exposed through the CLI; verify access, retention, drains, and the privacy allowlist in the Vercel dashboard. |
+| Domain cutover | PASS (partial) | `cali.so` is assigned to the correct team with third-party DNS pointing at Vercel and the production alias intact. The production-branch mapping and certificate still need a dashboard check before merge. |
+| Rollback | AWAITING CONFIRMATION | The last known-good production deployment is recorded in the audit baseline. An operator must still confirm promotion or merge-revert works without reversing additive migrations. |
 
 ## Automated evidence
 
@@ -161,13 +166,13 @@ Final review artifacts after the accessibility corrections:
   photos and their code path were removed, so release evidence must verify the
   production catalog, provider boundary, and publication rather than relying
   on a repository fallback.
-- The merged Media schema's `lifecycle` column conflicts with the Media
-  glossary. Rewriting merged migration `0005` would be unsafe, so the additive
-  vocabulary correction is tracked as post-launch issue
-  [#134](https://github.com/CaliCastle/cali.so/issues/134). The implemented
-  state transitions and publication behavior are unchanged, but this remains
-  a documented Standards breach. The cutover cannot receive a READY verdict
-  until the issue is resolved or the maintainer records an explicit exception.
+- The merged Media schema's `lifecycle` column conflicted with the Media
+  glossary. Rewriting merged migration `0005` would have been unsafe, so PR
+  #138 resolved [#134](https://github.com/CaliCastle/cali.so/issues/134) with
+  additive migration `0009`, renaming the column and constraint to Catalog
+  State and aligning the schema, repositories, admin surfaces, tests, and
+  glossary. State transitions and publication behavior are unchanged, and the
+  Standards breach is closed.
 - The complete-diff Standards review also found arbitrary `z-50` portal layers
   and widened letter spacing in admin chrome. Those findings are fixed with
   the existing `--z-card` layer and the shared `-0.011em` chrome tracking.
@@ -186,9 +191,9 @@ Final review artifacts after the accessibility corrections:
 ## Migration and provider boundary
 
 Migrations `0001` through `0004` are additive AMA foundations. Migrations
-`0005` through `0008` define the Media catalog, Photo Selection publication,
-publication revisions, and durable Purge progress. Their checked-in snapshots
-and migration tests pass. Unlike the optional public AMA flows, the v3 public
+`0005` through `0009` define the Media catalog, Photo Selection publication,
+publication revisions, durable Purge progress, and the Catalog State rename.
+Their checked-in snapshots and migration tests pass. Unlike the optional public AMA flows, the v3 public
 photo surfaces require the Media migrations, production Bunny configuration,
 and an active Published Photo Selection. Git remains authoritative for writing
 and ordinary site content, but not for the curated photo wall.
@@ -216,32 +221,34 @@ No manual DNS move is expected, but current project ownership, production
 branch, aliases, certificate, and environment scopes must be verified first.
 
 Rollback must prefer promoting the last known-good Vercel production deployment
-or reverting the cutover merge. The eight additive database migrations should
+or reverting the cutover merge. The nine additive database migrations should
 remain in place during application rollback; destructive down migrations are
 not part of the procedure. Record the known-good deployment identifier and an
 operator before cutover.
 
 ## Remaining manual actions
 
-1. Restore authorized read access to the current Vercel project and re-run the
-   hosted-control inventory without printing secret values.
-2. Separate Preview and Production Resend credentials if the historical shared
-   assignment still exists.
-3. Confirm the five optional Production capability switches are explicitly
-   false and owner admin remains protected by authentication.
-4. With two fresh confirmations, verify production runtime database grants,
-   migration-credential isolation, and migration state.
-5. Verify the production Bunny and Neon Media boundary, run the protected live
-   storage contract, and confirm the intended Published Photo Selection.
-6. Resolve #134 or record an explicit maintainer exception for the Media
-   vocabulary breach.
-7. Verify Vercel logs, drains, access, retention, firewall rules, production
-   branch, domains, and rollback deployment.
-8. Add `Quality` and `CodeQL` as required checks to both `v2` and `main` after
-   separate authorization.
-9. Review the #107 Vercel Preview across the remaining browser matrix and
-   update this report with its URL and result.
-10. Wait for the #107 PR's Quality, CodeQL, Vercel, and Greptile checks and
-    resolve any new finding or merge conflict.
-11. Only after every blocker above is passed, approve the separately operated
-    merge to `main` and production cutover.
+The maintainer-operated commands for actions 1 through 4 are collected in
+`docs/v3-cutover-ops-runbook.md`.
+
+1. Provision the Production environment for the v3 contract: replace the
+   legacy `DATABASE_URL` with the CRUD-only Neon runtime role and add the
+   missing secrets, rate limits, capability switches, and complete Bunny and
+   media configuration.
+2. Split the shared `RESEND_API_KEY` and `KV_*`/`REDIS_URL` credentials so
+   Preview and Production hold isolated values, and delete the dead
+   `AMA_ADMIN_ENABLED` variable from Preview.
+3. Add `Quality` and `CodeQL` as required checks to both `v2` and `main`.
+4. In the Vercel dashboard, verify logs, drains, retention, firewall rules,
+   the production-branch mapping, and the certificate.
+5. With two fresh confirmations, verify production runtime database grants
+   and migration state, then apply migrations `0001` through `0009` with the
+   separately supplied migration credential.
+6. Verify the production Bunny and Neon Media boundary, run the protected live
+   storage contract, and publish the intended two-photo Published Photo
+   Selection through the owner admin.
+7. Review a production-like Vercel Preview across the remaining browser matrix
+   and update this report with its URL and result.
+8. Confirm the rollback procedure against the recorded known-good deployment.
+9. Only after every blocker above is passed, approve the separately operated
+   merge to `main` and production cutover.

--- a/docs/v3-cutover-readiness.md
+++ b/docs/v3-cutover-readiness.md
@@ -23,8 +23,8 @@ running production migrations.
 | --- | --- |
 | Production branch | `main` at `8c258834af538dd501486a5fd319b3e96a2ff5bc` |
 | Integration branch | `v2` at `12fb6df` (post `#136` and `#138`) |
-| Vercel project | `cali-so` (`prj_oIl5MLjdm44QGv4v7ywZsPegtFoH`) on team `team_r1Mln12TRfgnkYJwXd62uJJ5` |
-| Production deployment | `dpl_BV7cKxGmfTAa1tUr2SScR6p9Uco8`, created 2024-03-10, status Ready |
+| Vercel project | `cali-so` (`prj_oIl5…`) on team `team_r1Mln…`; full IDs live in the local `.vercel/project.json` link state |
+| Production deployment | `dpl_BV7cK…`, created 2024-03-10, status Ready at inventory time |
 | Release issue | [#98](https://github.com/CaliCastle/cali.so/issues/98) |
 | Readiness issue | [#107](https://github.com/CaliCastle/cali.so/issues/107) |
 | Framework pin | `next@16.3.0-preview.6` |
@@ -50,7 +50,7 @@ Renditions. The retired static photo fallback has been removed.
 | Production-like PR Preview | AWAITING CONFIRMATION | The #107 PR is merged; review a current `v2` Preview across the full release matrix once Production provisioning lands, and record its URL here. |
 | GitHub security settings | PASS | Secret scanning, push protection, Dependabot security updates, read-only Actions defaults, and full-SHA action policy are enabled. |
 | Required GitHub checks | FAIL | Neither the `v2` ruleset nor `main` branch protection requires `Quality` and `CodeQL`. The maintainer-operated commands are in `docs/v3-cutover-ops-runbook.md`. |
-| Current Vercel project settings | PASS | Project inspection succeeds with the explicit team scope. The earlier `Not authorized` was a CLI quirk: the team slug `cali` resolves to the personal account, so commands must pass `--scope=team_r1Mln12TRfgnkYJwXd62uJJ5`. |
+| Current Vercel project settings | PASS | Project inspection succeeds with the explicit team scope. The earlier `Not authorized` was a CLI quirk: the team slug `cali` resolves to the personal account, so commands must pass the team ID as `--scope` (see the runbook). |
 | Production capability switches | PASS | All five optional `AMA_*_ENABLED` variables are absent from Production and therefore fail closed. Setting them explicitly `false` remains recommended during provisioning. `AMA_ADMIN_ENABLED` survives in Preview as dead configuration after ADR-0008 and should be removed. |
 | Preview and Production secret isolation | FAIL | `RESEND_API_KEY` is one variable targeting both Production and Preview, and the `KV_*`/`REDIS_URL` group added with the Preview provisioning also targets both environments. |
 | Production runtime environment | FAIL | Production `DATABASE_URL` predates the rewrite by over three years, and the v3 server-environment contract is otherwise unmet: no `SESSION_SECRET`, `AMA_ENCRYPTION_KEY`, `RATE_LIMIT_HASH_KEY`, `SITE_URL`, `RESEND_FROM_EMAIL`, rate-limit values, `CRON_SECRET`, or any `BUNNY_*`/`MEDIA_*` variable. The first v3 production build would fail environment validation. |


### PR DESCRIPTION
Part of #107 / #98.

Re-runs the hosted-control inventory against the current Vercel project and GitHub settings and replaces the report's historical UNKNOWNs with evidence. Adds `docs/v3-cutover-ops-runbook.md` collecting the maintainer-operated commands for every remaining hosted blocker.

## Gate movements

| Gate | Was | Now |
| --- | --- | --- |
| Complete diff Standards review | FAIL | PASS (#134 resolved by #138) |
| Current Vercel project settings | UNKNOWN | PASS — access works with the explicit team ID; the historical `Not authorized` was a CLI slug-resolution quirk |
| Production capability switches | UNKNOWN | PASS — all five `AMA_*_ENABLED` absent from Production, failing closed |
| Production migration credential | AWAITING | PASS (name level) — `MIGRATION_DATABASE_URL` absent from every environment |
| Other external providers | UNKNOWN | PASS (name level) — no Google/Tencent/payment credentials in Production |
| Domain cutover | UNKNOWN | PASS (partial) — team, DNS, and alias verified; branch mapping and certificate remain dashboard checks |
| Preview/Production secret isolation | UNKNOWN | **FAIL** — `RESEND_API_KEY` and the `KV_*`/`REDIS_URL` group target both environments |
| Production runtime environment | (not tracked) | **FAIL** — new gate: `DATABASE_URL` predates the rewrite and the v3 env contract, including all `BUNNY_*`/`MEDIA_*` values, is unmet |
| Media provider and publication | AWAITING | **FAIL** — nothing to confirm yet; Production has no media configuration |

The verdict stays **NOT READY**, now with a concrete provisioning work list instead of unknowns. The rollback anchor (`dpl_BV7cKxGmfTAa1tUr2SScR6p9Uco8`) is recorded in the audit baseline, and the remaining manual actions are rewritten around the runbook.

No production settings, credentials, or data were changed; the inventory used name-and-target-level reads only.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refreshes the hosted-control readiness inventory, replacing historical UNKNOWNs with current evidence, and adds `docs/v3-cutover-ops-runbook.md` — a new maintainer-operated command reference for the remaining hosted blockers. The verdict remains NOT READY, now with two concrete FAILs (secret isolation, Production environment provisioning) and a precise work list instead of unknowns.

- The runbook correctly incorporates fixes from prior review threads: `bypass_actors` is preserved in the GitHub Rulesets round-trip, deployment IDs use abbreviated forms, and the rollback section now guards against a silently empty `$DPL`.
- Two minor documentation inconsistencies remain: the migration step's inline credential pattern contradicts the runbook's stated interactive-prompt design principle, and the readiness doc's coverage claim (\"actions 1 through 4\") understates the runbook's scope since sections 5–6 also provide operational commands for database migration and rollback.

<h3>Confidence Score: 5/5</h3>

Documentation-only PR; no production settings, credentials, or code paths were changed.

Both files are purely operational documentation. All three previously-reviewed issues are confirmed addressed in the current diff. The remaining findings are documentation wording concerns that do not affect any running system.

No files require special attention; both changed files are documentation only.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/v3-cutover-ops-runbook.md | New maintainer ops runbook for six hosted blockers; previously-reviewed issues (bypass_actors, rollback guard, abbreviated IDs) are all addressed; the migration command's inline credential pattern contradicts the stated interactive-prompt design principle. |
| docs/v3-cutover-readiness.md | Refreshed readiness report replaces historical UNKNOWNs with current evidence; gate movements and FAIL statuses are accurate and consistent with the PR description; runbook coverage statement for "actions 1 through 4" understates the runbook's actual scope (sections 5–6 also provide operational commands). |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[v3 Cutover Readiness] --> B{Verdict}
    B --> |NOT READY| C[Gate Summary]
    C --> D[PASS Gates]
    C --> E[FAIL Gates]
    C --> F[AWAITING / UNKNOWN]
    D --> D1[Frozen install]
    D --> D2[Repository validation]
    D --> D3[Browser behavior]
    D --> D4[Owner admin boundary]
    D --> D5[Standards review]
    D --> D6[GitHub security settings]
    D --> D7[Vercel project access]
    D --> D8[Capability switches]
    D --> D9[Migration credential absent]
    D --> D10[Domain partial]
    E --> E1[Required GitHub checks - Runbook s1]
    E --> E2[Preview/Production isolation - Runbook s2]
    E --> E3[Production runtime env - Runbook s3]
    E --> E4[Media provider - Runbook s3 plus s5]
    F --> F1[Logs and drains - Runbook s4]
    F --> F2[DB grants - Runbook s5]
    F --> F3[Production migrations - Runbook s5]
    F --> F4[Rollback confirmation - Runbook s6]
    F --> F5[PR Preview review]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[v3 Cutover Readiness] --> B{Verdict}
    B --> |NOT READY| C[Gate Summary]
    C --> D[PASS Gates]
    C --> E[FAIL Gates]
    C --> F[AWAITING / UNKNOWN]
    D --> D1[Frozen install]
    D --> D2[Repository validation]
    D --> D3[Browser behavior]
    D --> D4[Owner admin boundary]
    D --> D5[Standards review]
    D --> D6[GitHub security settings]
    D --> D7[Vercel project access]
    D --> D8[Capability switches]
    D --> D9[Migration credential absent]
    D --> D10[Domain partial]
    E --> E1[Required GitHub checks - Runbook s1]
    E --> E2[Preview/Production isolation - Runbook s2]
    E --> E3[Production runtime env - Runbook s3]
    E --> E4[Media provider - Runbook s3 plus s5]
    F --> F1[Logs and drains - Runbook s4]
    F --> F2[DB grants - Runbook s5]
    F --> F3[Production migrations - Runbook s5]
    F --> F4[Rollback confirmation - Runbook s6]
    F --> F5[PR Preview review]
```

</a>

<sub>Reviews (4): Last reviewed commit: ["docs(release): guard rollback against em..."](https://github.com/calicastle/cali.so/commit/7a72ee12b37ccd35d1b6db7a062a5062c8eaecc9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44686240)</sub>

<!-- /greptile_comment -->