### PR TITLE
fix: prevent portrait theme flash

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1849,6 +1849,7 @@ a:focus-visible .external-label .external-mark {
 [data-halftone] {
   display: block;
   position: relative;
+  aspect-ratio: 1;
   user-select: none;
 }
 
@@ -1857,12 +1858,39 @@ a:focus-visible .external-label .external-mark {
 .halftone-source {
   display: block;
   width: 100%;
-  height: auto;
+  height: 100%;
+  object-fit: cover;
   filter: grayscale(1) contrast(1.05);
   opacity: 0.85;
 }
 
-[data-halftone][data-ready] .halftone-source {
+.halftone-source[data-theme='dark'] {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .halftone-source[data-theme='light'] {
+    opacity: 0;
+  }
+
+  .halftone-source[data-theme='dark'] {
+    opacity: 0.85;
+  }
+}
+
+html.light .halftone-source[data-theme='light'],
+html.dark .halftone-source[data-theme='dark'] {
+  opacity: 0.85;
+}
+
+html.light .halftone-source[data-theme='dark'],
+html.dark .halftone-source[data-theme='light'] {
+  opacity: 0;
+}
+
+[data-halftone][data-ready] .halftone-source[data-theme] {
   opacity: 0;
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -1861,7 +1861,11 @@ a:focus-visible .external-label .external-mark {
   height: 100%;
   object-fit: cover;
   filter: grayscale(1) contrast(1.05);
-  opacity: 0.85;
+  opacity: 1;
+}
+
+.halftone-source[data-theme='light'] {
+  filter: contrast(1.12) saturate(1.05);
 }
 
 .halftone-source[data-theme='dark'] {
@@ -1880,7 +1884,10 @@ a:focus-visible .external-label .external-mark {
   }
 }
 
-html.light .halftone-source[data-theme='light'],
+html.light .halftone-source[data-theme='light'] {
+  opacity: 1;
+}
+
 html.dark .halftone-source[data-theme='dark'] {
   opacity: 0.85;
 }

--- a/components/halftone-portrait.tsx
+++ b/components/halftone-portrait.tsx
@@ -267,6 +267,19 @@ export function HalftonePortrait({
 
   return (
     <span ref={wrapperRef} className={className} data-halftone>
+      {/* Keep both no-JS fallbacks in the document so CSS can select the
+          pre-paint-resolved theme before the canvas is ready. */}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={srcLight}
+        alt=""
+        width={1000}
+        height={1000}
+        crossOrigin="anonymous"
+        className="halftone-source"
+        data-theme="light"
+        aria-hidden
+      />
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         src={srcDark}
@@ -275,6 +288,7 @@ export function HalftonePortrait({
         height={1000}
         crossOrigin="anonymous"
         className="halftone-source"
+        data-theme="dark"
         aria-hidden
       />
       <canvas


### PR DESCRIPTION
The portrait fallback now follows the theme resolved by the pre-paint script before the interactive halftone canvas initializes. Light mode no longer flashes the dark portrait during the initial render.

## Changes

- Render dedicated light and dark fallback sources and select between them from the resolved root theme.
- Keep the operating-system color scheme as the no-JavaScript fallback.
- Preserve the square portrait frame while the canvas loads.
- Show the light portrait at full opacity with stronger natural contrast while retaining the quieter dark treatment.

## Verification

- `pnpm typecheck`
- `pnpm test:unit`: 64 files and 387 tests passed
- Playwright initial-render checks with saved light theme on a dark OS preference and saved dark theme on a light OS preference
- Playwright hydration check confirming both fallback sources are hidden after the canvas becomes ready

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a theme-flash bug where the dark portrait appeared briefly in light mode before the interactive halftone canvas initialised. The fix renders both a light and a dark `<img>` fallback into the DOM simultaneously and uses a CSS cascade (base defaults → OS media query → `html.light`/`html.dark` class override → `data-ready` teardown) to select the correct one based on the pre-paint-resolved theme.

- A second `<img data-theme="light">` is added alongside the existing dark one; CSS specificity ensures the `html.light`/`html.dark` class selectors (0,3,1) beat the `@media (prefers-color-scheme: dark)` rules (0,2,0), so a saved theme always wins over the OS preference.
- The wrapper gains `aspect-ratio: 1` to hold the square frame while both images load, and the `[data-halftone][data-ready]` selector (0,4,0) hides both fallbacks once the canvas is ready regardless of the active theme class.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to pre-canvas fallback rendering and does not touch the canvas drawing, theme switching, or any data paths.

The CSS cascade is carefully layered so that every combination of saved theme vs OS preference resolves to exactly one visible image, and the `data-ready` teardown selector has higher specificity than all theme selectors so it always wins. The JS side is untouched. The light `<img>` shares the same `crossOrigin="anonymous"` attribute as the existing dark one, so both hit the same cache entry that the canvas JS already uses.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| components/halftone-portrait.tsx | Adds a second fallback `<img>` for the light theme with `data-theme="light"`, paired with `crossOrigin="anonymous"` and `aria-hidden`, mirroring the existing dark-theme img; the canvas JS logic is unchanged. |
| app/globals.css | Adds `aspect-ratio: 1` to the wrapper, converts image sizing to `height: 100% / object-fit: cover`, and introduces a well-structured 4-layer CSS cascade (base → dark image default → OS media query → html class override → data-ready teardown) to show the correct portrait before the canvas initialises. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Page Load] --> B{html.light or html.dark class set by pre-paint script?}

    B -->|Yes - html.light| C[Show light image\nopacity: 1]
    B -->|Yes - html.dark| D[Show dark image\nopacity: 0.85]
    B -->|No - JS absent/not run yet| E{prefers-color-scheme: dark?}

    E -->|Yes| F[Show dark image\nopacity: 0.85]
    E -->|No| G[Show light image\nopacity: 1]

    C & D & F & G --> H[canvas + ResizeObserver initialise]
    H --> I[loadImage light + dark via JS]
    I --> J[layout called: buildField + draw canvas]
    J --> K[wrapper.dataset.ready set]
    K --> L["[data-halftone][data-ready] .halftone-source[data-theme]\nopacity: 0 — both images hidden"]
    L --> M[Canvas renders halftone dots]
    M --> N[Theme switch via MutationObserver\ncrossfade between dot fields]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Page Load] --> B{html.light or html.dark class set by pre-paint script?}

    B -->|Yes - html.light| C[Show light image\nopacity: 1]
    B -->|Yes - html.dark| D[Show dark image\nopacity: 0.85]
    B -->|No - JS absent/not run yet| E{prefers-color-scheme: dark?}

    E -->|Yes| F[Show dark image\nopacity: 0.85]
    E -->|No| G[Show light image\nopacity: 1]

    C & D & F & G --> H[canvas + ResizeObserver initialise]
    H --> I[loadImage light + dark via JS]
    I --> J[layout called: buildField + draw canvas]
    J --> K[wrapper.dataset.ready set]
    K --> L["[data-halftone][data-ready] .halftone-source[data-theme]\nopacity: 0 — both images hidden"]
    L --> M[Canvas renders halftone dots]
    M --> N[Theme switch via MutationObserver\ncrossfade between dot fields]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["style: strengthen light portrait contras..."](https://github.com/calicastle/cali.so/commit/ce70b0ef5587781b1fb65c478732abb47d79ad7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44700036)</sub>

<!-- /greptile_comment -->