### PR TITLE
docs: complete security baseline evidence

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,1 @@
+ebb8e5be77f00846010caa8c52d5b8e131319f1f:.github/workflows/security.yml:generic-api-key:29

--- a/docs/security/verification.md
+++ b/docs/security/verification.md
@@ -1,25 +1,26 @@
 # Security verification
 
-Last checked: 2026-07-15. This note separates repository evidence from hosted
-settings. Do not paste credentials, scan findings, or exploit details into this
-file; use GitHub private vulnerability reporting.
+Last checked: 2026-07-16. This note separates repository evidence from hosted
+settings. Do not paste credentials, scan findings, or exploit details here;
+use GitHub private vulnerability reporting.
 
 ## Local repository
 
 - [x] `SECURITY.md` directs coordinated disclosure to GitHub private
   vulnerability reporting.
-- [x] `.github/dependabot.yml` covers pnpm/npm dependencies and GitHub Actions.
-- [x] `.github/workflows/security.yml` runs the build, typecheck, AMA,
-  migration, localization, public-link, navigation, production-boundary, and
-  CodeQL checks on pull requests targeting any branch and on pushes to
-  integration or production; CodeQL also runs on a schedule and manually.
-- [x] Workflow actions are pinned to full, verified commit SHAs with release
-  tag comments.
-- [x] Workflow permissions default to read-only; only the CodeQL job adds the
-  required `security-events: write` permission.
-- [x] Gitleaks 8.30.1 scanned all reachable refs and 363 commits on
-  2026-07-15 with redaction enabled; no findings were reported. Re-run before
-  launch and rotate any real credential before discussing cleanup publicly.
+- [x] Dependabot covers pnpm/npm dependencies and GitHub Actions.
+- [x] `.github/workflows/security.yml` runs Quality and advanced CodeQL for
+  pull requests, `v2`, `main`, and the weekly schedule.
+- [x] Workflow permissions default to read-only. Only CodeQL adds
+  `security-events: write`.
+- [x] Third-party Actions are pinned to full reviewed commit SHAs.
+- [x] Gitleaks 8.30.1 scanned all 402 commits reachable from local branches
+  and tags with redaction enabled. The only match was Clerk's public
+  publishable key in the CI fixture; its exact fingerprint is documented in
+  `.gitleaksignore`. The repeat scan reported no leaks.
+- [x] Application security tests cover CSP and headers, same-origin mutation
+  policy, route limits, fail-closed AMA capabilities, privacy-safe audit
+  events, and the owner-admin boundary.
 
 Local recheck:
 
@@ -30,18 +31,18 @@ pnpm test:ama
 pnpm test:security
 pnpm audit:prod
 pnpm verify:security-boundary
