### PR TITLE
Use Neon rate limits in Preview environments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,10 +21,12 @@ CRON_SECRET=
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 
-# Upstash (rate limiting authenticated admin mutations)
-UPSTASH_REDIS_REST_URL=
-UPSTASH_REDIS_REST_TOKEN=
-# Vercel Marketplace aliases are also accepted as a complete pair:
+# Production-only Upstash (authenticated admin mutations and Media Alt Text
+# Suggestions). Preview uses its isolated Neon database; Local and CI use
+# process-local limits. Configure one complete pair in Production only:
+# UPSTASH_REDIS_REST_URL=
+# UPSTASH_REDIS_REST_TOKEN=
+# Vercel Marketplace aliases are accepted instead of the native pair:
 # KV_REST_API_URL=
 # KV_REST_API_TOKEN=
 ADMIN_MUTATION_RATE_LIMIT_MAX_REQUESTS=30

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,8 +34,6 @@ jobs:
       RATE_LIMIT_HASH_KEY: AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI=
       GOOGLE_CLIENT_ID: ci.apps.googleusercontent.com
       GOOGLE_CLIENT_SECRET: ci-google-secret
-      UPSTASH_REDIS_REST_URL: https://example.upstash.io
-      UPSTASH_REDIS_REST_TOKEN: ci-redis-token
       SITE_URL: https://cali.so
       BUNNY_MEDIA_REGION: ny
       BUNNY_ORIGINALS_ZONE: ci-media-originals

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ pnpm audit:prod
   a lockfile update, and the complete validation suite.
 - Preview and Production use separate credentials and data. Preview data must
   be disposable or irreversibly sanitized.
+- Redis is Production-only. Preview rate limits use its isolated Neon database;
+  Local and CI use process-local limits.
 - The Vercel runtime never receives migration credentials.
 - Owner admin remains available in every environment and relies on
   Clerk authentication plus the server-checked

--- a/db/migrations/0010_rate_limit_windows.sql
+++ b/db/migrations/0010_rate_limit_windows.sql
@@ -1,10 +1,10 @@
 CREATE TABLE "rate_limit_windows" (
 	"scope" varchar(128) NOT NULL,
 	"key_hash" varchar(64) NOT NULL,
-	"request_count" integer NOT NULL,
+	"request_times" timestamp with time zone[] NOT NULL,
 	"window_expires_at" timestamp with time zone NOT NULL,
 	CONSTRAINT "rate_limit_windows_scope_key_hash_pk" PRIMARY KEY("scope","key_hash"),
-	CONSTRAINT "rate_limit_windows_request_count_check" CHECK ("rate_limit_windows"."request_count" > 0)
+	CONSTRAINT "rate_limit_windows_request_times_check" CHECK (cardinality("rate_limit_windows"."request_times") > 0)
 );
 --> statement-breakpoint
 CREATE INDEX "rate_limit_windows_expiry_idx" ON "rate_limit_windows" USING btree ("window_expires_at");

--- a/db/migrations/0010_rate_limit_windows.sql
+++ b/db/migrations/0010_rate_limit_windows.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "rate_limit_windows" (
+	"scope" varchar(128) NOT NULL,
+	"key_hash" varchar(64) NOT NULL,
+	"request_count" integer NOT NULL,
+	"window_expires_at" timestamp with time zone NOT NULL,
+	CONSTRAINT "rate_limit_windows_scope_key_hash_pk" PRIMARY KEY("scope","key_hash"),
+	CONSTRAINT "rate_limit_windows_request_count_check" CHECK ("rate_limit_windows"."request_count" > 0)
+);
+--> statement-breakpoint
+CREATE INDEX "rate_limit_windows_expiry_idx" ON "rate_limit_windows" USING btree ("window_expires_at");

--- a/db/migrations/meta/0010_snapshot.json
+++ b/db/migrations/meta/0010_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "16090278-e2a7-479e-8ae1-a24cbd22d2d6",
+  "id": "fda4f8b0-5f95-4cce-b927-a3581d6449ef",
   "prevId": "255192c2-5fad-453b-9433-9ee567ec62fe",
   "version": "7",
   "dialect": "postgresql",
@@ -2080,9 +2080,9 @@
           "primaryKey": false,
           "notNull": true
         },
