### PR TITLE
fix: stabilize keyboard post navigation

### DIFF
--- a/components/post-transition-link.test.tsx
+++ b/components/post-transition-link.test.tsx
@@ -1,21 +1,21 @@
 /** @vitest-environment jsdom */
 
-import type { MouseEventHandler, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('next/link', () => ({
   default: ({
     children,
-    onClick,
+    onNavigate,
   }: {
     children: ReactNode
-    onClick?: MouseEventHandler<HTMLAnchorElement>
+    onNavigate?: () => void
   }) => (
     <a
       href="/blog/a-post"
       onClick={(event) => {
-        onClick?.(event)
+        if (!event.metaKey) onNavigate?.()
         event.preventDefault()
       }}
     >
@@ -62,7 +62,7 @@ describe('PostTransitionLink', () => {
     ).toBe('title-p01')
   })
 
-  it('leaves the current page unchanged for modified clicks', () => {
+  it('leaves the current page unchanged when Next does not navigate', () => {
     render(
       <PostTransitionLink
         href="/blog/a-post"

--- a/components/post-transition-link.test.tsx
+++ b/components/post-transition-link.test.tsx
@@ -1,21 +1,34 @@
 /** @vitest-environment jsdom */
 
-import type { ReactNode } from 'react'
+import type { MouseEventHandler, ReactNode } from 'react'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('next/link', () => ({
   default: ({
     children,
+    onClick,
     onNavigate,
   }: {
     children: ReactNode
+    onClick?: MouseEventHandler<HTMLAnchorElement>
     onNavigate?: () => void
   }) => (
     <a
       href="/blog/a-post"
       onClick={(event) => {
-        if (!event.metaKey) onNavigate?.()
+        onClick?.(event)
+        if (
+          event.defaultPrevented ||
+          event.button !== 0 ||
+          event.metaKey ||
+          event.ctrlKey ||
+          event.shiftKey ||
+          event.altKey
+        ) {
+          return
+        }
+        onNavigate?.()
         event.preventDefault()
       }}
     >
@@ -48,7 +61,9 @@ describe('PostTransitionLink', () => {
       </PostTransitionLink>,
     )
 
-    fireEvent.click(screen.getByRole('link', { name: 'Read post' }))
+    fireEvent.click(screen.getByRole('link', { name: 'Read post' }), {
+      detail: 1,
+    })
 
     expect(
       document.documentElement.style.getPropertyValue(
@@ -62,20 +77,27 @@ describe('PostTransitionLink', () => {
     ).toBe('title-p01')
   })
 
-  it('leaves the current page unchanged when Next does not navigate', () => {
+  it('navigates without a morph when activated from the keyboard', () => {
+    document.documentElement.style.setProperty(
+      '--post-cover-transition-name',
+      'stale-cover',
+    )
+    document.documentElement.style.setProperty(
+      '--post-title-transition-name',
+      'stale-title',
+    )
+
     render(
       <PostTransitionLink
         href="/blog/a-post"
         coverTransitionName="cover-p01"
         titleTransitionName="title-p01"
       >
-        Open post elsewhere
+        Read with keyboard
       </PostTransitionLink>,
     )
 
-    fireEvent.click(screen.getByRole('link', { name: 'Open post elsewhere' }), {
-      metaKey: true,
-    })
+    fireEvent.click(screen.getByRole('link', { name: 'Read with keyboard' }))
 
     expect(
       document.documentElement.style.getPropertyValue(
@@ -87,5 +109,34 @@ describe('PostTransitionLink', () => {
         '--post-title-transition-name',
       ),
     ).toBe('')
+  })
+
+  it('leaves the current page unchanged when Next does not navigate', () => {
+    render(
+      <PostTransitionLink
+        href="/blog/a-post"
+        coverTransitionName="cover-p01"
+        titleTransitionName="title-p01"
+      >
+        Open post elsewhere
+      </PostTransitionLink>,
+    )
+
+    const handled = fireEvent.click(
+      screen.getByRole('link', { name: 'Open post elsewhere' }),
+      { metaKey: true },
+    )
+
+    expect(
+      document.documentElement.style.getPropertyValue(
+        '--post-cover-transition-name',
+      ),
+    ).toBe('')
+    expect(
+      document.documentElement.style.getPropertyValue(
+        '--post-title-transition-name',
+      ),
+    ).toBe('')
+    expect(handled).toBe(true)
   })
 })

--- a/components/post-transition-link.test.tsx
+++ b/components/post-transition-link.test.tsx
@@ -111,32 +111,41 @@ describe('PostTransitionLink', () => {
     ).toBe('')
   })
 
-  it('leaves the current page unchanged when Next does not navigate', () => {
-    render(
-      <PostTransitionLink
-        href="/blog/a-post"
-        coverTransitionName="cover-p01"
-        titleTransitionName="title-p01"
-      >
-        Open post elsewhere
-      </PostTransitionLink>,
-    )
+  it.each([
+    ['Command-click', { metaKey: true }],
+    ['Control-click', { ctrlKey: true }],
+    ['Shift-click', { shiftKey: true }],
+    ['Alt-click', { altKey: true }],
+    ['middle-click', { button: 1 }],
+  ] satisfies Array<[string, MouseEventInit]>)(
+    'leaves %s native when Next does not navigate',
+    (_label, eventInit) => {
+      render(
+        <PostTransitionLink
+          href="/blog/a-post"
+          coverTransitionName="cover-p01"
+          titleTransitionName="title-p01"
+        >
+          Open post elsewhere
+        </PostTransitionLink>,
+      )
 
-    const handled = fireEvent.click(
-      screen.getByRole('link', { name: 'Open post elsewhere' }),
-      { metaKey: true },
-    )
+      const handled = fireEvent.click(
+        screen.getByRole('link', { name: 'Open post elsewhere' }),
+        eventInit,
+      )
 
-    expect(
-      document.documentElement.style.getPropertyValue(
-        '--post-cover-transition-name',
-      ),
-    ).toBe('')
-    expect(
-      document.documentElement.style.getPropertyValue(
-        '--post-title-transition-name',
-      ),
-    ).toBe('')
-    expect(handled).toBe(true)
-  })
+      expect(
+        document.documentElement.style.getPropertyValue(
+          '--post-cover-transition-name',
+        ),
+      ).toBe('')
+      expect(
+        document.documentElement.style.getPropertyValue(
+          '--post-title-transition-name',
+        ),
+      ).toBe('')
+      expect(handled).toBe(true)
+    },
+  )
 })

--- a/components/post-transition-link.tsx
+++ b/components/post-transition-link.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import type { MouseEvent, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 
 export function PostTransitionLink({
   href,
@@ -16,18 +16,7 @@ export function PostTransitionLink({
   className?: string
   children: ReactNode
 }) {
-  function prepareFallbackMorph(event: MouseEvent<HTMLAnchorElement>) {
-    if (
-      event.defaultPrevented ||
-      event.button !== 0 ||
-      event.metaKey ||
-      event.ctrlKey ||
-      event.shiftKey ||
-      event.altKey
-    ) {
-      return
-    }
-
+  function prepareFallbackMorph() {
     const root = document.documentElement
     root.style.setProperty('--post-cover-transition-name', coverTransitionName)
     root.style.setProperty('--post-title-transition-name', titleTransitionName)
@@ -38,7 +27,7 @@ export function PostTransitionLink({
       href={href}
       prefetch={true}
       className={className}
-      onClick={prepareFallbackMorph}
+      onNavigate={prepareFallbackMorph}
     >
       {children}
     </Link>

--- a/components/post-transition-link.tsx
+++ b/components/post-transition-link.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import type { ReactNode } from 'react'
+import { useRef, type MouseEvent, type ReactNode } from 'react'
 
 export function PostTransitionLink({
   href,
@@ -16,8 +16,20 @@ export function PostTransitionLink({
   className?: string
   children: ReactNode
 }) {
+  const pointerNavigationRef = useRef(false)
+
+  function recordInputModality(event: MouseEvent<HTMLAnchorElement>) {
+    pointerNavigationRef.current = event.detail !== 0
+  }
+
   function prepareFallbackMorph() {
     const root = document.documentElement
+    if (!pointerNavigationRef.current) {
+      root.style.removeProperty('--post-cover-transition-name')
+      root.style.removeProperty('--post-title-transition-name')
+      return
+    }
+
     root.style.setProperty('--post-cover-transition-name', coverTransitionName)
     root.style.setProperty('--post-title-transition-name', titleTransitionName)
   }
@@ -27,6 +39,7 @@ export function PostTransitionLink({
       href={href}
       prefetch={true}
       className={className}
+      onClick={recordInputModality}
       onNavigate={prepareFallbackMorph}
     >
       {children}

--- a/components/preferences.tsx
+++ b/components/preferences.tsx
@@ -83,6 +83,7 @@ export function Preferences() {
             type="button"
             className="dock-item"
             aria-label={localize(activeLocale, '偏好设置', 'Preferences')}
+            disabled={!mounted}
           >
             <PreferencesIcon />
             <span className="dock-tip" aria-hidden>

--- a/e2e/instant-navigation.spec.ts
+++ b/e2e/instant-navigation.spec.ts
@@ -251,6 +251,7 @@ test('keyboard controls restore focus across public overlays', async ({ page }) 
   await page.goto('/en')
 
   const preferences = page.getByRole('button', { name: 'Preferences' })
+  await expect(preferences).toBeEnabled()
   await preferences.focus()
   await page.keyboard.press('Enter')
   await expect(page.getByRole('tab', { name: 'English' })).toBeFocused()
@@ -269,6 +270,24 @@ test('keyboard controls restore focus across public overlays', async ({ page }) 
   await postLink.focus()
   await page.keyboard.press('Enter')
   await expect(page).toHaveURL(`/en/blog/${postSlug}`)
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        document.documentElement.style.getPropertyValue(
+          '--post-cover-transition-name',
+        ),
+      ),
+    )
+    .toBe('')
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        document.documentElement.style.getPropertyValue(
+          '--post-title-transition-name',
+        ),
+      ),
+    )
+    .toBe('')
 
   const zoom = page.getByRole('button', { name: /^Zoom image/ }).first()
   await zoom.focus()


### PR DESCRIPTION
## Summary

- prepare shared post morphs only after Next accepts a pointer navigation
- keep keyboard navigation instant and clear stale transition state
- hold Preferences disabled until hydration so immediate keyboard input cannot race event binding
- cover the real keyboard path and native modified-click behavior

## Verification

- `pnpm typecheck`
- `pnpm exec vitest run components/post-transition-link.test.tsx`
- full production `e2e/instant-navigation.spec.ts` suite, 9 passed
- repeated keyboard overlay/navigation path
- Standards and behavior reviews found no remaining issues

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stabilizes keyboard post navigation by splitting the shared-element morph preparation into two clearly-separated handlers: `onClick` records input modality (`event.detail !== 0` for pointer vs. keyboard), and the new Next.js 16 `onNavigate` callback — which fires only when the router commits to navigation — applies or clears the CSS custom properties accordingly. This prevents stale transition names from polluting subsequent keyboard-initiated navigations and also prevents modified clicks (meta, ctrl, shift, middle-button) from incorrectly writing those properties.

- **`post-transition-link.tsx`**: Replaced a single `onClick` guard (checking modifier keys and `event.button`) with a `useRef`-backed modality flag set in `onClick` and consumed in `onNavigate`, delegating the "will Next.js navigate?" decision entirely to the router.
- **`preferences.tsx`**: Adds `disabled={!mounted}` to the Preferences dock button so keyboard input cannot open the panel before React hydration completes and event handlers are bound.
- **Tests**: Unit tests now cover the keyboard path (clearing stale names) and all five modified-click variants; the E2E suite adds a `toBeEnabled()` guard before focusing Preferences and verifies CSS properties are empty after keyboard navigation.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three navigation paths (pointer, keyboard, modified-click) are correctly handled and covered by both unit and E2E tests.

The changes are narrow and well-scoped. Modality detection via event.detail is a reliable browser primitive, and delegating CSS mutation to onNavigate means the router acts as the gatekeeper for when transition names are written. The disabled={!mounted} guard on Preferences is a standard hydration safety pattern. No logic gaps were found across any of the changed files.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| components/post-transition-link.tsx | Core fix — replaces single onClick guard with useRef modality flag + onNavigate callback. Logic is correct and well-structured. |
| components/post-transition-link.test.tsx | Unit tests updated to mock onNavigate, cover the keyboard path and all five modified-click variants with parameterized cases. |
| components/preferences.tsx | Single-line change adding disabled={!mounted} to prevent pre-hydration keyboard race on the Preferences button. |
| e2e/instant-navigation.spec.ts | E2E test hardened with toBeEnabled() wait before Preferences focus, and CSS property assertions after keyboard navigation to the blog post. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant NLink as "Next.js Link"
    participant PTL as "PostTransitionLink"
    participant Router as "Next.js Router"
    participant DOM

    Note over User,DOM: Pointer click (detail=1)
    User->>NLink: "click event detail=1"
    NLink->>PTL: onClick recordInputModality
    PTL->>PTL: "pointerNavigationRef = true"
    NLink->>Router: initiate navigation
    Router->>PTL: onNavigate prepareFallbackMorph
    PTL->>DOM: setProperty cover and title names

    Note over User,DOM: Keyboard activation (detail=0, Enter key)
    User->>NLink: "click event detail=0"
    NLink->>PTL: onClick recordInputModality
    PTL->>PTL: "pointerNavigationRef = false"
    NLink->>Router: initiate navigation
    Router->>PTL: onNavigate prepareFallbackMorph
    PTL->>DOM: removeProperty cover and title names

    Note over User,DOM: Modified click (metaKey or middle-button)
    User->>NLink: "click event metaKey=true"
    NLink->>PTL: onClick recordInputModality
    PTL->>PTL: "pointerNavigationRef = true"
    Note over NLink,Router: Next.js skips navigation
    Note over PTL,DOM: onNavigate never fires, no CSS mutation
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant NLink as "Next.js Link"
    participant PTL as "PostTransitionLink"
    participant Router as "Next.js Router"
    participant DOM

    Note over User,DOM: Pointer click (detail=1)
    User->>NLink: "click event detail=1"
    NLink->>PTL: onClick recordInputModality
    PTL->>PTL: "pointerNavigationRef = true"
    NLink->>Router: initiate navigation
    Router->>PTL: onNavigate prepareFallbackMorph
    PTL->>DOM: setProperty cover and title names

    Note over User,DOM: Keyboard activation (detail=0, Enter key)
    User->>NLink: "click event detail=0"
    NLink->>PTL: onClick recordInputModality
    PTL->>PTL: "pointerNavigationRef = false"
    NLink->>Router: initiate navigation
    Router->>PTL: onNavigate prepareFallbackMorph
    PTL->>DOM: removeProperty cover and title names

    Note over User,DOM: Modified click (metaKey or middle-button)
    User->>NLink: "click event metaKey=true"
    NLink->>PTL: onClick recordInputModality
    PTL->>PTL: "pointerNavigationRef = true"
    Note over NLink,Router: Next.js skips navigation
    Note over PTL,DOM: onNavigate never fires, no CSS mutation
```

</a>

<sub>Reviews (2): Last reviewed commit: ["test: cover native modified post clicks"](https://github.com/calicastle/cali.so/commit/d6cc0ac3c1e51c02590ad2ff185533ff83cf855e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44706030)</sub>

<!-- /greptile_comment -->