### PR TITLE
style(prefs): compact 32px switches on fine pointers

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3936,6 +3936,16 @@ html[data-locale='en'] [data-en-block] {
   display: none;
 }
 
+/* The shared tab item carries a 44px touch target; inside this pointer
+   chrome that balloons every row, so fine pointers get compact 32px
+   pills. Touch keeps the full target. */
+@media (hover: hover) and (pointer: fine) {
+  .prefs-panel [role='tab'] {
+    height: 2rem;
+    min-width: 2.5rem;
+  }
+}
+
 .prefs-panel [role='tab'][aria-selected='true'] {
   border-radius: 999px;
   background: var(--foreground);


### PR DESCRIPTION
The dock preferences popover (语言 / 外观 / 音效) rendered each switch at the shared tab component's 44px touch-target height plus track padding — ~52px tall rows that made the panel feel enormous on desktop.

Fine pointers now get compact 32px pills (40px tracks; panel height 192px → 144px), scoped to `.prefs-panel` via `@media (hover: hover) and (pointer: fine)` so touch devices keep the full 44px targets per the design language. The proximity-hover indicator, hover highlight, and focus ring all measure live rects, so they follow the new size with no component changes.

Verified in the running dev server: tabs measure 32px, the panel opens correctly in dark mode, and selection/hover still render properly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single CSS media query to compact the preferences panel's tab switches from 44px to 32px tall on fine-pointer (mouse/trackpad) devices, while leaving touch targets unchanged.

- Adds `@media (hover: hover) and (pointer: fine)` scoped to `.prefs-panel [role='tab']`, setting `height: 2rem` and `min-width: 2.5rem`; the selector specificity (0,1,1) correctly overrides the Tailwind `h-11`/`min-w-11` classes (0,1,0) so no component edits are needed.
- The `TabsList` overlay indicators (selected pill, hover highlight, focus ring) all derive their geometry from live `getBoundingClientRect` measurements via `useProximityHover`, so they automatically track the new compact size without any JS changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single, well-scoped media query that only affects one panel on desktop mouse devices.

The diff touches exactly one CSS block. The media query condition, selector specificity, and cascade order are all correct. Touch targets are preserved, live rect measurements in the JS layer adapt automatically, and the override has no interaction with any other component or layout.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/globals.css | Adds a single `@media (hover: hover) and (pointer: fine)` block that reduces `.prefs-panel [role='tab']` height to 2rem and min-width to 2.5rem on mouse/trackpad devices; touch devices are unaffected. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Browser renders .prefs-panel] --> B{pointer: fine\nhover: hover?}
    B -- Yes / Mouse/Trackpad --> C[TabItem height = 2rem / 32px\nmin-width = 2.5rem / 40px]
    B -- No / Touch --> D[TabItem height = 2.75rem / 44px\nmin-width = 2.75rem / 44px\nTailwind h-11 min-w-11]
    C --> E[useProximityHover measures live DOM rects]
    D --> E
    E --> F[Selected indicator / Hover highlight / Focus ring\nall sized from measured rects]
    F --> G[Visual output matches actual tab dimensions]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Browser renders .prefs-panel] --> B{pointer: fine\nhover: hover?}
    B -- Yes / Mouse/Trackpad --> C[TabItem height = 2rem / 32px\nmin-width = 2.5rem / 40px]
    B -- No / Touch --> D[TabItem height = 2.75rem / 44px\nmin-width = 2.75rem / 44px\nTailwind h-11 min-w-11]
    C --> E[useProximityHover measures live DOM rects]
    D --> E
    E --> F[Selected indicator / Hover highlight / Focus ring\nall sized from measured rects]
    F --> G[Visual output matches actual tab dimensions]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["style(prefs): compact 32px switches on f..."](https://github.com/calicastle/cali.so/commit/07877b503da514a2b05b533e509b2dd15c08ab62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44703577)</sub>

<!-- /greptile_comment -->