### PR TITLE
feat(links): cache link media server-side and polish hover cards

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1768,8 +1768,12 @@ a:focus-visible .external-label .external-mark {
   z-index: var(--z-card);
 }
 
+/* Image-enabled preview cards: height comes from the content (the 16:9
+   frame still holds its slot while the image loads). Uniform padding so
+   the frame's corners run concentric with the card's. */
 .link-card-with-image {
-  height: 17rem;
+  padding: 0.625rem;
+  border-radius: var(--radius-2xl);
 }
 
 .link-card-image-frame {
@@ -1778,7 +1782,8 @@ a:focus-visible .external-label .external-mark {
   width: 100%;
   aspect-ratio: 16 / 9;
   overflow: hidden;
-  border-radius: calc(var(--radius) - 0.125rem);
+  /* concentric with the card: outer radius minus the padding inset */
+  border-radius: calc(var(--radius-2xl) - 0.625rem);
   background: color-mix(in oklch, var(--muted) 72%, var(--paper));
   box-shadow: inset 0 0 0 1px var(--border);
 }
@@ -1793,6 +1798,50 @@ a:focus-visible .external-label .external-mark {
 .external-link img[data-failed],
 .link-card img[data-failed] {
   visibility: hidden;
+}
+
+/* Favicon tone treatment (components/favicon-tone.ts): a pale glyph on
+   the light theme — or a dark one in dark mode — would vanish into the
+   page. Grayscale marks simply invert to the theme's ink, like native
+   icons; marks with brand color instead sit on a quiet chip (--primary
+   softened toward the page) since inverting would corrupt the color.
+   Padding + border-box keeps the slot size: no layout shift. Opaque
+   near-white tiles just get an edge on the light page. */
+.external-link img[data-tone='light-mono'],
+.link-card-site img[data-tone='light-mono'],
+.dark .external-link img[data-tone='dark-mono'],
+.dark .link-card-site img[data-tone='dark-mono'] {
+  filter: invert(1);
+}
+
+.dark .external-link img[data-tone='light-mono'],
+.dark .link-card-site img[data-tone='light-mono'] {
+  filter: none;
+}
+
+.external-link img[data-tone='light'],
+.link-card-site img[data-tone='light'],
+.dark .external-link img[data-tone='dark'],
+.dark .link-card-site img[data-tone='dark'] {
+  box-sizing: border-box;
+  padding: 2px;
+  background: color-mix(in oklab, var(--primary) 88%, var(--background));
+}
+
+.dark .external-link img[data-tone='light'],
+.dark .link-card-site img[data-tone='light'] {
+  padding: 0;
+  background: none;
+}
+
+.external-link img[data-tone='flat'],
+.link-card-site img[data-tone='flat'] {
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+
+.dark .external-link img[data-tone='flat'],
+.dark .link-card-site img[data-tone='flat'] {
+  box-shadow: none;
 }
 
 .link-card[data-open] {

--- a/app/link-media/[kind]/route.ts
+++ b/app/link-media/[kind]/route.ts
@@ -20,8 +20,11 @@ async function fetchLinkMedia(upstream: string) {
   const contentType = res.headers.get('content-type') ?? ''
   if (!contentType.startsWith('image/')) throw new Error('unexpected content type')
 
-  // reject oversized declarations before buffering the body at all
-  if (Number(res.headers.get('content-length')) > MAX_MEDIA_BYTES) {
+  // reject an oversized *declared* length before buffering the body at
+  // all; an absent or non-numeric header falls through to the
+  // post-buffer check below
+  const declaredLength = Number(res.headers.get('content-length'))
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_MEDIA_BYTES) {
     throw new Error('unexpected content length')
   }
 
@@ -54,11 +57,11 @@ export async function GET(
       headers: {
         'Content-Type': contentType,
         // browsers keep a copy for a day, the CDN for a week (serving
-        // stale while it refreshes against the data cache)
+        // stale while it refreshes against the data cache). The strict
+        // media CSP (sandbox) comes from next.config.ts, which already
+        // sends the global security headers — setting it here as well
+        // would emit a duplicate Content-Security-Policy header.
         'Cache-Control': 'public, max-age=86400, s-maxage=604800, stale-while-revalidate=604800',
-        // media only — never a document that could run in this origin
-        'Content-Security-Policy': "default-src 'none'; sandbox",
-        'X-Content-Type-Options': 'nosniff',
       },
     })
   } catch {

--- a/app/link-media/[kind]/route.ts
+++ b/app/link-media/[kind]/route.ts
@@ -1,0 +1,71 @@
+import { cacheLife } from 'next/cache'
+
+import { upstreamLinkMediaUrl } from '~/lib/link-media'
+
+// Link media are small; the cap defends the data cache against a
+// pathological upstream response.
+const MAX_MEDIA_BYTES = 4 * 1024 * 1024
+
+// Server-side cache for proxied link favicons and Open Graph images:
+// entries live in the data cache and refresh in the background, so the
+// browser talks only to this origin and repeat views never re-fetch
+// upstream. Failures throw and are never cached.
+async function fetchLinkMedia(upstream: string) {
+  'use cache'
+  cacheLife({ stale: 86_400, revalidate: 604_800, expire: 2_592_000 })
+
+  const res = await fetch(upstream, { signal: AbortSignal.timeout(10_000) })
+  if (!res.ok) throw new Error(`upstream ${res.status}`)
+
+  const contentType = res.headers.get('content-type') ?? ''
+  if (!contentType.startsWith('image/')) throw new Error('unexpected content type')
+
+  // reject oversized declarations before buffering the body at all
+  if (Number(res.headers.get('content-length')) > MAX_MEDIA_BYTES) {
+    throw new Error('unexpected content length')
+  }
+
+  const body = new Uint8Array(await res.arrayBuffer())
+  if (!body.byteLength || body.byteLength > MAX_MEDIA_BYTES) {
+    throw new Error('unexpected content length')
+  }
+
+  return { body, contentType }
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ kind: string }> },
+) {
+  const { kind } = await params
+  const target = new URL(request.url).searchParams.get('url')
+  const upstream = target ? upstreamLinkMediaUrl(kind, target) : null
+  if (!upstream) {
+    // cacheable briefly so probe traffic doesn't re-hit the server
+    return new Response('Not found', {
+      status: 404,
+      headers: { 'Cache-Control': 'public, max-age=300' },
+    })
+  }
+
+  try {
+    const { body, contentType } = await fetchLinkMedia(upstream)
+    return new Response(body, {
+      headers: {
+        'Content-Type': contentType,
+        // browsers keep a copy for a day, the CDN for a week (serving
+        // stale while it refreshes against the data cache)
+        'Cache-Control': 'public, max-age=86400, s-maxage=604800, stale-while-revalidate=604800',
+        // media only — never a document that could run in this origin
+        'Content-Security-Policy': "default-src 'none'; sandbox",
+        'X-Content-Type-Options': 'nosniff',
+      },
+    })
+  } catch {
+    // short-lived so a transient upstream failure never pins a missing icon
+    return new Response('Bad gateway', {
+      status: 502,
+      headers: { 'Cache-Control': 'public, max-age=60' },
+    })
+  }
+}

--- a/components/external-link.test.tsx
+++ b/components/external-link.test.tsx
@@ -27,7 +27,7 @@ describe('external link preview card', () => {
     const { getByRole } = render(
       <ExternalLink
         href={href}
-        favicon="https://og.zolplay.com/favicon/https%3A%2F%2Fexample.com%2Farticles%2Fdesign"
+        favicon="https://og.zolplay.com/favicon/https%3A%2F%2Fexample.com%2F"
         preview={{
           domain: 'example.com',
           title: '设计文章',
@@ -49,13 +49,74 @@ describe('external link preview card', () => {
       expect(card?.classList.contains('link-card-with-image')).toBe(true)
       expect(card?.textContent).toContain('example.com')
       expect(card?.textContent).toContain('A design article')
-      expect(card?.textContent).toContain('An article about design.')
+      // the image speaks for the page — description only on image-less cards
+      expect(card?.textContent).not.toContain('An article about design.')
       const image = card?.querySelector('.link-card-image')
       expect(image?.getAttribute('src')).toBe(
         'https://og.zolplay.com/image/https%3A%2F%2Fexample.com%2Farticles%2Fdesign',
       )
-      expect(image?.getAttribute('width')).toBe('232')
-      expect(image?.getAttribute('height')).toBe('131')
+      expect(image?.getAttribute('width')).toBe('236')
+      expect(image?.getAttribute('height')).toBe('133')
+    })
+  })
+
+  it('keeps the description on image-less cards', async () => {
+    document.documentElement.dataset.locale = 'en'
+    const { getByRole } = render(
+      <ExternalLink
+        href="https://example.com/articles/design"
+        favicon="https://og.zolplay.com/favicon/https%3A%2F%2Fexample.com%2F"
+        preview={{
+          domain: 'example.com',
+          titleEn: 'A design article',
+          descriptionEn: 'An article about design.',
+          hasImage: false,
+        }}
+      >
+        Example
+      </ExternalLink>,
+    )
+
+    fireEvent.focus(getByRole('link'))
+
+    await waitFor(() => {
+      const card = document.querySelector('.link-card')
+      expect(card).not.toBeNull()
+      expect(card?.classList.contains('link-card-with-image')).toBe(false)
+      expect(card?.textContent).toContain('An article about design.')
+    })
+  })
+
+  it('degrades to the text card when the Open Graph image fails', async () => {
+    document.documentElement.dataset.locale = 'en'
+    const { getByRole } = render(
+      <ExternalLink
+        href="https://example.com/articles/design"
+        favicon="https://og.zolplay.com/favicon/https%3A%2F%2Fexample.com%2F"
+        preview={{
+          domain: 'example.com',
+          titleEn: 'A design article',
+          descriptionEn: 'An article about design.',
+          hasImage: true,
+        }}
+      >
+        Example
+      </ExternalLink>,
+    )
+
+    fireEvent.focus(getByRole('link'))
+
+    await waitFor(() => {
+      expect(document.querySelector('.link-card-image')).not.toBeNull()
+    })
+
+    fireEvent.error(document.querySelector('.link-card-image')!)
+
+    await waitFor(() => {
+      const card = document.querySelector('.link-card')
+      expect(card?.classList.contains('link-card-with-image')).toBe(false)
+      expect(card?.querySelector('.link-card-image-frame')).toBeNull()
+      expect(card?.textContent).toContain('An article about design.')
     })
   })
 

--- a/components/external-link.tsx
+++ b/components/external-link.tsx
@@ -1,8 +1,11 @@
 'use client'
 
+import { useState } from 'react'
+
 import { PreviewCard } from '@base-ui/react/preview-card'
 
 import { ExternalLabel } from '~/components/external-mark'
+import { classifyFaviconTone } from '~/components/favicon-tone'
 import { ogImageUrl, type LinkPreview } from '~/lib/link-previews'
 import { useLocale } from '~/lib/locale-client'
 
@@ -17,9 +20,32 @@ function hideFailedImage(event: React.SyntheticEvent<HTMLImageElement>) {
   event.currentTarget.dataset.failed = 'true'
 }
 
+// The ref covers icons that settled before hydration attached onLoad/onError.
+function Favicon({ src, size }: { src: string; size: 14 | 16 }) {
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      ref={(img) => {
+        if (!img?.complete) return
+        if (img.naturalWidth) classifyFaviconTone(img)
+        else img.dataset.failed = 'true'
+      }}
+      src={src}
+      alt=""
+      width={size}
+      height={size}
+      loading="lazy"
+      aria-hidden
+      onLoad={(event) => classifyFaviconTone(event.currentTarget)}
+      onError={hideFailedImage}
+    />
+  )
+}
+
 // External prose links: inline favicon prefix, and — with build-time
-// preview data and a fine pointer — a fixed-size hover card. On touch
-// the trigger is just a link; the card is an enhancement, never content.
+// preview data and a fine pointer — a fixed-width hover card whose
+// height adapts to its content. On touch the trigger is just a link;
+// the card is an enhancement, never content.
 export function ExternalLink({
   href,
   favicon,
@@ -38,19 +64,11 @@ export function ExternalLink({
       ? englishOrSource(preview?.descriptionEn, preview?.description)
       : preview?.description
   const domain = preview?.domain
-  const image = preview?.hasImage ? ogImageUrl(href) : null
-  const icon = (
-    // eslint-disable-next-line @next/next/no-img-element
-    <img
-      src={favicon}
-      alt=""
-      width={14}
-      height={14}
-      loading="lazy"
-      aria-hidden
-      onError={hideFailedImage}
-    />
-  )
+  // a failed Open Graph image degrades the card to its text form instead
+  // of holding an empty frame with no description
+  const [imageFailed, setImageFailed] = useState(false)
+  const image = preview?.hasImage && !imageFailed ? ogImageUrl(href) : null
+  const icon = <Favicon src={favicon} size={14} />
 
   if (!title || !domain) {
     return (
@@ -86,28 +104,23 @@ export function ExternalLink({
                   className="link-card-image"
                   src={image}
                   alt=""
-                  width={232}
-                  height={131}
+                  width={236}
+                  height={133}
                   loading="eager"
-                  onError={hideFailedImage}
+                  onError={() => setImageFailed(true)}
                 />
               </span>
             )}
             <span className="link-card-site">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={favicon}
-                alt=""
-                width={16}
-                height={16}
-                loading="lazy"
-                aria-hidden
-                onError={hideFailedImage}
-              />
+              <Favicon src={favicon} size={16} />
               {domain}
             </span>
             <span className="link-card-title">{title}</span>
-            {description && <span className="link-card-description">{description}</span>}
+            {/* the image already says what the page is — description text
+                only earns its rows on image-less cards */}
+            {!image && description && (
+              <span className="link-card-description">{description}</span>
+            )}
           </PreviewCard.Popup>
         </PreviewCard.Positioner>
       </PreviewCard.Portal>

--- a/components/favicon-tone.test.ts
+++ b/components/favicon-tone.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+
+import { faviconTone } from './favicon-tone'
+
+// 4×4 RGBA buffer where `coverage` of the pixels carry the given color at
+// full alpha and the rest stay transparent.
+function icon(rgb: [number, number, number], coverage: number, alpha = 255) {
+  const pixels = 16
+  const data = new Uint8ClampedArray(pixels * 4)
+  const filled = Math.round(pixels * coverage)
+  for (let i = 0; i < filled; i++) {
+    data.set([...rgb, alpha], i * 4)
+  }
+  return { data, pixels }
+}
+
+// glyph that is mostly `rgb` with a smaller region of `accent` color
+function accentedIcon(
+  rgb: [number, number, number],
+  accent: [number, number, number],
+  coverage: number,
+  accentShare: number,
+) {
+  const { data, pixels } = icon(rgb, coverage)
+  const filled = Math.round(pixels * coverage)
+  for (let i = 0; i < Math.round(filled * accentShare); i++) {
+    data.set([...accent, 255], i * 4)
+  }
+  return { data, pixels }
+}
+
+describe('faviconTone', () => {
+  it('flags a grayscale white glyph on transparency as invertible', () => {
+    const { data, pixels } = icon([255, 255, 255], 0.4)
+    expect(faviconTone(data, pixels)).toBe('light-mono')
+  })
+
+  it('flags a grayscale black glyph on transparency as invertible', () => {
+    const { data, pixels } = icon([0, 0, 0], 0.4)
+    expect(faviconTone(data, pixels)).toBe('dark-mono')
+  })
+
+  it('keeps the chip for dark glyphs carrying brand color', () => {
+    // Astro-like: mostly black flame with a red gradient region
+    const { data, pixels } = accentedIcon([0, 0, 0], [230, 40, 80], 0.4, 0.2)
+    expect(faviconTone(data, pixels)).toBe('dark')
+  })
+
+  it('keeps the chip for light glyphs carrying brand color', () => {
+    const { data, pixels } = accentedIcon([255, 255, 255], [255, 200, 60], 0.4, 0.2)
+    expect(faviconTone(data, pixels)).toBe('light')
+  })
+
+  it('flags an opaque near-white tile as flat', () => {
+    const { data, pixels } = icon([250, 250, 250], 1)
+    expect(faviconTone(data, pixels)).toBe('flat')
+  })
+
+  it('leaves colorful or mid-tone icons alone', () => {
+    const orange = icon([230, 126, 34], 0.5)
+    expect(faviconTone(orange.data, orange.pixels)).toBeUndefined()
+
+    const opaqueDark = icon([20, 20, 20], 1)
+    expect(faviconTone(opaqueDark.data, opaqueDark.pixels)).toBeUndefined()
+  })
+
+  it('ignores fully transparent icons', () => {
+    const { data, pixels } = icon([255, 255, 255], 0)
+    expect(faviconTone(data, pixels)).toBeUndefined()
+  })
+})

--- a/components/favicon-tone.ts
+++ b/components/favicon-tone.ts
@@ -1,0 +1,92 @@
+// A favicon drawn as a white glyph on transparency vanishes on the light
+// theme, and its black twin vanishes in dark mode. Favicons are proxied
+// same-origin (/link-media), so their pixels are readable: sample the icon
+// once on load and tag it so CSS can restore the field it was drawn for.
+
+const SAMPLE_SIZE = 16
+
+export type FaviconTone = 'light' | 'light-mono' | 'dark' | 'dark-mono' | 'flat'
+
+// Alpha-weighted mean luminance over an RGBA buffer. Translucent glyphs
+// that would vanish into a theme background split by whether they carry
+// brand color: `*-mono` grayscale marks can simply invert to the theme's
+// ink, while colored ones (`light`/`dark`) need a contrast chip — an
+// inverted brand color would be a wrong color. `flat` marks an opaque
+// near-white tile that only needs an edge to stop bleeding into the
+// light page.
+export function faviconTone(
+  data: Uint8ClampedArray,
+  pixels: number,
+): FaviconTone | undefined {
+  let luminance = 0
+  let weight = 0
+  let colored = 0
+
+  for (let i = 0; i < data.length; i += 4) {
+    const alpha = data[i + 3] / 255
+    if (!alpha) continue
+    const [r, g, b] = [data[i], data[i + 1], data[i + 2]]
+    luminance += ((0.2126 * r + 0.7152 * g + 0.0722 * b) / 255) * alpha
+    weight += alpha
+    if (Math.max(r, g, b) - Math.min(r, g, b) > 40) colored += alpha
+  }
+
+  if (!weight) return undefined
+  const mean = luminance / weight
+  const coverage = weight / pixels
+  const mono = colored / weight < 0.05
+
+  if (coverage > 0.9) return mean > 0.86 ? 'flat' : undefined
+  if (mean > 0.8) return mono ? 'light-mono' : 'light'
+  if (mean < 0.22) return mono ? 'dark-mono' : 'dark'
+  return undefined
+}
+
+// Scheme-aware SVG favicons repaint themselves when the theme flips (the
+// .dark class toggle and the browser scheme change together), so a tone
+// sampled in one theme can describe the wrong pixels in the other.
+// Resample every visible favicon after the theme class changes.
+let observingTheme = false
+
+function observeThemeChanges() {
+  if (observingTheme || typeof MutationObserver === 'undefined') return
+  observingTheme = true
+
+  new MutationObserver(() => {
+    // double rAF: give the repainted SVG a frame to raster before sampling
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() => {
+        const icons = document.querySelectorAll<HTMLImageElement>(
+          '.external-link img, .link-card-site img',
+        )
+        for (const img of icons) {
+          delete img.dataset.tone
+          classifyFaviconTone(img)
+        }
+      }),
+    )
+  }).observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['class'],
+  })
+}
+
+export function classifyFaviconTone(img: HTMLImageElement) {
+  observeThemeChanges()
+  if (img.dataset.tone || !img.naturalWidth) return
+
+  try {
+    const canvas = document.createElement('canvas')
+    canvas.width = SAMPLE_SIZE
+    canvas.height = SAMPLE_SIZE
+    const context = canvas.getContext('2d', { willReadFrequently: true })
+    if (!context) return
+
+    context.drawImage(img, 0, 0, SAMPLE_SIZE, SAMPLE_SIZE)
+    const { data } = context.getImageData(0, 0, SAMPLE_SIZE, SAMPLE_SIZE)
+    const tone = faviconTone(data, SAMPLE_SIZE * SAMPLE_SIZE)
+    if (tone) img.dataset.tone = tone
+  } catch {
+    // a cross-origin fallback icon taints the canvas; leave it untagged
+  }
+}

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -167,8 +167,10 @@ open rich hover cards. The contract:
   `scale(0.95)` + `opacity: 0`, `transform-origin` at the trigger,
   `backface-visibility: hidden`. Exit faster than enter. Built on the fluid
   hover-card primitive so pointer exit mid-animation reverses smoothly.
-- **Fixed dimensions per card type** — content loads into a fixed-size card
-  (skeleton first), never resizing after open. No layout shift, ever.
+- **Fixed dimensions per service card type** — service-card content loads
+  into a fixed-size card (skeleton first). External-link preview cards are
+  instead fixed-width with content-driven height, settled at render. Either
+  way a card never resizes while open. No layout shift, ever.
 - **Touch fallback.** Hover cards require `@media (hover: hover) and (pointer:
   fine)` and are simply absent on touch — the trigger is a plain link to the
   destination (or inert text if there is no destination). The card is an
@@ -194,13 +196,31 @@ open rich hover cards. The contract:
   popup is informational and noninteractive, and touch follows that link
   without opening a separate surface.
 - **The implemented base: external-link previews.** Every external link in
-  prose carries a 14px inline favicon (fixed slot, no layout shift) served by
-  `og.zolplay.com` and — when build-time metadata exists in
-  `content/link-previews.json` — a preview card on the shared hover-card
-  primitive (`components/external-link.tsx`). Image-enabled cards reserve one
-  fixed 16:9 slot for the proxied Open Graph image above the favicon, domain,
-  title, and two-line description; media failure keeps the slot and link stable.
-  Refresh the metadata from the same first-party service with
+  prose carries a 14px inline favicon (fixed slot, no layout shift) — always
+  requested against the link's root domain, never the deep URL, so a page
+  that 404s or redirects can't fail the icon — and,
+  when build-time metadata exists in `content/link-previews.json`, a preview
+  card on the shared hover-card primitive (`components/external-link.tsx`).
+  The card is fixed-width; its height adapts to the content and never changes
+  after open. Image-enabled cards reserve one fixed 16:9 slot for the proxied
+  Open Graph image above the favicon, domain, and title — the image speaks
+  for the page, so the description renders only on image-less cards — with
+  the slot's corner radius concentric to the card's (outer radius minus
+  padding). A failed image degrades the card to its text form (description
+  included); a failed favicon hides in place, keeping its slot and the
+  link stable.
+  Favicons and Open Graph images are served through the server-side cache at
+  `/link-media` (`app/link-media/[kind]/route.ts`), allowlisted against the
+  snapshot so the proxy can't be aimed at arbitrary hosts; targets not yet in
+  the snapshot fall back to `og.zolplay.com` directly.
+  Favicon tone chips (`components/favicon-tone.ts`): the same-origin icon is
+  pixel-sampled once on load, and a glyph that would vanish into the theme
+  background — white-on-transparent in light mode, black-on-transparent in
+  dark — is set on a small `--primary` chip (2px inset padding, border-box,
+  slot size unchanged); opaque near-white tiles get a hairline edge on the
+  light page. Colorful icons, opaque dark tiles (their glyphs carry their
+  own contrast), and un-proxied fallback icons stay untouched. Refresh the metadata
+  from the same first-party service with
   `node scripts/refresh-link-previews.mjs`.
 - **External-link mark.** Text links that leave the site carry the shared
   northeast arrow inline; internal links, RSS, and Email do not. Shelf covers

--- a/lib/link-media.ts
+++ b/lib/link-media.ts
@@ -1,0 +1,51 @@
+import previews from '~/content/link-previews.json'
+import { ogZolplayUrl } from '~/lib/og-zolplay.mjs'
+
+// Targets the /link-media proxy will serve, derived from the build-time
+// preview snapshot (content/link-previews.json) plus the few chrome links
+// that live outside prose — the proxy can never be aimed at an arbitrary
+// host. Links added to a post before the snapshot refreshes fall back to
+// the service directly (see lib/link-previews.ts).
+const EXTRA_FAVICON_ORIGINS = ['https://zolplay.com']
+
+const snapshot = previews as Record<string, { hasImage?: boolean }>
+
+const faviconOrigins = new Set<string>(EXTRA_FAVICON_ORIGINS)
+const imageTargets = new Set<string>()
+
+for (const [href, preview] of Object.entries(snapshot)) {
+  try {
+    faviconOrigins.add(new URL(href).origin)
+  } catch {
+    continue
+  }
+  if (preview.hasImage) imageTargets.add(href)
+}
+
+export type LinkMediaKind = 'favicon' | 'image'
+
+// Resolves a proxy target to its og.zolplay.com upstream, or null when the
+// target isn't allowlisted. Favicons resolve per site: any target under a
+// known origin maps to that origin's icon; images require the exact page
+// URL recorded in the snapshot.
+export function upstreamLinkMediaUrl(kind: string, target: string): string | null {
+  if (kind === 'favicon') {
+    let origin: string
+    try {
+      origin = new URL(target).origin
+    } catch {
+      return null
+    }
+    return faviconOrigins.has(origin) ? ogZolplayUrl('favicon', origin) : null
+  }
+
+  if (kind === 'image') {
+    return imageTargets.has(target) ? ogZolplayUrl('image', target) : null
+  }
+
+  return null
+}
+
+export function linkMediaPath(kind: LinkMediaKind, target: string): string {
+  return `/link-media/${kind}?url=${encodeURIComponent(target)}`
+}

--- a/lib/link-previews.test.ts
+++ b/lib/link-previews.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import { upstreamLinkMediaUrl } from './link-media'
+import { faviconUrl, ogImageUrl } from './link-previews'
+
+describe('link preview media URLs', () => {
+  it('routes known targets through the cached first-party proxy', () => {
+    // astro.build is in content/link-previews.json with hasImage: true
+    expect(faviconUrl('https://astro.build/')).toBe(
+      '/link-media/favicon?url=https%3A%2F%2Fastro.build',
+    )
+    expect(ogImageUrl('https://astro.build/')).toBe(
+      '/link-media/image?url=https%3A%2F%2Fastro.build%2F',
+    )
+  })
+
+  it('requests favicons against the root domain only', () => {
+    // deep paths under a known origin collapse to that origin's icon
+    expect(faviconUrl('https://astro.build/blog/some-post?x=1#y')).toBe(
+      '/link-media/favicon?url=https%3A%2F%2Fastro.build',
+    )
+  })
+
+  it('falls back to the service for targets missing from the snapshot', () => {
+    expect(faviconUrl('https://not-in-snapshot.example/articles/design')).toBe(
+      'https://og.zolplay.com/favicon/https%3A%2F%2Fnot-in-snapshot.example%2F',
+    )
+    expect(ogImageUrl('https://not-in-snapshot.example/articles/design')).toBe(
+      'https://og.zolplay.com/image/https%3A%2F%2Fnot-in-snapshot.example%2Farticles%2Fdesign',
+    )
+  })
+
+  it('degrades bad links to null instead of throwing', () => {
+    expect(faviconUrl('not a url')).toBeNull()
+    expect(faviconUrl('javascript:alert(1)')).toBeNull()
+    expect(faviconUrl('http://localhost/admin')).toBeNull()
+  })
+})
+
+describe('link media proxy allowlist', () => {
+  it('resolves allowlisted targets to their og.zolplay.com upstream', () => {
+    expect(upstreamLinkMediaUrl('favicon', 'https://astro.build')).toBe(
+      'https://og.zolplay.com/favicon/https%3A%2F%2Fastro.build%2F',
+    )
+    expect(upstreamLinkMediaUrl('favicon', 'https://astro.build/deep/page')).toBe(
+      'https://og.zolplay.com/favicon/https%3A%2F%2Fastro.build%2F',
+    )
+    expect(upstreamLinkMediaUrl('image', 'https://astro.build/')).toBe(
+      'https://og.zolplay.com/image/https%3A%2F%2Fastro.build%2F',
+    )
+  })
+
+  it('serves chrome favicons outside prose', () => {
+    expect(upstreamLinkMediaUrl('favicon', 'https://zolplay.com')).toBe(
+      'https://og.zolplay.com/favicon/https%3A%2F%2Fzolplay.com%2F',
+    )
+  })
+
+  it('rejects everything else', () => {
+    expect(upstreamLinkMediaUrl('favicon', 'https://not-in-snapshot.example')).toBeNull()
+    // images match the exact page URL, never the bare origin
+    expect(upstreamLinkMediaUrl('image', 'https://astro.build/blog/some-post')).toBeNull()
+    expect(upstreamLinkMediaUrl('favicon', 'not a url')).toBeNull()
+    expect(upstreamLinkMediaUrl('metadata', 'https://astro.build')).toBeNull()
+  })
+})

--- a/lib/link-previews.ts
+++ b/lib/link-previews.ts
@@ -1,4 +1,5 @@
 import previews from '~/content/link-previews.json'
+import { linkMediaPath, upstreamLinkMediaUrl } from '~/lib/link-media'
 import {
   ogZolplayUrl,
   type LinkPreviewSnapshot,
@@ -17,10 +18,23 @@ export function getLinkPreview(url: string): LinkPreview | undefined {
 
 // Bad links in a post degrade to plain anchors instead of reaching the
 // first-party preview service or crashing the build.
+// Favicons resolve per site, not per page: only the root domain is
+// requested, so a deep link that 404s or redirects can't fail the icon.
+// Known targets route through the server-side cache at /link-media; a
+// link added before the snapshot refreshes falls back to the service
+// directly until `node scripts/refresh-link-previews.mjs` runs.
 export function faviconUrl(href: string): string | null {
-  return ogZolplayUrl('favicon', href)
+  let origin: string
+  try {
+    origin = new URL(href).origin
+  } catch {
+    return null
+  }
+  if (upstreamLinkMediaUrl('favicon', origin)) return linkMediaPath('favicon', origin)
+  return ogZolplayUrl('favicon', origin)
 }
 
 export function ogImageUrl(href: string): string | null {
+  if (upstreamLinkMediaUrl('image', href)) return linkMediaPath('image', href)
   return ogZolplayUrl('image', href)
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -66,6 +66,19 @@ const nextConfig: NextConfig = {
       source: '/api/admin/:path*',
       headers: [{ key: 'Referrer-Policy', value: 'no-referrer' }],
     },
+    {
+      // Proxied link media (favicons, Open Graph images) are never a
+      // document that may run in this origin. Same-key entries later in
+      // this list override the global policy above, so exactly one
+      // Content-Security-Policy header is sent.
+      source: '/link-media/:path*',
+      headers: [
+        {
+          key: 'Content-Security-Policy',
+          value: "default-src 'none'; sandbox",
+        },
+      ],
+    },
   ],
 
   // The checked-in manifest is the v3 cutover contract for every preserved,


### PR DESCRIPTION
## What

Four related upgrades to external-link previews:

### Root-domain favicons
`faviconUrl()` resolves `new URL(href).origin` before requesting, so a deep link that 404s or redirects can never fail the icon. Verified live: all 27 favicons on the clone-guide post request origins only.

### Server-side link media cache
New `/link-media/[kind]` route proxies favicons and OG images first-party, backed by the data cache (`'use cache'` + `cacheLife`, week-long revalidate) plus browser/CDN `Cache-Control`. Measured: 523ms cold, ~110ms warm. Targets are **allowlisted** against `content/link-previews.json` (+ zolplay.com), so the proxy can't be aimed at arbitrary hosts — unknown targets 404 (cacheable, 5m) and the client falls back to `og.zolplay.com` directly until `refresh-link-previews.mjs` runs. Responses carry `sandbox` CSP + `nosniff` (SVG favicons never execute in our origin); oversized upstreams are rejected before buffering (4MB cap). OG *metadata* stays build-time cached in the JSON snapshot as before.

### Hover card geometry
- Fixed `height: 17rem` dropped — height adapts to content (Astro card: 272px → 205px). The 16:9 frame still reserves its slot via `aspect-ratio`, so nothing shifts while the image loads.
- OG image corners run **concentric** with the card: 18px outer (`--radius-2xl`), uniform 10px padding, 8px inner. (Image-less cards keep the original 10px silhouette — deliberate.)
- Description yields to the image when one exists; a failed image degrades the card to its **text form** (frame dropped, description restored) instead of holding an empty frame.

### Favicon contrast (white-on-white problem)
Same-origin proxying makes icon pixels readable, so `components/favicon-tone.ts` samples each favicon once on load (alpha-weighted luminance + colorfulness):
- **Grayscale glyphs** that would vanish (GitHub/Umami in dark, white marks in light) `invert(1)` to the theme's ink — no chip, reads native.
- **Colored glyphs** (Astro's red flame — inverting would corrupt the brand color) sit on a quiet chip (`--primary` softened toward the page), 2px border-box padding, slot size unchanged.
- **Opaque near-white tiles** get a hairline edge on the light page; opaque dark tiles are left alone (their glyphs carry their own contrast).
- A `MutationObserver` on the `.dark` class resamples after theme flips — scheme-aware SVG favicons (Nextra, Astro serve light variants in dark mode) classify correctly per theme.

## Review
Two-axis review (standards + spec) ran via sub-agents; all findings addressed: design-doc contradiction on fixed card dimensions resolved, 404s made cacheable, content-length pre-check added, pre-hydration favicon error handling closed, failed-image degrade path added.

## Testing
- 18 new/updated unit tests (`link-previews`, `favicon-tone`, `external-link`); app + components + lib (root, security, ama) all green — 200+ tests. `lib/media` hangs in this sandbox with or without this diff (pre-existing, untouched here).
- Verified live in the browser in both themes: proxied requests + cache headers, warm-cache timings, hover-card geometry, image-failure degrade, tone treatment matrix, live theme-flip resampling.
- Typecheck clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a server-side caching proxy (`/link-media/[kind]`) for favicons and OG images, backed by Next.js data cache (`'use cache'`) and a build-time allowlist so the proxy can't be aimed at arbitrary hosts. It also adds client-side favicon tone classification via canvas pixel sampling, polishes hover card geometry (content-driven height, concentric border radii), and degrades gracefully when an OG image fails.

- **Proxy route** (`app/link-media/[kind]/route.ts` + `lib/link-media.ts`): fetches from `og.zolplay.com` through the allowlist, enforces a 4 MB cap with both a declared-length pre-check and a post-buffer guard, and returns a strict `default-src 'none'; sandbox` CSP via `next.config.ts` (overriding the global policy — no duplicate header).
- **Favicon tone** (`components/favicon-tone.ts`): alpha-weighted luminance and colorfulness classify each same-origin favicon into one of five treatment classes; a `MutationObserver` resamples after theme flips; cross-origin fallback icons taint the canvas and are left untagged.
- **Hover card polish** (`components/external-link.tsx`, `app/globals.css`): fixed `17rem` height removed in favour of content-driven layout; image failure now collapses to a text card (description restored) instead of holding an empty frame.

<h3>Confidence Score: 5/5</h3>

Safe to merge — allowlist, size cap, CSP, and canvas-taint handling are all in place; the one comment is a minor trigger-scope observation with no user-visible impact on this site.

The allowlist is built from a trusted build-time snapshot, so the proxy cannot be aimed at arbitrary hosts. Size limits are enforced both before and after buffering. The strict sandbox CSP is applied via next.config.ts without duplication. Canvas sampling is guarded against cross-origin taint. All changed paths have corresponding tests. The only finding is the MutationObserver firing on any class change rather than exclusively the dark-mode toggle, which carries no practical risk on this blog.

No files require special attention. components/favicon-tone.ts has the minor observer-scope observation noted above.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/link-media/[kind]/route.ts | New proxy route for favicons and OG images; uses 'use cache' + allowlist validation, 4 MB size cap with pre- and post-buffer checks, and 502 on upstream error with short cache TTL. |
| lib/link-media.ts | Allowlist built from build-time snapshot origins (favicons) and exact page URLs (images); rejects unlisted targets by returning null; extra origins for chrome links. |
| components/favicon-tone.ts | New module sampling alpha-weighted luminance/colorfulness via canvas to classify favicons; MutationObserver on document.documentElement class fires on any class change, not exclusively the dark toggle. |
| components/external-link.tsx | Adds Favicon sub-component with pre-hydration ref handling; replaces hideFailedImage on the OG image with setImageFailed state to degrade the card to text form; description now suppressed when image is present. |
| next.config.ts | Adds a /link-media/:path* header rule with strict CSP (default-src 'none'; sandbox), which overrides the global CSP for that route — correctly resulting in a single header. |
| app/globals.css | Replaces fixed 17rem card height with content-driven layout + concentric border-radius; adds data-tone CSS rules for favicon invert/chip/edge treatments. |
| lib/link-previews.ts | faviconUrl now resolves origin-only and routes through /link-media when allowlisted; falls back to og.zolplay.com for unknown targets; ogImageUrl follows the same two-tier pattern. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant B as Browser
    participant N as Next.js /link-media/[kind]
    participant C as Data Cache
    participant Z as og.zolplay.com

    B->>N: "GET /link-media/favicon?url=https://astro.build"
    N->>N: upstreamLinkMediaUrl() — allowlist check
    alt target not in allowlist
        N-->>B: "404 (Cache-Control: max-age=300)"
    else target allowlisted
        N->>C: fetchLinkMedia(upstream)
        alt cache hit
            C-->>N: "{body, contentType}"
        else cache miss
            C->>Z: fetch favicon/image
            Z-->>C: image bytes
            C->>C: "validate content-type, size <= 4 MB"
            C-->>N: "{body, contentType}"
        end
        N-->>B: "200 image (Cache-Control: max-age=86400)"
    end

    B->>B: classifyFaviconTone(img)
    B->>B: canvas.drawImage + getImageData + faviconTone()
    B->>B: "img.dataset.tone = tone value"
    B->>B: CSS applies invert/chip/edge via data-tone selector
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant B as Browser
    participant N as Next.js /link-media/[kind]
    participant C as Data Cache
    participant Z as og.zolplay.com

    B->>N: "GET /link-media/favicon?url=https://astro.build"
    N->>N: upstreamLinkMediaUrl() — allowlist check
    alt target not in allowlist
        N-->>B: "404 (Cache-Control: max-age=300)"
    else target allowlisted
        N->>C: fetchLinkMedia(upstream)
        alt cache hit
            C-->>N: "{body, contentType}"
        else cache miss
            C->>Z: fetch favicon/image
            Z-->>C: image bytes
            C->>C: "validate content-type, size <= 4 MB"
            C-->>N: "{body, contentType}"
        end
        N-->>B: "200 image (Cache-Control: max-age=86400)"
    end

    B->>B: classifyFaviconTone(img)
    B->>B: canvas.drawImage + getImageData + faviconTone()
    B->>B: "img.dataset.tone = tone value"
    B->>B: CSS applies invert/chip/edge via data-tone selector
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(link-media): single CSP header and h..."](https://github.com/calicastle/cali.so/commit/ad8e617063ac0f1f6e25657c8766dd9b9771033f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44697575)</sub>

<!-- /greptile_comment -->