+gitleaks git --redact --no-banner --log-opts='--branches --tags' --verbose
 git grep -nE 'uses: [^#[:space:]]+@(v|main|master|[0-9a-f]{1,39})([[:space:]]|$)' -- '.github/workflows/*.yml'
 ```
 
-The production dependency audit queries OSV from the installed pnpm graph
-because npm retired the endpoint used by `pnpm audit`. Public CI reports only
-the finding count; re-run privately with `AUDIT_DETAILS=true` for package and
-advisory identifiers. The `git grep` command should return no unpinned action
-references. Security scan output must remain private.
+The production dependency audit queries OSV from the installed pnpm graph.
+Public CI reports only the finding count; re-run privately with
+`AUDIT_DETAILS=true` for package and advisory identifiers. Security scan output
+must remain private.
 
 ## GitHub
 
-Repository API checks on 2026-07-15 verified:
+Repository API checks on 2026-07-16 verified:
 
 - [x] Private vulnerability reporting, secret scanning, push protection, and
   Dependabot security updates are enabled.
@@ -49,66 +50,47 @@ Repository API checks on 2026-07-15 verified:
   approve pull requests.
 - [x] Actions must be pinned to a full commit SHA.
 - [x] The `v2` ruleset requires pull requests, blocks force pushes and branch
-  deletion, and limits emergency bypass to repository administrators so GitHub
-  retains the audit trail. It currently requires no approval while the project
-  has one maintainer.
-- [x] CodeQL default setup remains disabled so the committed advanced workflow
-  is the single analysis source.
-- [ ] Add `Quality` and `CodeQL` as required `v2` checks after both check names
-  have completed successfully at least once. The active ruleset currently has
-  no required-status-check rule.
-- [ ] Non-provider secret patterns and validity checks remain unavailable in
-  the repository's current GitHub product mode. Recheck the setting before
-  launch or after a plan change.
-- [ ] Confirm Dependabot can open an update without repository or production
-  credentials after this configuration reaches the `v2` integration branch.
-- [x] The latest `v2` Security workflow for
-  `3097a4926582e884d080aa24a2c5347b7b7cdbc3` passed both `Quality` and
-  `CodeQL` in run
-  [29412753711](https://github.com/CaliCastle/cali.so/actions/runs/29412753711).
-- [ ] `main` branch protection also has no required status checks. Require
-  `Quality` and `CodeQL` on both `v2` and `main` before cutover.
-
-Recheck these settings through the GitHub Security and Actions settings pages
-or with read-only `gh api` calls. Keep sensitive evidence in private
-vulnerability reports rather than public issues or logs.
+  deletion, and limits the audited emergency bypass to repository
+  administrators. It requires no approving review while the project has one
+  maintainer.
+- [ ] Require the successful GitHub Actions checks named `Quality` and
+  `CodeQL` on both `v2` and `main`.
+- [x] CodeQL default setup is disabled so the committed advanced workflow is
+  the single analysis source.
+- [ ] Non-provider secret patterns and validity checks are unavailable in the
+  repository's current GitHub product mode. Recheck after a product or plan
+  change.
+- [x] Fork pull requests cannot receive Vercel secrets, and the GitHub Actions
+  workflow uses committed non-secret fixtures instead of repository secrets.
 
 ## Vercel
 
-Current inspection on 2026-07-15 is blocked: `vercel whoami` returns `cali`,
-but inspecting project `cali-so` returns `Not authorized`. The historical
-checks below remain useful context, but every unchecked item and every hosted
-state that may have changed is unknown until access is restored. Do not count
-historical evidence as current cutover proof.
+Project API checks on 2026-07-16 verified:
 
-Project checks completed on 2026-07-14 and 2026-07-15 verified:
+- [x] `cali-so` is accessible in the `Cali` Pro workspace. Its production
+  branch remains `main`, and Git fork protection is enabled.
+- [x] Production and Preview have distinct database variables. Preview uses a
+  disposable Neon branch and a pooled CRUD-only runtime role; migrations use a
+  separate direct credential that is absent from Vercel.
+- [x] Preview explicitly sets all five optional AMA capability switches to
+  `false`. Owner admin has no capability switch and remains protected by Clerk
+  authentication plus the exact server-side `siteOwner: "yes"` marker.
+- [ ] Add the five explicit false AMA capability switches to Production before
+  the v3 cutover.
+- [ ] Add an isolated Preview `CLERK_SECRET_KEY`; never expose the Production
+  Clerk secret to Preview.
+- [ ] Split the shared Resend and Marketplace KV credentials so Preview and
+  Production never receive the same provider secret.
+- [ ] Remove the obsolete `Admin Security` challenge for the removed
+  `POST /api/admin/auth/request` route.
+- [x] Vercel reports no configured log drains for the workspace. A grouped,
+  payload-free Preview query confirmed runtime-log access. The Pro workspace
+  has Observability Plus enabled for this project, so Vercel's documented
+  runtime-log retention is 30 days with a maximum 14-day query window.
+- [ ] At cutover, replace the legacy Production database variable with the
+  verified Neon runtime role and verify its grants under issue #107. Production
+  database inspection still requires two fresh explicit confirmations.
 
-- [x] The production branch remains `main`, matching the documented plan to
-  keep the legacy v2 site live until the one-time v3 cutover.
-- [x] Git fork protection is enabled.
-- [x] Production and Preview use distinct database credentials.
-- [x] Preview uses an isolated Neon branch and a pooled runtime credential. Its
-  runtime role was exercised with CRUD-only access and no schema, database,
-  role-management, RLS-bypass, replication, or Neon-admin privileges.
-- [x] The Preview environment explicitly sets all five optional AMA capability
-  switches to `false`. Owner admin has no capability switch.
-- [ ] Configure Preview and Production with their environment-specific Clerk
-  secret keys and the public `clerk.cali.so` publishable key. Mark the owner in
-  the Clerk Dashboard with public metadata `{ "siteOwner": "yes" }` and verify
-  a non-owner account receives HTTP 403 from admin APIs. No values are recorded
-  here.
-- [ ] Rotate the Preview-only Google OAuth secret before enabling the Google
-  capability; the integration remains disabled meanwhile.
-- [ ] Remove the obsolete `Admin Security` firewall rule for
-  `POST /api/admin/auth/request`; Clerk replaced that endpoint and the route now
-  returns 404.
-- [ ] Provision isolated Development credentials before expecting that
-  environment to exercise authenticated AMA or provider integrations.
-- [ ] Verify the production runtime database role cannot perform DDL or role
-  management, and keep `MIGRATION_DATABASE_URL` absent from Vercel.
-- [ ] Verify logs and drains follow the allowlist in `baseline.md`, with
-  deliberate access and retention.
-- [ ] Configure the five optional kill switches explicitly in Development and
-  Production; keep them false until the corresponding capability is approved
-  for release. Verify owner admin remains reachable only through its
-  authentication boundary.
+Clerk provider configuration and owner recovery remain tracked by issue #93.
+Production provider values remain a cutover concern until v3 replaces the
+historical site on `main`.

--- a/docs/security/verification.md
+++ b/docs/security/verification.md
@@ -4,6 +4,12 @@ Last checked: 2026-07-16. This note separates repository evidence from hosted
 settings. Do not paste credentials, scan findings, or exploit details here;
 use GitHub private vulnerability reporting.
 
+Owner admin is an always-available control plane for Media and AMA operations.
+It has no environment kill switch: Clerk authentication plus the exact
+server-checked `publicMetadata.siteOwner = "yes"` marker protects access. The
+five AMA switches cover only public mutations, payments, booking finalization,
+Google, and Tencent; an absent switch is deliberately equivalent to `false`.
+
 ## Local repository
 
 - [x] `SECURITY.md` directs coordinated disclosure to GitHub private
@@ -75,14 +81,19 @@ Project API checks on 2026-07-16 verified:
 - [x] Preview explicitly sets all five optional AMA capability switches to
   `false`. Owner admin has no capability switch and remains protected by Clerk
   authentication plus the exact server-side `siteOwner: "yes"` marker.
-- [ ] Add the five explicit false AMA capability switches to Production before
-  the v3 cutover.
+- [x] Production omits the five optional AMA capability switches, which is the
+  schema's documented fail-closed state. Explicit `false` values are optional,
+  not a launch requirement.
 - [ ] Add an isolated Preview `CLERK_SECRET_KEY`; never expose the Production
   Clerk secret to Preview.
-- [ ] Split the shared Resend and Marketplace KV credentials so Preview and
-  Production never receive the same provider secret.
+- [ ] Remove the unused Resend key from Preview instead of provisioning a v3
+  replacement, and split the Marketplace KV credentials so Preview and
+  Production never receive the same datastore secret. Keep the legacy
+  Production Resend key only until the historical site is cut over.
 - [ ] Remove the obsolete `Admin Security` challenge for the removed
   `POST /api/admin/auth/request` route.
+- [ ] Remove the dead `AMA_ADMIN_ENABLED` Preview variable if it still exists;
+  the owner admin boundary is not environment-gated.
 - [x] Vercel reports no configured log drains for the workspace. A grouped,
   payload-free Preview query confirmed runtime-log access. The Pro workspace
   has Observability Plus enabled for this project, so Vercel's documented

--- a/docs/v3-cutover-ops-runbook.md
+++ b/docs/v3-cutover-ops-runbook.md
@@ -54,20 +54,21 @@ JSON
 
 ## 2. Isolate Preview and Production credentials
 
-- `RESEND_API_KEY` is a single variable targeting both environments. Create a
-  second Resend key for Preview, then rescope: in the dashboard, edit the
-  existing variable to Production only and add a Preview-only variable with
-  the new key. CLI equivalent (each `env add` prompts for the value):
+- The v3 app no longer uses Resend. Remove the legacy key from Preview rather
+  than creating another key. Keep its Production assignment only while the
+  historical site is live, then remove it after cutover:
 
   ```bash
   npx vercel env rm RESEND_API_KEY preview $SCOPE
