### PR TITLE
test: share one PGlite per file to stop suite wedging under load

### DIFF
--- a/db/testing/fixtures/seeded-migration.sql
+++ b/db/testing/fixtures/seeded-migration.sql
@@ -1,0 +1,13 @@
+-- Fixture for db/testing/pglite.test.ts: a migration that creates both a
+-- reference table it seeds itself and a plain table it leaves empty.
+CREATE TABLE seeded_lookup (
+  id integer PRIMARY KEY,
+  label text NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO seeded_lookup (id, label) VALUES (1, 'alpha'), (2, 'beta');
+--> statement-breakpoint
+CREATE TABLE plain (
+  id serial PRIMARY KEY,
+  note text NOT NULL
+);

--- a/db/testing/pglite.test.ts
+++ b/db/testing/pglite.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { usePGliteTestClient } from './pglite'
+
+// The two tests are order-dependent by design: the first dirties every
+// table, the second proves each test starts from post-migration state.
+describe('usePGliteTestClient', () => {
+  const getClient = usePGliteTestClient(['../testing/fixtures/seeded-migration.sql'])
+
+  it('serves a booted client with migrations applied', async () => {
+    const client = getClient()
+
+    await client.query("insert into plain (note) values ('scratch')")
+    await client.query('delete from seeded_lookup where id = 2')
+
+    const plain = await client.query<{ n: number }>(
+      'select count(*)::int as n from plain',
+    )
+    expect(plain.rows[0]!.n).toBe(1)
+  })
+
+  it('resets to post-migration state between tests, seeds included', async () => {
+    const client = getClient()
+
+    const plain = await client.query<{ n: number }>(
+      'select count(*)::int as n from plain',
+    )
+    expect(plain.rows[0]!.n).toBe(0)
+
+    const seeded = await client.query<{ id: number; label: string }>(
+      'select id, label from seeded_lookup order by id',
+    )
+    expect(seeded.rows).toEqual([
+      { id: 1, label: 'alpha' },
+      { id: 2, label: 'beta' },
+    ])
+
+    // identities restart too: the first insert lands back on id 1
+    const inserted = await client.query<{ id: number }>(
+      "insert into plain (note) values ('fresh') returning id",
+    )
+    expect(inserted.rows[0]!.id).toBe(1)
+  })
+})

--- a/db/testing/pglite.ts
+++ b/db/testing/pglite.ts
@@ -1,0 +1,43 @@
+import { readFile } from 'node:fs/promises'
+
+import { PGlite } from '@electric-sql/pglite'
+import { afterAll, beforeAll, beforeEach } from 'vitest'
+
+const migrationsDir = new URL('../migrations/', import.meta.url)
+
+// One WASM Postgres per test FILE, shared across its tests. Instantiating
+// PGlite in beforeEach multiplies concurrent WASM inits across vitest
+// workers; under load that init can wedge Node in a permanent microtask
+// spin (a fork worker pinned at 100% CPU that no test/hook timeout can
+// interrupt, because timers never run while the microtask queue churns).
+// Reusing a single instance per file keeps instantiations rare, and each
+// test still starts from empty tables via TRUNCATE.
+export function usePGliteTestClient(migrationFiles: string[]): () => PGlite {
+  let client: PGlite
+
+  // generous timeout: the WASM boot is legitimately slow when several
+  // vitest runs compete for the machine — wait instead of failing
+  beforeAll(async () => {
+    client = new PGlite()
+    for (const file of migrationFiles) {
+      const migration = await readFile(new URL(file, migrationsDir), 'utf8')
+      await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
+    }
+  }, 120_000)
+
+  beforeEach(async () => {
+    const { rows } = await client.query<{ tablename: string }>(
+      "select tablename from pg_tables where schemaname = 'public'",
+    )
+    if (rows.length > 0) {
+      const tables = rows.map((row) => `"${row.tablename}"`).join(', ')
+      await client.exec(`truncate table ${tables} restart identity cascade`)
+    }
+  })
+
+  afterAll(async () => {
+    await client.close()
+  })
+
+  return () => client
+}

--- a/db/testing/pglite.ts
+++ b/db/testing/pglite.ts
@@ -4,6 +4,7 @@ import { PGlite } from '@electric-sql/pglite'
 import { afterAll, beforeAll, beforeEach } from 'vitest'
 
 const migrationsDir = new URL('../migrations/', import.meta.url)
+const SEED_SCHEMA = '_migration_seed'
 
 // One WASM Postgres per test FILE, shared across its tests. Instantiating
 // PGlite in beforeEach multiplies concurrent WASM inits across vitest
@@ -11,33 +12,69 @@ const migrationsDir = new URL('../migrations/', import.meta.url)
 // spin (a fork worker pinned at 100% CPU that no test/hook timeout can
 // interrupt, because timers never run while the microtask queue churns).
 // Reusing a single instance per file keeps instantiations rare, and each
-// test still starts from empty tables via TRUNCATE.
+// test still starts from post-migration state: tables are truncated, and
+// any rows the migrations themselves seeded (captured at boot into a
+// shadow schema) are restored.
 export function usePGliteTestClient(migrationFiles: string[]): () => PGlite {
-  let client: PGlite
+  let client: PGlite | undefined
+  let seededTables: string[] = []
 
   // generous timeout: the WASM boot is legitimately slow when several
   // vitest runs compete for the machine — wait instead of failing
   beforeAll(async () => {
-    client = new PGlite()
+    const booted = new PGlite()
     for (const file of migrationFiles) {
       const migration = await readFile(new URL(file, migrationsDir), 'utf8')
-      await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
+      await booted.exec(migration.replaceAll('--> statement-breakpoint', ''))
     }
+
+    const { rows } = await booted.query<{ tablename: string }>(
+      "select tablename from pg_tables where schemaname = 'public'",
+    )
+    seededTables = []
+    await booted.exec(`create schema if not exists "${SEED_SCHEMA}"`)
+    for (const { tablename } of rows) {
+      const count = await booted.query<{ n: number }>(
+        `select count(*)::int as n from public."${tablename}"`,
+      )
+      if (count.rows[0]!.n === 0) continue
+      await booted.exec(
+        `create table "${SEED_SCHEMA}"."${tablename}" as table public."${tablename}"`,
+      )
+      seededTables.push(tablename)
+    }
+
+    client = booted
   }, 120_000)
 
   beforeEach(async () => {
-    const { rows } = await client.query<{ tablename: string }>(
+    const db = requireClient(client)
+    const { rows } = await db.query<{ tablename: string }>(
       "select tablename from pg_tables where schemaname = 'public'",
     )
     if (rows.length > 0) {
       const tables = rows.map((row) => `"${row.tablename}"`).join(', ')
-      await client.exec(`truncate table ${tables} restart identity cascade`)
+      await db.exec(`truncate table ${tables} restart identity cascade`)
+    }
+    for (const tablename of seededTables) {
+      await db.exec(
+        `insert into public."${tablename}" select * from "${SEED_SCHEMA}"."${tablename}"`,
+      )
     }
   })
 
   afterAll(async () => {
-    await client.close()
+    // a failed boot leaves no client; closing nothing must not mask the
+    // original beforeAll error with a TypeError
+    await client?.close()
   })
 
-  return () => client
+  return () => requireClient(client)
+}
+
+function requireClient(client: PGlite | undefined): PGlite {
+  if (!client) {
+    throw new Error('PGlite test client used before beforeAll booted it')
+  }
+  return client
 }

--- a/lib/ama/availability/repository.test.ts
+++ b/lib/ama/availability/repository.test.ts
@@ -1,37 +1,25 @@
-import { readFile } from 'node:fs/promises'
-
-import { PGlite } from '@electric-sql/pglite'
 import { drizzle } from 'drizzle-orm/pglite'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('server-only', () => ({}))
+
+import { usePGliteTestClient } from '~/db/testing/pglite'
 
 import {
   createAvailabilityRepository,
   type AvailabilityDatabase,
 } from './repository'
 
-const migrations = [
-  new URL('../../../db/migrations/0001_ama_owner_auth.sql', import.meta.url),
-  new URL('../../../db/migrations/0002_ama_availability.sql', import.meta.url),
-]
-
 describe('Availability Window repository', () => {
-  let client: PGlite
+  const getClient = usePGliteTestClient([
+    '0001_ama_owner_auth.sql',
+    '0002_ama_availability.sql',
+  ])
   let repository: ReturnType<typeof createAvailabilityRepository>
 
-  beforeEach(async () => {
-    client = new PGlite()
-    for (const migrationUrl of migrations) {
-      const migration = await readFile(migrationUrl, 'utf8')
-      await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
-    }
-    const database = drizzle(client)
+  beforeEach(() => {
+    const database = drizzle(getClient())
     repository = createAvailabilityRepository(() => database as unknown as AvailabilityDatabase)
-  })
-
-  afterEach(async () => {
-    await client.close()
   })
 
   it('stores multiple same-day Availability Windows in deterministic order', async () => {

--- a/lib/ama/google/repository.test.ts
+++ b/lib/ama/google/repository.test.ts
@@ -1,10 +1,9 @@
-import { readFile } from 'node:fs/promises'
-
-import { PGlite } from '@electric-sql/pglite'
 import { drizzle } from 'drizzle-orm/pglite'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('server-only', () => ({}))
+
+import { usePGliteTestClient } from '~/db/testing/pglite'
 
 import { createSecretBox } from '../secrets'
 import {
@@ -13,33 +12,22 @@ import {
 } from '../availability/repository'
 import { createGoogleRepository, type GoogleDatabase } from './repository'
 
-const migrations = [
-  new URL('../../../db/migrations/0001_ama_owner_auth.sql', import.meta.url),
-  new URL('../../../db/migrations/0002_ama_availability.sql', import.meta.url),
-  new URL('../../../db/migrations/0003_ama_google_calendar.sql', import.meta.url),
-  new URL('../../../db/migrations/0004_ama_google_oauth.sql', import.meta.url),
-]
-
 describe('Google Calendar persistence', () => {
-  let client: PGlite
+  const getClient = usePGliteTestClient([
+    '0001_ama_owner_auth.sql',
+    '0002_ama_availability.sql',
+    '0003_ama_google_calendar.sql',
+    '0004_ama_google_oauth.sql',
+  ])
   let repository: ReturnType<typeof createGoogleRepository>
   let availability: ReturnType<typeof createAvailabilityRepository>
 
-  beforeEach(async () => {
-    client = new PGlite()
-    for (const migrationUrl of migrations) {
-      const migration = await readFile(migrationUrl, 'utf8')
-      await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
-    }
-    const database = drizzle(client)
+  beforeEach(() => {
+    const database = drizzle(getClient())
     repository = createGoogleRepository(() => database as unknown as GoogleDatabase)
     availability = createAvailabilityRepository(
       () => database as unknown as AvailabilityDatabase,
     )
-  })
-
-  afterEach(async () => {
-    await client.close()
   })
 
   it('persists one connected calendar with an encrypted refresh-token envelope', async () => {
@@ -85,7 +73,7 @@ describe('Google Calendar persistence', () => {
       createdAt: now,
     })
 
-    const stored = await client.query<{
+    const stored = await getClient().query<{
       state_hash: string
       pkce_verifier_envelope: unknown
     }>('select state_hash, pkce_verifier_envelope from ama_google_oauth_attempts')

--- a/lib/media/alt-text/repository.test.ts
+++ b/lib/media/alt-text/repository.test.ts
@@ -1,38 +1,30 @@
-import { readFile } from 'node:fs/promises'
-
-import { PGlite } from '@electric-sql/pglite'
+import type { PGlite } from '@electric-sql/pglite'
 import { drizzle } from 'drizzle-orm/pglite'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('server-only', () => ({}))
+
+import { usePGliteTestClient } from '~/db/testing/pglite'
 
 import {
   createMediaAltTextRepository,
   type MediaAltTextDatabase,
 } from './repository'
-
-const migrations = [
-  new URL('../../../db/migrations/0005_media_catalog.sql', import.meta.url),
-  new URL(
-    '../../../db/migrations/0009_media_catalog_state.sql',
-    import.meta.url,
-  ),
-]
 const mediaAssetId = '11111111-1111-4111-8111-111111111111'
 const uploadIntentId = '22222222-2222-4222-8222-222222222222'
 const checksum = 'a'.repeat(64)
 const now = new Date('2026-07-15T10:00:00.000Z')
 
 describe('Media Library Alt Text Suggestion repository', () => {
+  const getClient = usePGliteTestClient([
+    '0005_media_catalog.sql',
+    '0009_media_catalog_state.sql',
+  ])
   let client: PGlite
   let repository: ReturnType<typeof createMediaAltTextRepository>
 
   beforeEach(async () => {
-    client = new PGlite()
-    for (const url of migrations) {
-      const migration = await readFile(url, 'utf8')
-      await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
-    }
+    client = getClient()
     const database = drizzle(client)
     repository = createMediaAltTextRepository(
       () => database as unknown as MediaAltTextDatabase,
@@ -70,10 +62,6 @@ describe('Media Library Alt Text Suggestion repository', () => {
         checksum,
       ],
     )
-  })
-
-  afterEach(async () => {
-    await client.close()
   })
 
   it('reads only the bounded sanitized Rendition projection', async () => {

--- a/lib/media/asset-review/repository.test.ts
+++ b/lib/media/asset-review/repository.test.ts
@@ -1,42 +1,30 @@
-import { readFile } from 'node:fs/promises'
-
-import { PGlite } from '@electric-sql/pglite'
+import type { PGlite } from '@electric-sql/pglite'
 import { drizzle } from 'drizzle-orm/pglite'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('server-only', () => ({}))
+
+import { usePGliteTestClient } from '~/db/testing/pglite'
 
 import {
   createMediaAssetReviewRepository,
   type MediaAssetReviewDatabase,
 } from './repository'
-
-const migrations = [
-  new URL('../../../db/migrations/0005_media_catalog.sql', import.meta.url),
-  new URL('../../../db/migrations/0006_photo_selection.sql', import.meta.url),
-  new URL(
-    '../../../db/migrations/0007_photo_publication_revision.sql',
-    import.meta.url,
-  ),
-  new URL(
-    '../../../db/migrations/0009_media_catalog_state.sql',
-    import.meta.url,
-  ),
-]
 const assetId = '11111111-1111-4111-8111-111111111111'
 const intentId = '22222222-2222-4222-8222-222222222222'
 
 describe('Media Asset review repository', () => {
+  const getClient = usePGliteTestClient([
+    '0005_media_catalog.sql',
+    '0006_photo_selection.sql',
+    '0007_photo_publication_revision.sql',
+    '0009_media_catalog_state.sql',
+  ])
   let client: PGlite
   let repository: ReturnType<typeof createMediaAssetReviewRepository>
 
   beforeEach(async () => {
-    client = new PGlite()
-    for (const url of migrations) {
-      await client.exec(
-        (await readFile(url, 'utf8')).replaceAll('--> statement-breakpoint', ''),
-      )
-    }
+    client = getClient()
     await client.query(
       `INSERT INTO media_upload_intents
         (id, owner_user_id, idempotency_key, original_key, content_type,
@@ -69,8 +57,6 @@ describe('Media Asset review repository', () => {
       (key) => `https://media.example.com/${key}`,
     )
   })
-
-  afterEach(async () => client.close())
 
   it('lists only owned catalogState views with public 640-pixel previews', async () => {
     await expect(

--- a/lib/media/catalog/schema.test.ts
+++ b/lib/media/catalog/schema.test.ts
@@ -1,41 +1,26 @@
-import { readFile } from 'node:fs/promises'
+import type { PGlite } from '@electric-sql/pglite'
+import { beforeEach, describe, expect, it } from 'vitest'
 
-import { PGlite } from '@electric-sql/pglite'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-
-const migrations = [
-  new URL('../../../db/migrations/0001_ama_owner_auth.sql', import.meta.url),
-  new URL('../../../db/migrations/0002_ama_availability.sql', import.meta.url),
-  new URL('../../../db/migrations/0003_ama_google_calendar.sql', import.meta.url),
-  new URL('../../../db/migrations/0004_ama_google_oauth.sql', import.meta.url),
-  new URL('../../../db/migrations/0005_media_catalog.sql', import.meta.url),
-  new URL('../../../db/migrations/0006_photo_selection.sql', import.meta.url),
-  new URL(
-    '../../../db/migrations/0007_photo_publication_revision.sql',
-    import.meta.url,
-  ),
-  new URL('../../../db/migrations/0008_media_purge_progress.sql', import.meta.url),
-  new URL(
-    '../../../db/migrations/0009_media_catalog_state.sql',
-    import.meta.url,
-  ),
-]
+import { usePGliteTestClient } from '~/db/testing/pglite'
 
 const checksum = 'a'.repeat(64)
 
 describe('Media Library catalog migration', () => {
+  const getClient = usePGliteTestClient([
+    '0001_ama_owner_auth.sql',
+    '0002_ama_availability.sql',
+    '0003_ama_google_calendar.sql',
+    '0004_ama_google_oauth.sql',
+    '0005_media_catalog.sql',
+    '0006_photo_selection.sql',
+    '0007_photo_publication_revision.sql',
+    '0008_media_purge_progress.sql',
+    '0009_media_catalog_state.sql',
+  ])
   let client: PGlite
 
-  beforeEach(async () => {
-    client = new PGlite()
-    for (const migrationUrl of migrations) {
-      const migration = await readFile(migrationUrl, 'utf8')
-      await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
-    }
-  })
-
-  afterEach(async () => {
-    await client.close()
+  beforeEach(() => {
+    client = getClient()
   })
 
   async function createUploadIntent(overrides: Record<string, unknown> = {}) {

--- a/lib/media/geocoding/repository.test.ts
+++ b/lib/media/geocoding/repository.test.ts
@@ -1,23 +1,15 @@
-import { readFile } from 'node:fs/promises'
-
-import { PGlite } from '@electric-sql/pglite'
+import type { PGlite } from '@electric-sql/pglite'
 import { drizzle } from 'drizzle-orm/pglite'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('server-only', () => ({}))
+
+import { usePGliteTestClient } from '~/db/testing/pglite'
 
 import {
   createMediaGeocodingRepository,
   type MediaGeocodingDatabase,
 } from './repository'
-
-const migrations = [
-  new URL('../../../db/migrations/0005_media_catalog.sql', import.meta.url),
-  new URL(
-    '../../../db/migrations/0009_media_catalog_state.sql',
-    import.meta.url,
-  ),
-]
 const mediaAssetId = '11111111-1111-4111-8111-111111111111'
 const uploadIntentId = '22222222-2222-4222-8222-222222222222'
 const checksum = 'a'.repeat(64)
@@ -30,15 +22,15 @@ const envelope = {
 }
 
 describe('Media Geocoding repository', () => {
+  const getClient = usePGliteTestClient([
+    '0005_media_catalog.sql',
+    '0009_media_catalog_state.sql',
+  ])
   let client: PGlite
   let repository: ReturnType<typeof createMediaGeocodingRepository>
 
   beforeEach(async () => {
-    client = new PGlite()
-    for (const url of migrations) {
-      const migration = await readFile(url, 'utf8')
-      await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
-    }
+    client = getClient()
     const database = drizzle(client)
     repository = createMediaGeocodingRepository(
       () => database as unknown as MediaGeocodingDatabase,
@@ -66,10 +58,6 @@ describe('Media Geocoding repository', () => {
         envelope,
       ],
     )
-  })
-
-  afterEach(async () => {
-    await client.close()
   })
 
   it('returns the encrypted Capture Location only to the owning principal', async () => {

--- a/lib/media/ingestion/repository.test.ts
+++ b/lib/media/ingestion/repository.test.ts
@@ -1,23 +1,15 @@
-import { readFile } from 'node:fs/promises'
-
-import { PGlite } from '@electric-sql/pglite'
+import type { PGlite } from '@electric-sql/pglite'
 import { drizzle } from 'drizzle-orm/pglite'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('server-only', () => ({}))
+
+import { usePGliteTestClient } from '~/db/testing/pglite'
 
 import {
   createMediaIngestionRepository,
   type MediaIngestionDatabase,
 } from './repository'
-
-const migrations = [
-  new URL('../../../db/migrations/0005_media_catalog.sql', import.meta.url),
-  new URL(
-    '../../../db/migrations/0009_media_catalog_state.sql',
-    import.meta.url,
-  ),
-]
 const intentInput = {
   id: '11111111-1111-4111-8111-111111111111',
   ownerUserId: 'owner_01',
@@ -32,23 +24,19 @@ const intentInput = {
 }
 
 describe('Media Library ingestion repository', () => {
+  const getClient = usePGliteTestClient([
+    '0005_media_catalog.sql',
+    '0009_media_catalog_state.sql',
+  ])
   let client: PGlite
   let repository: ReturnType<typeof createMediaIngestionRepository>
 
-  beforeEach(async () => {
-    client = new PGlite()
-    for (const url of migrations) {
-      const migration = await readFile(url, 'utf8')
-      await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
-    }
+  beforeEach(() => {
+    client = getClient()
     const database = drizzle(client)
     repository = createMediaIngestionRepository(
       () => database as unknown as MediaIngestionDatabase,
     )
-  })
-
-  afterEach(async () => {
-    await client.close()
   })
 
   it('returns the first Upload Intent for an idempotency replay', async () => {

--- a/lib/media/photo-selection/repository.test.ts
+++ b/lib/media/photo-selection/repository.test.ts
@@ -1,10 +1,10 @@
-import { readFile } from 'node:fs/promises'
-
-import { PGlite } from '@electric-sql/pglite'
+import type { PGlite } from '@electric-sql/pglite'
 import { drizzle } from 'drizzle-orm/pglite'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('server-only', () => ({}))
+
+import { usePGliteTestClient } from '~/db/testing/pglite'
 
 import {
   createPhotoSelectionRepository,
@@ -12,42 +12,27 @@ import {
   getHomepagePhotoPreview,
   type PhotoSelectionDatabase,
 } from './repository'
-
-const migrationUrls = [
-  new URL('../../../db/migrations/0005_media_catalog.sql', import.meta.url),
-  new URL('../../../db/migrations/0006_photo_selection.sql', import.meta.url),
-  new URL(
-    '../../../db/migrations/0007_photo_publication_revision.sql',
-    import.meta.url,
-  ),
-  new URL(
-    '../../../db/migrations/0009_media_catalog_state.sql',
-    import.meta.url,
-  ),
-]
 const checksum = 'a'.repeat(64)
 
 describe('Photo Selection repository', () => {
+  const getClient = usePGliteTestClient([
+    '0005_media_catalog.sql',
+    '0006_photo_selection.sql',
+    '0007_photo_publication_revision.sql',
+    '0009_media_catalog_state.sql',
+  ])
   let client: PGlite
   let repository: ReturnType<typeof createPhotoSelectionRepository>
   let publicRepository: ReturnType<typeof createPublicPhotoSelectionRepository>
 
-  beforeEach(async () => {
-    client = new PGlite()
-    for (const migrationUrl of migrationUrls) {
-      const migration = await readFile(migrationUrl, 'utf8')
-      await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
-    }
+  beforeEach(() => {
+    client = getClient()
     const database = drizzle(client) as unknown as PhotoSelectionDatabase
     repository = createPhotoSelectionRepository(() => database)
     publicRepository = createPublicPhotoSelectionRepository(
       () => database,
       new URL('https://media.example.com/photos/'),
     )
-  })
-
-  afterEach(async () => {
-    await client.close()
   })
 
   async function createAsset(

--- a/lib/media/purge/repository.test.ts
+++ b/lib/media/purge/repository.test.ts
@@ -1,44 +1,33 @@
-import { readFile } from 'node:fs/promises'
-
-import { PGlite } from '@electric-sql/pglite'
+import type { PGlite } from '@electric-sql/pglite'
 import { drizzle } from 'drizzle-orm/pglite'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('server-only', () => ({}))
+
+import { usePGliteTestClient } from '~/db/testing/pglite'
 
 import {
   createMediaPurgeRepository,
   type MediaPurgeDatabase,
 } from './repository'
-
-const migrations = [
-  new URL('../../../db/migrations/0005_media_catalog.sql', import.meta.url),
-  new URL('../../../db/migrations/0006_photo_selection.sql', import.meta.url),
-  new URL(
-    '../../../db/migrations/0007_photo_publication_revision.sql',
-    import.meta.url,
-  ),
-  new URL('../../../db/migrations/0008_media_purge_progress.sql', import.meta.url),
-  new URL(
-    '../../../db/migrations/0009_media_catalog_state.sql',
-    import.meta.url,
-  ),
-]
 const assetId = '11111111-1111-4111-8111-111111111111'
 const intentId = '22222222-2222-4222-8222-222222222222'
 const firstClaimToken = '33333333-3333-4333-8333-333333333333'
 const secondClaimToken = '44444444-4444-4444-8444-444444444444'
 
 describe('Media Asset Purge repository', () => {
+  const getClient = usePGliteTestClient([
+    '0005_media_catalog.sql',
+    '0006_photo_selection.sql',
+    '0007_photo_publication_revision.sql',
+    '0008_media_purge_progress.sql',
+    '0009_media_catalog_state.sql',
+  ])
   let client: PGlite
   let repository: ReturnType<typeof createMediaPurgeRepository>
 
   beforeEach(async () => {
-    client = new PGlite()
-    for (const migrationUrl of migrations) {
-      const migration = await readFile(migrationUrl, 'utf8')
-      await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
-    }
+    client = getClient()
     await client.query(
       `INSERT INTO media_upload_intents
         (id, owner_user_id, idempotency_key, original_key, content_type,
@@ -74,8 +63,6 @@ describe('Media Asset Purge repository', () => {
     const database = drizzle(client) as unknown as MediaPurgeDatabase
     repository = createMediaPurgeRepository(() => database)
   })
-
-  afterEach(async () => client.close())
 
   function claimInput(overrides: Record<string, unknown> = {}) {
     return {

--- a/lib/media/reconciliation/repository.test.ts
+++ b/lib/media/reconciliation/repository.test.ts
@@ -1,23 +1,15 @@
-import { readFile } from 'node:fs/promises'
-
-import { PGlite } from '@electric-sql/pglite'
+import type { PGlite } from '@electric-sql/pglite'
 import { drizzle } from 'drizzle-orm/pglite'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('server-only', () => ({}))
+
+import { usePGliteTestClient } from '~/db/testing/pglite'
 
 import {
   createMediaReconciliationRepository,
   type MediaReconciliationDatabase,
 } from './repository'
-
-const migrations = [
-  new URL('../../../db/migrations/0005_media_catalog.sql', import.meta.url),
-  new URL(
-    '../../../db/migrations/0009_media_catalog_state.sql',
-    import.meta.url,
-  ),
-]
 const abandonedIntentId = '11111111-1111-4111-8111-111111111111'
 const retryIntentId = '22222222-2222-4222-8222-222222222222'
 const retryAssetId = '33333333-3333-4333-8333-333333333333'
@@ -28,15 +20,15 @@ const laterReadyAssetId = '77777777-7777-4777-8777-777777777777'
 const checksum = 'a'.repeat(64)
 
 describe('Media reconciliation repository', () => {
+  const getClient = usePGliteTestClient([
+    '0005_media_catalog.sql',
+    '0009_media_catalog_state.sql',
+  ])
   let client: PGlite
   let repository: ReturnType<typeof createMediaReconciliationRepository>
 
   beforeEach(async () => {
-    client = new PGlite()
-    for (const url of migrations) {
-      const migration = await readFile(url, 'utf8')
-      await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
-    }
+    client = getClient()
     const database = drizzle(client)
     repository = createMediaReconciliationRepository(
       () => database as unknown as MediaReconciliationDatabase,
@@ -114,10 +106,6 @@ describe('Media reconciliation repository', () => {
         checksum,
       ],
     )
-  })
-
-  afterEach(async () => {
-    await client.close()
   })
 
   it('finds recoverable work, scopes owner resume, and deletes only abandoned intents', async () => {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:ama": "vitest run lib/ama && pnpm db:validate",
     "test:navigation": "NEXT_INSTANT_NAVIGATION_TEST=1 next build && playwright test",
     "test:security": "vitest run lib/security",
-    "test:unit": "vitest run app components lib --exclude='**/*.live.test.ts'",
+    "test:unit": "vitest run app components db lib --exclude='**/*.live.test.ts'",
     "test:localization": "node --test scripts/localization.test.mjs",
     "test:media:catalog": "vitest run lib/media/catalog",
     "test:media:geocoding": "vitest run lib/media/geocoding",


### PR DESCRIPTION
## Problem

`pnpm run test:unit` could run forever in a local/sandboxed environment: a vitest fork worker pinned at 100% CPU, surviving for hours (one specimen from another worktree burned 2.5+ CPU-hours). A `sample` of a live wedged worker showed the signature — a **permanent microtask spin** (`RunMicrotasks → PromiseFulfillReactionJob → AsyncFunctionAwaitResolveClosure`, entered right after a `FileHandle` close), which no test/hook timeout can interrupt because timers never fire while the microtask queue churns.

## Root cause

Repository tests booted a **fresh PGlite (WASM Postgres) in `beforeEach`** — ~100 instantiations per suite run, multiplied across fork workers. PGlite's WASM boot (which loads its bundle via file handles) can enter that spin under load. Bisection evidence:
- every directory passes in isolation; failures/wedges only appear under contention (concurrent suite runs, dev server compiling)
- under a 3-way concurrent stress test, **exactly the 10 PGlite files** failed with `Hook timed out in 10000ms` on `new PGlite()`
- nothing else in the suite is load-sensitive

## Fix

New `db/testing/pglite.ts`: **one PGlite per test file** (`beforeAll`, 120s timeout so contended boots wait instead of flaking) with `TRUNCATE ... RESTART IDENTITY CASCADE` on all public tables before each test — tests keep starting from empty state. Ten repository/schema test files adopt it; per-test `new PGlite()` + migration replays and the `afterEach` closes are gone.

## Verification

| Scenario | Before | After |
|---|---|---|
| Solo `pnpm run test:unit` | ~19s (when it completed at all) | **8s, 396 passed** |
| 3 concurrent suite runs | 11 files failed (`Hook timed out`) or permanent wedge | **64/64 files pass, ×3, in 30s** |

Typecheck clean. Residual risk: a single PGlite boot can still theoretically spin (it's inside the WASM init, uninterruptible in-process), but exposure is ~10× lower and a boot that merely runs slow now waits out the contention instead of failing.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a hard-to-reproduce test wedge where vitest fork workers could pin at 100% CPU indefinitely: multiple concurrent `new PGlite()` calls in `beforeEach` triggered a permanent WASM microtask spin that no timeout could interrupt. The fix introduces `usePGliteTestClient`, which boots **one PGlite instance per test file** in `beforeAll` (120 s timeout) and resets state between tests via `TRUNCATE … RESTART IDENTITY CASCADE` + shadow-schema seed restoration.

- **`db/testing/pglite.ts`** — new shared helper; captures any migration-seeded rows into a `_migration_seed` shadow schema at boot and replays them before each test, so both empty and pre-seeded tables reset cleanly.
- **Ten repository/schema test files** — drop per-test `new PGlite()` + `afterEach` close in favour of `usePGliteTestClient`; `beforeEach` bodies now only wire up Drizzle and repository instances.
- **`package.json`** — adds `db` to `test:unit` so `db/testing/pglite.test.ts` runs in the standard unit-test pass.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is test-infrastructure only and demonstrably reduces wedge exposure by ~10x.

All ten consumer test files follow the new pattern consistently. The helper's boot-once / truncate-restore contract is validated by an intentionally order-dependent spec. The only gap is that the seed-restoration loop does not advance sequences after re-inserting explicit IDs, which would cause duplicate-key errors if a future migration seeds a serial-PK table — but no current migration does, and the fixture deliberately avoids the case.

db/testing/pglite.ts — the beforeEach seed-restoration loop is the one place to revisit if any future migration inserts rows into a table with a serial or GENERATED ALWAYS AS IDENTITY column.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| db/testing/pglite.ts | New shared-PGlite helper: boots one WASM instance per file in beforeAll (120 s timeout), snapshots seeded rows into a shadow schema, then truncates+restores on each beforeEach; afterAll uses optional chaining to avoid masking boot errors. |
| db/testing/pglite.test.ts | Intentionally order-dependent two-test spec that validates the truncate-and-restore contract: first test dirties all tables, second confirms post-migration state is fully recovered including seed rows and sequence restart. |
| db/testing/fixtures/seeded-migration.sql | Fixture migration used only by pglite.test.ts; deliberately uses a plain integer PK for the seeded table and a separate serial-PK empty table to cover both code paths of the snapshot logic. |
| lib/ama/google/repository.test.ts | Migrated to usePGliteTestClient; one raw client.query call replaced with getClient().query — semantically identical since getClient() returns the same shared instance. |
| lib/media/catalog/schema.test.ts | Migrated to usePGliteTestClient; largest migration list (9 files); beforeEach now synchronous getter call. |
| package.json | Adds db directory to test:unit vitest run so pglite.test.ts participates in the standard unit-test pass. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant VW as Vitest Worker
    participant H as usePGliteTestClient
    participant PG as PGlite (WASM)
    participant SS as _migration_seed schema

    Note over VW,SS: beforeAll (120 s timeout)
    VW->>H: describe() calls usePGliteTestClient(migrationFiles)
    H->>PG: new PGlite()
    H->>PG: exec(migration SQL) x N
    H->>PG: "SELECT tablename FROM pg_tables WHERE schemaname='public'"
    PG-->>H: [table list]
    loop each table with rows
        H->>PG: "SELECT count(*) FROM public.table"
        H->>SS: CREATE TABLE _migration_seed.table AS TABLE public.table
    end
    H-->>VW: client ready

    Note over VW,SS: beforeEach (per test)
    VW->>H: getClient() called by test setup
    H->>PG: "SELECT tablename FROM pg_tables WHERE schemaname='public'"
    PG-->>H: [table list]
    H->>PG: TRUNCATE table1, table2 RESTART IDENTITY CASCADE
    loop each seeded table
        H->>PG: "INSERT INTO public.table SELECT * FROM _migration_seed.table"
    end
    H-->>VW: PGlite (clean state)

    Note over VW,SS: Test body
    VW->>PG: queries / mutations
    PG-->>VW: results

    Note over VW,SS: afterAll
    VW->>H: afterAll hook fires
    H->>PG: client?.close()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant VW as Vitest Worker
    participant H as usePGliteTestClient
    participant PG as PGlite (WASM)
    participant SS as _migration_seed schema

    Note over VW,SS: beforeAll (120 s timeout)
    VW->>H: describe() calls usePGliteTestClient(migrationFiles)
    H->>PG: new PGlite()
    H->>PG: exec(migration SQL) x N
    H->>PG: "SELECT tablename FROM pg_tables WHERE schemaname='public'"
    PG-->>H: [table list]
    loop each table with rows
        H->>PG: "SELECT count(*) FROM public.table"
        H->>SS: CREATE TABLE _migration_seed.table AS TABLE public.table
    end
    H-->>VW: client ready

    Note over VW,SS: beforeEach (per test)
    VW->>H: getClient() called by test setup
    H->>PG: "SELECT tablename FROM pg_tables WHERE schemaname='public'"
    PG-->>H: [table list]
    H->>PG: TRUNCATE table1, table2 RESTART IDENTITY CASCADE
    loop each seeded table
        H->>PG: "INSERT INTO public.table SELECT * FROM _migration_seed.table"
    end
    H-->>VW: PGlite (clean state)

    Note over VW,SS: Test body
    VW->>PG: queries / mutations
    PG-->>VW: results

    Note over VW,SS: afterAll
    VW->>H: afterAll hook fires
    H->>PG: client?.close()
```

</a>

<sub>Reviews (2): Last reviewed commit: ["test: harden PGlite helper against faile..."](https://github.com/calicastle/cali.so/commit/aa4ceada50c5cbede54a962c7ae396685529268d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44702762)</sub>

<!-- /greptile_comment -->