### PR TITLE
feat: harden Clerk owner reverification

### DIFF
--- a/app/admin/(protected)/AdminDashboard.tsx
+++ b/app/admin/(protected)/AdminDashboard.tsx
@@ -2,6 +2,10 @@
 
 import { useEffect, useRef, useState, type FormEvent } from 'react'
 
+import {
+  PasskeyVerificationError,
+  usePasskeyVerification,
+} from '~/lib/admin/passkey-client'
 import { T } from '~/lib/i18n'
 import { localize, useLocale } from '~/lib/locale-client'
 
@@ -154,6 +158,31 @@ function GoogleCalendarSection({
 }) {
   const locale = useLocale()
   const [pending, setPending] = useState<'connect' | 'disconnect' | null>(null)
+  const [passkeyCancelled, setPasskeyCancelled] = useState(false)
+  const verifyWithPasskey = usePasskeyVerification()
+
+  async function verifyAndSubmit(
+    form: HTMLFormElement,
+    action: 'connect' | 'disconnect',
+  ) {
+    if (pending !== null) return
+    setPasskeyCancelled(false)
+    setPending(action)
+    try {
+      await verifyWithPasskey()
+      form.submit()
+    } catch (error) {
+      setPending(null)
+      if (error instanceof PasskeyVerificationError) {
+        setPasskeyCancelled(true)
+      }
+    }
+  }
+
+  function connect(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    void verifyAndSubmit(event.currentTarget, 'connect')
+  }
 
   function disconnect(event: FormEvent<HTMLFormElement>) {
     if (
@@ -168,7 +197,8 @@ function GoogleCalendarSection({
       event.preventDefault()
       return
     }
-    setPending('disconnect')
+    event.preventDefault()
+    void verifyAndSubmit(event.currentTarget, 'disconnect')
   }
 
   const stateCopy = {
@@ -223,7 +253,7 @@ function GoogleCalendarSection({
             <form
               action="/api/admin/ama/google/connect"
               method="post"
-              onSubmit={() => setPending('connect')}
+              onSubmit={connect}
             >
               <button
                 type="submit"
@@ -264,6 +294,18 @@ function GoogleCalendarSection({
         notices={notice ? { calendar: notice } : undefined}
         restoreFocus={restoreNoticeFocus}
       />
+
+      {passkeyCancelled && (
+        <p
+          role="status"
+          className="mt-4 text-sm leading-6 text-muted-foreground"
+        >
+          <T
+            zh="未完成通行密钥验证，Google 日历没有变化。"
+            en="Passkey verification was not completed. Google Calendar was not changed."
+          />
+        </p>
+      )}
 
       {connection.identity && (
         <dl className="mt-4 grid gap-x-6 gap-y-2 text-sm sm:grid-cols-[7rem_minmax(0,1fr)]">

--- a/app/admin/(protected)/media/MediaLibrary.tsx
+++ b/app/admin/(protected)/media/MediaLibrary.tsx
@@ -560,8 +560,8 @@ function Inspector({
         error instanceof PasskeyVerificationError
           ? localize(
               locale,
-              '未完成通行密钥验证，没有清除任何内容。',
-              'Passkey verification was not completed. Nothing was purged.',
+              '未能确认通行密钥验证，没有清除任何内容。请重试。',
+              'Passkey verification could not be confirmed. Nothing was purged. Try again.',
             )
           : localize(
               locale,

--- a/app/admin/(protected)/media/MediaLibrary.tsx
+++ b/app/admin/(protected)/media/MediaLibrary.tsx
@@ -11,6 +11,11 @@ import {
   type MouseEvent,
 } from 'react'
 
+import {
+  isReverificationResponse,
+  PasskeyVerificationError,
+  usePasskeyReverification,
+} from '~/lib/admin/passkey-client'
 import { T } from '~/lib/i18n'
 import { localize, useLocale } from '~/lib/locale-client'
 import type { MediaAssetReviewRecord } from '~/lib/media/asset-review/service'
@@ -348,6 +353,15 @@ function Inspector({
   const [pending, setPending] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
   const noticeRef = useRef<HTMLParagraphElement>(null)
+  const purgeAsset = usePasskeyReverification(async (confirmation: string) => {
+    const response = await fetch(`/api/admin/media/assets/${asset.id}/purge`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ confirmation }),
+    })
+    if (await isReverificationResponse(response)) return response
+    return responseJson(response)
+  })
 
   useEffect(() => {
     if (notice) noticeRef.current?.focus()
@@ -539,20 +553,21 @@ function Inspector({
     setPending('purge')
     setNotice(null)
     try {
-      const response = await fetch(`/api/admin/media/assets/${asset.id}/purge`, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ confirmation }),
-      })
-      await responseJson(response)
+      await purgeAsset(confirmation)
       onUpdated(null)
-    } catch {
+    } catch (error) {
       setNotice(
-        localize(
-          locale,
-          '清除未完成。已确认的步骤已保存，可以安全重试。',
-          'Purge is incomplete. Confirmed progress was saved and can be retried safely.',
-        ),
+        error instanceof PasskeyVerificationError
+          ? localize(
+              locale,
+              '未完成通行密钥验证，没有清除任何内容。',
+              'Passkey verification was not completed. Nothing was purged.',
+            )
+          : localize(
+              locale,
+              '清除未完成。已确认的步骤已保存，可以安全重试。',
+              'Purge is incomplete. Confirmed progress was saved and can be retried safely.',
+            ),
       )
     } finally {
       setPending(null)

--- a/app/admin/(protected)/photos/PhotoSelectionEditor.tsx
+++ b/app/admin/(protected)/photos/PhotoSelectionEditor.tsx
@@ -8,6 +8,11 @@ import {
   type DragEvent,
 } from 'react'
 
+import {
+  isReverificationResponse,
+  PasskeyVerificationError,
+  usePasskeyReverification,
+} from '~/lib/admin/passkey-client'
 import { T } from '~/lib/i18n'
 import { localize, useLocale } from '~/lib/locale-client'
 import type { MediaAssetReviewRecord } from '~/lib/media/asset-review/service'
@@ -93,6 +98,20 @@ export function PhotoSelectionEditor({
   const [draggedId, setDraggedId] = useState<string | null>(null)
   const noticeRef = useRef<HTMLParagraphElement>(null)
   const publishKeyRef = useRef<string | null>(null)
+  const publishSelection = usePasskeyReverification(
+    async (expectedDraftRevision: number, idempotencyKey: string) => {
+      const response = await fetch(
+        '/api/admin/media/photo-selection/publish',
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ expectedDraftRevision, idempotencyKey }),
+        },
+      )
+      if (await isReverificationResponse(response)) return response
+      return responseJson(response)
+    },
+  )
 
   const assetById = useMemo(
     () => new Map(initialAssets.map((asset) => [asset.id, asset])),
@@ -195,15 +214,7 @@ export function PhotoSelectionEditor({
     const idempotencyKey = publishKeyRef.current ?? crypto.randomUUID()
     publishKeyRef.current = idempotencyKey
     try {
-      const response = await fetch('/api/admin/media/photo-selection/publish', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          expectedDraftRevision: revision,
-          idempotencyKey,
-        }),
-      })
-      await responseJson(response)
+      await publishSelection(revision, idempotencyKey)
       publishKeyRef.current = null
       setNotice(
         localize(
@@ -215,7 +226,13 @@ export function PhotoSelectionEditor({
     } catch (error) {
       const code = error instanceof Error ? error.message : ''
       setNotice(
-        code === 'ineligible_assets'
+        error instanceof PasskeyVerificationError
+          ? localize(
+              locale,
+              '未完成通行密钥验证，没有发布任何更改。',
+              'Passkey verification was not completed. Nothing was published.',
+            )
+          : code === 'ineligible_assets'
           ? localize(
               locale,
               '草稿中有不再符合发布条件的媒体素材。请移除或修复后重试。',

--- a/app/admin/(protected)/photos/PhotoSelectionEditor.tsx
+++ b/app/admin/(protected)/photos/PhotoSelectionEditor.tsx
@@ -229,8 +229,8 @@ export function PhotoSelectionEditor({
         error instanceof PasskeyVerificationError
           ? localize(
               locale,
-              '未完成通行密钥验证，没有发布任何更改。',
-              'Passkey verification was not completed. Nothing was published.',
+              '未能确认通行密钥验证，没有发布任何更改。请重试。',
+              'Passkey verification could not be confirmed. Nothing was published. Try again.',
             )
           : code === 'ineligible_assets'
           ? localize(

--- a/app/api/admin/ama/google/callback/route.ts
+++ b/app/api/admin/ama/google/callback/route.ts
@@ -1,6 +1,7 @@
 import { createGoogleCallbackHandler } from '~/lib/ama/admin/http'
 import {
   getAmaAdminServices,
+  ownerHighImpactReverifier,
   ownerRequestAuthenticator,
 } from '~/lib/ama/admin/server'
 import { protectAmaLaunchBoundary } from '~/lib/ama/security/launch-boundary-server'
@@ -14,5 +15,6 @@ export async function GET(request: Request) {
     service: google,
     security,
     baseUrl,
+    reverifier: ownerHighImpactReverifier,
   })(request)
 }

--- a/app/api/admin/ama/google/connect/route.ts
+++ b/app/api/admin/ama/google/connect/route.ts
@@ -1,6 +1,7 @@
 import { createGoogleConnectHandler } from '~/lib/ama/admin/http'
 import {
   getAmaAdminServices,
+  ownerHighImpactReverifier,
   ownerRequestAuthenticator,
 } from '~/lib/ama/admin/server'
 import { protectAmaLaunchBoundary } from '~/lib/ama/security/launch-boundary-server'
@@ -14,5 +15,6 @@ export async function POST(request: Request) {
     service: google,
     security,
     baseUrl,
+    reverifier: ownerHighImpactReverifier,
   })(request)
 }

--- a/app/api/admin/ama/google/disconnect/route.ts
+++ b/app/api/admin/ama/google/disconnect/route.ts
@@ -1,6 +1,7 @@
 import { createGoogleDisconnectHandler } from '~/lib/ama/admin/http'
 import {
   getAmaAdminServices,
+  ownerHighImpactReverifier,
   ownerRequestAuthenticator,
 } from '~/lib/ama/admin/server'
 import { protectAmaLaunchBoundary } from '~/lib/ama/security/launch-boundary-server'
@@ -14,5 +15,6 @@ export async function POST(request: Request) {
     service: google,
     security,
     baseUrl,
+    reverifier: ownerHighImpactReverifier,
   })(request)
 }

--- a/app/api/admin/media/assets/[mediaAssetId]/purge/route.ts
+++ b/app/api/admin/media/assets/[mediaAssetId]/purge/route.ts
@@ -1,6 +1,7 @@
 import { createMediaPurgeHandler } from '~/lib/media/admin/http'
 import {
   getMediaAdminServices,
+  ownerHighImpactReverifier,
   ownerRequestAuthenticator,
 } from '~/lib/media/admin/server'
 
@@ -10,6 +11,7 @@ function handler() {
     authenticator: ownerRequestAuthenticator,
     purge,
     security,
+    reverifier: ownerHighImpactReverifier,
   })
 }
 

--- a/app/api/admin/media/photo-selection/publish/route.ts
+++ b/app/api/admin/media/photo-selection/publish/route.ts
@@ -1,6 +1,7 @@
 import { createPhotoSelectionPublishHandler } from '~/lib/media/admin/http'
 import {
   getMediaAdminServices,
+  ownerHighImpactReverifier,
   ownerRequestAuthenticator,
 } from '~/lib/media/admin/server'
 
@@ -10,5 +11,6 @@ export async function POST(request: Request) {
     authenticator: ownerRequestAuthenticator,
     security,
     selection,
+    reverifier: ownerHighImpactReverifier,
   })(request)
 }

--- a/docs/adr/0009-clerk-owner-metadata.md
+++ b/docs/adr/0009-clerk-owner-metadata.md
@@ -21,3 +21,18 @@ receive HTTP 401. The retired magic-link
 request and verification endpoints remain absent. Same-origin mutation checks,
 rate limits, privacy-safe audit events, strict admin CSP, and independent
 provider capability switches remain in force.
+
+Current high-impact actions require Clerk's first-factor verification age to be
+less than ten minutes. The browser initiates Clerk's passkey verification before
+submitting an action and only sends or retries the mutation after it completes.
+This applies to Google Calendar connection changes, Media Asset Purge, and Photo
+Selection publication. Refunds, exports, security settings, bulk operations,
+and destructive Booking actions must use the same boundary when they ship.
+
+Clerk 7.5.19 exposes only first- and second-factor ages to the server, not the
+strategy that produced the fresh factor. The server therefore proves fresh
+first-factor verification but cannot cryptographically prove it was a passkey;
+the owned client deliberately selects `verifyWithPasskey()`. Exact server-side
+passkey attestation would require app-owned WebAuthn credentials, challenges,
+counters, and recovery, which is not part of this Clerk-only decision. This
+limitation must remain explicit in reviews and operations evidence.

--- a/docs/adr/0009-clerk-owner-metadata.md
+++ b/docs/adr/0009-clerk-owner-metadata.md
@@ -24,10 +24,11 @@ provider capability switches remain in force.
 
 Current high-impact actions require Clerk's first-factor verification age to be
 less than ten minutes. The browser initiates Clerk's passkey verification before
-submitting an action and only sends or retries the mutation after it completes.
-This applies to Google Calendar connection changes, Media Asset Purge, and Photo
-Selection publication. Refunds, exports, security settings, bulk operations,
-and destructive Booking actions must use the same boundary when they ship.
+submitting an action. It never automatically retries a server freshness denial;
+the owner must explicitly retry after the no-side-effect response. This applies
+to Google Calendar connection changes, Media Asset Purge, and Photo Selection
+publication. Refunds, exports, security settings, bulk operations, and
+destructive Booking actions must use the same boundary when they ship.
 
 Clerk 7.5.19 exposes only first- and second-factor ages to the server, not the
 strategy that produced the fresh factor. The server therefore proves fresh

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -135,9 +135,11 @@ The Vercel runtime receives only the CRUD-only `DATABASE_URL`. Never put
 
 ## Post-launch work
 
-- Complete the remaining passkey and recovery work in #93 without disabling
-  owner admin, then resume the public AMA product slices (#82 through #87)
-  behind their security and privacy gates.
+- Maintain #93's Clerk-native passkey-first high-impact boundary without
+  disabling owner admin. Hosted setup, session revocation, credential rotation,
+  and Clerk's server-side factor-strategy limitation are documented in
+  `docs/security/clerk-admin-operations.md`. Resume the public AMA product
+  slices (#82 through #87) only behind their security and privacy gates.
 - Revisit Bunny S3 preview constraints and provider capabilities before
   expanding the Media Library beyond the curated photo workflow.
 - Re-enable private capabilities only after their provider, retention,

--- a/docs/security/clerk-admin-operations.md
+++ b/docs/security/clerk-admin-operations.md
@@ -1,0 +1,138 @@
+# Clerk owner-admin operations
+
+This runbook covers hosted Clerk configuration, owner recovery, session
+revocation, and Clerk credential rotation for the owner admin. It contains no
+credentials or user identifiers. Perform each hosted change in one Clerk
+environment at a time and verify the matching Vercel environment before moving
+on.
+
+The application authorization contract is ADR-0009: every admin page and API
+loads the authoritative Clerk user on the server and requires
+`publicMetadata.siteOwner` to equal the exact string `"yes"`. Email addresses,
+browser state, unsafe metadata, and the durable `ADMIN_EMAIL` data namespace
+never grant access.
+
+## Environment configuration
+
+Production, Preview, and local development use different Clerk applications or
+instances and different secret keys. Never copy the Production secret into
+Preview, Development, CI, or a pull request.
+
+For each deployed environment:
+
+1. Set `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY` from the same
+   Clerk instance. The publishable key is client-visible; the secret key is a
+   server credential and must be sensitive and environment-scoped in Vercel.
+2. Keep Production signup disabled until issue #94's policy, deletion, consent,
+   and privacy-contact gates are complete. The application's retired
+   `/sign-in` and `/sign-up` routes are not sufficient on their own because the
+   Clerk-hosted sign-in surface is reachable from `/admin`.
+3. Allow only verified email codes, Google, and X when public signup is
+   eventually approved. Keep passwords, SMS, Apple, and every other social
+   provider disabled.
+4. Enable passkeys and register the owner before enforcing the passkey gate.
+   Keep at least two independently recoverable owner passkeys. Do not enable a
+   gate that could lock the owner out before recovery has been exercised.
+5. Mark only the intended owner record with public metadata
+   `{ "siteOwner": "yes" }`. Public metadata is readable by the browser but
+   writable only by the server or Clerk Dashboard. Private metadata is
+   server-only. Unsafe metadata is client-writable and must never authorize
+   anything.
+6. Verify a signed-out admin API receives 401, a signed-in user without the
+   marker receives 403, and the marked owner can open `/admin`. Confirm that
+   `/api/admin/auth/request` and `/api/admin/auth/verify` remain 404.
+
+## Passkey enforcement boundary
+
+The browser runs Clerk's `verifyWithPasskey()` before Google Calendar
+connection changes, Media Asset Purge, and Photo Selection publication. It
+does not send the mutation when the passkey prompt is cancelled and retries a
+Clerk reverification denial only after another successful passkey assertion.
+The server independently requires a first-factor verification age below ten
+minutes before any of those effects run.
+
+Clerk 7.5.19 gives the server factor ages but not the factor strategy. The
+server can prove that the first factor is fresh, but it cannot prove that the
+factor was specifically a passkey. The passkey choice is enforced by the owned
+client flow and must not be described as server-side passkey attestation. An
+exact proof would require a separate app-owned WebAuthn credential system.
+
+Future refunds, exports, security settings, bulk operations, and destructive
+Booking actions must use the same high-impact boundary before they ship.
+
+AMA Bookings remain accountless and use private Manage Links. Do not attach a
+Clerk user ID to a Booking until issue #89 has its own threat model and ships.
+
+## Suspected owner-session exposure
+
+Containment comes before investigation:
+
+1. In Clerk, remove `siteOwner` from the affected user. This immediately makes
+   subsequent authoritative checks return 403 without changing the stable
+   Media or AMA data namespace.
+2. Revoke every active session for the affected user in the Clerk Dashboard.
+   The site's Sign out action revokes only the current session and is not an
+   incident-wide response.
+3. If the Clerk account itself may be compromised, disable the account or block
+   sign-in while recovery is underway. Preserve only privacy-safe timestamps
+   and identifiers needed for the incident record.
+4. Inspect Clerk and Vercel audit events for unexpected admin access. Never copy
+   session tokens, request bodies, email addresses, provider payloads, Booking
+   Briefs, or Media Originals into tickets or logs.
+5. Recover the identity provider account, remove unknown passkeys and connected
+   accounts, register known passkeys, then restore
+   `{ "siteOwner": "yes" }` only after the account and sessions are clean.
+6. Sign in through `/admin`, verify the authoritative owner check, and exercise
+   one non-destructive admin read before resuming privileged work.
+
+If the owner device alone is lost, revoke its session and passkey from a known
+device. Do not rotate application credentials unless they may also have been
+exposed.
+
+## Clerk secret-key exposure
+
+Treat a pasted, logged, committed, or otherwise disclosed `CLERK_SECRET_KEY` as
+compromised even if no misuse is visible.
+
+1. Remove the exposed value from the immediate surface without publishing the
+   credential in an issue or pull request. Report repository exposures through
+   GitHub private vulnerability reporting.
+2. Create a replacement secret in the affected Clerk environment.
+3. Replace only that environment's `CLERK_SECRET_KEY` in Vercel and trigger a
+   fresh deployment. Do not reuse the key in another environment.
+4. Verify the new deployment: public pages return normally, signed-out
+   `/admin` redirects to Clerk, the owner reaches `/admin`, a non-owner receives
+   403, and admin API denials contain no provider detail.
+5. Revoke the old secret in Clerk only after the replacement deployment is
+   Ready and verified. If Clerk does not support overlap, schedule a short
+   maintenance window and fail admin closed during the swap.
+6. Revoke active sessions when the exposure could have allowed session or user
+   manipulation. Review owner metadata and passkeys before restoring access.
+7. Record the environment, detection time, rotation time, revocation time, and
+   verification result without recording either key.
+
+Rotating a secret key does not replace session revocation, owner-metadata
+review, or passkey review. Rotating the publishable key is unnecessary unless
+the Clerk instance or domain configuration also changes.
+
+## Recovery proof
+
+The operator closes an incident only after recording all applicable checks:
+
+- affected sessions are revoked;
+- the old secret is revoked and absent from Vercel;
+- Production and Preview still use distinct Clerk secrets;
+- exactly the intended owner has `siteOwner: "yes"`;
+- the owner has independently recoverable passkeys;
+- signed-out, non-owner, and owner HTTP behavior matches ADR-0009;
+- logs and audit records contain no prohibited personal or credential data;
+- any public-signup setting remains consistent with issue #94.
+
+Run the repository checks after an authentication or routing change:
+
+```sh
+pnpm typecheck
+pnpm test:unit
+pnpm test:security
+pnpm verify:security-boundary
+```

--- a/docs/security/clerk-admin-operations.md
+++ b/docs/security/clerk-admin-operations.md
@@ -46,10 +46,11 @@ For each deployed environment:
 
 The browser runs Clerk's `verifyWithPasskey()` before Google Calendar
 connection changes, Media Asset Purge, and Photo Selection publication. It
-does not send the mutation when the passkey prompt is cancelled and retries a
-Clerk reverification denial only after another successful passkey assertion.
-The server independently requires a first-factor verification age below ten
-minutes before any of those effects run.
+does not send the mutation when the passkey prompt is cancelled. A server
+freshness denial is never retried automatically, avoiding a second prompt or
+an ambiguous duplicate mutation; the owner receives a no-side-effect message
+and explicitly retries the action. The server independently requires a
+first-factor verification age below ten minutes before any effect runs.
 
 Clerk 7.5.19 gives the server factor ages but not the factor strategy. The
 server can prove that the first factor is fresh, but it cannot prove that the

--- a/lib/admin/authorization.test.ts
+++ b/lib/admin/authorization.test.ts
@@ -79,6 +79,31 @@ describe('owner authorization', () => {
     await expect(authorize()).resolves.toEqual({ status: 'forbidden' })
   })
 
+  it('never authorizes through email or client-writable metadata', async () => {
+    const authorize = createOwnerAuthorizer({
+      getOwnerDataId() {
+        return 'owner@example.com'
+      },
+      async getAuthentication() {
+        return {
+          isAuthenticated: true,
+          sessionStatus: 'active',
+          userId: 'user_public_account',
+        }
+      },
+      async getUser() {
+        return {
+          id: 'user_public_account',
+          emailAddresses: [{ emailAddress: 'owner@example.com' }],
+          publicMetadata: {},
+          unsafeMetadata: { siteOwner: 'yes' },
+        }
+      },
+    })
+
+    await expect(authorize()).resolves.toEqual({ status: 'forbidden' })
+  })
+
   it('authorizes the Clerk user marked as the site owner', async () => {
     const authorize = createOwnerAuthorizer({
       getOwnerDataId() {

--- a/lib/admin/passkey-client.test.tsx
+++ b/lib/admin/passkey-client.test.tsx
@@ -12,39 +12,6 @@ const clerk = vi.hoisted(() => ({
 
 vi.mock('@clerk/nextjs', () => ({
   useSession: () => ({ isLoaded: true, session: clerk.session }),
-  useReverification: (
-    fetcher: (...args: unknown[]) => Promise<unknown>,
-    options: {
-      onNeedsReverification(input: {
-        cancel(): void
-        complete(): void
-        level: 'first_factor'
-      }): void
-    },
-  ) =>
-    async (...args: unknown[]) => {
-      const first = await fetcher(...args)
-      if (!(first instanceof Response) || first.status !== 403) return first
-      const body = (await first.clone().json()) as {
-        clerk_error?: { reason?: string }
-      }
-      if (body.clerk_error?.reason !== 'reverification-error') return first
-
-      await new Promise<void>((resolve, reject) => {
-        options.onNeedsReverification({
-          level: 'first_factor',
-          complete: resolve,
-          cancel: () => reject(new Error('reverification_cancelled')),
-        })
-      })
-      const retry = await fetcher(...args)
-      return retry instanceof Response ? retry.json() : retry
-    },
-}))
-
-vi.mock('@clerk/nextjs/errors', () => ({
-  isReverificationCancelledError: (error: unknown) =>
-    error instanceof Error && error.message === 'reverification_cancelled',
 }))
 
 import { usePasskeyReverification } from './passkey-client'
@@ -81,44 +48,8 @@ describe('passkey-first client reverification', () => {
     expect(mutation).toHaveBeenCalledOnce()
   })
 
-  it('retries a server reverification denial only after another passkey succeeds', async () => {
-    clerk.session.verifyWithPasskey
-      .mockResolvedValueOnce({ status: 'complete' })
-      .mockResolvedValueOnce({ status: 'complete' })
-    const mutation = vi
-      .fn()
-      .mockResolvedValueOnce(
-        Response.json(
-          {
-            clerk_error: {
-              type: 'forbidden',
-              reason: 'reverification-error',
-              metadata: {
-                reverification: {
-                  level: 'first_factor',
-                  afterMinutes: 10,
-                },
-              },
-            },
-          },
-          { status: 403 },
-        ),
-      )
-      .mockResolvedValueOnce({ ok: true })
-    const { result } = renderHook(() => usePasskeyReverification(mutation))
-
-    await act(async () => {
-      await expect(result.current()).resolves.toEqual({ ok: true })
-    })
-
-    expect(clerk.session.verifyWithPasskey).toHaveBeenCalledTimes(2)
-    expect(mutation).toHaveBeenCalledTimes(2)
-  })
-
-  it('does not retry when the second passkey prompt is cancelled', async () => {
-    clerk.session.verifyWithPasskey
-      .mockResolvedValueOnce({ status: 'complete' })
-      .mockRejectedValueOnce(new Error('passkey cancelled'))
+  it('does not prompt or retry automatically after a server freshness denial', async () => {
+    clerk.session.verifyWithPasskey.mockResolvedValueOnce({ status: 'complete' })
     const mutation = vi.fn(async () =>
       Response.json(
         {
@@ -141,6 +72,7 @@ describe('passkey-first client reverification', () => {
     await expect(
       act(async () => result.current()),
     ).rejects.toThrow('passkey_verification_failed')
+    expect(clerk.session.verifyWithPasskey).toHaveBeenCalledOnce()
     expect(mutation).toHaveBeenCalledOnce()
   })
 
@@ -157,32 +89,4 @@ describe('passkey-first client reverification', () => {
     expect(mutation).toHaveBeenCalledOnce()
   })
 
-  it('does not report success when the retry remains denied', async () => {
-    clerk.session.verifyWithPasskey
-      .mockResolvedValueOnce({ status: 'complete' })
-      .mockResolvedValueOnce({ status: 'complete' })
-    const denied = () =>
-      Response.json(
-        {
-          clerk_error: {
-            type: 'forbidden',
-            reason: 'reverification-error',
-            metadata: {
-              reverification: {
-                level: 'first_factor',
-                afterMinutes: 10,
-              },
-            },
-          },
-        },
-        { status: 403 },
-      )
-    const mutation = vi.fn(async () => denied())
-    const { result } = renderHook(() => usePasskeyReverification(mutation))
-
-    await expect(
-      act(async () => result.current()),
-    ).rejects.toThrow('passkey_verification_failed')
-    expect(mutation).toHaveBeenCalledTimes(2)
-  })
 })

--- a/lib/admin/passkey-client.test.tsx
+++ b/lib/admin/passkey-client.test.tsx
@@ -1,0 +1,188 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const clerk = vi.hoisted(() => ({
+  session: {
+    id: 'sess_owner',
+    verifyWithPasskey: vi.fn(),
+  },
+}))
+
+vi.mock('@clerk/nextjs', () => ({
+  useSession: () => ({ isLoaded: true, session: clerk.session }),
+  useReverification: (
+    fetcher: (...args: unknown[]) => Promise<unknown>,
+    options: {
+      onNeedsReverification(input: {
+        cancel(): void
+        complete(): void
+        level: 'first_factor'
+      }): void
+    },
+  ) =>
+    async (...args: unknown[]) => {
+      const first = await fetcher(...args)
+      if (!(first instanceof Response) || first.status !== 403) return first
+      const body = (await first.clone().json()) as {
+        clerk_error?: { reason?: string }
+      }
+      if (body.clerk_error?.reason !== 'reverification-error') return first
+
+      await new Promise<void>((resolve, reject) => {
+        options.onNeedsReverification({
+          level: 'first_factor',
+          complete: resolve,
+          cancel: () => reject(new Error('reverification_cancelled')),
+        })
+      })
+      const retry = await fetcher(...args)
+      return retry instanceof Response ? retry.json() : retry
+    },
+}))
+
+vi.mock('@clerk/nextjs/errors', () => ({
+  isReverificationCancelledError: (error: unknown) =>
+    error instanceof Error && error.message === 'reverification_cancelled',
+}))
+
+import { usePasskeyReverification } from './passkey-client'
+
+afterEach(() => {
+  cleanup()
+  clerk.session.verifyWithPasskey.mockReset()
+})
+
+describe('passkey-first client reverification', () => {
+  it('sends no mutation when the owner cancels the passkey prompt', async () => {
+    clerk.session.verifyWithPasskey.mockRejectedValueOnce(
+      new Error('passkey cancelled'),
+    )
+    const mutation = vi.fn(async () => ({ ok: true }))
+    const { result } = renderHook(() => usePasskeyReverification(mutation))
+
+    await expect(
+      act(async () => result.current()),
+    ).rejects.toThrow('passkey_verification_failed')
+    expect(mutation).not.toHaveBeenCalled()
+  })
+
+  it('sends the mutation only after a successful passkey assertion', async () => {
+    clerk.session.verifyWithPasskey.mockResolvedValueOnce({ status: 'complete' })
+    const mutation = vi.fn(async () => ({ ok: true }))
+    const { result } = renderHook(() => usePasskeyReverification(mutation))
+
+    await act(async () => {
+      await expect(result.current()).resolves.toEqual({ ok: true })
+    })
+
+    expect(clerk.session.verifyWithPasskey).toHaveBeenCalledOnce()
+    expect(mutation).toHaveBeenCalledOnce()
+  })
+
+  it('retries a server reverification denial only after another passkey succeeds', async () => {
+    clerk.session.verifyWithPasskey
+      .mockResolvedValueOnce({ status: 'complete' })
+      .mockResolvedValueOnce({ status: 'complete' })
+    const mutation = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json(
+          {
+            clerk_error: {
+              type: 'forbidden',
+              reason: 'reverification-error',
+              metadata: {
+                reverification: {
+                  level: 'first_factor',
+                  afterMinutes: 10,
+                },
+              },
+            },
+          },
+          { status: 403 },
+        ),
+      )
+      .mockResolvedValueOnce({ ok: true })
+    const { result } = renderHook(() => usePasskeyReverification(mutation))
+
+    await act(async () => {
+      await expect(result.current()).resolves.toEqual({ ok: true })
+    })
+
+    expect(clerk.session.verifyWithPasskey).toHaveBeenCalledTimes(2)
+    expect(mutation).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retry when the second passkey prompt is cancelled', async () => {
+    clerk.session.verifyWithPasskey
+      .mockResolvedValueOnce({ status: 'complete' })
+      .mockRejectedValueOnce(new Error('passkey cancelled'))
+    const mutation = vi.fn(async () =>
+      Response.json(
+        {
+          clerk_error: {
+            type: 'forbidden',
+            reason: 'reverification-error',
+            metadata: {
+              reverification: {
+                level: 'first_factor',
+                afterMinutes: 10,
+              },
+            },
+          },
+        },
+        { status: 403 },
+      ),
+    )
+    const { result } = renderHook(() => usePasskeyReverification(mutation))
+
+    await expect(
+      act(async () => result.current()),
+    ).rejects.toThrow('passkey_verification_failed')
+    expect(mutation).toHaveBeenCalledOnce()
+  })
+
+  it('preserves non-cancellation operation errors', async () => {
+    clerk.session.verifyWithPasskey.mockResolvedValueOnce({ status: 'complete' })
+    const mutation = vi.fn(async () => {
+      throw new Error('dependency_unavailable')
+    })
+    const { result } = renderHook(() => usePasskeyReverification(mutation))
+
+    await expect(
+      act(async () => result.current()),
+    ).rejects.toThrow('dependency_unavailable')
+    expect(mutation).toHaveBeenCalledOnce()
+  })
+
+  it('does not report success when the retry remains denied', async () => {
+    clerk.session.verifyWithPasskey
+      .mockResolvedValueOnce({ status: 'complete' })
+      .mockResolvedValueOnce({ status: 'complete' })
+    const denied = () =>
+      Response.json(
+        {
+          clerk_error: {
+            type: 'forbidden',
+            reason: 'reverification-error',
+            metadata: {
+              reverification: {
+                level: 'first_factor',
+                afterMinutes: 10,
+              },
+            },
+          },
+        },
+        { status: 403 },
+      )
+    const mutation = vi.fn(async () => denied())
+    const { result } = renderHook(() => usePasskeyReverification(mutation))
+
+    await expect(
+      act(async () => result.current()),
+    ).rejects.toThrow('passkey_verification_failed')
+    expect(mutation).toHaveBeenCalledTimes(2)
+  })
+})

--- a/lib/admin/passkey-client.ts
+++ b/lib/admin/passkey-client.ts
@@ -1,0 +1,88 @@
+'use client'
+
+import { useReverification, useSession } from '@clerk/nextjs'
+import { isReverificationCancelledError } from '@clerk/nextjs/errors'
+import { useCallback } from 'react'
+
+type AsyncFetcher<Arguments extends unknown[], Result> = (
+  ...args: Arguments
+) => Promise<Result>
+
+export class PasskeyVerificationError extends Error {
+  constructor() {
+    super('passkey_verification_failed')
+    this.name = 'PasskeyVerificationError'
+  }
+}
+
+function isReverificationHint(value: unknown) {
+  if (!value || typeof value !== 'object') return false
+  const clerkError = (value as { clerk_error?: unknown }).clerk_error
+  return (
+    Boolean(clerkError) &&
+    typeof clerkError === 'object' &&
+    (clerkError as { reason?: unknown }).reason === 'reverification-error'
+  )
+}
+
+export async function isReverificationResponse(response: Response) {
+  if (response.status !== 403) return false
+  try {
+    return isReverificationHint(await response.clone().json())
+  } catch {
+    return false
+  }
+}
+
+export function usePasskeyVerification() {
+  const { isLoaded, session } = useSession()
+
+  return useCallback(async () => {
+    if (!isLoaded || !session) {
+      throw new PasskeyVerificationError()
+    }
+    try {
+      const verification = await session.verifyWithPasskey()
+      if (verification.status !== 'complete') {
+        throw new PasskeyVerificationError()
+      }
+    } catch (error) {
+      if (error instanceof PasskeyVerificationError) throw error
+      throw new PasskeyVerificationError()
+    }
+  }, [isLoaded, session])
+}
+
+export function usePasskeyReverification<
+  Arguments extends unknown[],
+  Result,
+>(fetcher: AsyncFetcher<Arguments, Result>) {
+  const verifyWithPasskey = usePasskeyVerification()
+  const reverifyingFetcher = useReverification(fetcher, {
+    onNeedsReverification({ cancel, complete, level }) {
+      if (level !== 'first_factor') {
+        cancel()
+        return
+      }
+      void verifyWithPasskey().then(complete, () => cancel())
+    },
+  })
+
+  return useCallback(
+    async (...args: Arguments) => {
+      await verifyWithPasskey()
+      let result: Awaited<Result>
+      try {
+        result = await reverifyingFetcher(...args)
+      } catch (error) {
+        if (isReverificationCancelledError(error)) {
+          throw new PasskeyVerificationError()
+        }
+        throw error
+      }
+      if (isReverificationHint(result)) throw new PasskeyVerificationError()
+      return result
+    },
+    [reverifyingFetcher, verifyWithPasskey],
+  )
+}

--- a/lib/admin/passkey-client.ts
+++ b/lib/admin/passkey-client.ts
@@ -1,7 +1,6 @@
 'use client'
 
-import { useReverification, useSession } from '@clerk/nextjs'
-import { isReverificationCancelledError } from '@clerk/nextjs/errors'
+import { useSession } from '@clerk/nextjs'
 import { useCallback } from 'react'
 
 type AsyncFetcher<Arguments extends unknown[], Result> = (
@@ -58,31 +57,18 @@ export function usePasskeyReverification<
   Result,
 >(fetcher: AsyncFetcher<Arguments, Result>) {
   const verifyWithPasskey = usePasskeyVerification()
-  const reverifyingFetcher = useReverification(fetcher, {
-    onNeedsReverification({ cancel, complete, level }) {
-      if (level !== 'first_factor') {
-        cancel()
-        return
-      }
-      void verifyWithPasskey().then(complete, () => cancel())
-    },
-  })
 
   return useCallback(
     async (...args: Arguments) => {
       await verifyWithPasskey()
-      let result: Awaited<Result>
-      try {
-        result = await reverifyingFetcher(...args)
-      } catch (error) {
-        if (isReverificationCancelledError(error)) {
-          throw new PasskeyVerificationError()
-        }
-        throw error
-      }
-      if (isReverificationHint(result)) throw new PasskeyVerificationError()
+      const result = await fetcher(...args)
+      const denied =
+        result instanceof Response
+          ? await isReverificationResponse(result)
+          : isReverificationHint(result)
+      if (denied) throw new PasskeyVerificationError()
       return result
     },
-    [reverifyingFetcher, verifyWithPasskey],
+    [fetcher, verifyWithPasskey],
   )
 }

--- a/lib/admin/reverification.test.ts
+++ b/lib/admin/reverification.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import {
+  createOwnerReverifier,
+  HIGH_IMPACT_REVERIFICATION,
+} from './reverification'
+
+describe('owner high-impact reverification', () => {
+  it('returns Clerk standard reverification metadata for a stale first factor', async () => {
+    const reverifier = createOwnerReverifier({
+      hasFreshFirstFactor: vi.fn(async () => false),
+    })
+
+    const response = await reverifier.verify(
+      new Request('https://cali.so/api/admin/media/photo-selection/publish'),
+    )
+
+    expect(response?.status).toBe(403)
+    expect(response?.headers.get('cache-control')).toBe('no-store')
+    expect(response?.headers.get('content-type')).toBe(
+      'application/json; charset=utf-8',
+    )
+    expect(response?.headers.get('referrer-policy')).toBe('no-referrer')
+    await expect(response?.json()).resolves.toEqual({
+      clerk_error: {
+        type: 'forbidden',
+        reason: 'reverification-error',
+        metadata: { reverification: HIGH_IMPACT_REVERIFICATION },
+      },
+    })
+  })
+
+  it('allows a first factor verified less than ten minutes ago', async () => {
+    const hasFreshFirstFactor = vi.fn(async () => true)
+    const reverifier = createOwnerReverifier({ hasFreshFirstFactor })
+    const request = new Request(
+      'https://cali.so/api/admin/media/photo-selection/publish',
+    )
+
+    await expect(reverifier.verify(request)).resolves.toBeNull()
+    expect(hasFreshFirstFactor).toHaveBeenCalledExactlyOnceWith(
+      HIGH_IMPACT_REVERIFICATION,
+    )
+  })
+})

--- a/lib/admin/reverification.ts
+++ b/lib/admin/reverification.ts
@@ -1,0 +1,38 @@
+import 'server-only'
+
+import { reverificationErrorResponse } from '@clerk/nextjs/server'
+
+export const HIGH_IMPACT_REVERIFICATION = {
+  level: 'first_factor',
+  afterMinutes: 10,
+} as const
+
+export type OwnerReverifier = {
+  verify(request: Request): Promise<Response | null>
+}
+
+export function createOwnerReverifier({
+  hasFreshFirstFactor,
+}: {
+  hasFreshFirstFactor(
+    requirement: typeof HIGH_IMPACT_REVERIFICATION,
+  ): Promise<boolean>
+}): OwnerReverifier {
+  return {
+    async verify(_request) {
+      if (await hasFreshFirstFactor(HIGH_IMPACT_REVERIFICATION)) return null
+      const response = reverificationErrorResponse(
+        HIGH_IMPACT_REVERIFICATION,
+      )
+      const headers = new Headers(response.headers)
+      headers.set('cache-control', 'no-store')
+      headers.set('content-type', 'application/json; charset=utf-8')
+      headers.set('referrer-policy', 'no-referrer')
+      headers.set('x-content-type-options', 'nosniff')
+      return new Response(response.body, {
+        status: response.status,
+        headers,
+      })
+    },
+  }
+}

--- a/lib/admin/server.ts
+++ b/lib/admin/server.ts
@@ -11,6 +11,7 @@ import {
   createOwnerAuthorizer,
   type OwnerPrincipal,
 } from './authorization'
+import { createOwnerReverifier } from './reverification'
 
 const authorizeOwner = createOwnerAuthorizer({
   getOwnerDataId() {
@@ -26,6 +27,13 @@ const authorizeOwner = createOwnerAuthorizer({
 })
 
 export const getOwnerAccess = cache(authorizeOwner)
+
+export const ownerHighImpactReverifier = createOwnerReverifier({
+  async hasFreshFirstFactor(requirement) {
+    const { has } = await auth()
+    return has({ reverification: requirement })
+  },
+})
 
 export async function requireOwnerPage(
   returnBackUrl: string,

--- a/lib/ama/admin/dashboard.test.tsx
+++ b/lib/ama/admin/dashboard.test.tsx
@@ -1,17 +1,34 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const clerk = vi.hoisted(() => ({
+  verifyWithPasskey: vi.fn(),
+}))
+
+vi.mock('@clerk/nextjs', () => ({
+  useSession: () => ({
+    isLoaded: true,
+    session: { id: 'sess_owner', verifyWithPasskey: clerk.verifyWithPasskey },
+  }),
+  useReverification: (fetcher: unknown) => fetcher,
+}))
 
 import { AdminDashboard } from '../../../app/admin/(protected)/AdminDashboard'
 import { AvailabilityWindowForm } from '../../../app/admin/(protected)/AvailabilityWindowForm'
 import { LOCALE_CHANGE_EVENT } from '../../locale-client'
 
+beforeEach(() => {
+  clerk.verifyWithPasskey.mockResolvedValue({ status: 'complete' })
+})
+
 afterEach(() => {
   cleanup()
   vi.restoreAllMocks()
   delete document.documentElement.dataset.locale
+  clerk.verifyWithPasskey.mockReset()
 })
 
 function renderDashboard(
@@ -74,6 +91,53 @@ describe('AMA admin dashboard UI contract', () => {
 
     expect(html).toContain('action="/api/admin/ama/google/connect"')
     expect(html).not.toContain('action="/api/admin/ama/google/disconnect"')
+  })
+
+  it('does not submit a Google integration change when passkey verification is cancelled', async () => {
+    clerk.verifyWithPasskey.mockRejectedValueOnce(
+      new Error('passkey cancelled'),
+    )
+    const nativeSubmit = vi
+      .spyOn(HTMLFormElement.prototype, 'submit')
+      .mockImplementation(() => undefined)
+    const { container } = render(
+      <AdminDashboard
+        windows={[]}
+        googleConnection={{ status: 'disconnected', identity: null }}
+        previewSlots={[]}
+      />,
+    )
+
+    fireEvent.submit(
+      container.querySelector<HTMLFormElement>(
+        'form[action="/api/admin/ama/google/connect"]',
+      )!,
+    )
+
+    await waitFor(() => expect(clerk.verifyWithPasskey).toHaveBeenCalledOnce())
+    expect(nativeSubmit).not.toHaveBeenCalled()
+  })
+
+  it('submits a Google integration change only after passkey verification', async () => {
+    const nativeSubmit = vi
+      .spyOn(HTMLFormElement.prototype, 'submit')
+      .mockImplementation(() => undefined)
+    const { container } = render(
+      <AdminDashboard
+        windows={[]}
+        googleConnection={{ status: 'disconnected', identity: null }}
+        previewSlots={[]}
+      />,
+    )
+    const form = container.querySelector<HTMLFormElement>(
+      'form[action="/api/admin/ama/google/connect"]',
+    )!
+
+    fireEvent.submit(form)
+
+    await waitFor(() => expect(nativeSubmit).toHaveBeenCalledOnce())
+    expect(clerk.verifyWithPasskey).toHaveBeenCalledOnce()
+    expect(nativeSubmit).toHaveBeenCalledWith()
   })
 
   it('preserves an edited weekday when the locale changes mid-form', () => {

--- a/lib/ama/admin/http.test.ts
+++ b/lib/ama/admin/http.test.ts
@@ -11,6 +11,7 @@ import {
   type AvailabilityMutationService,
   type OwnerRequestAuthenticator,
 } from './http'
+import { createOwnerReverifier } from '../../admin/reverification'
 import { createAmaSecurity, type SecurityAuditEvent } from '../security/service'
 
 function formRequest(path: string, values: Record<string, string>, authenticated = true) {
@@ -95,6 +96,9 @@ function fixture(rateLimitAllows = true) {
     googleEvents,
     security,
     securityEvents,
+    reverifier: createOwnerReverifier({
+      hasFreshFirstFactor: async () => true,
+    }),
   }
 }
 
@@ -252,6 +256,7 @@ describe('AMA admin HTTP contract', () => {
       service: f.google,
       security: f.security,
       baseUrl: new URL('https://cali.so'),
+      reverifier: f.reverifier,
     })
 
     const response = await handler(
@@ -270,6 +275,41 @@ describe('AMA admin HTTP contract', () => {
     expect(f.googleEvents).toEqual([['begin']])
   })
 
+  it.each([
+    ['connect', createGoogleConnectHandler],
+    ['disconnect', createGoogleDisconnectHandler],
+  ] as const)(
+    'requires recent first-factor verification before Google %s effects',
+    async (_operation, createHandler) => {
+      const f = fixture()
+      const reverifier = createOwnerReverifier({
+        hasFreshFirstFactor: async () => false,
+      })
+      const handler = createHandler({
+        authenticator: f.authenticator,
+        service: f.google,
+        security: f.security,
+        baseUrl: new URL('https://cali.so'),
+        reverifier,
+      })
+
+      const response = await handler(
+        formRequest(`/api/admin/ama/google/${_operation}`, {}),
+      )
+
+      expect(response.status).toBe(403)
+      await expect(response.json()).resolves.toMatchObject({
+        clerk_error: {
+          reason: 'reverification-error',
+          metadata: {
+            reverification: { level: 'first_factor', afterMinutes: 10 },
+          },
+        },
+      })
+      expect(f.googleEvents).toEqual([])
+    },
+  )
+
   it('passes the OAuth callback values through one authenticated boundary', async () => {
     const f = fixture()
     const handler = createGoogleCallbackHandler({
@@ -277,6 +317,7 @@ describe('AMA admin HTTP contract', () => {
       service: f.google,
       security: f.security,
       baseUrl: new URL('https://cali.so'),
+      reverifier: f.reverifier,
     })
     const request = new Request(
       'https://cali.so/api/admin/ama/google/callback?state=s&code=c',
@@ -291,6 +332,29 @@ describe('AMA admin HTTP contract', () => {
     expect(response.headers.get('location')).toBe('https://cali.so/admin?calendar=connected')
   })
 
+  it('does not finalize Google connection after first-factor freshness expires', async () => {
+    const f = fixture()
+    const handler = createGoogleCallbackHandler({
+      authenticator: f.authenticator,
+      service: f.google,
+      security: f.security,
+      baseUrl: new URL('https://cali.so'),
+      reverifier: createOwnerReverifier({
+        hasFreshFirstFactor: async () => false,
+      }),
+    })
+
+    const response = await handler(
+      new Request(
+        'https://cali.so/api/admin/ama/google/callback?state=s&code=c',
+        { headers: { cookie: 'owner=valid' } },
+      ),
+    )
+
+    expect(response.status).toBe(403)
+    expect(f.googleEvents).toEqual([])
+  })
+
   it('disconnects Calendar without touching Availability Windows', async () => {
     const f = fixture()
     const handler = createGoogleDisconnectHandler({
@@ -298,6 +362,7 @@ describe('AMA admin HTTP contract', () => {
       service: f.google,
       security: f.security,
       baseUrl: new URL('https://cali.so'),
+      reverifier: f.reverifier,
     })
 
     const response = await handler(
@@ -347,6 +412,7 @@ describe('AMA admin HTTP contract', () => {
       service: f.google,
       security: f.security,
       baseUrl: new URL('https://cali.so'),
+      reverifier: f.reverifier,
     })
 
     const response = await handler(

--- a/lib/ama/admin/http.ts
+++ b/lib/ama/admin/http.ts
@@ -2,6 +2,7 @@ import type {
   OwnerAccess,
   OwnerPrincipal,
 } from '~/lib/admin/authorization'
+import type { OwnerReverifier } from '~/lib/admin/reverification'
 
 import { securityDenialHeaders } from '../security/request-policy'
 import type { AmaFeature, AmaSecurity } from '../security/service'
@@ -46,6 +47,10 @@ type HandlerDependencies<T> = {
   baseUrl: URL
 }
 
+type HighImpactHandlerDependencies<T> = HandlerDependencies<T> & {
+  reverifier: OwnerReverifier
+}
+
 type AdminRequestMode = 'browser-mutation' | 'provider-callback'
 
 function redirect(baseUrl: URL, pathOrUrl: string | URL) {
@@ -65,6 +70,7 @@ async function enforceAdminRequestPolicy(
   request: Request,
   mode: AdminRequestMode,
   requiredFeatures?: readonly AmaFeature[],
+  reverifier?: OwnerReverifier,
 ) {
   const { authenticator, security } = dependencies
   const blocked = mode === 'browser-mutation'
@@ -95,7 +101,19 @@ async function enforceAdminRequestPolicy(
     request,
     access.principal.actorId,
   )
-  return limited ?? access.principal
+  if (limited) return limited
+  if (reverifier) {
+    try {
+      const required = await reverifier.verify(request)
+      if (required) return required
+    } catch {
+      return new Response(null, {
+        status: 503,
+        headers: securityDenialHeaders(),
+      })
+    }
+  }
+  return access.principal
 }
 
 function denied(result: Response | OwnerPrincipal): result is Response {
@@ -206,7 +224,7 @@ export function createAvailabilityMutationHandler(
 }
 
 export function createGoogleConnectHandler(
-  dependencies: HandlerDependencies<AdminGoogleService>,
+  dependencies: HighImpactHandlerDependencies<AdminGoogleService>,
 ) {
   const { service, baseUrl } = dependencies
   return async function POST(request: Request) {
@@ -215,6 +233,7 @@ export function createGoogleConnectHandler(
       request,
       'browser-mutation',
       ['google'],
+      dependencies.reverifier,
     )
     if (denied(access)) return access
     try {
@@ -232,7 +251,7 @@ export function createGoogleConnectHandler(
 }
 
 export function createGoogleCallbackHandler(
-  dependencies: HandlerDependencies<AdminGoogleService>,
+  dependencies: HighImpactHandlerDependencies<AdminGoogleService>,
 ) {
   const { service, baseUrl } = dependencies
   return async function GET(request: Request) {
@@ -241,6 +260,7 @@ export function createGoogleCallbackHandler(
       request,
       'provider-callback',
       ['google'],
+      dependencies.reverifier,
     )
     if (denied(access)) return access
     const params = new URL(request.url).searchParams
@@ -263,7 +283,7 @@ export function createGoogleCallbackHandler(
 }
 
 export function createGoogleDisconnectHandler(
-  dependencies: HandlerDependencies<AdminGoogleService>,
+  dependencies: HighImpactHandlerDependencies<AdminGoogleService>,
 ) {
   const { service, baseUrl } = dependencies
   return async function POST(request: Request) {
@@ -272,6 +292,7 @@ export function createGoogleDisconnectHandler(
       request,
       'browser-mutation',
       ['google'],
+      dependencies.reverifier,
     )
     if (denied(access)) return access
     try {

--- a/lib/ama/admin/server.ts
+++ b/lib/ama/admin/server.ts
@@ -1,6 +1,9 @@
 import 'server-only'
 
-import { ownerRequestAuthenticator } from '~/lib/admin/server'
+import {
+  ownerHighImpactReverifier,
+  ownerRequestAuthenticator,
+} from '~/lib/admin/server'
 
 import { availabilityRepository } from '../availability/repository'
 import { createAvailabilityService } from '../availability/service'
@@ -83,4 +86,4 @@ export function getAmaAdminServices() {
   return services
 }
 
-export { ownerRequestAuthenticator }
+export { ownerHighImpactReverifier, ownerRequestAuthenticator }

--- a/lib/media/admin/http.test.ts
+++ b/lib/media/admin/http.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 vi.mock('server-only', () => ({}))
 
 import { createAmaSecurity, type SecurityAuditEvent } from '../../ama/security/service'
+import { createOwnerReverifier } from '../../admin/reverification'
 import { MediaAssetReviewError } from '../asset-review/service'
 import { MediaGeocodingError } from '../geocoding/service'
 import { PhotoSelectionError } from '../photo-selection/service'
@@ -13,6 +14,7 @@ import {
   createMediaAssetListHandler,
   createMediaLocationLabelHandler,
   createMediaOriginalUploadHandler,
+  createMediaPurgeHandler,
   createMediaResumeHandler,
   createMediaUploadCompletionHandler,
   createMediaUploadIntentHandler,
@@ -86,7 +88,15 @@ function fixture(rateLimitAllows = true) {
     },
     requestId: () => 'media-request-id',
   })
-  return { auditEvents, authenticator, calls, security }
+  return {
+    auditEvents,
+    authenticator,
+    calls,
+    security,
+    reverifier: createOwnerReverifier({
+      hasFreshFirstFactor: async () => true,
+    }),
+  }
 }
 
 describe('Media admin HTTP contract', () => {
@@ -404,6 +414,7 @@ describe('Media admin HTTP contract', () => {
     const handler = createPhotoSelectionPublishHandler({
       authenticator: f.authenticator,
       security: f.security,
+      reverifier: f.reverifier,
       selection: {
         async publish(input) {
           f.calls.push(input)
@@ -444,6 +455,7 @@ describe('Media admin HTTP contract', () => {
     const handler = createPhotoSelectionPublishHandler({
       authenticator: f.authenticator,
       security: f.security,
+      reverifier: f.reverifier,
       selection: {
         async publish() {
           throw new PhotoSelectionError('cache_invalidation_failed', {
@@ -466,6 +478,100 @@ describe('Media admin HTTP contract', () => {
     expect(f.auditEvents.at(-1)?.event).toBe(
       'media_photo_selection.published',
     )
+  })
+
+  it.each(['publish', 'purge'] as const)(
+    'requires recent first-factor verification before Media %s effects',
+    async (operation) => {
+      const f = fixture()
+      const reverifier = createOwnerReverifier({
+        hasFreshFirstFactor: async () => false,
+      })
+      const response =
+        operation === 'publish'
+          ? await createPhotoSelectionPublishHandler({
+              authenticator: f.authenticator,
+              security: f.security,
+              reverifier,
+              selection: {
+                async publish(input) {
+                  f.calls.push(input)
+                  return input
+                },
+              },
+            })(
+              request('/api/admin/media/photo-selection/publish', {
+                body: JSON.stringify({
+                  expectedDraftRevision: 4,
+                  idempotencyKey: 'publish_01',
+                }),
+              }),
+            )
+          : await createMediaPurgeHandler({
+              authenticator: f.authenticator,
+              security: f.security,
+              reverifier,
+              purge: {
+                async getStatus() {
+                  return null
+                },
+                async purge(input) {
+                  f.calls.push(input)
+                  return input
+                },
+              },
+            }).POST(
+              request(`/api/admin/media/assets/${mediaAssetId}/purge`, {
+                body: JSON.stringify({ confirmation: 'PURGE' }),
+              }),
+              mediaAssetId,
+            )
+
+      expect(response.status).toBe(403)
+      await expect(response.json()).resolves.toMatchObject({
+        clerk_error: {
+          reason: 'reverification-error',
+          metadata: {
+            reverification: { level: 'first_factor', afterMinutes: 10 },
+          },
+        },
+      })
+      expect(f.calls).toEqual([])
+    },
+  )
+
+  it('keeps non-owner denial ahead of high-impact reverification', async () => {
+    const f = fixture()
+    const hasFreshFirstFactor = vi.fn(async () => true)
+    const handler = createPhotoSelectionPublishHandler({
+      authenticator: {
+        async authenticate() {
+          return { status: 'forbidden' }
+        },
+      },
+      security: f.security,
+      reverifier: createOwnerReverifier({ hasFreshFirstFactor }),
+      selection: {
+        async publish(input) {
+          f.calls.push(input)
+          return input
+        },
+      },
+    })
+
+    const response = await handler(
+      request('/api/admin/media/photo-selection/publish', {
+        body: JSON.stringify({
+          expectedDraftRevision: 4,
+          idempotencyKey: 'publish_01',
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({ error: 'forbidden' })
+    expect(hasFreshFirstFactor).not.toHaveBeenCalled()
+    expect(f.calls).toEqual([])
   })
 
   it('rejects unauthenticated and cross-site Photo Selection writes', async () => {

--- a/lib/media/admin/http.ts
+++ b/lib/media/admin/http.ts
@@ -4,6 +4,7 @@ import type {
   OwnerAccess,
   OwnerPrincipal,
 } from '~/lib/admin/authorization'
+import type { OwnerReverifier } from '~/lib/admin/reverification'
 import type { AmaSecurity, PrivilegedAuditEvent } from '~/lib/ama/security/service'
 
 import { MediaAltTextError } from '../alt-text/service'
@@ -33,6 +34,10 @@ type Security = Pick<
 type BaseDependencies = {
   authenticator: Authenticator
   security: Security
+}
+
+type HighImpactDependencies = BaseDependencies & {
+  reverifier: OwnerReverifier
 }
 
 type AccessResult =
@@ -122,7 +127,7 @@ export function createPhotoSelectionDraftHandler(
 }
 
 export function createPhotoSelectionPublishHandler(
-  dependencies: BaseDependencies & {
+  dependencies: HighImpactDependencies & {
     selection: {
       publish(input: {
         ownerUserId: string
@@ -133,7 +138,12 @@ export function createPhotoSelectionPublishHandler(
   },
 ) {
   return async function POST(request: Request) {
-    const access = await authenticate(dependencies, request, true)
+    const access = await authenticate(
+      dependencies,
+      request,
+      true,
+      dependencies.reverifier,
+    )
     if ('response' in access) return access.response
     try {
       const body = await requestJson(request)
@@ -175,6 +185,7 @@ async function authenticate(
   dependencies: BaseDependencies,
   request: Request,
   mutation: boolean,
+  reverifier?: OwnerReverifier,
 ): Promise<AccessResult> {
   const blocked = mutation
     ? await dependencies.security.protectOwnerAdminMutation(request)
@@ -202,6 +213,14 @@ async function authenticate(
       access.principal.actorId,
     )
     if (limited) return { response: limited }
+  }
+  if (reverifier) {
+    try {
+      const required = await reverifier.verify(request)
+      if (required) return { response: required }
+    } catch {
+      return { response: json(503, { error: 'dependency_unavailable' }) }
+    }
   }
   return { principal: access.principal }
 }
@@ -443,7 +462,7 @@ export function createMediaResumeHandler(
 }
 
 export function createMediaPurgeHandler(
-  dependencies: BaseDependencies & {
+  dependencies: HighImpactDependencies & {
     purge: {
       getStatus(input: {
         ownerUserId: string
@@ -472,7 +491,12 @@ export function createMediaPurgeHandler(
       }
     },
     async POST(request: Request, mediaAssetId: string) {
-      const access = await authenticate(dependencies, request, true)
+      const access = await authenticate(
+        dependencies,
+        request,
+        true,
+        dependencies.reverifier,
+      )
       if ('response' in access) return access.response
       try {
         const body = await requestJson(request)

--- a/lib/media/admin/photo-selection-ui.test.tsx
+++ b/lib/media/admin/photo-selection-ui.test.tsx
@@ -2,7 +2,19 @@
 
 import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const clerk = vi.hoisted(() => ({
+  verifyWithPasskey: vi.fn(),
+}))
+
+vi.mock('@clerk/nextjs', () => ({
+  useSession: () => ({
+    isLoaded: true,
+    session: { id: 'sess_owner', verifyWithPasskey: clerk.verifyWithPasskey },
+  }),
+  useReverification: (fetcher: unknown) => fetcher,
+}))
 
 import { PhotoSelectionEditor } from '../../../app/admin/(protected)/photos/PhotoSelectionEditor'
 import type { MediaAssetReviewRecord } from '../asset-review/service'
@@ -44,11 +56,16 @@ const second = asset('22222222-2222-4222-8222-222222222222', 'Second')
 const third = asset('33333333-3333-4333-8333-333333333333', 'Third')
 const fourth = asset('44444444-4444-4444-8444-444444444444', 'Fourth')
 
+beforeEach(() => {
+  clerk.verifyWithPasskey.mockResolvedValue({ status: 'complete' })
+})
+
 afterEach(() => {
   cleanup()
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
   delete document.documentElement.dataset.locale
+  clerk.verifyWithPasskey.mockReset()
 })
 
 describe('Photo Selection admin UI contract', () => {
@@ -187,6 +204,28 @@ describe('Photo Selection admin UI contract', () => {
     expect(
       await findByText(/The Draft contains Media Assets that are no longer eligible/),
     ).toBeTruthy()
+  })
+
+  it('does not publish when passkey verification is cancelled', async () => {
+    document.documentElement.dataset.locale = 'en'
+    vi.stubGlobal('confirm', vi.fn(() => true))
+    vi.stubGlobal('crypto', { randomUUID: vi.fn(() => 'publish_01') })
+    clerk.verifyWithPasskey.mockRejectedValueOnce(
+      new Error('passkey cancelled'),
+    )
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const { getByRole } = render(
+      <PhotoSelectionEditor
+        initialDraft={{ revision: 2, mediaAssetIds: [first.id], updatedAt: null }}
+        initialAssets={[first]}
+      />,
+    )
+
+    fireEvent.click(getByRole('button', { name: /Publish/ }))
+
+    await waitFor(() => expect(clerk.verifyWithPasskey).toHaveBeenCalledOnce())
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it('reuses the publish key when cache refresh needs a safe retry', async () => {

--- a/lib/media/admin/server.ts
+++ b/lib/media/admin/server.ts
@@ -7,6 +7,7 @@ import { revalidateTag } from 'next/cache'
 import { getDatabase } from '~/db'
 import {
   getOwnerAdminSecurity,
+  ownerHighImpactReverifier,
   ownerRequestAuthenticator,
 } from '~/lib/admin/server'
 import { getServerEnv } from '~/lib/ama/server-env'
@@ -131,4 +132,4 @@ export function getMediaAdminServices() {
   return services
 }
 
-export { ownerRequestAuthenticator }
+export { ownerHighImpactReverifier, ownerRequestAuthenticator }

--- a/lib/media/admin/ui.test.tsx
+++ b/lib/media/admin/ui.test.tsx
@@ -4,6 +4,18 @@ import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const clerk = vi.hoisted(() => ({
+  verifyWithPasskey: vi.fn(),
+}))
+
+vi.mock('@clerk/nextjs', () => ({
+  useSession: () => ({
+    isLoaded: true,
+    session: { id: 'sess_owner', verifyWithPasskey: clerk.verifyWithPasskey },
+  }),
+  useReverification: (fetcher: unknown) => fetcher,
+}))
+
 import { MediaLibrary } from '../../../app/admin/(protected)/media/MediaLibrary'
 import type { MediaAssetReviewRecord } from '../asset-review/service'
 
@@ -43,6 +55,7 @@ const activeAsset: MediaAssetReviewRecord = {
 }
 
 beforeEach(() => {
+  clerk.verifyWithPasskey.mockResolvedValue({ status: 'complete' })
   const entries = new Map<string, string>()
   vi.stubGlobal('localStorage', {
     get length() {
@@ -69,6 +82,7 @@ afterEach(() => {
   localStorage.clear()
   vi.unstubAllGlobals()
   delete document.documentElement.dataset.locale
+  clerk.verifyWithPasskey.mockReset()
 })
 
 describe('Media Library UI contract', () => {
@@ -105,6 +119,30 @@ describe('Media Library UI contract', () => {
         'button[aria-label="设置焦点"] span[style]',
       )?.style.left,
     ).toBe('45%')
+  })
+
+  it('does not purge when passkey verification is cancelled', async () => {
+    document.documentElement.dataset.locale = 'en'
+    const archivedAsset: MediaAssetReviewRecord = {
+      ...activeAsset,
+      catalogState: 'archived',
+      archivedAt: new Date('2026-07-15T13:00:00.000Z'),
+    }
+    vi.stubGlobal('prompt', vi.fn(() => 'PURGE'))
+    clerk.verifyWithPasskey.mockRejectedValueOnce(
+      new Error('passkey cancelled'),
+    )
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const { getByRole } = render(
+      <MediaLibrary initialActive={[]} initialArchived={[archivedAsset]} />,
+    )
+
+    fireEvent.click(getByRole('tab', { name: /Archived/ }))
+    fireEvent.click(getByRole('button', { name: /Purge permanently/ }))
+
+    await waitFor(() => expect(clerk.verifyWithPasskey).toHaveBeenCalledOnce())
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it('retries a failed Original transfer before attempting completion', async () => {


### PR DESCRIPTION
Refs [#93](https://github.com/CaliCastle/cali.so/issues/93)

## Summary

- keeps owner admin always available behind exact server-authoritative `publicMetadata.siteOwner === "yes"` authorization
- adds passkey-first client reverification for Google connection changes, Media Asset Purge, and Photo Selection publication
- independently requires a fresh Clerk first factor under ten minutes before high-impact side effects
- preserves owner authorization and mutation rate limits ahead of reverification
- documents owner recovery, session revocation, credential rotation, and Clerk's factor-strategy limitation
- proves email addresses and unsafe metadata never authorize admin access

## Stack

Depends on [#148](https://github.com/CaliCastle/cali.so/pull/148).

## Verification

- 73 focused admin, AMA, Media, and passkey tests passed after the review fix
- 5 security tests passed
- typecheck passed
- production build passed with the committed non-secret CI fixtures
- production HTTP security-boundary verifier passed
- Standards re-review: no findings
- Spec/security re-review: no findings

## Clerk limitation

Clerk 7.5.19 exposes fresh factor age to the server, but not the factor strategy. The owned client deliberately invokes `verifyWithPasskey()`; the server proves a fresh first factor, not cryptographic passkey attestation. Exact proof would require a separate app-owned WebAuthn system and is not claimed here.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the owner admin boundary by adding passkey-first client reverification before Google Calendar connection changes, Media Asset Purge, and Photo Selection publication, backed by an independent server-side Clerk first-factor freshness check (≤10 minutes). Authorization ordering is preserved: same-origin checks → auth → rate limiting → reverification, ensuring the new gate never runs for unauthenticated or non-owner requests.

- `lib/admin/passkey-client.ts` introduces `usePasskeyVerification` and `usePasskeyReverification` hooks that call `session.verifyWithPasskey()` before any mutation is sent; cancellation throws `PasskeyVerificationError` and short-circuits the fetch.
- `lib/admin/reverification.ts` adds a server-only `createOwnerReverifier` that wraps Clerk's `has({ reverification })` check and returns a standard 403 JSON body on staleness, hardened with `cache-control: no-store`, `referrer-policy: no-referrer`, and `x-content-type-options: nosniff`.
- Route handlers for Google connect/disconnect/callback, media purge, and photo-selection publish now accept an `OwnerReverifier` dependency, typed as `HighImpactHandlerDependencies` to make the reverifier required at those boundaries.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the authorization chain is correct, the reverification gate runs after auth and rate-limiting on every targeted handler, and the client-side passkey call reliably blocks mutations before the fetch is sent.

The security boundary is well-layered and the ordering (same-origin then auth then rate limit then reverification) is consistently applied across both the AMA and media handler families. Tests explicitly verify that non-owner denial precedes reverification and that a stale first factor prevents side effects. The only concern found is that inline fetchers passed to usePasskeyReverification make its internal useCallback a no-op, which has no correctness impact in the current event-handler-only call sites.

app/admin/(protected)/media/MediaLibrary.tsx and app/admin/(protected)/photos/PhotoSelectionEditor.tsx — both pass inline async functions to usePasskeyReverification, defeating its memoisation. Worth fixing before the hook acquires additional call sites.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/admin/passkey-client.ts | New client-side passkey gate: usePasskeyVerification wraps session.verifyWithPasskey() and normalises all errors to PasskeyVerificationError; usePasskeyReverification sequences the gate before any mutation fetch and re-checks the server reverification hint on the response. The useCallback([fetcher]) dep on an inline fetcher argument is a minor memoisation no-op. |
| lib/admin/reverification.ts | Server-only reverifier factory: wraps Clerk's reverificationErrorResponse with hardened security headers and a clean null-on-pass / Response-on-deny interface. Correctly uses 'server-only' import guard. |
| lib/admin/server.ts | Exports ownerHighImpactReverifier wired to Clerk's has({ reverification }) check via auth(); both getOwnerAccess and the reverifier call auth() but Next.js caches auth() per request so there is no double RPC cost. |
| lib/ama/admin/http.ts | Reverifier correctly inserted after auth and rate-limit in enforceAdminRequestPolicy. All three Google handlers now require HighImpactHandlerDependencies. |
| lib/media/admin/http.ts | authenticate() helper accepts optional reverifier running after rate limiting. Both publish and purge handlers updated to HighImpactDependencies. |
| app/admin/(protected)/AdminDashboard.tsx | verifyAndSubmit guards both connect and disconnect with usePasskeyVerification before calling form.submit(); native submit intentionally skips onSubmit to avoid re-triggering the passkey prompt. |
| app/admin/(protected)/media/MediaLibrary.tsx | purgeAsset uses usePasskeyReverification with an inline async fetcher; the fetcher is a new reference each render so the internal useCallback provides no memoisation. Not a bug in current usage but the hook contract is misleading. |
| app/admin/(protected)/photos/PhotoSelectionEditor.tsx | publishSelection has the same inline-fetcher memoisation no-op as MediaLibrary. Idempotency key is passed as an argument so there is no stale-closure risk across re-renders. |
| docs/security/clerk-admin-operations.md | New runbook covering environment setup, passkey enforcement boundary, session exposure containment, and secret-key rotation with a recovery proof checklist. Accurately documents the Clerk factor-strategy limitation. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Owner as Owner Browser
    participant Clerk as Clerk SDK
    participant Server as Next.js Route Handler
    participant ClerkAPI as Clerk Auth API

    Owner->>Clerk: verifyWithPasskey()
    alt passkey cancelled / error
        Clerk-->>Owner: throws
        Owner->>Owner: PasskeyVerificationError - show message, no fetch
    else passkey verified
        Clerk-->>Owner: status complete
        Owner->>Server: POST /api/admin/.../action
        Server->>Server: protectOwnerAdminMutation (CSRF / same-origin)
        Server->>ClerkAPI: auth() - getOwnerAccess()
        alt not authorized
            Server-->>Owner: 401 / 403
        else authorized
            Server->>Server: rate limit check
            alt rate limited
                Server-->>Owner: 429
            else within limits
                Server->>ClerkAPI: has reverification first_factor afterMinutes 10
                alt first-factor stale
                    Server-->>Owner: 403 clerk_error reverification-error
                    Owner->>Owner: PasskeyVerificationError - show retry message
                else fresh first factor
                    Server->>Server: execute side effect
                    Server-->>Owner: 200 / 303 redirect
                end
            end
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Owner as Owner Browser
    participant Clerk as Clerk SDK
    participant Server as Next.js Route Handler
    participant ClerkAPI as Clerk Auth API

    Owner->>Clerk: verifyWithPasskey()
    alt passkey cancelled / error
        Clerk-->>Owner: throws
        Owner->>Owner: PasskeyVerificationError - show message, no fetch
    else passkey verified
        Clerk-->>Owner: status complete
        Owner->>Server: POST /api/admin/.../action
        Server->>Server: protectOwnerAdminMutation (CSRF / same-origin)
        Server->>ClerkAPI: auth() - getOwnerAccess()
        alt not authorized
            Server-->>Owner: 401 / 403
        else authorized
            Server->>Server: rate limit check
            alt rate limited
                Server-->>Owner: 429
            else within limits
                Server->>ClerkAPI: has reverification first_factor afterMinutes 10
                alt first-factor stale
                    Server-->>Owner: 403 clerk_error reverification-error
                    Owner->>Owner: PasskeyVerificationError - show retry message
                else fresh first factor
                    Server->>Server: execute side effect
                    Server-->>Owner: 200 / 303 redirect
                end
            end
        end
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/api/admin/ama/google/callback/route.ts`, line 9-19 ([link](https://github.com/calicastle/cali.so/blob/ad71a09aca68d8e94b167d78de265994a9c37e72/app/api/admin/ama/google/callback/route.ts#L9-L19)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Reverification timeout on OAuth callback returns raw JSON 403**

   `createGoogleCallbackHandler` applies the reverifier to the OAuth callback GET request. If the user spends more than 10 minutes on Google's consent screen, the Clerk reverification window lapses and `enforceAdminRequestPolicy` returns the raw Clerk JSON `403` response — which the browser renders as a plain JSON page rather than being redirected back to `/admin?calendar=...`. Every other failure path in this handler produces a `303` redirect to a user-facing admin status URL, so this is the only branch that leaves the user on a raw error page. Handling the stale-reverification case with a redirect (e.g. to `/admin?calendar=unavailable` or a dedicated `reverification_expired` status) would keep the error experience consistent.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: app/api/admin/ama/google/callback/route.ts
   Line: 9-19

   Comment:
   **Reverification timeout on OAuth callback returns raw JSON 403**

   `createGoogleCallbackHandler` applies the reverifier to the OAuth callback GET request. If the user spends more than 10 minutes on Google's consent screen, the Clerk reverification window lapses and `enforceAdminRequestPolicy` returns the raw Clerk JSON `403` response — which the browser renders as a plain JSON page rather than being redirected back to `/admin?calendar=...`. Every other failure path in this handler produces a `303` redirect to a user-facing admin status URL, so this is the only branch that leaves the user on a raw error page. Handling the stale-reverification case with a redirect (e.g. to `/admin?calendar=unavailable` or a dedicated `reverification_expired` status) would keep the error experience consistent.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22calicastle%2Fcali.so%22%20on%20the%20existing%20branch%20%22cali%2Fcomplete-clerk-hardening%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cali%2Fcomplete-clerk-hardening%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fapi%2Fadmin%2Fama%2Fgoogle%2Fcallback%2Froute.ts%0ALine%3A%209-19%0A%0AComment%3A%0A**Reverification%20timeout%20on%20OAuth%20callback%20returns%20raw%20JSON%20403**%0A%0A%60createGoogleCallbackHandler%60%20applies%20the%20reverifier%20to%20the%20OAuth%20callback%20GET%20request.%20If%20the%20user%20spends%20more%20than%2010%20minutes%20on%20Google's%20consent%20screen%2C%20the%20Clerk%20reverification%20window%20lapses%20and%20%60enforceAdminRequestPolicy%60%20returns%20the%20raw%20Clerk%20JSON%20%60403%60%20response%20%E2%80%94%20which%20the%20browser%20renders%20as%20a%20plain%20JSON%20page%20rather%20than%20being%20redirected%20back%20to%20%60%2Fadmin%3Fcalendar%3D...%60.%20Every%20other%20failure%20path%20in%20this%20handler%20produces%20a%20%60303%60%20redirect%20to%20a%20user-facing%20admin%20status%20URL%2C%20so%20this%20is%20the%20only%20branch%20that%20leaves%20the%20user%20on%20a%20raw%20error%20page.%20Handling%20the%20stale-reverification%20case%20with%20a%20redirect%20%28e.g.%20to%20%60%2Fadmin%3Fcalendar%3Dunavailable%60%20or%20a%20dedicated%20%60reverification_expired%60%20status%29%20would%20keep%20the%20error%20experience%20consistent.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=calicastle%2Fcali.so&pr=149&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fapi%2Fadmin%2Fama%2Fgoogle%2Fcallback%2Froute.ts%0ALine%3A%209-19%0A%0AComment%3A%0A**Reverification%20timeout%20on%20OAuth%20callback%20returns%20raw%20JSON%20403**%0A%0A%60createGoogleCallbackHandler%60%20applies%20the%20reverifier%20to%20the%20OAuth%20callback%20GET%20request.%20If%20the%20user%20spends%20more%20than%2010%20minutes%20on%20Google's%20consent%20screen%2C%20the%20Clerk%20reverification%20window%20lapses%20and%20%60enforceAdminRequestPolicy%60%20returns%20the%20raw%20Clerk%20JSON%20%60403%60%20response%20%E2%80%94%20which%20the%20browser%20renders%20as%20a%20plain%20JSON%20page%20rather%20than%20being%20redirected%20back%20to%20%60%2Fadmin%3Fcalendar%3D...%60.%20Every%20other%20failure%20path%20in%20this%20handler%20produces%20a%20%60303%60%20redirect%20to%20a%20user-facing%20admin%20status%20URL%2C%20so%20this%20is%20the%20only%20branch%20that%20leaves%20the%20user%20on%20a%20raw%20error%20page.%20Handling%20the%20stale-reverification%20case%20with%20a%20redirect%20%28e.g.%20to%20%60%2Fadmin%3Fcalendar%3Dunavailable%60%20or%20a%20dedicated%20%60reverification_expired%60%20status%29%20would%20keep%20the%20error%20experience%20consistent.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=149&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fapi%2Fadmin%2Fama%2Fgoogle%2Fcallback%2Froute.ts%0ALine%3A%209-19%0A%0AComment%3A%0A**Reverification%20timeout%20on%20OAuth%20callback%20returns%20raw%20JSON%20403**%0A%0A%60createGoogleCallbackHandler%60%20applies%20the%20reverifier%20to%20the%20OAuth%20callback%20GET%20request.%20If%20the%20user%20spends%20more%20than%2010%20minutes%20on%20Google's%20consent%20screen%2C%20the%20Clerk%20reverification%20window%20lapses%20and%20%60enforceAdminRequestPolicy%60%20returns%20the%20raw%20Clerk%20JSON%20%60403%60%20response%20%E2%80%94%20which%20the%20browser%20renders%20as%20a%20plain%20JSON%20page%20rather%20than%20being%20redirected%20back%20to%20%60%2Fadmin%3Fcalendar%3D...%60.%20Every%20other%20failure%20path%20in%20this%20handler%20produces%20a%20%60303%60%20redirect%20to%20a%20user-facing%20admin%20status%20URL%2C%20so%20this%20is%20the%20only%20branch%20that%20leaves%20the%20user%20on%20a%20raw%20error%20page.%20Handling%20the%20stale-reverification%20case%20with%20a%20redirect%20%28e.g.%20to%20%60%2Fadmin%3Fcalendar%3Dunavailable%60%20or%20a%20dedicated%20%60reverification_expired%60%20status%29%20would%20keep%20the%20error%20experience%20consistent.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=calicastle%2Fcali.so&pr=149&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix: avoid duplicate passkey prompts"](https://github.com/calicastle/cali.so/commit/0fd2089ad5cfb80dd66651ca8fb70a35b22586b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44712466)</sub>

<!-- /greptile_comment -->