-  npx vercel env add RESEND_API_KEY preview $SCOPE
   ```
 
 - The `KV_URL`, `KV_REST_API_*`, and `REDIS_URL` group comes from one storage
   integration connected to both environments. Isolation happens in the
   dashboard's Storage tab: connect a separate store (or database) for Preview
   so Production traffic and Preview experiments never share data.
+
+- Add a Preview-only `CLERK_SECRET_KEY` from the non-production Clerk
+  environment. Never copy the Production Clerk secret into Preview.
 
 - Remove the dead capability switch left behind by ADR-0008:
 
@@ -89,30 +90,24 @@ add() { npx vercel env add "$1" production $SCOPE; }
 npx vercel env rm DATABASE_URL production $SCOPE
 add DATABASE_URL
 
-# Identity and delivery.
+# Identity and runtime ownership.
 add SITE_URL                 # https://cali.so
 add ADMIN_EMAIL
-add RESEND_FROM_EMAIL
+add NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+add CLERK_SECRET_KEY
 add CRON_SECRET              # openssl rand -hex 32
 
 # Server-only key material — generate per environment, never reuse Preview's.
-add SESSION_SECRET           # openssl rand -hex 32
 add AMA_ENCRYPTION_KEY       # openssl rand -hex 32
 add RATE_LIMIT_HASH_KEY      # openssl rand -hex 32
 add MEDIA_ENCRYPTION_KEY     # openssl rand -hex 32
 
 # Rate limits (values from .env.example defaults unless tuned).
-add AUTH_RATE_LIMIT_MAX_REQUESTS
-add AUTH_RATE_LIMIT_WINDOW_SECONDS
 add ADMIN_MUTATION_RATE_LIMIT_MAX_REQUESTS
 add ADMIN_MUTATION_RATE_LIMIT_WINDOW_SECONDS
 
-# Capability switches — explicitly false for launch.
-add AMA_PUBLIC_MUTATIONS_ENABLED
-add AMA_PAYMENTS_ENABLED
-add AMA_BOOKING_FINALIZATION_ENABLED
-add AMA_GOOGLE_INTEGRATION_ENABLED
-add AMA_TENCENT_INTEGRATION_ENABLED
+# The five optional AMA capability switches default to false when absent.
+# If you set them for operational visibility, enter the literal value `false`.
 
 # Bunny media storage (production zones, not the preview zones).
 add BUNNY_MEDIA_REGION

--- a/docs/v3-cutover-readiness.md
+++ b/docs/v3-cutover-readiness.md
@@ -51,9 +51,9 @@ Renditions. The retired static photo fallback has been removed.
 | GitHub security settings | PASS | Secret scanning, push protection, Dependabot security updates, read-only Actions defaults, and full-SHA action policy are enabled. |
 | Required GitHub checks | FAIL | Neither the `v2` ruleset nor `main` branch protection requires `Quality` and `CodeQL`. The maintainer-operated commands are in `docs/v3-cutover-ops-runbook.md`. |
 | Current Vercel project settings | PASS | Project inspection succeeds with the explicit team scope. The earlier `Not authorized` was a CLI quirk: the team slug `cali` resolves to the personal account, so commands must pass the team ID as `--scope` (see the runbook). |
-| Production capability switches | PASS | All five optional `AMA_*_ENABLED` variables are absent from Production and therefore fail closed. Setting them explicitly `false` remains recommended during provisioning. `AMA_ADMIN_ENABLED` survives in Preview as dead configuration after ADR-0008 and should be removed. |
-| Preview and Production secret isolation | FAIL | `RESEND_API_KEY` is one variable targeting both Production and Preview, and the `KV_*`/`REDIS_URL` group added with the Preview provisioning also targets both environments. |
-| Production runtime environment | FAIL | Production `DATABASE_URL` predates the rewrite by over three years, and the v3 server-environment contract is otherwise unmet: no `SESSION_SECRET`, `AMA_ENCRYPTION_KEY`, `RATE_LIMIT_HASH_KEY`, `SITE_URL`, `RESEND_FROM_EMAIL`, rate-limit values, `CRON_SECRET`, or any `BUNNY_*`/`MEDIA_*` variable. The first v3 production build would fail environment validation. |
+| Production capability switches | PASS | All five optional `AMA_*_ENABLED` variables are absent from Production and therefore fail closed. Owner admin has no capability switch. `AMA_ADMIN_ENABLED` survives in Preview as dead configuration after ADR-0008 and should be removed. |
+| Preview and Production secret isolation | FAIL | The v3 app no longer uses Resend, so Preview should not receive the legacy Production key. The `KV_*`/`REDIS_URL` group still targets both environments, and Preview needs its own Clerk secret. |
+| Production runtime environment | FAIL | Production `DATABASE_URL` predates the rewrite by over three years, and the v3 server-environment contract is otherwise unmet: the environment-specific Clerk keys, `AMA_ENCRYPTION_KEY`, `RATE_LIMIT_HASH_KEY`, `SITE_URL`, admin rate-limit values, `CRON_SECRET`, and required `BUNNY_*`/`MEDIA_*` variables are not fully provisioned. The first v3 production build would fail environment validation. |
 | Production runtime database grants | AWAITING CONFIRMATION | Requires two fresh confirmations before inspecting the production role or sensitive cloud state. |
 | Production migration credential | PASS (name level) | `MIGRATION_DATABASE_URL` is absent from every Vercel environment. Its availability to the controlled migration operation is confirmed at cutover time. |
 | Production migrations | AWAITING CONFIRMATION | Nine additive migrations validate locally. Media migrations `0005` through `0009` are required for the v3 photo surface; execution and schema state require a separately authorized cutover step. |
@@ -206,7 +206,7 @@ Before cutover, an authorized operator must:
    role, preserving the additive migration history;
 4. verify private Originals, public Renditions, and the active Published Photo
    Selection against the production Bunny and Neon boundary;
-5. leave all five optional AMA capability switches explicitly false; and
+5. leave all five optional AMA capability switches absent or `false`; and
 6. smoke-test the public site without exercising disabled AMA provider
    workflows.
 
@@ -235,9 +235,9 @@ The maintainer-operated commands for actions 1 through 4 are collected in
    legacy `DATABASE_URL` with the CRUD-only Neon runtime role and add the
    missing secrets, rate limits, capability switches, and complete Bunny and
    media configuration.
-2. Split the shared `RESEND_API_KEY` and `KV_*`/`REDIS_URL` credentials so
-   Preview and Production hold isolated values, and delete the dead
-   `AMA_ADMIN_ENABLED` variable from Preview.
+2. Remove the unused `RESEND_API_KEY` from Preview, split the shared
+   `KV_*`/`REDIS_URL` credentials, add an isolated Preview Clerk secret, and
+   delete the dead `AMA_ADMIN_ENABLED` variable from Preview.
 3. Add `Quality` and `CodeQL` as required checks to both `v2` and `main`.
 4. In the Vercel dashboard, verify logs, drains, retention, firewall rules,
    the production-branch mapping, and the certificate.


### PR DESCRIPTION
Refs [#92](https://github.com/CaliCastle/cali.so/issues/92)

## Summary

- records the current full-history Gitleaks, OSV, security-test, and production-boundary evidence
- aligns the security and cutover records with the always-available Clerk owner admin
- keeps only the five deferred public AMA capabilities fail closed
- removes retired magic-link and Preview Resend requirements from the cutover instructions
- records the remaining GitHub and Vercel controls without treating unknown hosted state as complete

## Verification

- Gitleaks 8.30.1 scanned 402 branch/tag-reachable commits; the only match was Clerk's intentionally public publishable-key fixture, narrowly ignored by fingerprint
- repeat Gitleaks scan: no findings
- 5 security tests passed
- OSV checked 626 production package versions: no findings
- production security-boundary verifier passed
- documentation diff check passed

## Remaining hosted controls

Issue #92 stays open until the required GitHub checks, obsolete firewall cleanup, Preview Clerk/KV isolation, and dead Preview variables are verified. Production database work remains in #107 and is outside this PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates four documentation files to reflect the completed security baseline evidence for the v3 launch, aligned with 2026-07-16 verification runs. No application code changes are included; the only non-documentation file is a single `.gitleaksignore` entry.

- **`.gitleaksignore`**: Adds one fingerprint-scoped ignore for Clerk's intentionally public publishable key in the CI fixture (`NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`), which Gitleaks flags as `generic-api-key` at line 29 of `security.yml`.
- **`docs/security/verification.md`**: Updates the full-history Gitleaks evidence (363 → 402 commits), documents the five-test AMA security suite, adds the Vercel log-drain inspection result, and cleans up the GitHub/Vercel checklist to reflect current access.
- **`docs/v3-cutover-ops-runbook.md` & `docs/v3-cutover-readiness.md`**: Removes retired magic-link and Resend provisioning steps, replaces them with Clerk key provisioning, and clarifies that the five AMA capability switches default fail-closed when absent (no explicit `false` required at launch).

<h3>Confidence Score: 5/5</h3>

Safe to merge — all four changed files are documentation or a narrowly scoped Gitleaks ignore entry with no application code touched.

The only non-documentation change is a single .gitleaksignore fingerprint that silences a well-explained false positive (Clerk's intentionally public publishable key in the CI fixture). The documentation updates accurately reflect the current project state: restored Vercel access, the Clerk-based auth model replacing magic-link/Resend, and honest tracking of the remaining open items before cutover. Nothing in the diff introduces new code paths, alters runtime behavior, or weakens any security control.

No files require special attention. The open checklist items in docs/security/verification.md and docs/v3-cutover-readiness.md are correctly tracked as deferred work rather than being silently closed.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .gitleaksignore | New file with a single commit-SHA-scoped fingerprint that silences the Gitleaks generic-api-key hit on Clerk's intentionally public publishable key in the CI workflow fixture at line 29 of security.yml. |
| docs/security/verification.md | Refreshed verification evidence: updates commit count to 402, documents the owner-admin auth invariant, adds the Vercel log-drain inspection outcome, and consolidates the GitHub/Vercel checklists to reflect current access and state. |
| docs/v3-cutover-ops-runbook.md | Removes retired Resend Preview key provisioning and SESSION_SECRET/AUTH_RATE_LIMIT_* variables; adds Clerk key provisioning steps and clarifies AMA capability switch defaults. |
| docs/v3-cutover-readiness.md | Updates the readiness table to reflect resolved Vercel access, the simplified Resend/Clerk isolation strategy, and the correct list of missing production environment variables. |

<sub>Reviews (2): Last reviewed commit: ["chore: merge latest v2 security updates"](https://github.com/calicastle/cali.so/commit/4ffcabee3fcd6e17f5326cf9f00c6580cb8c5aea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44712430)</sub>

<!-- /greptile_comment -->