-        "request_count": {
-          "name": "request_count",
-          "type": "integer",
+        "request_times": {
+          "name": "request_times",
+          "type": "timestamp with time zone[]",
           "primaryKey": false,
           "notNull": true
         },
@@ -2123,9 +2123,9 @@
       "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {
-        "rate_limit_windows_request_count_check": {
-          "name": "rate_limit_windows_request_count_check",
-          "value": "\"rate_limit_windows\".\"request_count\" > 0"
+        "rate_limit_windows_request_times_check": {
+          "name": "rate_limit_windows_request_times_check",
+          "value": "cardinality(\"rate_limit_windows\".\"request_times\") > 0"
         }
       },
       "isRLSEnabled": false

--- a/db/migrations/meta/0010_snapshot.json
+++ b/db/migrations/meta/0010_snapshot.json
@@ -1,0 +1,2195 @@
+{
+  "id": "16090278-e2a7-479e-8ae1-a24cbd22d2d6",
+  "prevId": "255192c2-5fad-453b-9433-9ee567ec62fe",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ama_admin_sessions": {
+      "name": "ama_admin_sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_admin_sessions_expires_at_idx": {
+          "name": "ama_admin_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ama_auth_tokens": {
+      "name": "ama_auth_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_auth_tokens_expires_at_idx": {
+          "name": "ama_auth_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ama_availability_windows": {
+      "name": "ama_availability_windows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "iso_weekday": {
+          "name": "iso_weekday",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_minute": {
+          "name": "start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_minute": {
+          "name": "end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_availability_windows_order_idx": {
+          "name": "ama_availability_windows_order_idx",
+          "columns": [
+            {
+              "expression": "iso_weekday",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_minute",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_minute",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_availability_windows_iso_weekday_check": {
+          "name": "ama_availability_windows_iso_weekday_check",
+          "value": "\"ama_availability_windows\".\"iso_weekday\" BETWEEN 1 AND 7"
+        },
+        "ama_availability_windows_start_minute_check": {
+          "name": "ama_availability_windows_start_minute_check",
+          "value": "\"ama_availability_windows\".\"start_minute\" BETWEEN 0 AND 1439"
+        },
+        "ama_availability_windows_end_minute_check": {
+          "name": "ama_availability_windows_end_minute_check",
+          "value": "\"ama_availability_windows\".\"end_minute\" BETWEEN 1 AND 1440"
+        },
+        "ama_availability_windows_same_day_check": {
+          "name": "ama_availability_windows_same_day_check",
+          "value": "\"ama_availability_windows\".\"start_minute\" < \"ama_availability_windows\".\"end_minute\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_google_calendar_connections": {
+      "name": "ama_google_calendar_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_email": {
+          "name": "calendar_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_summary": {
+          "name": "calendar_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_scopes": {
+          "name": "granted_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "refresh_token_envelope": {
+          "name": "refresh_token_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_google_calendar_connections_singleton_check": {
+          "name": "ama_google_calendar_connections_singleton_check",
+          "value": "\"ama_google_calendar_connections\".\"id\" = 1"
+        },
+        "ama_google_calendar_connections_status_check": {
+          "name": "ama_google_calendar_connections_status_check",
+          "value": "\"ama_google_calendar_connections\".\"status\" IN ('disconnected', 'connected', 'expired', 'revoked', 'denied_scope', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_google_oauth_attempts": {
+      "name": "ama_google_oauth_attempts",
+      "schema": "",
+      "columns": {
+        "state_hash": {
+          "name": "state_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pkce_verifier_envelope": {
+          "name": "pkce_verifier_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_google_oauth_attempts_expires_at_idx": {
+          "name": "ama_google_oauth_attempts_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_active_photo_publication": {
+      "name": "media_active_photo_publication",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "published_selection_id": {
+          "name": "published_selection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_active_photo_publication_selection_uidx": {
+          "name": "media_active_photo_publication_selection_uidx",
+          "columns": [
+            {
+              "expression": "published_selection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_active_photo_publication_published_selection_id_media_published_photo_selections_id_fk": {
+          "name": "media_active_photo_publication_published_selection_id_media_published_photo_selections_id_fk",
+          "tableFrom": "media_active_photo_publication",
+          "tableTo": "media_published_photo_selections",
+          "columnsFrom": [
+            "published_selection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_active_photo_publication_singleton_check": {
+          "name": "media_active_photo_publication_singleton_check",
+          "value": "\"media_active_photo_publication\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_asset_purge_jobs": {
+      "name": "media_asset_purge_jobs",
+      "schema": "",
+      "columns": {
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_deleted_at": {
+          "name": "original_deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "media_asset_purge_jobs_owner_idx": {
+          "name": "media_asset_purge_jobs_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_asset_purge_jobs_owner_check": {
+          "name": "media_asset_purge_jobs_owner_check",
+          "value": "length(btrim(\"media_asset_purge_jobs\".\"owner_user_id\")) > 0"
+        },
+        "media_asset_purge_jobs_claim_check": {
+          "name": "media_asset_purge_jobs_claim_check",
+          "value": "num_nonnulls(\"media_asset_purge_jobs\".\"claim_token\", \"media_asset_purge_jobs\".\"claim_expires_at\") IN (0, 2)"
+        },
+        "media_asset_purge_jobs_error_check": {
+          "name": "media_asset_purge_jobs_error_check",
+          "value": "\"media_asset_purge_jobs\".\"last_error_code\" IS NULL OR length(btrim(\"media_asset_purge_jobs\".\"last_error_code\")) > 0"
+        },
+        "media_asset_purge_jobs_completion_check": {
+          "name": "media_asset_purge_jobs_completion_check",
+          "value": "(\"media_asset_purge_jobs\".\"completed_at\" IS NULL AND \"media_asset_purge_jobs\".\"original_key\" IS NOT NULL) OR (\"media_asset_purge_jobs\".\"completed_at\" IS NOT NULL AND \"media_asset_purge_jobs\".\"original_key\" IS NULL AND \"media_asset_purge_jobs\".\"original_deleted_at\" IS NOT NULL AND \"media_asset_purge_jobs\".\"claim_token\" IS NULL AND \"media_asset_purge_jobs\".\"claim_expires_at\" IS NULL AND \"media_asset_purge_jobs\".\"last_error_code\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_asset_purge_renditions": {
+      "name": "media_asset_purge_renditions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_deleted_at": {
+          "name": "object_deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cdn_purged_at": {
+          "name": "cdn_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "media_asset_purge_renditions_object_uidx": {
+          "name": "media_asset_purge_renditions_object_uidx",
+          "columns": [
+            {
+              "expression": "media_asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_asset_purge_renditions_media_asset_id_media_asset_purge_jobs_media_asset_id_fk": {
+          "name": "media_asset_purge_renditions_media_asset_id_media_asset_purge_jobs_media_asset_id_fk",
+          "tableFrom": "media_asset_purge_renditions",
+          "tableTo": "media_asset_purge_jobs",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "media_asset_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_asset_purge_renditions_object_key_check": {
+          "name": "media_asset_purge_renditions_object_key_check",
+          "value": "length(btrim(\"media_asset_purge_renditions\".\"object_key\")) > 0"
+        },
+        "media_asset_purge_renditions_progress_check": {
+          "name": "media_asset_purge_renditions_progress_check",
+          "value": "\"media_asset_purge_renditions\".\"cdn_purged_at\" IS NULL OR \"media_asset_purge_renditions\".\"object_deleted_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_assets": {
+      "name": "media_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "upload_intent_id": {
+          "name": "upload_intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'image'"
+        },
+        "catalog_state": {
+          "name": "catalog_state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "processing_state": {
+          "name": "processing_state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upload_initiated'"
+        },
+        "processing_error_code": {
+          "name": "processing_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_content_type": {
+          "name": "original_content_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_byte_size": {
+          "name": "original_byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_checksum_sha256": {
+          "name": "original_checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera_make": {
+          "name": "camera_make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera_model": {
+          "name": "camera_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lens": {
+          "name": "lens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_length_millimeters": {
+          "name": "focal_length_millimeters",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aperture": {
+          "name": "aperture",
+          "type": "numeric(6, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutter_speed_seconds": {
+          "name": "shutter_speed_seconds",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iso": {
+          "name": "iso",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_point_x": {
+          "name": "focal_point_x",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_point_y": {
+          "name": "focal_point_y",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_location_envelope": {
+          "name": "capture_location_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_label_zh_hans": {
+          "name": "location_label_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_label_en": {
+          "name": "location_label_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_suggestion_zh_hans": {
+          "name": "alt_text_suggestion_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_suggestion_en": {
+          "name": "alt_text_suggestion_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_suggestion_model": {
+          "name": "alt_text_suggestion_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_suggested_at": {
+          "name": "alt_text_suggested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_zh_hans": {
+          "name": "alt_text_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_en": {
+          "name": "alt_text_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_approved_at": {
+          "name": "alt_text_approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purge_started_at": {
+          "name": "purge_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_assets_upload_intent_uidx": {
+          "name": "media_assets_upload_intent_uidx",
+          "columns": [
+            {
+              "expression": "upload_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_assets_original_key_uidx": {
+          "name": "media_assets_original_key_uidx",
+          "columns": [
+            {
+              "expression": "original_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_assets_library_idx": {
+          "name": "media_assets_library_idx",
+          "columns": [
+            {
+              "expression": "catalog_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processing_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_assets_upload_intent_id_media_upload_intents_id_fk": {
+          "name": "media_assets_upload_intent_id_media_upload_intents_id_fk",
+          "tableFrom": "media_assets",
+          "tableTo": "media_upload_intents",
+          "columnsFrom": [
+            "upload_intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_assets_kind_check": {
+          "name": "media_assets_kind_check",
+          "value": "\"media_assets\".\"kind\" = 'image'"
+        },
+        "media_assets_catalog_state_check": {
+          "name": "media_assets_catalog_state_check",
+          "value": "\"media_assets\".\"catalog_state\" IN ('active', 'archived', 'purging')"
+        },
+        "media_assets_processing_state_check": {
+          "name": "media_assets_processing_state_check",
+          "value": "\"media_assets\".\"processing_state\" IN ('upload_initiated', 'original_verified', 'processing', 'ready', 'retryable_failure', 'repair_required')"
+        },
+        "media_assets_processing_error_check": {
+          "name": "media_assets_processing_error_check",
+          "value": "(\"media_assets\".\"processing_state\" IN ('retryable_failure', 'repair_required')) = (\"media_assets\".\"processing_error_code\" IS NOT NULL AND length(btrim(\"media_assets\".\"processing_error_code\")) > 0)"
+        },
+        "media_assets_original_key_check": {
+          "name": "media_assets_original_key_check",
+          "value": "length(btrim(\"media_assets\".\"original_key\")) > 0"
+        },
+        "media_assets_original_content_type_check": {
+          "name": "media_assets_original_content_type_check",
+          "value": "\"media_assets\".\"original_content_type\" IN ('image/jpeg', 'image/png', 'image/heic', 'image/heif')"
+        },
+        "media_assets_original_byte_size_check": {
+          "name": "media_assets_original_byte_size_check",
+          "value": "\"media_assets\".\"original_byte_size\" BETWEEN 1 AND 52428800"
+        },
+        "media_assets_original_checksum_check": {
+          "name": "media_assets_original_checksum_check",
+          "value": "\"media_assets\".\"original_checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "media_assets_dimensions_check": {
+          "name": "media_assets_dimensions_check",
+          "value": "num_nonnulls(\"media_assets\".\"width\", \"media_assets\".\"height\") IN (0, 2) AND (\"media_assets\".\"width\" IS NULL OR (\"media_assets\".\"width\" > 0 AND \"media_assets\".\"height\" > 0 AND (\"media_assets\".\"width\"::bigint * \"media_assets\".\"height\"::bigint) <= 100000000))"
+        },
+        "media_assets_focal_point_check": {
+          "name": "media_assets_focal_point_check",
+          "value": "num_nonnulls(\"media_assets\".\"focal_point_x\", \"media_assets\".\"focal_point_y\") IN (0, 2) AND (\"media_assets\".\"focal_point_x\" IS NULL OR (\"media_assets\".\"focal_point_x\" BETWEEN 0 AND 1 AND \"media_assets\".\"focal_point_y\" BETWEEN 0 AND 1))"
+        },
+        "media_assets_camera_values_check": {
+          "name": "media_assets_camera_values_check",
+          "value": "(\"media_assets\".\"focal_length_millimeters\" IS NULL OR \"media_assets\".\"focal_length_millimeters\" > 0) AND (\"media_assets\".\"aperture\" IS NULL OR \"media_assets\".\"aperture\" > 0) AND (\"media_assets\".\"shutter_speed_seconds\" IS NULL OR \"media_assets\".\"shutter_speed_seconds\" > 0) AND (\"media_assets\".\"iso\" IS NULL OR \"media_assets\".\"iso\" > 0)"
+        },
+        "media_assets_alt_suggestion_check": {
+          "name": "media_assets_alt_suggestion_check",
+          "value": "num_nonnulls(\"media_assets\".\"alt_text_suggestion_zh_hans\", \"media_assets\".\"alt_text_suggestion_en\", \"media_assets\".\"alt_text_suggestion_model\", \"media_assets\".\"alt_text_suggested_at\") IN (0, 4) AND (\"media_assets\".\"alt_text_suggestion_zh_hans\" IS NULL OR (length(btrim(\"media_assets\".\"alt_text_suggestion_zh_hans\")) > 0 AND length(btrim(\"media_assets\".\"alt_text_suggestion_en\")) > 0 AND length(btrim(\"media_assets\".\"alt_text_suggestion_model\")) > 0))"
+        },
+        "media_assets_alt_text_check": {
+          "name": "media_assets_alt_text_check",
+          "value": "num_nonnulls(\"media_assets\".\"alt_text_zh_hans\", \"media_assets\".\"alt_text_en\", \"media_assets\".\"alt_text_approved_at\") IN (0, 3) AND (\"media_assets\".\"alt_text_zh_hans\" IS NULL OR (length(btrim(\"media_assets\".\"alt_text_zh_hans\")) > 0 AND length(btrim(\"media_assets\".\"alt_text_en\")) > 0))"
+        },
+        "media_assets_archive_check": {
+          "name": "media_assets_archive_check",
+          "value": "(\"media_assets\".\"catalog_state\" = 'active' AND \"media_assets\".\"archived_at\" IS NULL AND \"media_assets\".\"purge_started_at\" IS NULL) OR (\"media_assets\".\"catalog_state\" = 'archived' AND \"media_assets\".\"archived_at\" IS NOT NULL AND \"media_assets\".\"purge_started_at\" IS NULL) OR (\"media_assets\".\"catalog_state\" = 'purging' AND \"media_assets\".\"archived_at\" IS NOT NULL AND \"media_assets\".\"purge_started_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_photo_selection_draft_entries": {
+      "name": "media_photo_selection_draft_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_photo_selection_draft_entries_asset_uidx": {
+          "name": "media_photo_selection_draft_entries_asset_uidx",
+          "columns": [
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_photo_selection_draft_entries_position_uidx": {
+          "name": "media_photo_selection_draft_entries_position_uidx",
+          "columns": [
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_photo_selection_draft_entries_draft_id_media_photo_selection_drafts_id_fk": {
+          "name": "media_photo_selection_draft_entries_draft_id_media_photo_selection_drafts_id_fk",
+          "tableFrom": "media_photo_selection_draft_entries",
+          "tableTo": "media_photo_selection_drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_photo_selection_draft_entries_media_asset_id_media_assets_id_fk": {
+          "name": "media_photo_selection_draft_entries_media_asset_id_media_assets_id_fk",
+          "tableFrom": "media_photo_selection_draft_entries",
+          "tableTo": "media_assets",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_photo_selection_draft_entries_position_check": {
+          "name": "media_photo_selection_draft_entries_position_check",
+          "value": "\"media_photo_selection_draft_entries\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_photo_selection_drafts": {
+      "name": "media_photo_selection_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_photo_selection_drafts_owner_uidx": {
+          "name": "media_photo_selection_drafts_owner_uidx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_photo_selection_drafts_owner_check": {
+          "name": "media_photo_selection_drafts_owner_check",
+          "value": "length(btrim(\"media_photo_selection_drafts\".\"owner_user_id\")) > 0"
+        },
+        "media_photo_selection_drafts_revision_check": {
+          "name": "media_photo_selection_drafts_revision_check",
+          "value": "\"media_photo_selection_drafts\".\"revision\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_published_photo_selection_entries": {
+      "name": "media_published_photo_selection_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "published_selection_id": {
+          "name": "published_selection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_media_asset_id": {
+          "name": "source_media_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "focal_point_x": {
+          "name": "focal_point_x",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_point_y": {
+          "name": "focal_point_y",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_zh_hans": {
+          "name": "alt_text_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt_text_en": {
+          "name": "alt_text_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_label_zh_hans": {
+          "name": "location_label_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_label_en": {
+          "name": "location_label_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera_make": {
+          "name": "camera_make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera_model": {
+          "name": "camera_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lens": {
+          "name": "lens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_length_millimeters": {
+          "name": "focal_length_millimeters",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aperture": {
+          "name": "aperture",
+          "type": "numeric(6, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutter_speed_seconds": {
+          "name": "shutter_speed_seconds",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iso": {
+          "name": "iso",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_published_photo_selection_entries_asset_uidx": {
+          "name": "media_published_photo_selection_entries_asset_uidx",
+          "columns": [
+            {
+              "expression": "published_selection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_media_asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_published_photo_selection_entries_position_uidx": {
+          "name": "media_published_photo_selection_entries_position_uidx",
+          "columns": [
+            {
+              "expression": "published_selection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_published_photo_selection_entries_published_selection_id_media_published_photo_selections_id_fk": {
+          "name": "media_published_photo_selection_entries_published_selection_id_media_published_photo_selections_id_fk",
+          "tableFrom": "media_published_photo_selection_entries",
+          "tableTo": "media_published_photo_selections",
+          "columnsFrom": [
+            "published_selection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_published_photo_selection_entries_position_check": {
+          "name": "media_published_photo_selection_entries_position_check",
+          "value": "\"media_published_photo_selection_entries\".\"position\" >= 0"
+        },
+        "media_published_photo_selection_entries_dimensions_check": {
+          "name": "media_published_photo_selection_entries_dimensions_check",
+          "value": "\"media_published_photo_selection_entries\".\"width\" > 0 AND \"media_published_photo_selection_entries\".\"height\" > 0 AND (\"media_published_photo_selection_entries\".\"width\"::bigint * \"media_published_photo_selection_entries\".\"height\"::bigint) <= 100000000"
+        },
+        "media_published_photo_selection_entries_focal_point_check": {
+          "name": "media_published_photo_selection_entries_focal_point_check",
+          "value": "num_nonnulls(\"media_published_photo_selection_entries\".\"focal_point_x\", \"media_published_photo_selection_entries\".\"focal_point_y\") IN (0, 2) AND (\"media_published_photo_selection_entries\".\"focal_point_x\" IS NULL OR (\"media_published_photo_selection_entries\".\"focal_point_x\" BETWEEN 0 AND 1 AND \"media_published_photo_selection_entries\".\"focal_point_y\" BETWEEN 0 AND 1))"
+        },
+        "media_published_photo_selection_entries_alt_text_check": {
+          "name": "media_published_photo_selection_entries_alt_text_check",
+          "value": "length(btrim(\"media_published_photo_selection_entries\".\"alt_text_zh_hans\")) > 0 AND length(btrim(\"media_published_photo_selection_entries\".\"alt_text_en\")) > 0"
+        },
+        "media_published_photo_selection_entries_camera_values_check": {
+          "name": "media_published_photo_selection_entries_camera_values_check",
+          "value": "(\"media_published_photo_selection_entries\".\"focal_length_millimeters\" IS NULL OR \"media_published_photo_selection_entries\".\"focal_length_millimeters\" > 0) AND (\"media_published_photo_selection_entries\".\"aperture\" IS NULL OR \"media_published_photo_selection_entries\".\"aperture\" > 0) AND (\"media_published_photo_selection_entries\".\"shutter_speed_seconds\" IS NULL OR \"media_published_photo_selection_entries\".\"shutter_speed_seconds\" > 0) AND (\"media_published_photo_selection_entries\".\"iso\" IS NULL OR \"media_published_photo_selection_entries\".\"iso\" > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_published_photo_selection_renditions": {
+      "name": "media_published_photo_selection_renditions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "published_entry_id": {
+          "name": "published_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_width": {
+          "name": "profile_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_published_photo_selection_renditions_profile_uidx": {
+          "name": "media_published_photo_selection_renditions_profile_uidx",
+          "columns": [
+            {
+              "expression": "published_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_width",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_published_photo_selection_renditions_published_entry_id_media_published_photo_selection_entries_id_fk": {
+          "name": "media_published_photo_selection_renditions_published_entry_id_media_published_photo_selection_entries_id_fk",
+          "tableFrom": "media_published_photo_selection_renditions",
+          "tableTo": "media_published_photo_selection_entries",
+          "columnsFrom": [
+            "published_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_published_photo_selection_renditions_profile_check": {
+          "name": "media_published_photo_selection_renditions_profile_check",
+          "value": "\"media_published_photo_selection_renditions\".\"profile_width\" IN (640, 1024, 1600)"
+        },
+        "media_published_photo_selection_renditions_object_key_check": {
+          "name": "media_published_photo_selection_renditions_object_key_check",
+          "value": "length(btrim(\"media_published_photo_selection_renditions\".\"object_key\")) > 0"
+        },
+        "media_published_photo_selection_renditions_dimensions_check": {
+          "name": "media_published_photo_selection_renditions_dimensions_check",
+          "value": "\"media_published_photo_selection_renditions\".\"width\" BETWEEN 1 AND \"media_published_photo_selection_renditions\".\"profile_width\" AND \"media_published_photo_selection_renditions\".\"height\" > 0 AND (\"media_published_photo_selection_renditions\".\"width\"::bigint * \"media_published_photo_selection_renditions\".\"height\"::bigint) <= 100000000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_published_photo_selections": {
+      "name": "media_published_photo_selections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_revision": {
+          "name": "draft_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_count": {
+          "name": "item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "media_published_photo_selections_idempotency_uidx": {
+          "name": "media_published_photo_selections_idempotency_uidx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_published_photo_selections_draft_revision_uidx": {
+          "name": "media_published_photo_selections_draft_revision_uidx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "draft_revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_published_photo_selections_identity_check": {
+          "name": "media_published_photo_selections_identity_check",
+          "value": "length(btrim(\"media_published_photo_selections\".\"owner_user_id\")) > 0 AND length(btrim(\"media_published_photo_selections\".\"idempotency_key\")) > 0"
+        },
+        "media_published_photo_selections_revision_check": {
+          "name": "media_published_photo_selections_revision_check",
+          "value": "\"media_published_photo_selections\".\"draft_revision\" >= 0"
+        },
+        "media_published_photo_selections_item_count_check": {
+          "name": "media_published_photo_selections_item_count_check",
+          "value": "\"media_published_photo_selections\".\"item_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_renditions": {
+      "name": "media_renditions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_width": {
+          "name": "profile_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum_sha256": {
+          "name": "checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'image/jpeg'"
+        },
+        "color_space": {
+          "name": "color_space",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'srgb'"
+        },
+        "progressive": {
+          "name": "progressive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata_stripped": {
+          "name": "metadata_stripped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_renditions_asset_profile_uidx": {
+          "name": "media_renditions_asset_profile_uidx",
+          "columns": [
+            {
+              "expression": "media_asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_width",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_renditions_object_key_uidx": {
+          "name": "media_renditions_object_key_uidx",
+          "columns": [
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_renditions_media_asset_id_media_assets_id_fk": {
+          "name": "media_renditions_media_asset_id_media_assets_id_fk",
+          "tableFrom": "media_renditions",
+          "tableTo": "media_assets",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_renditions_object_key_check": {
+          "name": "media_renditions_object_key_check",
+          "value": "length(btrim(\"media_renditions\".\"object_key\")) > 0"
+        },
+        "media_renditions_profile_check": {
+          "name": "media_renditions_profile_check",
+          "value": "\"media_renditions\".\"profile_width\" IN (640, 1024, 1600)"
+        },
+        "media_renditions_checksum_check": {
+          "name": "media_renditions_checksum_check",
+          "value": "\"media_renditions\".\"checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "media_renditions_dimensions_check": {
+          "name": "media_renditions_dimensions_check",
+          "value": "\"media_renditions\".\"width\" BETWEEN 1 AND \"media_renditions\".\"profile_width\" AND \"media_renditions\".\"height\" > 0 AND (\"media_renditions\".\"width\"::bigint * \"media_renditions\".\"height\"::bigint) <= 100000000"
+        },
+        "media_renditions_byte_size_check": {
+          "name": "media_renditions_byte_size_check",
+          "value": "\"media_renditions\".\"byte_size\" > 0"
+        },
+        "media_renditions_content_type_check": {
+          "name": "media_renditions_content_type_check",
+          "value": "\"media_renditions\".\"content_type\" = 'image/jpeg'"
+        },
+        "media_renditions_color_space_check": {
+          "name": "media_renditions_color_space_check",
+          "value": "\"media_renditions\".\"color_space\" = 'srgb'"
+        },
+        "media_renditions_progressive_check": {
+          "name": "media_renditions_progressive_check",
+          "value": "\"media_renditions\".\"progressive\" = true"
+        },
+        "media_renditions_metadata_stripped_check": {
+          "name": "media_renditions_metadata_stripped_check",
+          "value": "\"media_renditions\".\"metadata_stripped\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_upload_intents": {
+      "name": "media_upload_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum_sha256": {
+          "name": "checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_upload_intents_owner_idempotency_uidx": {
+          "name": "media_upload_intents_owner_idempotency_uidx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_upload_intents_original_key_uidx": {
+          "name": "media_upload_intents_original_key_uidx",
+          "columns": [
+            {
+              "expression": "original_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_upload_intents_expiry_idx": {
+          "name": "media_upload_intents_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_upload_intents_identity_check": {
+          "name": "media_upload_intents_identity_check",
+          "value": "length(btrim(\"media_upload_intents\".\"owner_user_id\")) > 0 AND length(btrim(\"media_upload_intents\".\"idempotency_key\")) > 0"
+        },
+        "media_upload_intents_original_key_check": {
+          "name": "media_upload_intents_original_key_check",
+          "value": "length(btrim(\"media_upload_intents\".\"original_key\")) > 0"
+        },
+        "media_upload_intents_content_type_check": {
+          "name": "media_upload_intents_content_type_check",
+          "value": "\"media_upload_intents\".\"content_type\" IN ('image/jpeg', 'image/png', 'image/heic', 'image/heif')"
+        },
+        "media_upload_intents_byte_size_check": {
+          "name": "media_upload_intents_byte_size_check",
+          "value": "\"media_upload_intents\".\"byte_size\" BETWEEN 1 AND 52428800"
+        },
+        "media_upload_intents_checksum_check": {
+          "name": "media_upload_intents_checksum_check",
+          "value": "\"media_upload_intents\".\"checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "media_upload_intents_expiry_check": {
+          "name": "media_upload_intents_expiry_check",
+          "value": "\"media_upload_intents\".\"expires_at\" > \"media_upload_intents\".\"created_at\""
+        },
+        "media_upload_intents_completion_check": {
+          "name": "media_upload_intents_completion_check",
+          "value": "\"media_upload_intents\".\"completed_at\" IS NULL OR \"media_upload_intents\".\"completed_at\" >= \"media_upload_intents\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.newsletters": {
+      "name": "newsletters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_windows": {
+      "name": "rate_limit_windows",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_expires_at": {
+          "name": "window_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_windows_expiry_idx": {
+          "name": "rate_limit_windows_expiry_idx",
+          "columns": [
+            {
+              "expression": "window_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_windows_scope_key_hash_pk": {
+          "name": "rate_limit_windows_scope_key_hash_pk",
+          "columns": [
+            "scope",
+            "key_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "rate_limit_windows_request_count_check": {
+          "name": "rate_limit_windows_request_count_check",
+          "value": "\"rate_limit_windows\".\"request_count\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subscribers": {
+      "name": "subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1784261629000,
       "tag": "0009_media_catalog_state",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1784261629001,
+      "tag": "0010_rate_limit_windows",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -7,6 +7,7 @@ import {
   jsonb,
   numeric,
   pgTable,
+  primaryKey,
   serial,
   text,
   timestamp,
@@ -59,6 +60,26 @@ export const amaAdminSessions = pgTable(
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
   },
   (table) => [index('ama_admin_sessions_expires_at_idx').on(table.expiresAt)],
+)
+
+export const rateLimitWindows = pgTable(
+  'rate_limit_windows',
+  {
+    scope: varchar('scope', { length: 128 }).notNull(),
+    keyHash: varchar('key_hash', { length: 64 }).notNull(),
+    requestCount: integer('request_count').notNull(),
+    windowExpiresAt: timestamp('window_expires_at', {
+      withTimezone: true,
+    }).notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.scope, table.keyHash] }),
+    index('rate_limit_windows_expiry_idx').on(table.windowExpiresAt),
+    check(
+      'rate_limit_windows_request_count_check',
+      sql`${table.requestCount} > 0`,
+    ),
+  ],
 )
 
 export const amaAvailabilityWindows = pgTable(

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -67,7 +67,9 @@ export const rateLimitWindows = pgTable(
   {
     scope: varchar('scope', { length: 128 }).notNull(),
     keyHash: varchar('key_hash', { length: 64 }).notNull(),
-    requestCount: integer('request_count').notNull(),
+    requestTimes: timestamp('request_times', { withTimezone: true })
+      .array()
+      .notNull(),
     windowExpiresAt: timestamp('window_expires_at', {
       withTimezone: true,
     }).notNull(),
@@ -76,8 +78,8 @@ export const rateLimitWindows = pgTable(
     primaryKey({ columns: [table.scope, table.keyHash] }),
     index('rate_limit_windows_expiry_idx').on(table.windowExpiresAt),
     check(
-      'rate_limit_windows_request_count_check',
-      sql`${table.requestCount} > 0`,
+      'rate_limit_windows_request_times_check',
+      sql`cardinality(${table.requestTimes}) > 0`,
     ),
   ],
 )

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -39,6 +39,8 @@ Current as of July 2026.
   limits, audit events, and the strict admin CSP remain in force. Public AMA
   mutations, payment, provider, and finalization capabilities stay disabled for
   the v3 production launch.
+- Rate limits use Upstash only in Production. Preview persists its limits in
+  the isolated Neon database, while Local and CI use process-local limits.
 - Security baseline controls from PR #97 remain mandatory: CSP and security
   headers, same-origin mutation policy, rate limits, kill switches,
   privacy-safe audit events, isolated credentials, and security automation.
@@ -127,7 +129,8 @@ The Vercel runtime receives only the CRUD-only `DATABASE_URL`. Never put
   dock owns its SVG filter as an inline style; ordinary blur uses Tailwind
   utilities.
 - Preview and Production credentials and data are separate. Preview data must
-  be disposable or irreversibly sanitized.
+  be disposable or irreversibly sanitized. Never attach Redis credentials to
+  Preview; its rate-limit windows live in the Preview Neon database.
 - The five optional `AMA_*_ENABLED` variables fail closed. Leave every one
   `false` for the v3 launch; owner admin has no capability switch.
 - Design references are private. Public code and documentation use only the

--- a/docs/security/verification.md
+++ b/docs/security/verification.md
@@ -97,6 +97,10 @@ Project checks completed on 2026-07-14 and 2026-07-15 verified:
   the Clerk Dashboard with public metadata `{ "siteOwner": "yes" }` and verify
   a non-owner account receives HTTP 403 from admin APIs. No values are recorded
   here.
+- [ ] Apply migration `0010` to the Preview Neon branch, grant its runtime role
+  CRUD-only access to `rate_limit_windows`, and deploy the database-backed
+  limiter. Then remove every `KV_*`, `REDIS_URL`, and `UPSTASH_*` variable from
+  Preview and keep the storage integration scoped to Production only.
 - [ ] Rotate the Preview-only Google OAuth secret before enabling the Google
   capability; the integration remains disabled meanwhile.
 - [ ] Remove the obsolete `Admin Security` firewall rule for

--- a/docs/v3-cutover-ops-runbook.md
+++ b/docs/v3-cutover-ops-runbook.md
@@ -64,10 +64,23 @@ JSON
   npx vercel env add RESEND_API_KEY preview $SCOPE
   ```
 
-- The `KV_URL`, `KV_REST_API_*`, and `REDIS_URL` group comes from one storage
-  integration connected to both environments. Isolation happens in the
-  dashboard's Storage tab: connect a separate store (or database) for Preview
-  so Production traffic and Preview experiments never share data.
+- Redis is Production-only. In the dashboard's Storage tab, change the
+  existing Upstash integration to target Production only, or remove the
+  integration and reconnect it for Production only. Delete every `KV_*`,
+  `REDIS_URL`, and `UPSTASH_*` variable from Preview. Do not create a Preview
+  Redis store: Preview rate limits use its isolated Neon database.
+
+- Before deploying this runtime contract to Preview, apply migration `0010`
+  with the separately held Preview migration credential. This is sensitive
+  remote database access and requires two fresh explicit confirmations. Never
+  place the migration credential in Vercel:
+
+  ```bash
+  MIGRATION_DATABASE_URL=postgresql://... pnpm db:migrate
+  ```
+
+  Verify the Preview runtime role can only select, insert, update, and delete
+  `rate_limit_windows`; it must not own the table or receive DDL privileges.
 
 - Remove the dead capability switch left behind by ADR-0008:
 
@@ -107,6 +120,12 @@ add AUTH_RATE_LIMIT_WINDOW_SECONDS
 add ADMIN_MUTATION_RATE_LIMIT_MAX_REQUESTS
 add ADMIN_MUTATION_RATE_LIMIT_WINDOW_SECONDS
 
+# Redis rate-limit backend: Production only. A Vercel Marketplace integration
+# may inject KV_REST_API_URL and KV_REST_API_TOKEN instead; configure one
+# complete credential pair, never both pairs and never any pair in Preview.
+add UPSTASH_REDIS_REST_URL
+add UPSTASH_REDIS_REST_TOKEN
+
 # Capability switches — explicitly false for launch.
 add AMA_PUBLIC_MUTATIONS_ENABLED
 add AMA_PAYMENTS_ENABLED
@@ -144,7 +163,7 @@ results in the readiness report:
 ## 5. Production database and migrations
 
 Gated by two fresh explicit confirmations immediately before access. Verify
-the runtime role has only CRUD grants, then apply the nine additive
+the runtime role has only CRUD grants, then apply the ten additive
 migrations with the separately held credential:
 
 ```bash

--- a/docs/v3-cutover-readiness.md
+++ b/docs/v3-cutover-readiness.md
@@ -52,11 +52,11 @@ Renditions. The retired static photo fallback has been removed.
 | Required GitHub checks | FAIL | Neither the `v2` ruleset nor `main` branch protection requires `Quality` and `CodeQL`. The maintainer-operated commands are in `docs/v3-cutover-ops-runbook.md`. |
 | Current Vercel project settings | PASS | Project inspection succeeds with the explicit team scope. The earlier `Not authorized` was a CLI quirk: the team slug `cali` resolves to the personal account, so commands must pass the team ID as `--scope` (see the runbook). |
 | Production capability switches | PASS | All five optional `AMA_*_ENABLED` variables are absent from Production and therefore fail closed. Setting them explicitly `false` remains recommended during provisioning. `AMA_ADMIN_ENABLED` survives in Preview as dead configuration after ADR-0008 and should be removed. |
-| Preview and Production secret isolation | FAIL | `RESEND_API_KEY` is one variable targeting both Production and Preview, and the `KV_*`/`REDIS_URL` group added with the Preview provisioning also targets both environments. |
+| Preview and Production secret isolation | FAIL | `RESEND_API_KEY` is one variable targeting both Production and Preview. The `KV_*`/`REDIS_URL` group also still targets Preview and must be removed there: Redis is Production-only, while Preview rate limits use its isolated Neon database. |
 | Production runtime environment | FAIL | Production `DATABASE_URL` predates the rewrite by over three years, and the v3 server-environment contract is otherwise unmet: no `SESSION_SECRET`, `AMA_ENCRYPTION_KEY`, `RATE_LIMIT_HASH_KEY`, `SITE_URL`, `RESEND_FROM_EMAIL`, rate-limit values, `CRON_SECRET`, or any `BUNNY_*`/`MEDIA_*` variable. The first v3 production build would fail environment validation. |
 | Production runtime database grants | AWAITING CONFIRMATION | Requires two fresh confirmations before inspecting the production role or sensitive cloud state. |
 | Production migration credential | PASS (name level) | `MIGRATION_DATABASE_URL` is absent from every Vercel environment. Its availability to the controlled migration operation is confirmed at cutover time. |
-| Production migrations | AWAITING CONFIRMATION | Nine additive migrations validate locally. Media migrations `0005` through `0009` are required for the v3 photo surface; execution and schema state require a separately authorized cutover step. |
+| Production migrations | AWAITING CONFIRMATION | Ten additive migrations validate locally. Media migrations `0005` through `0009` are required for the v3 photo surface, and `0010` adds Preview's durable rate-limit windows; execution and schema state require a separately authorized cutover step. |
 | Media provider and publication | FAIL | Production has no Bunny or media configuration at all, so the provider boundary, live storage contract, and the two-photo Published Photo Selection cannot exist yet. Provisioning precedes verification. |
 | Other external providers | PASS (name level) | No Google, Tencent, payment, or booking-finalization credentials exist in Production. Legacy-era variables (Clerk, Sanity, Edge Config, a three-year-old Upstash pair) remain for the current `main` site and need pruning or rotation at cutover. |
 | Logs and drains | UNKNOWN | Not exposed through the CLI; verify access, retention, drains, and the privacy allowlist in the Vercel dashboard. |
@@ -193,10 +193,12 @@ Final review artifacts after the accessibility corrections:
 Migrations `0001` through `0004` are additive AMA foundations. Migrations
 `0005` through `0009` define the Media catalog, Photo Selection publication,
 publication revisions, durable Purge progress, and the Catalog State rename.
-Their checked-in snapshots and migration tests pass. Unlike the optional public AMA flows, the v3 public
-photo surfaces require the Media migrations, production Bunny configuration,
-and an active Published Photo Selection. Git remains authoritative for writing
-and ordinary site content, but not for the curated photo wall.
+Migration `0010` adds durable Preview rate-limit windows without storing raw
+request keys. Their checked-in snapshots and migration tests pass. Unlike the
+optional public AMA flows, the v3 public photo surfaces require the Media
+migrations, production Bunny configuration, and an active Published Photo
+Selection. Git remains authoritative for writing and ordinary site content,
+but not for the curated photo wall.
 
 Before cutover, an authorized operator must:
 
@@ -221,7 +223,7 @@ No manual DNS move is expected, but current project ownership, production
 branch, aliases, certificate, and environment scopes must be verified first.
 
 Rollback must prefer promoting the last known-good Vercel production deployment
-or reverting the cutover merge. The nine additive database migrations should
+or reverting the cutover merge. The ten additive database migrations should
 remain in place during application rollback; destructive down migrations are
 not part of the procedure. Record the known-good deployment identifier and an
 operator before cutover.
@@ -235,14 +237,14 @@ The maintainer-operated commands for actions 1 through 4 are collected in
    legacy `DATABASE_URL` with the CRUD-only Neon runtime role and add the
    missing secrets, rate limits, capability switches, and complete Bunny and
    media configuration.
-2. Split the shared `RESEND_API_KEY` and `KV_*`/`REDIS_URL` credentials so
-   Preview and Production hold isolated values, and delete the dead
-   `AMA_ADMIN_ENABLED` variable from Preview.
+2. Split the shared `RESEND_API_KEY`, scope the `KV_*`/`REDIS_URL` integration
+   to Production only, remove every Redis variable from Preview, and delete the
+   dead `AMA_ADMIN_ENABLED` variable from Preview.
 3. Add `Quality` and `CodeQL` as required checks to both `v2` and `main`.
 4. In the Vercel dashboard, verify logs, drains, retention, firewall rules,
    the production-branch mapping, and the certificate.
 5. With two fresh confirmations, verify production runtime database grants
-   and migration state, then apply migrations `0001` through `0009` with the
+   and migration state, then apply migrations `0001` through `0010` with the
    separately supplied migration credential.
 6. Verify the production Bunny and Neon Media boundary, run the protected live
    storage contract, and publish the intended two-photo Published Photo

--- a/lib/ama/security/server.ts
+++ b/lib/ama/security/server.ts
@@ -1,9 +1,7 @@
 import 'server-only'
 
-import { Ratelimit } from '@upstash/ratelimit'
-import { Redis } from '@upstash/redis'
-
 import { getServerEnv } from '../server-env'
+import { createRateLimiter } from '../../rate-limit/server'
 import { amaSecurityAuditSink } from './audit-server'
 import { createAmaSecurity } from './service'
 
@@ -13,17 +11,10 @@ export function getAmaSecurity() {
   if (security) return security
 
   const environment = getServerEnv()
-  const redis = new Redis({
-    url: environment.UPSTASH_REDIS_REST_URL,
-    token: environment.UPSTASH_REDIS_REST_TOKEN,
-  })
-  const limiter = new Ratelimit({
-    redis,
-    limiter: Ratelimit.slidingWindow(
-      environment.ADMIN_MUTATION_RATE_LIMIT_MAX_REQUESTS,
-      `${environment.ADMIN_MUTATION_RATE_LIMIT_WINDOW_SECONDS} s`,
-    ),
+  const limiter = createRateLimiter(environment.rateLimitBackend, {
     prefix: 'cali:ama:admin-mutation',
+    maxRequests: environment.ADMIN_MUTATION_RATE_LIMIT_MAX_REQUESTS,
+    windowSeconds: environment.ADMIN_MUTATION_RATE_LIMIT_WINDOW_SECONDS,
   })
 
   security = createAmaSecurity({

--- a/lib/ama/server-env-schema.ts
+++ b/lib/ama/server-env-schema.ts
@@ -76,6 +76,10 @@ const serverEnvironmentSchema = z
     UPSTASH_REDIS_REST_TOKEN: z.string().trim().min(1).optional(),
     KV_REST_API_URL: redisRestUrl.optional(),
     KV_REST_API_TOKEN: z.string().trim().min(1).optional(),
+    KV_REST_API_READ_ONLY_TOKEN: z.string().trim().min(1).optional(),
+    KV_URL: z.string().trim().min(1).optional(),
+    REDIS_URL: z.string().trim().min(1).optional(),
+    VERCEL_ENV: z.enum(['development', 'preview', 'production']).optional(),
     SITE_URL: z
       .url()
       .refine((value) => {
@@ -102,6 +106,10 @@ const serverEnvironmentSchema = z
         UPSTASH_REDIS_REST_TOKEN,
         KV_REST_API_URL,
         KV_REST_API_TOKEN,
+        KV_REST_API_READ_ONLY_TOKEN,
+        KV_URL,
+        REDIS_URL,
+        VERCEL_ENV,
         GOOGLE_CLIENT_ID,
         GOOGLE_CLIENT_SECRET,
         AMA_GOOGLE_INTEGRATION_ENABLED,
@@ -114,6 +122,15 @@ const serverEnvironmentSchema = z
       const marketplacePairComplete = Boolean(
         KV_REST_API_URL && KV_REST_API_TOKEN,
       )
+      const redisFields = {
+        UPSTASH_REDIS_REST_URL,
+        UPSTASH_REDIS_REST_TOKEN,
+        KV_REST_API_URL,
+        KV_REST_API_TOKEN,
+        KV_REST_API_READ_ONLY_TOKEN,
+        KV_URL,
+        REDIS_URL,
+      }
 
       if (
         Boolean(UPSTASH_REDIS_REST_URL) !== Boolean(UPSTASH_REDIS_REST_TOKEN)
@@ -139,7 +156,11 @@ const serverEnvironmentSchema = z
         })
       }
 
-      if (!upstashPairComplete && !marketplacePairComplete) {
+      if (
+        VERCEL_ENV === 'production' &&
+        !upstashPairComplete &&
+        !marketplacePairComplete
+      ) {
         if (!UPSTASH_REDIS_REST_URL) {
           context.addIssue({
             code: 'custom',
@@ -153,6 +174,18 @@ const serverEnvironmentSchema = z
             path: ['UPSTASH_REDIS_REST_TOKEN'],
             message: 'A complete Redis credential pair is required',
           })
+        }
+      }
+
+      if (VERCEL_ENV !== 'production') {
+        for (const [field, value] of Object.entries(redisFields)) {
+          if (value) {
+            context.addIssue({
+              code: 'custom',
+              path: [field],
+              message: 'Redis credentials are allowed only in Production',
+            })
+          }
         }
       }
 
@@ -179,6 +212,10 @@ const serverEnvironmentSchema = z
       UPSTASH_REDIS_REST_TOKEN,
       KV_REST_API_URL,
       KV_REST_API_TOKEN,
+      KV_REST_API_READ_ONLY_TOKEN: _kvReadOnlyToken,
+      KV_URL: _kvUrl,
+      REDIS_URL: _redisUrl,
+      VERCEL_ENV,
       AMA_PUBLIC_MUTATIONS_ENABLED,
       AMA_PAYMENTS_ENABLED,
       AMA_BOOKING_FINALIZATION_ENABLED,
@@ -187,8 +224,16 @@ const serverEnvironmentSchema = z
       ...environment
     }) => ({
       ...environment,
-      UPSTASH_REDIS_REST_URL: UPSTASH_REDIS_REST_URL ?? KV_REST_API_URL!,
-      UPSTASH_REDIS_REST_TOKEN: UPSTASH_REDIS_REST_TOKEN ?? KV_REST_API_TOKEN!,
+      rateLimitBackend:
+        VERCEL_ENV === 'production'
+          ? {
+              kind: 'upstash' as const,
+              url: UPSTASH_REDIS_REST_URL ?? KV_REST_API_URL!,
+              token: UPSTASH_REDIS_REST_TOKEN ?? KV_REST_API_TOKEN!,
+            }
+          : VERCEL_ENV === 'preview'
+            ? { kind: 'database' as const }
+            : { kind: 'memory' as const },
       features: featureFlags({
         AMA_PUBLIC_MUTATIONS_ENABLED,
         AMA_PAYMENTS_ENABLED,

--- a/lib/ama/server-env-schema.ts
+++ b/lib/ama/server-env-schema.ts
@@ -106,9 +106,6 @@ const serverEnvironmentSchema = z
         UPSTASH_REDIS_REST_TOKEN,
         KV_REST_API_URL,
         KV_REST_API_TOKEN,
-        KV_REST_API_READ_ONLY_TOKEN,
-        KV_URL,
-        REDIS_URL,
         VERCEL_ENV,
         GOOGLE_CLIENT_ID,
         GOOGLE_CLIENT_SECRET,
@@ -122,17 +119,8 @@ const serverEnvironmentSchema = z
       const marketplacePairComplete = Boolean(
         KV_REST_API_URL && KV_REST_API_TOKEN,
       )
-      const redisFields = {
-        UPSTASH_REDIS_REST_URL,
-        UPSTASH_REDIS_REST_TOKEN,
-        KV_REST_API_URL,
-        KV_REST_API_TOKEN,
-        KV_REST_API_READ_ONLY_TOKEN,
-        KV_URL,
-        REDIS_URL,
-      }
-
       if (
+        VERCEL_ENV === 'production' &&
         Boolean(UPSTASH_REDIS_REST_URL) !== Boolean(UPSTASH_REDIS_REST_TOKEN)
       ) {
         context.addIssue({
@@ -147,7 +135,10 @@ const serverEnvironmentSchema = z
         })
       }
 
-      if (Boolean(KV_REST_API_URL) !== Boolean(KV_REST_API_TOKEN)) {
+      if (
+        VERCEL_ENV === 'production' &&
+        Boolean(KV_REST_API_URL) !== Boolean(KV_REST_API_TOKEN)
+      ) {
         context.addIssue({
           code: 'custom',
           path: [KV_REST_API_URL ? 'KV_REST_API_TOKEN' : 'KV_REST_API_URL'],
@@ -174,18 +165,6 @@ const serverEnvironmentSchema = z
             path: ['UPSTASH_REDIS_REST_TOKEN'],
             message: 'A complete Redis credential pair is required',
           })
-        }
-      }
-
-      if (VERCEL_ENV !== 'production') {
-        for (const [field, value] of Object.entries(redisFields)) {
-          if (value) {
-            context.addIssue({
-              code: 'custom',
-              path: [field],
-              message: 'Redis credentials are allowed only in Production',
-            })
-          }
         }
       }
 

--- a/lib/ama/server-env.test.ts
+++ b/lib/ama/server-env.test.ts
@@ -111,30 +111,37 @@ describe('AMA server environment', () => {
     ).toEqual({ kind: 'database' })
   })
 
-  it('rejects Redis credentials outside Production', () => {
-    expect(() =>
-      parseServerEnv({ ...validEnvironment, VERCEL_ENV: 'preview' }),
-    ).toThrowError(/UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN/)
-
+  it('ignores transitional Redis credentials outside Production', () => {
     const {
       UPSTASH_REDIS_REST_URL: _upstashUrl,
       UPSTASH_REDIS_REST_TOKEN: _upstashToken,
       ...withoutUpstash
     } = validEnvironment
-    expect(() =>
-      parseServerEnv({
-        ...withoutUpstash,
-        VERCEL_ENV: 'preview',
-        KV_REST_API_URL: 'https://marketplace.upstash.io',
-        KV_REST_API_TOKEN: 'marketplace-secret',
-        KV_URL: 'redis://default:secret@example.upstash.io:6379',
-        REDIS_URL: 'redis://default:secret@example.upstash.io:6379',
-      }),
-    ).toThrowError(/KV_REST_API_URL, KV_REST_API_TOKEN, KV_URL, REDIS_URL/)
+    const previewEnvironment = parseServerEnv({
+      ...withoutUpstash,
+      VERCEL_ENV: 'preview',
+      KV_REST_API_URL: 'https://marketplace.upstash.io',
+      KV_REST_API_TOKEN: 'marketplace-secret',
+      KV_REST_API_READ_ONLY_TOKEN: 'marketplace-read-only-secret',
+      KV_URL: 'redis://default:secret@example.upstash.io:6379',
+      REDIS_URL: 'redis://default:secret@example.upstash.io:6379',
+    })
 
-    expect(() =>
-      parseServerEnv({ ...validEnvironment, VERCEL_ENV: 'development' }),
-    ).toThrowError(/UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN/)
+    expect(previewEnvironment.rateLimitBackend).toEqual({ kind: 'database' })
+    for (const field of [
+      'KV_REST_API_URL',
+      'KV_REST_API_TOKEN',
+      'KV_REST_API_READ_ONLY_TOKEN',
+      'KV_URL',
+      'REDIS_URL',
+    ]) {
+      expect(previewEnvironment).not.toHaveProperty(field)
+    }
+
+    expect(
+      parseServerEnv({ ...validEnvironment, VERCEL_ENV: 'development' })
+        .rateLimitBackend,
+    ).toEqual({ kind: 'memory' })
   })
 
   it('uses an in-memory rate limiter outside Vercel', () => {

--- a/lib/ama/server-env.test.ts
+++ b/lib/ama/server-env.test.ts
@@ -12,6 +12,7 @@ const validEnvironment = {
   UPSTASH_REDIS_REST_URL: 'https://example.upstash.io',
   UPSTASH_REDIS_REST_TOKEN: 'redis-secret',
   SITE_URL: 'https://cali.so',
+  VERCEL_ENV: 'production',
 }
 
 describe('AMA server environment', () => {
@@ -36,6 +37,11 @@ describe('AMA server environment', () => {
 
     expect(environment.ADMIN_EMAIL).toBe('owner@example.com')
     expect(environment.ADMIN_MUTATION_RATE_LIMIT_MAX_REQUESTS).toBe(30)
+    expect(environment.rateLimitBackend).toEqual({
+      kind: 'upstash',
+      url: 'https://example.upstash.io',
+      token: 'redis-secret',
+    })
     expect(environment.features).toEqual({
       publicMutations: false,
       payments: false,
@@ -67,10 +73,13 @@ describe('AMA server environment', () => {
       KV_REST_API_TOKEN: 'marketplace-secret',
     })
 
-    expect(environment.UPSTASH_REDIS_REST_URL).toBe(
-      'https://marketplace.upstash.io',
-    )
-    expect(environment.UPSTASH_REDIS_REST_TOKEN).toBe('marketplace-secret')
+    expect(environment.rateLimitBackend).toEqual({
+      kind: 'upstash',
+      url: 'https://marketplace.upstash.io',
+      token: 'marketplace-secret',
+    })
+    expect(environment).not.toHaveProperty('UPSTASH_REDIS_REST_URL')
+    expect(environment).not.toHaveProperty('UPSTASH_REDIS_REST_TOKEN')
     expect(environment).not.toHaveProperty('KV_REST_API_URL')
     expect(environment).not.toHaveProperty('KV_REST_API_TOKEN')
   })
@@ -82,12 +91,63 @@ describe('AMA server environment', () => {
       KV_REST_API_TOKEN: 'marketplace-secret',
     })
 
-    expect(environment.UPSTASH_REDIS_REST_URL).toBe(
-      validEnvironment.UPSTASH_REDIS_REST_URL,
-    )
-    expect(environment.UPSTASH_REDIS_REST_TOKEN).toBe(
-      validEnvironment.UPSTASH_REDIS_REST_TOKEN,
-    )
+    expect(environment.rateLimitBackend).toEqual({
+      kind: 'upstash',
+      url: validEnvironment.UPSTASH_REDIS_REST_URL,
+      token: validEnvironment.UPSTASH_REDIS_REST_TOKEN,
+    })
+  })
+
+  it('uses the database rate limiter in Preview without Redis credentials', () => {
+    const {
+      UPSTASH_REDIS_REST_URL: _upstashUrl,
+      UPSTASH_REDIS_REST_TOKEN: _upstashToken,
+      ...withoutUpstash
+    } = validEnvironment
+
+    expect(
+      parseServerEnv({ ...withoutUpstash, VERCEL_ENV: 'preview' })
+        .rateLimitBackend,
+    ).toEqual({ kind: 'database' })
+  })
+
+  it('rejects Redis credentials outside Production', () => {
+    expect(() =>
+      parseServerEnv({ ...validEnvironment, VERCEL_ENV: 'preview' }),
+    ).toThrowError(/UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN/)
+
+    const {
+      UPSTASH_REDIS_REST_URL: _upstashUrl,
+      UPSTASH_REDIS_REST_TOKEN: _upstashToken,
+      ...withoutUpstash
+    } = validEnvironment
+    expect(() =>
+      parseServerEnv({
+        ...withoutUpstash,
+        VERCEL_ENV: 'preview',
+        KV_REST_API_URL: 'https://marketplace.upstash.io',
+        KV_REST_API_TOKEN: 'marketplace-secret',
+        KV_URL: 'redis://default:secret@example.upstash.io:6379',
+        REDIS_URL: 'redis://default:secret@example.upstash.io:6379',
+      }),
+    ).toThrowError(/KV_REST_API_URL, KV_REST_API_TOKEN, KV_URL, REDIS_URL/)
+
+    expect(() =>
+      parseServerEnv({ ...validEnvironment, VERCEL_ENV: 'development' }),
+    ).toThrowError(/UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN/)
+  })
+
+  it('uses an in-memory rate limiter outside Vercel', () => {
+    const {
+      UPSTASH_REDIS_REST_URL: _upstashUrl,
+      UPSTASH_REDIS_REST_TOKEN: _upstashToken,
+      VERCEL_ENV: _vercelEnvironment,
+      ...localEnvironment
+    } = validEnvironment
+
+    expect(parseServerEnv(localEnvironment).rateLimitBackend).toEqual({
+      kind: 'memory',
+    })
   })
 
   it('rejects partial Redis credential pairs', () => {

--- a/lib/media/admin/server.ts
+++ b/lib/media/admin/server.ts
@@ -1,7 +1,5 @@
 import 'server-only'
 
-import { Ratelimit } from '@upstash/ratelimit'
-import { Redis } from '@upstash/redis'
 import { revalidateTag } from 'next/cache'
 
 import { getDatabase } from '~/db'
@@ -10,6 +8,7 @@ import {
   ownerRequestAuthenticator,
 } from '~/lib/admin/server'
 import { getServerEnv } from '~/lib/ama/server-env'
+import { createRateLimiter } from '~/lib/rate-limit/server'
 
 import { parseMediaAltTextEnv } from '../alt-text/config'
 import { createMediaAltTextGenerator } from '../alt-text/gateway'
@@ -72,24 +71,16 @@ function createServices() {
   })
 
   const altTextConfig = parseMediaAltTextEnv(process.env)
-  const redis = new Redis({
-    url: environment.UPSTASH_REDIS_REST_URL,
-    token: environment.UPSTASH_REDIS_REST_TOKEN,
-  })
-  const altTextLimiter = new Ratelimit({
-    redis,
-    limiter: Ratelimit.slidingWindow(
-      altTextConfig.rateLimitMaxRequests,
-      `${altTextConfig.rateLimitWindowSeconds} s`,
-    ),
-    prefix: 'cali:media:alt-text',
-  })
   const altText = altTextConfig.enabled
     ? createMediaAltTextService({
         repository: createMediaAltTextRepository(database),
         storage,
         generator: createMediaAltTextGenerator(altTextConfig),
-        rateLimiter: altTextLimiter,
+        rateLimiter: createRateLimiter(environment.rateLimitBackend, {
+          prefix: 'cali:media:alt-text',
+          maxRequests: altTextConfig.rateLimitMaxRequests,
+          windowSeconds: altTextConfig.rateLimitWindowSeconds,
+        }),
       })
     : null
 

--- a/lib/rate-limit/memory.ts
+++ b/lib/rate-limit/memory.ts
@@ -1,12 +1,4 @@
-type RateLimitPolicy = {
-  prefix: string
-  maxRequests: number
-  windowSeconds: number
-}
-
-type Clock = {
-  now(): Date
-}
+import type { Clock, RateLimitPolicy } from './types'
 
 type Window = {
   requestCount: number

--- a/lib/rate-limit/memory.ts
+++ b/lib/rate-limit/memory.ts
@@ -1,0 +1,41 @@
+type RateLimitPolicy = {
+  prefix: string
+  maxRequests: number
+  windowSeconds: number
+}
+
+type Clock = {
+  now(): Date
+}
+
+type Window = {
+  requestCount: number
+  expiresAt: number
+}
+
+export function createMemoryRateLimiter(
+  policy: RateLimitPolicy,
+  clock: Clock = { now: () => new Date() },
+) {
+  const windows = new Map<string, Window>()
+
+  return {
+    async limit(key: string) {
+      const now = clock.now().getTime()
+      const current = windows.get(key)
+      const window =
+        !current || current.expiresAt <= now
+          ? {
+              requestCount: 1,
+              expiresAt: now + policy.windowSeconds * 1_000,
+            }
+          : {
+              requestCount: current.requestCount + 1,
+              expiresAt: current.expiresAt,
+            }
+
+      windows.set(key, window)
+      return { success: window.requestCount <= policy.maxRequests }
+    },
+  }
+}

--- a/lib/rate-limit/repository.test.ts
+++ b/lib/rate-limit/repository.test.ts
@@ -1,0 +1,78 @@
+import { readFile } from 'node:fs/promises'
+
+import { PGlite } from '@electric-sql/pglite'
+import { drizzle } from 'drizzle-orm/pglite'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import {
+  createDatabaseRateLimiter,
+  type RateLimitDatabase,
+} from './repository'
+
+const migrationUrl = new URL(
+  '../../db/migrations/0010_rate_limit_windows.sql',
+  import.meta.url,
+)
+
+describe('database rate limiter', () => {
+  let client: PGlite
+  let now: Date
+
+  beforeEach(async () => {
+    client = new PGlite()
+    const migration = await readFile(migrationUrl, 'utf8')
+    await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
+    now = new Date('2026-07-16T06:00:00.000Z')
+  })
+
+  afterEach(async () => {
+    await client.close()
+  })
+
+  it('allows only the configured number of concurrent requests', async () => {
+    const limiter = createDatabaseRateLimiter(
+      () => drizzle(client) as unknown as RateLimitDatabase,
+      {
+        prefix: 'cali:ama:owner-auth',
+        maxRequests: 2,
+        windowSeconds: 60,
+      },
+      { now: () => now },
+    )
+
+    const results = await Promise.all([
+      limiter.limit('private-request-key'),
+      limiter.limit('private-request-key'),
+      limiter.limit('private-request-key'),
+    ])
+
+    expect(results.filter((result) => result.success)).toHaveLength(2)
+  })
+
+  it('starts a fresh allowance after the window expires', async () => {
+    const limiter = createDatabaseRateLimiter(
+      () => drizzle(client) as unknown as RateLimitDatabase,
+      {
+        prefix: 'cali:ama:admin-mutation',
+        maxRequests: 1,
+        windowSeconds: 60,
+      },
+      { now: () => now },
+    )
+
+    await expect(limiter.limit('private-owner-key')).resolves.toEqual({
+      success: true,
+    })
+    await expect(limiter.limit('private-owner-key')).resolves.toEqual({
+      success: false,
+    })
+
+    now = new Date('2026-07-16T06:01:00.000Z')
+
+    await expect(limiter.limit('private-owner-key')).resolves.toEqual({
+      success: true,
+    })
+  })
+})

--- a/lib/rate-limit/repository.test.ts
+++ b/lib/rate-limit/repository.test.ts
@@ -75,4 +75,36 @@ describe('database rate limiter', () => {
       success: true,
     })
   })
+
+  it('does not allow a burst across the first request boundary', async () => {
+    const limiter = createDatabaseRateLimiter(
+      () => drizzle(client) as unknown as RateLimitDatabase,
+      {
+        prefix: 'cali:ama:admin-mutation',
+        maxRequests: 3,
+        windowSeconds: 60,
+      },
+      { now: () => now },
+    )
+
+    await expect(limiter.limit('private-owner-key')).resolves.toEqual({
+      success: true,
+    })
+
+    now = new Date('2026-07-16T06:00:59.000Z')
+    await expect(
+      Promise.all([
+        limiter.limit('private-owner-key'),
+        limiter.limit('private-owner-key'),
+      ]),
+    ).resolves.toEqual([{ success: true }, { success: true }])
+
+    now = new Date('2026-07-16T06:01:00.000Z')
+    await expect(
+      Promise.all([
+        limiter.limit('private-owner-key'),
+        limiter.limit('private-owner-key'),
+      ]),
+    ).resolves.toEqual([{ success: true }, { success: false }])
+  })
 })

--- a/lib/rate-limit/repository.ts
+++ b/lib/rate-limit/repository.ts
@@ -2,7 +2,7 @@ import 'server-only'
 
 import { createHash } from 'node:crypto'
 
-import { lte, sql } from 'drizzle-orm'
+import { and, eq, lte, sql } from 'drizzle-orm'
 
 import { getDatabase } from '~/db'
 import { rateLimitWindows } from '~/db/schema'
@@ -22,29 +22,49 @@ export function createDatabaseRateLimiter(
       const windowExpiresAt = new Date(
         now.getTime() + policy.windowSeconds * 1_000,
       )
+      const windowStartedAt = new Date(
+        now.getTime() - policy.windowSeconds * 1_000,
+      )
       const keyHash = createHash('sha256').update(key).digest('hex')
       const client = database()
 
       await client
         .delete(rateLimitWindows)
-        .where(lte(rateLimitWindows.windowExpiresAt, now))
+        .where(
+          and(
+            eq(rateLimitWindows.scope, policy.prefix),
+            eq(rateLimitWindows.keyHash, keyHash),
+            lte(rateLimitWindows.windowExpiresAt, now),
+          ),
+        )
+
+      const activeRequestTimes = sql<Date[]>`ARRAY(
+        SELECT requested_at
+        FROM unnest(${rateLimitWindows.requestTimes}) AS active_request(requested_at)
+        WHERE requested_at > ${windowStartedAt}
+      )`
 
       const [window] = await client
         .insert(rateLimitWindows)
         .values({
           scope: policy.prefix,
           keyHash,
-          requestCount: 1,
+          requestTimes: [now],
           windowExpiresAt,
         })
         .onConflictDoUpdate({
           target: [rateLimitWindows.scope, rateLimitWindows.keyHash],
           set: {
-            requestCount: sql`${rateLimitWindows.requestCount} + 1`,
+            requestTimes: sql`${activeRequestTimes} || ARRAY[${now}]::timestamptz[]`,
+            windowExpiresAt,
           },
+          setWhere: sql`cardinality(${activeRequestTimes}) < ${policy.maxRequests}`,
         })
-        .returning({ requestCount: rateLimitWindows.requestCount })
+        .returning({
+          requestCount: sql<number>`cardinality(${rateLimitWindows.requestTimes})`,
+        })
 
+      if (!window) return { success: false }
       return { success: window.requestCount <= policy.maxRequests }
     },
   }

--- a/lib/rate-limit/repository.ts
+++ b/lib/rate-limit/repository.ts
@@ -1,0 +1,59 @@
+import 'server-only'
+
+import { createHash } from 'node:crypto'
+
+import { lte, sql } from 'drizzle-orm'
+
+import { getDatabase } from '~/db'
+import { rateLimitWindows } from '~/db/schema'
+
+export type RateLimitDatabase = ReturnType<typeof getDatabase>
+
+type RateLimitPolicy = {
+  prefix: string
+  maxRequests: number
+  windowSeconds: number
+}
+
+type Clock = {
+  now(): Date
+}
+
+export function createDatabaseRateLimiter(
+  database: () => RateLimitDatabase,
+  policy: RateLimitPolicy,
+  clock: Clock = { now: () => new Date() },
+) {
+  return {
+    async limit(key: string) {
+      const now = clock.now()
+      const windowExpiresAt = new Date(
+        now.getTime() + policy.windowSeconds * 1_000,
+      )
+      const keyHash = createHash('sha256').update(key).digest('hex')
+      const client = database()
+
+      await client
+        .delete(rateLimitWindows)
+        .where(lte(rateLimitWindows.windowExpiresAt, now))
+
+      const [window] = await client
+        .insert(rateLimitWindows)
+        .values({
+          scope: policy.prefix,
+          keyHash,
+          requestCount: 1,
+          windowExpiresAt,
+        })
+        .onConflictDoUpdate({
+          target: [rateLimitWindows.scope, rateLimitWindows.keyHash],
+          set: {
+            requestCount: sql`${rateLimitWindows.requestCount} + 1`,
+          },
+        })
+        .returning({ requestCount: rateLimitWindows.requestCount })
+
+      return { success: window.requestCount <= policy.maxRequests }
+    },
+  }
+}

--- a/lib/rate-limit/repository.ts
+++ b/lib/rate-limit/repository.ts
@@ -7,17 +7,9 @@ import { lte, sql } from 'drizzle-orm'
 import { getDatabase } from '~/db'
 import { rateLimitWindows } from '~/db/schema'
 
+import type { Clock, RateLimitPolicy } from './types'
+
 export type RateLimitDatabase = ReturnType<typeof getDatabase>
-
-type RateLimitPolicy = {
-  prefix: string
-  maxRequests: number
-  windowSeconds: number
-}
-
-type Clock = {
-  now(): Date
-}
 
 export function createDatabaseRateLimiter(
   database: () => RateLimitDatabase,

--- a/lib/rate-limit/server.ts
+++ b/lib/rate-limit/server.ts
@@ -8,12 +8,7 @@ import type { ServerEnvironment } from '~/lib/ama/server-env-schema'
 
 import { createMemoryRateLimiter } from './memory'
 import { createDatabaseRateLimiter } from './repository'
-
-type RateLimitPolicy = {
-  prefix: string
-  maxRequests: number
-  windowSeconds: number
-}
+import type { RateLimitPolicy } from './types'
 
 export function createRateLimiter(
   backend: ServerEnvironment['rateLimitBackend'],

--- a/lib/rate-limit/server.ts
+++ b/lib/rate-limit/server.ts
@@ -1,0 +1,38 @@
+import 'server-only'
+
+import { Ratelimit } from '@upstash/ratelimit'
+import { Redis } from '@upstash/redis'
+
+import { getDatabase } from '~/db'
+import type { ServerEnvironment } from '~/lib/ama/server-env-schema'
+
+import { createMemoryRateLimiter } from './memory'
+import { createDatabaseRateLimiter } from './repository'
+
+type RateLimitPolicy = {
+  prefix: string
+  maxRequests: number
+  windowSeconds: number
+}
+
+export function createRateLimiter(
+  backend: ServerEnvironment['rateLimitBackend'],
+  policy: RateLimitPolicy,
+) {
+  if (backend.kind === 'database') {
+    return createDatabaseRateLimiter(getDatabase, policy)
+  }
+
+  if (backend.kind === 'memory') {
+    return createMemoryRateLimiter(policy)
+  }
+
+  return new Ratelimit({
+    redis: new Redis({ url: backend.url, token: backend.token }),
+    limiter: Ratelimit.slidingWindow(
+      policy.maxRequests,
+      `${policy.windowSeconds} s`,
+    ),
+    prefix: policy.prefix,
+  })
+}

--- a/lib/rate-limit/types.ts
+++ b/lib/rate-limit/types.ts
@@ -1,0 +1,9 @@
+export type RateLimitPolicy = {
+  prefix: string
+  maxRequests: number
+  windowSeconds: number
+}
+
+export type Clock = {
+  now(): Date
+}

--- a/scripts/ama-migrations.test.mjs
+++ b/scripts/ama-migrations.test.mjs
@@ -64,7 +64,8 @@ test('rate-limit migration stores bounded windows without private request keys',
 
   assert.match(sql, /create table "rate_limit_windows"/)
   assert.match(sql, /primary key\("scope","key_hash"\)/)
-  assert.match(sql, /"request_count" > 0/)
+  assert.match(sql, /"request_times" timestamp with time zone\[\] not null/)
+  assert.match(sql, /cardinality\("rate_limit_windows"\."request_times"\) > 0/)
   assert.match(sql, /create index "rate_limit_windows_expiry_idx"/)
   assert.doesNotMatch(sql, /"request_key"/)
 })

--- a/scripts/ama-migrations.test.mjs
+++ b/scripts/ama-migrations.test.mjs
@@ -7,6 +7,7 @@ const migrationUrls = {
   availability: new URL('../db/migrations/0002_ama_availability.sql', import.meta.url),
   googleCalendar: new URL('../db/migrations/0003_ama_google_calendar.sql', import.meta.url),
   googleOAuth: new URL('../db/migrations/0004_ama_google_oauth.sql', import.meta.url),
+  rateLimits: new URL('../db/migrations/0010_rate_limit_windows.sql', import.meta.url),
 }
 
 async function readMigration(url) {
@@ -56,6 +57,16 @@ test('AMA Google OAuth migration stores hashed state and encrypted PKCE material
   assert.match(sql, /"consumed_at" timestamp with time zone/)
   assert.doesNotMatch(sql, /"state"\s/)
   assert.doesNotMatch(sql, /"pkce_verifier"\s/)
+})
+
+test('rate-limit migration stores bounded windows without private request keys', async () => {
+  const sql = await readMigration(migrationUrls.rateLimits)
+
+  assert.match(sql, /create table "rate_limit_windows"/)
+  assert.match(sql, /primary key\("scope","key_hash"\)/)
+  assert.match(sql, /"request_count" > 0/)
+  assert.match(sql, /create index "rate_limit_windows_expiry_idx"/)
+  assert.doesNotMatch(sql, /"request_key"/)
 })
 
 test('AMA migrations never mutate legacy subscriber or newsletter tables', async () => {

--- a/scripts/verify-production-security-boundary.mjs
+++ b/scripts/verify-production-security-boundary.mjs
@@ -6,7 +6,6 @@ import { openProductionServer } from './production-server.mjs'
 
 const privateMarkers = [
   'ci-google-secret',
-  'ci-redis-token',
   'sk_live_ci_secret_not_real',
   'owner@example.com',
   'security-boundary-callback-code',


### PR DESCRIPTION
## Summary

- keep Upstash Redis as the Production-only rate-limit backend
- persist Preview rate-limit windows in the isolated Neon database
- use process-local limits for Local and CI
- ignore and strip transitional Redis, Upstash, and Vercel KV credentials outside Production without constructing a Redis client
- update the cutover runbook and readiness documentation to remove the separate Preview Redis requirement

## Why

Preview deployments currently receive Redis credentials because the existing Vercel storage integration targets both environments. The server used to require those credentials, while the first version of this PR rejected them before the Preview could deploy. The new backend boundary always selects Neon in Preview and safely ignores the stale variables until an operator removes them.

## Deployment order

1. Apply migration `0010` to the Preview Neon branch with the separately held migration credential.
2. Grant the Preview runtime role CRUD-only access to `rate_limit_windows`.
3. Deploy this change to Preview.
4. Remove all `KV_*`, `REDIS_URL`, and `UPSTASH_*` variables from Preview and scope the storage integration to Production only.

Production database and hosted configuration were not changed by this PR.

## Validation

- `pnpm typecheck`
- `pnpm test:unit` (401 tests)
- `pnpm test:ama` (115 tests plus migration validation)
- focused environment and rate-limit tests
- Preview-mode `pnpm build` with all existing KV and Redis variables present
- `pnpm verify:security-boundary`
- Standards review: pass
- Spec review: pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR routes rate-limit backends by Vercel environment: Production keeps Upstash Redis (sliding window), Preview uses an isolated Neon database (new `rate_limit_windows` table with a timestamp-array sliding window), and Local/CI use a process-local in-memory map. Stale Redis/KV credentials present in Preview deployments are accepted by the schema but stripped before any client is constructed.

- Adds the `rate_limit_windows` table (migration `0010`) with a composite primary key on `(scope, key_hash)`, a `timestamptz[]` column for request timestamps, and an expiry index for cleanup.
- Replaces the previous fixed-window counter logic with a sliding-window implementation: each conflict update filters `requestTimes` to the last `windowSeconds` interval before appending the new timestamp, and the `setWhere` guard uses that filtered count to enforce the limit atomically.
- `server-env-schema.ts` adds a `superRefine` pass that validates Redis credentials only when `VERCEL_ENV === 'production'` and a `transform` pass that strips all KV/Redis fields from the parsed output and sets `rateLimitBackend` to `{ kind: 'database' }` for Preview.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the environment boundary is enforced at parse time, no Redis client is constructed outside Production, and the database sliding-window implementation handles concurrent requests correctly via PostgreSQL ON CONFLICT DO UPDATE WHERE mechanics.

All three correctness concerns raised in the previous review round (undefined-window dereference, unbounded global DELETE, fixed-window-vs-sliding-window mismatch) are addressed. The scoped DELETE targets only the current scope+key pair, the undefined guard returns { success: false } before touching the window object, and the new implementation stores a timestamptz[] and filters it on every call rather than incrementing a counter, giving true sliding-window semantics. The migration matches the Drizzle schema, and the PGlite unit tests exercise concurrent admission, window expiry, and cross-boundary burst protection.

No files require special attention. The core logic in lib/rate-limit/repository.ts and lib/ama/server-env-schema.ts is well-tested and the migration is consistent with the schema.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/rate-limit/repository.ts | New database rate-limiter using INSERT ON CONFLICT DO UPDATE with a sliding-window timestamp array; scoped DELETE, undefined-window guard, and setWhere cardinality check are all correct. |
| lib/ama/server-env-schema.ts | Environment parsing correctly gates Redis validation/selection to Production, routes Preview to the database backend, routes Local to memory, and strips all KV/Redis fields from the output object. |
| db/migrations/0010_rate_limit_windows.sql | Creates rate_limit_windows with composite PK, non-empty array CHECK constraint, and expiry btree index; matches the Drizzle schema definition exactly. |
| lib/rate-limit/repository.test.ts | Unit tests using PGlite cover concurrent admission, window reset, and the burst-across-boundary case; all three previously-flagged correctness scenarios are now exercised. |
| lib/ama/server-env.test.ts | New tests confirm the database backend is selected in Preview with or without stale KV/Redis vars, and that the memory backend is selected when VERCEL_ENV is absent. |
| lib/rate-limit/server.ts | Thin factory that delegates to the correct backend based on rateLimitBackend.kind; no logic issues. |
| db/schema.ts | Adds the rateLimitWindows table definition matching the migration; composite PK, array column, and cardinality check constraint are all consistent. |
| .github/workflows/security.yml | Removes the now-unnecessary UPSTASH CI stub variables; CI tests will exercise the memory backend path as intended. |
| lib/rate-limit/memory.ts | Simple fixed-window in-process map; intentionally non-persistent, used only for Local/CI where persistence across invocations is not needed. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant RateLimiter as createRateLimiter()
    participant Schema as server-env-schema
    participant DB as Neon (Preview)
    participant Redis as Upstash (Production)
    participant Mem as Memory (Local/CI)

    Schema->>Schema: parse VERCEL_ENV
    alt "VERCEL_ENV = production"
        Schema-->>RateLimiter: "{ kind: upstash, url, token }"
        Client->>RateLimiter: limit(key)
        RateLimiter->>Redis: slidingWindow check
        Redis-->>RateLimiter: "{ success }"
    else "VERCEL_ENV = preview"
        Schema-->>RateLimiter: "{ kind: database }"
        Client->>RateLimiter: limit(key)
        RateLimiter->>DB: DELETE expired rows scoped to scope+keyHash
        RateLimiter->>DB: INSERT ON CONFLICT DO UPDATE SET requestTimes WHERE cardinality less than maxRequests RETURNING cardinality
        alt UPDATE skipped limit hit
            DB-->>RateLimiter: no row returned
            RateLimiter-->>Client: "{ success: false }"
        else INSERT or UPDATE applied
            DB-->>RateLimiter: "{ requestCount }"
            RateLimiter-->>Client: "{ success: true }"
        end
    else no VERCEL_ENV Local or CI
        Schema-->>RateLimiter: "{ kind: memory }"
        Client->>RateLimiter: limit(key)
        RateLimiter->>Mem: increment in-process Map
        Mem-->>RateLimiter: "{ requestCount }"
        RateLimiter-->>Client: "{ success }"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant RateLimiter as createRateLimiter()
    participant Schema as server-env-schema
    participant DB as Neon (Preview)
    participant Redis as Upstash (Production)
    participant Mem as Memory (Local/CI)

    Schema->>Schema: parse VERCEL_ENV
    alt "VERCEL_ENV = production"
        Schema-->>RateLimiter: "{ kind: upstash, url, token }"
        Client->>RateLimiter: limit(key)
        RateLimiter->>Redis: slidingWindow check
        Redis-->>RateLimiter: "{ success }"
    else "VERCEL_ENV = preview"
        Schema-->>RateLimiter: "{ kind: database }"
        Client->>RateLimiter: limit(key)
        RateLimiter->>DB: DELETE expired rows scoped to scope+keyHash
        RateLimiter->>DB: INSERT ON CONFLICT DO UPDATE SET requestTimes WHERE cardinality less than maxRequests RETURNING cardinality
        alt UPDATE skipped limit hit
            DB-->>RateLimiter: no row returned
            RateLimiter-->>Client: "{ success: false }"
        else INSERT or UPDATE applied
            DB-->>RateLimiter: "{ requestCount }"
            RateLimiter-->>Client: "{ success: true }"
        end
    else no VERCEL_ENV Local or CI
        Schema-->>RateLimiter: "{ kind: memory }"
        Client->>RateLimiter: limit(key)
        RateLimiter->>Mem: increment in-process Map
        Mem-->>RateLimiter: "{ requestCount }"
        RateLimiter-->>Client: "{ success }"
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix: match Preview sliding rate limits"](https://github.com/calicastle/cali.so/commit/27bef923fd98ab3a2b764f5a5726273fe30d7f13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44701926)</sub>

<!-- /greptile_comment -->