### PR TITLE
Refine editorial interactions and article wayfinding

### DIFF
--- a/app/_components/site-document.tsx
+++ b/app/_components/site-document.tsx
@@ -43,7 +43,7 @@ export async function SiteDocument({
       lang={english ? 'en' : 'zh-CN'}
       data-locale={english ? 'en' : undefined}
       suppressHydrationWarning
-      className={cn('font-sans', fontVariables)}
+      className={cn('font-sans', fontVariables, !restoreLocale && 'public-site')}
     >
       <head>
         {/* Pre-paint handles the visited flag and theme. Locale restoration
@@ -56,7 +56,21 @@ export async function SiteDocument({
           <AmbientBackground />
           <div className="flex min-h-screen flex-col pb-20">
             <main className="flex-1 pt-14">
-              <ViewTransition>{children}</ViewTransition>
+              <ViewTransition
+                enter={{
+                  'page-forward': 'page-forward',
+                  'page-back': 'page-back',
+                  default: 'page-sheet',
+                }}
+                exit={{
+                  'page-forward': 'page-forward',
+                  'page-back': 'page-back',
+                  default: 'page-sheet',
+                }}
+                default="none"
+              >
+                {children}
+              </ViewTransition>
             </main>
             <SiteFooter social={social} github={github} locale={locale} />
           </div>

--- a/app/_views/home-page.tsx
+++ b/app/_views/home-page.tsx
@@ -41,7 +41,7 @@ export async function HomePageView({ locale }: { locale: Locale }) {
     <div className="mx-auto w-full max-w-[37.5rem] px-6">
       <div className="flex flex-col-reverse justify-between gap-10 sm:flex-row sm:items-start">
         <div className="enter max-w-[19rem]">
-          <h1 className="text-sm font-semibold">Cali Castle</h1>
+          <h1 className="text-base font-semibold tracking-tight text-foreground">Cali Castle</h1>
           <div className="mt-4">
             <HomeIntroduction social={social.x} github={github} />
           </div>

--- a/app/_views/projects-page.tsx
+++ b/app/_views/projects-page.tsx
@@ -14,7 +14,7 @@ export function ProjectsPageView() {
           <T zh="项目" en="Projects" />
         </h1>
         <p
-          className="enter mt-4 text-balance text-sm leading-relaxed text-foreground"
+          className="page-introduction enter mt-4 text-balance"
           style={{ '--enter-delay': '70ms' } as React.CSSProperties}
         >
           <T

--- a/app/globals.css
+++ b/app/globals.css
@@ -341,7 +341,7 @@
 
 .page-introduction {
   color: var(--gray-10, var(--foreground));
-  font-size: 1rem;
+  font-size: 0.875rem;
   line-height: 1.7;
 }
 
@@ -886,7 +886,7 @@
 
 .prose {
   color: var(--gray-10, var(--foreground));
-  font-size: 1rem;
+  font-size: 0.875rem;
   line-height: 1.72;
 }
 
@@ -902,7 +902,7 @@
 .prose h2 {
   margin-top: 2.5em;
   color: var(--gray-12, var(--foreground));
-  font-size: 1.25rem;
+  font-size: 1.125rem;
   line-height: 1.35;
   font-weight: var(--font-weight-semibold);
   letter-spacing: -0.02em;
@@ -1620,7 +1620,7 @@ a:focus-visible .external-label .external-mark {
 
 .home-introduction p {
   color: var(--gray-10, var(--muted-foreground));
-  font-size: 1rem;
+  font-size: 0.875rem;
   line-height: 1.72;
 }
 
@@ -4094,7 +4094,7 @@ html[data-locale='en'] [data-en-block] {
   height: 3.5rem;
   padding: 0.375rem;
   border-radius: 999px;
-  background: color-mix(in oklab, var(--background) 55%, transparent);
+  background: color-mix(in oklab, var(--background) 68%, transparent);
   box-shadow: 0 0 0 1px var(--border), var(--shadow-medium);
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -266,6 +266,63 @@
   --guide-opacity: 0.4;
 }
 
+/* Public pages use warm paper and ink. Admin keeps the neutral product
+   palette above so editorial refinements cannot change operational UI. */
+.public-site {
+  --gray-1: oklch(0.99 0.004 95);
+  --gray-2: oklch(0.975 0.005 95);
+  --gray-3: oklch(0.95 0.006 95);
+  --gray-4: oklch(0.91 0.007 92);
+  --gray-5: oklch(0.85 0.008 88);
+  --gray-6: oklch(0.77 0.009 84);
+  --gray-7: oklch(0.67 0.01 80);
+  --gray-8: oklch(0.56 0.011 78);
+  --gray-9: oklch(0.47 0.012 76);
+  --gray-10: oklch(0.39 0.012 74);
+  --gray-11: oklch(0.31 0.012 72);
+  --gray-12: oklch(0.23 0.012 70);
+  --selection-highlight: oklch(0.9 0.17 105 / 0.58);
+
+  --background: var(--gray-1);
+  --foreground: var(--gray-12);
+  --card: var(--gray-2);
+  --card-foreground: var(--gray-12);
+  --popover: var(--gray-2);
+  --popover-foreground: var(--gray-12);
+  --primary: var(--gray-12);
+  --primary-foreground: var(--gray-1);
+  --secondary: var(--gray-3);
+  --secondary-foreground: var(--gray-11);
+  --muted: var(--gray-3);
+  --muted-foreground: var(--gray-8);
+  --accent: var(--gray-3);
+  --accent-foreground: var(--gray-11);
+  --border: var(--gray-4);
+  --input: var(--gray-4);
+  --ring: var(--gray-8);
+  --focus-ring: var(--gray-9);
+}
+
+.dark.public-site {
+  --gray-1: oklch(0.16 0.006 80);
+  --gray-2: oklch(0.19 0.007 80);
+  --gray-3: oklch(0.22 0.008 80);
+  --gray-4: oklch(0.27 0.009 80);
+  --gray-5: oklch(0.32 0.01 80);
+  --gray-6: oklch(0.4 0.011 80);
+  --gray-7: oklch(0.5 0.011 82);
+  --gray-8: oklch(0.61 0.01 84);
+  --gray-9: oklch(0.7 0.009 86);
+  --gray-10: oklch(0.78 0.008 88);
+  --gray-11: oklch(0.87 0.007 90);
+  --gray-12: oklch(0.94 0.006 92);
+  --selection-highlight: oklch(0.8 0.14 105 / 0.28);
+}
+
+.public-site ::selection {
+  background: var(--selection-highlight);
+}
+
 .hairline-top {
   border-top: var(--border-hairline) solid var(--border);
 }
@@ -279,7 +336,13 @@
   gap: 0.25rem 1rem;
   min-height: 4.75rem;
   padding-block: 0.875rem;
-  font-size: 0.875rem;
+  font-size: 0.9375rem;
+}
+
+.page-introduction {
+  color: var(--gray-10, var(--foreground));
+  font-size: 1rem;
+  line-height: 1.7;
 }
 
 .project-row:focus-visible {
@@ -340,6 +403,7 @@
 
 .project-name {
   max-width: 100%;
+  color: var(--gray-11, var(--foreground));
   text-wrap: balance;
 }
 
@@ -353,6 +417,7 @@
 
 .project-description {
   min-width: 0;
+  color: var(--gray-8, var(--muted-foreground));
   line-height: 1.55;
   text-wrap: balance;
 }
@@ -736,14 +801,11 @@
 
 @media (hover: hover) and (pointer: fine) {
   .focus-list > li {
-    transition:
-      filter 200ms var(--ease-swift),
-      opacity 200ms var(--ease-swift);
+    transition: opacity 180ms var(--ease-swift);
   }
 
   .focus-list:hover > li:not(:hover):not(:focus-within) {
-    filter: blur(1.5px);
-    opacity: 0.55;
+    opacity: 0.44;
   }
 }
 
@@ -751,7 +813,6 @@
   .focus-list > li,
   .focus-list:hover > li:not(:hover):not(:focus-within) {
     transition: none;
-    filter: none;
     opacity: 1;
   }
 }
@@ -824,13 +885,14 @@
 /* ── Post prose ───────────────────────────────────────────────────── */
 
 .prose {
-  font-size: 14px;
-  line-height: 1.7;
+  color: var(--gray-10, var(--foreground));
+  font-size: 1rem;
+  line-height: 1.72;
 }
 
 .prose:lang(zh-CN),
 .prose:lang(zh) {
-  line-height: 1.85;
+  line-height: 1.9;
 }
 
 .prose > * + * {
@@ -839,33 +901,61 @@
 
 .prose h2 {
   margin-top: 2.5em;
-  font-size: 1.125rem;
+  color: var(--gray-12, var(--foreground));
+  font-size: 1.25rem;
+  line-height: 1.35;
   font-weight: var(--font-weight-semibold);
-  letter-spacing: -0.015em;
+  letter-spacing: -0.02em;
   text-wrap: balance;
 }
 
 .prose h3 {
   margin-top: 2em;
+  color: var(--gray-12, var(--foreground));
   font-size: 1rem;
+  line-height: 1.45;
   font-weight: var(--font-weight-semibold);
   letter-spacing: -0.01em;
   text-wrap: balance;
 }
 
 .prose a {
-  text-decoration: underline;
-  text-underline-offset: 4px;
-  text-decoration-color: color-mix(in oklab, var(--foreground) 30%, transparent);
-  transition: text-decoration-color 150ms ease;
+  color: var(--gray-10, var(--foreground));
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+  text-decoration-thickness: 0.1em;
+  text-underline-offset: 0.16em;
+  text-decoration-color: color-mix(in oklab, currentColor 38%, transparent);
+  text-decoration-skip-ink: auto;
+  transition: color 150ms ease, text-decoration-color 150ms ease;
 }
 
-.prose a:hover {
-  text-decoration-color: var(--foreground);
+@media (hover: hover) and (pointer: fine) {
+  .prose a:hover {
+    color: var(--gray-12, var(--foreground));
+    text-decoration-color: currentColor;
+  }
+}
+
+.prose a:focus-visible {
+  color: var(--gray-12, var(--foreground));
+  text-decoration-color: currentColor;
 }
 
 .prose strong {
+  color: var(--gray-12, var(--foreground));
   font-weight: var(--font-weight-semibold);
+}
+
+.post-title-card h1 {
+  color: var(--gray-12, var(--foreground));
+  font-size: clamp(1.75rem, 4vw, 2rem);
+  line-height: 1.18;
+  letter-spacing: -0.03em;
+}
+
+.post-title-meta {
+  color: var(--gray-8, var(--muted-foreground));
 }
 
 .prose ul,
@@ -1306,8 +1396,8 @@ html[data-visited] .enter-polaroid .polaroid {
   animation-delay: calc(var(--reveal-delay, 0ms) + 250ms);
 }
 
-/* Route transition: the origin defocuses while the destination rises.
-   Shared covers/titles morph via view-transition-name. */
+/* Route transition: ambient guides and chrome stay fixed while the content
+   sheet lifts and settles. Shared covers/titles still own their morph. */
 .post-loading-cover {
   view-transition-name: var(--post-cover-transition-name, none);
 }
@@ -1316,26 +1406,76 @@ html[data-visited] .enter-polaroid .polaroid {
   view-transition-name: var(--post-title-transition-name, none);
 }
 
-@keyframes vt-defocus {
+@keyframes page-sheet-out {
   to {
     opacity: 0;
-    filter: blur(2px);
+    transform: translate3d(-8px, 6px, 0) rotate(-0.2deg);
   }
 }
 
-@keyframes vt-focus {
+@keyframes page-sheet-in {
   from {
     opacity: 0;
-    filter: blur(2px);
+    transform: translate3d(14px, -10px, 0) rotate(0.45deg);
   }
 }
 
-::view-transition-old(root) {
-  animation: vt-defocus 250ms var(--ease-swift) both;
+@keyframes page-forward-out {
+  to {
+    opacity: 0;
+    transform: translate3d(-14px, 5px, 0) rotate(-0.25deg);
+  }
 }
 
-::view-transition-new(root) {
-  animation: vt-focus 300ms var(--ease-swift) both;
+@keyframes page-forward-in {
+  from {
+    opacity: 0;
+    transform: translate3d(18px, -8px, 0) rotate(0.4deg);
+  }
+}
+
+@keyframes page-back-out {
+  to {
+    opacity: 0;
+    transform: translate3d(14px, 5px, 0) rotate(0.25deg);
+  }
+}
+
+@keyframes page-back-in {
+  from {
+    opacity: 0;
+    transform: translate3d(-18px, -8px, 0) rotate(-0.4deg);
+  }
+}
+
+::view-transition-old(.page-sheet) {
+  transform-origin: 50% 0;
+  animation: page-sheet-out 210ms var(--ease-swift) both;
+}
+
+::view-transition-new(.page-sheet) {
+  transform-origin: 50% 0;
+  animation: page-sheet-in 320ms var(--ease-swift) both;
+}
+
+::view-transition-old(.page-forward) {
+  transform-origin: 50% 0;
+  animation: page-forward-out 210ms var(--ease-swift) both;
+}
+
+::view-transition-new(.page-forward) {
+  transform-origin: 50% 0;
+  animation: page-forward-in 320ms var(--ease-swift) both;
+}
+
+::view-transition-old(.page-back) {
+  transform-origin: 50% 0;
+  animation: page-back-out 210ms var(--ease-swift) both;
+}
+
+::view-transition-new(.page-back) {
+  transform-origin: 50% 0;
+  animation: page-back-in 320ms var(--ease-swift) both;
 }
 
 ::view-transition-group(*) {
@@ -1478,6 +1618,12 @@ a:focus-visible .external-label .external-mark {
 
 /* ── Homepage introduction: small marks, deliberate responses ───── */
 
+.home-introduction p {
+  color: var(--gray-10, var(--muted-foreground));
+  font-size: 1rem;
+  line-height: 1.72;
+}
+
 .home-intro-trigger {
   display: inline-flex;
   align-items: baseline;
@@ -1566,12 +1712,23 @@ a:focus-visible .external-label .external-mark {
   touch-action: manipulation;
 }
 
+.home-zolplay-link .external-link,
 .home-contact-link {
-  color: var(--foreground);
+  color: var(--gray-10, var(--foreground));
   text-decoration-line: underline;
-  text-decoration-color: var(--border);
-  text-underline-offset: 0.25rem;
-  transition: text-decoration-color 150ms ease;
+  text-decoration-style: dotted;
+  text-decoration-thickness: 0.1em;
+  text-underline-offset: 0.16em;
+  text-decoration-color: color-mix(in oklab, currentColor 38%, transparent);
+  text-decoration-skip-ink: auto;
+}
+
+.home-zolplay-link .external-link {
+  transition: color 150ms ease, text-decoration-color 150ms ease;
+}
+
+.home-contact-link {
+  transition: color 150ms ease, text-decoration-color 150ms ease;
   touch-action: manipulation;
 }
 
@@ -1580,8 +1737,10 @@ a:focus-visible .external-label .external-mark {
 }
 
 @media (hover: hover) and (pointer: fine) {
+  .home-zolplay-link .external-link:hover,
   .home-contact-link:hover {
-    text-decoration-color: var(--foreground);
+    color: var(--gray-12, var(--foreground));
+    text-decoration-color: currentColor;
   }
 }
 
@@ -3003,7 +3162,7 @@ html.dark .halftone-source[data-theme='light'] {
   align-items: center;
   gap: 0.75rem;
   padding: 0.5rem 0;
-  font-size: 0.875rem;
+  font-size: 0.9375rem;
 }
 
 .print-pile {
@@ -3058,6 +3217,7 @@ html.dark .halftone-source[data-theme='light'] {
 
 .blog-row-title {
   min-width: 0;
+  color: var(--gray-11, var(--foreground));
   font-weight: var(--font-weight-medium);
   white-space: nowrap;
   overflow: hidden;
@@ -3240,6 +3400,68 @@ html[data-locale='en'] [data-en-block] {
   display: none;
 }
 
+.post-minimap-utilities {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  min-height: 2.75rem;
+  flex: none;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.75rem;
+  padding-right: 0.5rem;
+}
+
+.post-minimap-utilities-top {
+  margin-bottom: 1.25rem;
+}
+
+.post-minimap-utilities-bottom {
+  justify-content: flex-end;
+  margin-top: 1.25rem;
+}
+
+.post-minimap-utility {
+  position: relative;
+  display: inline-flex;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+  align-items: center;
+  gap: 0.375rem;
+  color: color-mix(in oklab, var(--muted-foreground) 82%, transparent);
+  font-size: 0.8125rem;
+  line-height: 1;
+  white-space: nowrap;
+  outline: none;
+  touch-action: manipulation;
+  transition: color 150ms ease, opacity 150ms ease;
+}
+
+.post-minimap-utility::after {
+  position: absolute;
+  inset: 0 -0.5rem;
+  border-radius: 0.375rem;
+  content: '';
+}
+
+.post-minimap-utility:focus-visible::after {
+  outline: 1px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.post-minimap-back-to-top {
+  justify-content: flex-end;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.post-minimap-back-to-top[data-visible] {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
 .post-minimap-node {
   display: flex;
   height: 1px;
@@ -3395,7 +3617,8 @@ html[data-locale='en'] [data-en-block] {
 
 @media (hover: hover) and (pointer: fine) {
   .post-minimap-node > a:hover,
-  .post-minimap-toggle:hover {
+  .post-minimap-toggle:hover,
+  .post-minimap-utility:hover {
     color: var(--foreground);
   }
 
@@ -3421,7 +3644,7 @@ html[data-locale='en'] [data-en-block] {
     flex-direction: column;
     overflow: visible;
     color: var(--muted-foreground);
-    background: color-mix(in oklab, var(--popover) 76%, transparent);
+    background: color-mix(in oklab, var(--popover) 88%, transparent);
     border-radius: 1.375rem;
     box-shadow:
       0 0 0 var(--border-hairline) color-mix(in oklab, var(--foreground) 12%, transparent),
@@ -3480,7 +3703,7 @@ html[data-locale='en'] [data-en-block] {
     z-index: 0;
     display: block;
     border-radius: 1rem;
-    background: color-mix(in oklab, var(--popover) 76%, transparent);
+    background: color-mix(in oklab, var(--popover) 94%, transparent);
     box-shadow:
       0 0 0 var(--border-hairline) color-mix(in oklab, var(--foreground) 14%, transparent),
       0 16px 40px -18px rgb(0 0 0 / 0.42);
@@ -3508,6 +3731,19 @@ html[data-locale='en'] [data-en-block] {
 
   .post-minimap-nodes {
     padding-bottom: 1rem;
+  }
+
+  .post-minimap-utilities {
+    margin: 0;
+    padding-inline: 0.25rem;
+  }
+
+  .post-minimap-utilities-top {
+    padding-block: 0.25rem 0.5rem;
+  }
+
+  .post-minimap-utilities-bottom {
+    padding-bottom: 0.5rem;
   }
 
   .post-minimap-toggle {
@@ -3611,7 +3847,8 @@ html[data-locale='en'] [data-en-block] {
   .post-minimap-toggle,
   .post-minimap-toggle-panel,
   .post-minimap-toggle-chevron,
-  .post-minimap-island-chevron {
+  .post-minimap-island-chevron,
+  .post-minimap-utility {
     transition: none;
   }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -3739,7 +3739,7 @@ html[data-locale='en'] [data-en-block] {
   }
 
   .post-minimap-utilities-top {
-    padding-block: 0.25rem 0.5rem;
+    display: none;
   }
 
   .post-minimap-utilities-bottom {

--- a/components/liquid-glass.tsx
+++ b/components/liquid-glass.tsx
@@ -85,7 +85,7 @@ function makeDisplacementMap(w: number, h: number, radius: number): string {
 
 let generation = 0
 
-export function LiquidGlass({ blur = 2, saturate = 1.4 }: { blur?: number; saturate?: number }) {
+export function LiquidGlass({ blur = 4, saturate = 1.25 }: { blur?: number; saturate?: number }) {
   const ref = useRef<HTMLSpanElement>(null)
   const [glass, setGlass] = useState<{ id: string; w: number; h: number; map: string } | null>(null)
   // Safari/Firefox drop the whole declaration when it references an SVG

--- a/components/post-toc.tsx
+++ b/components/post-toc.tsx
@@ -1,11 +1,13 @@
 'use client'
 
 import { animate, stagger } from 'motion'
+import Link from 'next/link'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { flushSync } from 'react-dom'
 
 import type { PostRailNode } from '~/lib/content'
 import { localize, useLocale } from '~/lib/locale-client'
+import { localePath } from '~/lib/locale-route'
 
 const DESKTOP_QUERY = '(min-width: 64rem)'
 const DESKTOP_EXIT_DURATION = 0.2
@@ -23,6 +25,21 @@ function getReadingTop(target: HTMLElement) {
   // RevealScope gives unread prose a temporary 5px translate. Navigation and
   // scroll-spy should use the heading's settled layout position instead.
   return rectTop - new DOMMatrixReadOnly(transform).m42
+}
+
+function WayfindingArrow({ direction }: { direction: 'back' | 'top' }) {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" aria-hidden>
+      <path
+        d={direction === 'back' ? 'M10 6H2M5 3 2 6l3 3' : 'M6 10V2M3 5l3-3 3 3'}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
 }
 
 export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: PostRailNode[] }) {
@@ -46,6 +63,7 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
   const [phone, setPhone] = useState(false)
   const [phoneQueryReady, setPhoneQueryReady] = useState(false)
   const [phoneIslandVisible, setPhoneIslandVisible] = useState(false)
+  const [backToTopVisible, setBackToTopVisible] = useState(false)
   const [active, setActive] = useState(landmarks[0]?.id)
   const activeRef = useRef(active)
   const progressCircleRef = useRef<SVGCircleElement>(null)
@@ -141,6 +159,12 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
       setDesktop(query.matches)
 
       if (query.matches && !desktopEntrancePlayedRef.current) {
+        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+          desktopEntrancePlayedRef.current = true
+          setOpen(true)
+          return
+        }
+
         if (frame) window.cancelAnimationFrame(frame)
         frame = window.requestAnimationFrame(() => {
           frame = 0
@@ -207,6 +231,7 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
       const scrollable = document.documentElement.scrollHeight - window.innerHeight
       const progress = scrollable > 0 ? Math.min(1, Math.max(0, window.scrollY / scrollable)) : 0
       progressCircleRef.current?.setAttribute('stroke-dasharray', `${progress} 1`)
+      setBackToTopVisible(window.scrollY >= window.innerHeight * 0.75)
       const titleCard = document.querySelector('.post-title-card')
       setPhoneIslandVisible(
         titleCard ? titleCard.getBoundingClientRect().bottom <= TARGET_OFFSET : window.scrollY > 1,
@@ -251,6 +276,11 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
       window.scrollTo({ top: window.scrollY + getReadingTop(target) - TARGET_OFFSET })
       history.replaceState(null, '', `#${id}`)
     })
+  }
+
+  function returnToTop() {
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    window.scrollTo({ top: 0, behavior: reducedMotion ? 'auto' : 'smooth' })
   }
 
   if (landmarks.length < 2) return null
@@ -346,6 +376,17 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
           inert={open ? undefined : true}
         >
           <div className="post-minimap-phone-surface backdrop-blur-[12px]" aria-hidden />
+          <div className="post-minimap-utilities post-minimap-utilities-top">
+            <Link
+              href={localePath(locale, '/blog')}
+              transitionTypes={['page-back']}
+              className="post-minimap-utility"
+              aria-label={localize(locale, '返回写作', 'Back to writing')}
+            >
+              <WayfindingArrow direction="back" />
+              <span>{localize(locale, '写作', 'Writing')}</span>
+            </Link>
+          </div>
           <div className="post-minimap-clip">
             <div className="post-minimap-nodes">
               {displayedNodes.map((node) => (
@@ -368,6 +409,20 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
                 </div>
               ))}
             </div>
+          </div>
+          <div className="post-minimap-utilities post-minimap-utilities-bottom">
+            <button
+              type="button"
+              className="post-minimap-utility post-minimap-back-to-top"
+              aria-label={localize(locale, '返回顶部', 'Back to top')}
+              aria-hidden={!backToTopVisible}
+              tabIndex={backToTopVisible ? 0 : -1}
+              data-visible={backToTopVisible || undefined}
+              onClick={returnToTop}
+            >
+              <WayfindingArrow direction="top" />
+              <span>{localize(locale, '顶部', 'Top')}</span>
+            </button>
           </div>
         </nav>
       </div>

--- a/components/post-toc.tsx
+++ b/components/post-toc.tsx
@@ -280,6 +280,7 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
 
   function returnToTop() {
     const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (!desktop) animateOpenState(false)
     window.scrollTo({ top: 0, behavior: reducedMotion ? 'auto' : 'smooth' })
   }
 

--- a/components/post-transition-link.test.tsx
+++ b/components/post-transition-link.test.tsx
@@ -8,12 +8,15 @@ vi.mock('next/link', () => ({
   default: ({
     children,
     onClick,
+    transitionTypes,
   }: {
     children: ReactNode
     onClick?: MouseEventHandler<HTMLAnchorElement>
+    transitionTypes?: string[]
   }) => (
     <a
       href="/blog/a-post"
+      data-transition-types={transitionTypes?.join(',')}
       onClick={(event) => {
         onClick?.(event)
         event.preventDefault()
@@ -49,6 +52,12 @@ describe('PostTransitionLink', () => {
     )
 
     fireEvent.click(screen.getByRole('link', { name: 'Read post' }))
+
+    expect(
+      screen
+        .getByRole('link', { name: 'Read post' })
+        .getAttribute('data-transition-types'),
+    ).toBe('page-forward')
 
     expect(
       document.documentElement.style.getPropertyValue(

--- a/components/post-transition-link.tsx
+++ b/components/post-transition-link.tsx
@@ -37,6 +37,7 @@ export function PostTransitionLink({
     <Link
       href={href}
       prefetch={true}
+      transitionTypes={['page-forward']}
       className={className}
       onClick={prepareFallbackMorph}
     >

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -413,8 +413,9 @@ title card clears the reading line, then retreats when the reader returns to the
 post hero. Opening reveals one continuous translucent surface around the tick
 map using opacity and transform only. The expanded list starts at the first
 heading because the article title already remains in the island header. The
-post stays in place underneath. Writing remains above the map and Top remains
-in the expanded island footer so the collapsed 44px surface stays quiet.
+post stays in place underneath. The phone layout omits the Writing return link;
+Top remains in the expanded island footer so the collapsed 44px surface stays
+quiet.
 Landmark jumps collapse the compact map after selection; tapping outside or
 pressing Escape also closes it. It keeps bottom-dock and safe-area
 clearance, and the map scrolls internally when its fixed rhythm exceeds the

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -33,6 +33,7 @@ it on chrome.
 | Exit (any) | ~2/3 of its enter | `--ease-swift` |
 | Photo pick-up / settle | 300–350ms | `--ease-spring` |
 | Shared-element page transition | 300–350ms | `--ease-swift` |
+| Content-sheet page transition | 210ms exit / 320ms enter | `--ease-swift` |
 
 Shadow scale (one alpha, growing throw — don't invent one-off shadows):
 
@@ -52,6 +53,12 @@ Hard rules:
   animated.
 - Elements that move together share one duration and easing (card + its
   shadow, cover + its caption).
+- Route changes keep the ambient guides, dock, and other global chrome fixed.
+  Only the route content sheet moves: a small 8–18px translation, less than
+  half a degree of rotation, and opacity. Forward and explicitly tagged back
+  links reverse the horizontal direction. Browser history without a tag gets
+  the neutral sheet motion. Shared post covers and titles remain separate
+  morph elements. Reduced motion swaps every route instantly.
 - Scroll reveals are allowed only as gentle arrivals: below-fold long-form
   blocks may sharpen in (blur 2px → 0 + fade, 300ms `--ease-swift`, ≤45ms
   stagger within a batch) as they enter the viewport. Never parallax, never
@@ -70,15 +77,14 @@ Hard rules:
   Weights 400/500/600 only, as `--font-weight-{normal,medium,semibold}`
   variables. Weight never changes on hover or selection — state is shown with
   color, never with weight or size.
-- **One size for chrome.** Site chrome — header, nav, footer, list rows,
-  dates, section labels, even page-level headings outside post bodies — is a
-  single size (14px, letter-spacing −0.011em); hierarchy comes from weight
-  and color only. Resist adding a size before exhausting weight + color.
-- **One base size: 14px.** Post bodies match the chrome at 14px/1.7 (CJK
-  line-height 1.85) — density is part of the print voice. Post titles may
-  still be large; prose h2 is 18px, h3 16px, code 13px. Form inputs are the
-  one exception: they stay ≥16px to prevent iOS zoom. Headings use
-  `text-wrap: balance` and tighter letter-spacing as size grows.
+- **Chrome stays compact.** Navigation, footer, dates, section labels, and
+  utility controls remain 14px with letter-spacing −0.011em. Compact chrome
+  provides contrast against the editorial content instead of flattening it.
+- **Editorial scale.** List titles and project rows are 15px. Homepage and
+  introductory paragraphs are 16px/1.7. Post bodies are 16px/1.72, with CJK
+  at 1.9. Post titles scale from 28px to 32px; prose h2 is 20px/1.35 and h3 is
+  16px/1.45. Code remains 13px. Form inputs stay ≥16px to prevent iOS zoom.
+  Headings use `text-wrap: balance` and tighter letter-spacing as size grows.
 - Content column is narrow: ~600px (`37.5rem`) plus padding.
 - `font-variant-numeric: tabular-nums` on anything that counts: dates in
   lists, reading time, subscriber counts.
@@ -88,8 +94,14 @@ Hard rules:
 ## Color, borders, dark mode
 
 - Grays are a numbered scale (`--gray-1` … `--gray-12`) that flips wholesale
-  in dark mode. Components reference scale variables, never Tailwind `dark:`
-  overrides — if a component needs a `dark:` modifier, the token is wrong.
+  in dark mode. The public scale carries a slight warm-paper hue; admin keeps
+  its neutral product palette. Headings use the strongest ink, body copy steps
+  down two levels, and metadata steps down again. Components reference scale
+  variables, never Tailwind `dark:` overrides — if a component needs a
+  `dark:` modifier, the token is wrong.
+- Text selection uses a translucent yellow-green highlighter token and never
+  changes the selected text color. The dark token lowers opacity so it reads
+  as marker on dark paper rather than a luminous block.
 - 1px borders are the exception: prefer `box-shadow: 0 0 0 1px` for card
   edges (blends with any background) and hairline dividers via
   `--border-hairline` (0.5px on retina, 1px otherwise).
@@ -222,6 +234,10 @@ open rich hover cards. The contract:
   own contrast), and un-proxied fallback icons stay untouched. Refresh the metadata
   from the same first-party service with
   `node scripts/refresh-link-previews.mjs`.
+- **Link texture.** Inline prose and homepage contact links use a fine dotted
+  underline at 38% current ink. Hover and keyboard focus deepen both text and
+  decoration to full ink. Dots reuse the catalog-leader and drafting
+  vocabulary; list rows, cards, shelves, and navigation remain undecorated.
 - **External-link mark.** Text links that leave the site carry the shared
   northeast arrow inline; internal links, RSS, and Email do not. Shelf covers
   are selection controls only. Each shelf instead keeps one plain-text
@@ -352,17 +368,16 @@ and chrome develop without rotation.
 
 ## Selective focus
 
-The governing attention grammar: **only the thing being attended to is
-sharp.** Applications:
+The governing attention grammar: **the thing being attended to keeps full
+ink.** Applications:
 
-- **List rows (writing index, home list)**: hovering a row blurs (~1–2px) and
-  dims everything else on the page over ~200ms `--ease-swift`; mouse-out
-  restores instantly. The hovered row itself does not move.
+- **List rows (writing index, home list)**: hovering a row dims its siblings to
+  44% opacity over 180ms `--ease-swift`; mouse-out restores instantly. Rows
+  remain sharp and the hovered row itself does not move.
 - **Media loading**: images/video in card grids sit as blur-up placeholders
   and resolve to sharp when loaded or attended.
-- Focus-pull requires `@media (hover: hover) and (pointer: fine)` and is
-  fully disabled under `prefers-reduced-motion` (no blur transitions —
-  content stays sharp).
+- Focus-pull requires `@media (hover: hover) and (pointer: fine)` and is fully
+  disabled under `prefers-reduced-motion`.
 
 ## Post marginalia
 
@@ -380,13 +395,16 @@ and reveals in place over the left gutter without moving itself or the article
 on the x-axis. Across that compact range, opening the rail also develops a
 masked 8px backdrop blur that fades into the page and leaves when the rail
 closes, keeping overlapping prose quiet without shifting it. The rail itself
-has no panel background, border, or back link: compact 1px ticks and
+has no panel background or border: compact 1px ticks and
 two-line-clamped labels sit directly in the margin. Fine-pointer layouts use a
 9px vertical step; coarse-pointer layouts use an 11px step so the four steps
 between landmarks provide non-overlapping 44px hit regions. Labels overlay that
 fixed track so wrapping never changes its cadence.
 Active, hovered, and keyboard-focused labels shift right to clear the longer
-lead tick.
+lead tick. A localized 44px back link sits above the map and returns to the
+Writing index with a backward page transition. Back to top sits below the map
+and becomes available after 75% of one viewport. Reduced motion makes the top
+jump instant.
 
 Below 40rem the same map becomes a top-center reading island. Its collapsed
 44px surface is a true pill showing circular document progress, the
@@ -395,7 +413,8 @@ title card clears the reading line, then retreats when the reader returns to the
 post hero. Opening reveals one continuous translucent surface around the tick
 map using opacity and transform only. The expanded list starts at the first
 heading because the article title already remains in the island header. The
-post stays in place underneath.
+post stays in place underneath. Writing remains above the map and Top remains
+in the expanded island footer so the collapsed 44px surface stays quiet.
 Landmark jumps collapse the compact map after selection; tapping outside or
 pressing Escape also closes it. It keeps bottom-dock and safe-area
 clearance, and the map scrolls internally when its fixed rhythm exceeds the

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -80,9 +80,10 @@ Hard rules:
 - **Chrome stays compact.** Navigation, footer, dates, section labels, and
   utility controls remain 14px with letter-spacing −0.011em. Compact chrome
   provides contrast against the editorial content instead of flattening it.
-- **Editorial scale.** List titles and project rows are 15px. Homepage and
-  introductory paragraphs are 16px/1.7. Post bodies are 16px/1.72, with CJK
-  at 1.9. Post titles scale from 28px to 32px; prose h2 is 20px/1.35 and h3 is
+- **Editorial scale.** The scale is based on 14px body copy. List titles and
+  project rows are 15px. Homepage and introductory paragraphs are 14px/1.7.
+  Post bodies are 14px/1.72, with CJK at 1.9. Post titles scale from 28px to
+  32px; prose h2 is 18px/1.35 and h3 is
   16px/1.45. Code remains 13px. Form inputs stay ≥16px to prevent iOS zoom.
   Headings use `text-wrap: balance` and tighter letter-spacing as size grows.
 - Content column is narrow: ~600px (`37.5rem`) plus padding.
@@ -491,7 +492,7 @@ The dock pill is real glass: a runtime-built displacement map (rounded-rect
 SDF, four-fold symmetric — one quadrant computed, mirrored into four; R/G
 channels encode the x/y bend, ramping outward through a 16px edge band,
 curve 1.6) drives an SVG `feDisplacementMap` applied as an inline-style
-`backdrop-filter: url(#…) blur(2px) saturate(1.4)` over a 55% paper
+`backdrop-filter: url(#…) blur(4px) saturate(1.25)` over a 68% paper
 background. Three displacement passes at staggered scales (44 ±10%) split
 the RGB channels for a faint chromatic fringe along the rim, recombined
 with screen blends; an inset top highlight (white 0.2 over, 0.06 under) plays the

--- a/e2e/instant-navigation.spec.ts
+++ b/e2e/instant-navigation.spec.ts
@@ -192,12 +192,19 @@ test('public motion and typography follow the design contract', async ({ page })
 
   await expect(page.locator('.home-introduction p').first()).toHaveCSS(
     'font-size',
-    '16px',
+    '14px',
   )
   await expect(page.locator('.home-contact-link').first()).toHaveCSS(
     'text-decoration-style',
     'dotted',
   )
+  await expect
+    .poll(() =>
+      page
+        .locator('.liquid-glass')
+        .evaluate((element) => getComputedStyle(element).backdropFilter),
+    )
+    .toContain('blur(4px)')
 
   const preferences = page.getByRole('button', { name: 'Preferences' })
   await preferences.click()
@@ -234,8 +241,8 @@ test('public motion and typography follow the design contract', async ({ page })
   await expect(focusRows.nth(1)).toHaveCSS('opacity', '0.44')
 
   await page.goto('/en/blog/do-buttons-need-pointer-cursors')
-  await expect(page.locator('.prose')).toHaveCSS('font-size', '16px')
-  await expect(page.locator('.prose h2').first()).toHaveCSS('font-size', '20px')
+  await expect(page.locator('.prose')).toHaveCSS('font-size', '14px')
+  await expect(page.locator('.prose h2').first()).toHaveCSS('font-size', '18px')
   await expect(page.getByRole('link', { name: 'Back to writing' })).toBeVisible()
   await expect(page.locator('.tweet-card-body')).toHaveCSS('font-size', '14px')
 
@@ -305,10 +312,28 @@ test('keyboard controls restore focus across public overlays', async ({ page }) 
   await page.keyboard.press('Enter')
   await expect(articleMap).toHaveAttribute('aria-expanded', 'true')
   await expect(page.getByRole('link', { name: 'Back to writing' })).toHaveCount(0)
-  await expect(page.getByRole('button', { name: 'Back to top' })).toBeVisible()
   await page.keyboard.press('Escape')
   await expect(articleMap).toHaveAttribute('aria-expanded', 'false')
   await expect(articleMap).toBeFocused()
+  await page.keyboard.press('Enter')
+  await expect(articleMap).toHaveAttribute('aria-expanded', 'true')
+  await page.evaluate(() => {
+    const scrollTo = window.scrollTo.bind(window)
+    window.scrollTo = ((options: ScrollToOptions) => {
+      document.documentElement.dataset.articleMapOpenAtScroll =
+        document.querySelector('.post-minimap-toggle')?.getAttribute('aria-expanded') ??
+        'missing'
+      scrollTo(options)
+    }) as typeof window.scrollTo
+  })
+  const backToTop = page.getByRole('button', { name: 'Back to top' })
+  await expect(backToTop).toBeVisible()
+  await backToTop.click()
+  await expect(articleMap).toHaveAttribute('aria-expanded', 'false')
+  await expect(page.locator('html')).toHaveAttribute(
+    'data-article-map-open-at-scroll',
+    'false',
+  )
 })
 
 test('administration stays outside public prefetching and requires login', async ({

--- a/e2e/instant-navigation.spec.ts
+++ b/e2e/instant-navigation.spec.ts
@@ -236,6 +236,7 @@ test('public motion and typography follow the design contract', async ({ page })
   await page.goto('/en/blog/do-buttons-need-pointer-cursors')
   await expect(page.locator('.prose')).toHaveCSS('font-size', '16px')
   await expect(page.locator('.prose h2').first()).toHaveCSS('font-size', '20px')
+  await expect(page.getByRole('link', { name: 'Back to writing' })).toBeVisible()
   await expect(page.locator('.tweet-card-body')).toHaveCSS('font-size', '14px')
 
   const zoom = page.locator('.zoom-trigger').last()
@@ -303,10 +304,7 @@ test('keyboard controls restore focus across public overlays', async ({ page }) 
   await articleMap.focus()
   await page.keyboard.press('Enter')
   await expect(articleMap).toHaveAttribute('aria-expanded', 'true')
-  await expect(page.getByRole('link', { name: 'Back to writing' })).toHaveAttribute(
-    'href',
-    '/en/blog',
-  )
+  await expect(page.getByRole('link', { name: 'Back to writing' })).toHaveCount(0)
   await expect(page.getByRole('button', { name: 'Back to top' })).toBeVisible()
   await page.keyboard.press('Escape')
   await expect(articleMap).toHaveAttribute('aria-expanded', 'false')

--- a/e2e/instant-navigation.spec.ts
+++ b/e2e/instant-navigation.spec.ts
@@ -190,6 +190,15 @@ test('preferences preserve theme, locale, and reduced motion', async ({ page }) 
 test('public motion and typography follow the design contract', async ({ page }) => {
   await page.goto('/en')
 
+  await expect(page.locator('.home-introduction p').first()).toHaveCSS(
+    'font-size',
+    '16px',
+  )
+  await expect(page.locator('.home-contact-link').first()).toHaveCSS(
+    'text-decoration-style',
+    'dotted',
+  )
+
   const preferences = page.getByRole('button', { name: 'Preferences' })
   await preferences.click()
 
@@ -218,7 +227,15 @@ test('public motion and typography follow the design contract', async ({ page })
     '-0.154px',
   )
 
+  await page.goto('/en/blog')
+  const focusRows = page.locator('.focus-list > li')
+  await focusRows.first().hover()
+  await expect(focusRows.nth(1)).toHaveCSS('filter', 'none')
+  await expect(focusRows.nth(1)).toHaveCSS('opacity', '0.44')
+
   await page.goto('/en/blog/do-buttons-need-pointer-cursors')
+  await expect(page.locator('.prose')).toHaveCSS('font-size', '16px')
+  await expect(page.locator('.prose h2').first()).toHaveCSS('font-size', '20px')
   await expect(page.locator('.tweet-card-body')).toHaveCSS('font-size', '14px')
 
   const zoom = page.locator('.zoom-trigger').last()
@@ -286,6 +303,11 @@ test('keyboard controls restore focus across public overlays', async ({ page }) 
   await articleMap.focus()
   await page.keyboard.press('Enter')
   await expect(articleMap).toHaveAttribute('aria-expanded', 'true')
+  await expect(page.getByRole('link', { name: 'Back to writing' })).toHaveAttribute(
+    'href',
+    '/en/blog',
+  )
+  await expect(page.getByRole('button', { name: 'Back to top' })).toBeVisible()
   await page.keyboard.press('Escape')
   await expect(articleMap).toHaveAttribute('aria-expanded', 'false')
   await expect(articleMap).toBeFocused()

--- a/lib/next-config.test.ts
+++ b/lib/next-config.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import nextConfig from '../next.config'
+
+describe('server output tracing', () => {
+  it('packages repository-authored content for runtime routes', () => {
+    expect(nextConfig.outputFileTracingIncludes).toMatchObject({
+      '/blog/\\[slug\\]': ['./content/blog/**/*'],
+      '/en/blog/\\[slug\\]': ['./content/blog/**/*'],
+      '/content/\\[\\.\\.\\.path\\]': [
+        './content/blog/**/*',
+        './content/newsletters/**/*',
+      ],
+    })
+  })
+})

--- a/lib/public-content-proxy.test.ts
+++ b/lib/public-content-proxy.test.ts
@@ -1,7 +1,13 @@
 import { NextRequest } from 'next/server'
+import type { NextFetchEvent } from 'next/server'
 import { describe, expect, it } from 'vitest'
 
-import { siteProxy } from '../proxy'
+import { proxy, siteProxy } from '../proxy'
+
+const event = {
+  passThroughOnException() {},
+  waitUntil() {},
+} as unknown as NextFetchEvent
 
 describe('public content proxy', () => {
   it.each([
@@ -23,11 +29,14 @@ describe('public content proxy', () => {
     '/en/blog/how-to-add-rss-to-your-nextjs-app-router',
     '/newsletters/1',
     '/en/newsletters/1',
-  ])('passes through a published content route: %s', (pathname) => {
-    const response = siteProxy(new NextRequest(`https://cali.so${pathname}`))
+  ])('passes through a published content route without Clerk: %s', async (pathname) => {
+    const response = await proxy(
+      new NextRequest(`https://cali.so${pathname}`),
+      event,
+    )
 
-    expect(response.status).toBe(200)
-    expect(response.headers.get('x-middleware-next')).toBe('1')
-    expect(response.headers.has('x-middleware-rewrite')).toBe(false)
+    expect(response?.status).toBe(200)
+    expect(response?.headers.get('x-middleware-next')).toBe('1')
+    expect(response?.headers.has('x-middleware-rewrite')).toBe(false)
   })
 })

--- a/next.config.ts
+++ b/next.config.ts
@@ -28,6 +28,18 @@ const nextConfig: NextConfig = {
   cacheComponents: true,
   partialPrefetching: true,
 
+  // Posts and newsletters are read from the repository at render time. The
+  // slug is dynamic, so output tracing cannot discover these files from the
+  // readFile calls on its own when packaging serverless functions.
+  outputFileTracingIncludes: {
+    '/blog/\\[slug\\]': ['./content/blog/**/*'],
+    '/en/blog/\\[slug\\]': ['./content/blog/**/*'],
+    '/content/\\[\\.\\.\\.path\\]': [
+      './content/blog/**/*',
+      './content/newsletters/**/*',
+    ],
+  },
+
   // Pin the project root: when developing from a git worktree nested inside
   // another checkout, Next's lockfile-based root inference walks too far up.
   turbopack: { root: import.meta.dirname },

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 
 import { clerkMiddleware } from '@clerk/nextjs/server'
-import type { NextRequest } from 'next/server'
+import type { NextFetchEvent, NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 
 import {
@@ -24,6 +24,14 @@ function missingPublicContent(pathname: string) {
 
 function isAdminPage(pathname: string) {
   return pathname === '/admin' || pathname.startsWith('/admin/')
+}
+
+function usesClerk(pathname: string) {
+  return (
+    isAdminPage(pathname) ||
+    pathname === '/api/admin' ||
+    pathname.startsWith('/api/admin/')
+  )
 }
 
 export function siteProxy(request: NextRequest) {
@@ -50,10 +58,15 @@ export function siteProxy(request: NextRequest) {
   return response
 }
 
-export const proxy = clerkMiddleware(async (auth, request) => {
+const clerkProxy = clerkMiddleware(async (auth, request) => {
   if (isAdminPage(request.nextUrl.pathname)) await auth.protect()
   return siteProxy(request)
 })
+
+export function proxy(request: NextRequest, event: NextFetchEvent) {
+  if (!usesClerk(request.nextUrl.pathname)) return siteProxy(request)
+  return clerkProxy(request, event)
+}
 
 export const config = {
   matcher: [


### PR DESCRIPTION
## Summary

- introduce a warmer paper-and-ink hierarchy, highlighter-style selection, and dotted inline links on public pages
- replace blurred list de-emphasis with opacity-only focus and add restrained content-sheet route transitions
- improve article wayfinding with a desktop Writing return link and contextual Top action, while keeping the phone map limited to Top
- update the design-language contract and browser coverage for the new responsive behavior

## Validation

- `pnpm typecheck`
- `pnpm test:unit` (67 files, 414 tests)
- `PLAYWRIGHT_BASE_URL=http://localhost:4312 pnpm exec playwright test -g 'public motion and typography'`
- `PLAYWRIGHT_BASE_URL=http://localhost:4312 pnpm exec playwright test -g 'keyboard controls'`

## Environment note

`pnpm test:navigation` compiles and typechecks, but its production prerender requires local database, admin, and site environment values that are not available in this worktree.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refines the editorial experience across the public site: it introduces a warm paper-and-ink color palette (`.public-site` tokens), replaces the blur-based focus-list de-emphasis with opacity-only, converts prose and homepage inline links to a fine dotted underline, and adds a desktop "Back to Writing" return link plus a scroll-gated "Back to top" action to the article minimap. Route transitions are upgraded from a single root-element blur/fade to three named content-sheet animations (forward, back, neutral) using View Transitions Level 2 class selectors, while the dock glass is tuned to blur 4px / saturate 1.25.

- **Proxy optimization** (`proxy.ts`): Clerk middleware is now bypassed for public routes; only `/admin/*` and `/api/admin/*` paths go through `clerkProxy`, preserving the existing auth model while avoiding unnecessary Clerk initialization on public pages.
- **Output tracing fix** (`next.config.ts`): `outputFileTracingIncludes` is added so blog and newsletter MDX files are bundled with their dynamic route handlers in serverless deployments — a real correctness fix.
- **Test coverage**: E2E tests anchor the new dotted-link, opacity-only focus-list, and back-to-top behaviors; a new unit test guards `outputFileTracingIncludes` against accidental removal.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changed paths are well-tested and the auth model is unchanged.

The middleware refactoring correctly skips Clerk only for routes that never needed it, the new wayfinding actions close the phone island before scrolling (matching existing landmark behavior), and the outputFileTracingIncludes fix is a genuine deployment correctness improvement. E2E and unit tests cover every behavioral change, including the scroll-gated back-to-top validated after an explicit scrollTo(0, 700) call. No logic paths were found to be incorrect or unguarded.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| proxy.ts | Refactors middleware to skip Clerk initialization for public routes, exposing a new `proxy` export that routes to `clerkProxy` only for admin/api-admin paths; `siteProxy` routing logic is unchanged and security model is preserved. |
| components/post-toc.tsx | Adds desktop 'Back to Writing' link and a scroll-gated 'Back to top' button to the minimap; `returnToTop` collapses the phone island before scrolling (consistent with `visitLandmark`), and the reduced-motion path bypasses the desktop entrance animation correctly. |
| app/globals.css | Introduces `.public-site` warm-paper color tokens, named view-transition keyframes (page-sheet, page-forward, page-back), `.post-minimap-utilities` layout classes, and switches focus-list from blur+opacity to opacity-only; no correctness issues. |
| app/_components/site-document.tsx | Adds `public-site` class to the html element for non-locale-restore pages and wires named transition types (page-forward, page-back, page-sheet) into the ViewTransition wrapper. |
| next.config.ts | Adds `outputFileTracingIncludes` so blog and newsletter content files are packaged with their dynamic route handlers during serverless deployment; a genuine fix for missing content at runtime. |
| e2e/instant-navigation.spec.ts | Extends E2E coverage for dotted links, blur removal, back-to-top visibility (validated after explicit `scrollTo(0, 700)`), and island-collapse-on-scroll; tests are well-anchored and not flaky. |
| lib/next-config.test.ts | New unit test that snapshots `outputFileTracingIncludes` to guard against accidental removal of content-file packaging in CI. |
| lib/public-content-proxy.test.ts | Updated to use the new top-level `proxy` export (bypassing Clerk), adding a mock `NextFetchEvent`; assertions are unchanged so behaviour is still verified. |
| components/liquid-glass.tsx | Default blur 2 to 4 and saturate 1.4 to 1.25 to thicken the dock glass; matches the updated design-language doc and LiquidGlass backdrop-filter E2E assertion. |
| components/post-transition-link.tsx | Adds `transitionTypes={['page-forward']}` to the Next.js Link so article-list to article navigation triggers the forward page-sheet animation. |
| components/post-transition-link.test.tsx | Mock updated to thread `transitionTypes` through via a `data-transition-types` attribute, and the test asserts `page-forward` is set on click. |
| docs/design-language.md | Documents the warm-paper public palette, content-sheet transition spec, updated selective-focus grammar, dotted-link contract, and expanded post marginalia back-link rules. |
| app/_views/home-page.tsx | Minor typography refinement to the h1 — text-base, tracking-tight, text-foreground added; no logic change. |
| app/_views/projects-page.tsx | Replaces ad-hoc inline text styles with the new `page-introduction` utility class for the Projects intro paragraph. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    NAV[Navigation event] --> TYPE{Transition type?}
    TYPE -- "page-forward" --> FWD_OUT["page-forward-out 210ms"]
    TYPE -- "page-back" --> BACK_OUT["page-back-out 210ms"]
    TYPE -- "default" --> SHEET_OUT["page-sheet-out 210ms"]
    TYPE -- "none" --> INSTANT[Instant swap]
    FWD_OUT --> FWD_IN["page-forward-in 320ms"]
    BACK_OUT --> BACK_IN["page-back-in 320ms"]
    SHEET_OUT --> SHEET_IN["page-sheet-in 320ms"]
    INSTANT --> DONE
    FWD_IN --> MORPH{Shared elements?}
    BACK_IN --> MORPH
    SHEET_IN --> MORPH
    MORPH -- Yes --> COVER[Cover + title morph]
    MORPH -- No --> DONE[Route settled]
    COVER --> DONE
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    NAV[Navigation event] --> TYPE{Transition type?}
    TYPE -- "page-forward" --> FWD_OUT["page-forward-out 210ms"]
    TYPE -- "page-back" --> BACK_OUT["page-back-out 210ms"]
    TYPE -- "default" --> SHEET_OUT["page-sheet-out 210ms"]
    TYPE -- "none" --> INSTANT[Instant swap]
    FWD_OUT --> FWD_IN["page-forward-in 320ms"]
    BACK_OUT --> BACK_IN["page-back-in 320ms"]
    SHEET_OUT --> SHEET_IN["page-sheet-in 320ms"]
    INSTANT --> DONE
    FWD_IN --> MORPH{Shared elements?}
    BACK_IN --> MORPH
    SHEET_IN --> MORPH
    MORPH -- Yes --> COVER[Cover + title morph]
    MORPH -- No --> DONE[Route settled]
    COVER --> DONE
```

</a>

<sub>Reviews (3): Last reviewed commit: ["fix(site): isolate public routes from Cl..."](https://github.com/calicastle/cali.so/commit/ee7184f97a125636eea7c558cf81092b79c959d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44707422)</sub>

<!-- /greptile_comment -->