### PR TITLE
Soften the light mode palette

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -269,18 +269,18 @@
 /* Public pages use warm paper and ink. Admin keeps the neutral product
    palette above so editorial refinements cannot change operational UI. */
 .public-site {
-  --gray-1: oklch(0.99 0.004 95);
-  --gray-2: oklch(0.975 0.005 95);
-  --gray-3: oklch(0.95 0.006 95);
-  --gray-4: oklch(0.91 0.007 92);
-  --gray-5: oklch(0.85 0.008 88);
-  --gray-6: oklch(0.77 0.009 84);
-  --gray-7: oklch(0.67 0.01 80);
-  --gray-8: oklch(0.56 0.011 78);
-  --gray-9: oklch(0.47 0.012 76);
-  --gray-10: oklch(0.39 0.012 74);
-  --gray-11: oklch(0.31 0.012 72);
-  --gray-12: oklch(0.23 0.012 70);
+  --gray-1: oklch(0.99 0.001 95);
+  --gray-2: oklch(0.975 0.0015 95);
+  --gray-3: oklch(0.95 0.002 95);
+  --gray-4: oklch(0.91 0.0025 92);
+  --gray-5: oklch(0.85 0.003 88);
+  --gray-6: oklch(0.77 0.0035 84);
+  --gray-7: oklch(0.67 0.004 80);
+  --gray-8: oklch(0.56 0.004 78);
+  --gray-9: oklch(0.47 0.0045 76);
+  --gray-10: oklch(0.39 0.0045 74);
+  --gray-11: oklch(0.31 0.0045 72);
+  --gray-12: oklch(0.23 0.0045 70);
   --selection-highlight: oklch(0.9 0.17 105 / 0.58);
 
   --background: var(--gray-1);


### PR DESCRIPTION
Reduces chroma across the public light-mode gray scale instead of overriding only the page background. Surfaces, borders, text, and navigation now share one coherent near-neutral palette while retaining a faint warm-paper cast.

Dark mode and the admin product palette are unchanged.

## Verification

- `pnpm typecheck`
- Reviewed the homepage and a blog article in light mode on the local development server

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces the OKLCH chroma (saturation) on all 12 public-site light-mode gray scale steps — roughly halving the warm-paper tint (e.g. `gray-1`: 0.004 → 0.001, `gray-12`: 0.012 → 0.0045) — while leaving lightness, hue, dark mode, and the admin palette completely untouched.

- All 12 gray steps keep their original lightness and hue values; only chroma is lowered, so contrast ratios between adjacent steps are preserved.
- Semantic tokens (`--background`, `--foreground`, `--border`, etc.) continue to reference the gray variables and require no changes.
- The `--paper` / `--paper-ink` variables are intentionally left at their original chroma to retain the distinctive warm-paper look for print artifacts.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a narrow CSS-variable tweak that affects only light-mode public pages and carries no logic, data, or compatibility risk.

Every modified value touches only the chroma channel of the gray scale, leaving lightness and hue intact. Dark mode, admin UI, and semantic token aliases are all unchanged. The --paper variable is intentionally retained at its original chroma, consistent with the existing comment. There is nothing here that could break layout, contrast ratios between adjacent steps, or any downstream computation.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/globals.css | Reduces chroma of all 12 public-site light-mode gray scale steps by roughly half (e.g. gray-1: 0.004→0.001, gray-12: 0.012→0.0045); dark mode and admin palette are untouched. No logic or structural issues. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["CSS Variables\n(app/globals.css)"]
    A --> B[":root — base palette\n(neutral product grays, unchanged)"]
    A --> C[".dark — dark theme tweaks\n(unchanged)"]
    A --> D[".public-site — light mode override\n(chroma reduced on all 12 gray steps)"]
    A --> E[".dark.public-site — dark mode override\n(unchanged)"]

    D --> F["--gray-1 … --gray-12\nchroma: ~0.004–0.012 → ~0.001–0.0045\nlightness & hue unchanged"]
    D --> G["--selection-highlight\n(unchanged)"]
    D --> H["Semantic tokens\n--background, --foreground,\n--card, --border, etc.\n(still reference gray vars, unchanged)"]

    B --> I["--paper / --paper-ink\n(retained at original chroma, intentional)"]

    style D fill:#f0e8d0,stroke:#b0a080
    style F fill:#e8f0d0,stroke:#90a060
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["CSS Variables\n(app/globals.css)"]
    A --> B[":root — base palette\n(neutral product grays, unchanged)"]
    A --> C[".dark — dark theme tweaks\n(unchanged)"]
    A --> D[".public-site — light mode override\n(chroma reduced on all 12 gray steps)"]
    A --> E[".dark.public-site — dark mode override\n(unchanged)"]

    D --> F["--gray-1 … --gray-12\nchroma: ~0.004–0.012 → ~0.001–0.0045\nlightness & hue unchanged"]
    D --> G["--selection-highlight\n(unchanged)"]
    D --> H["Semantic tokens\n--background, --foreground,\n--card, --border, etc.\n(still reference gray vars, unchanged)"]

    B --> I["--paper / --paper-ink\n(retained at original chroma, intentional)"]

    style D fill:#f0e8d0,stroke:#b0a080
    style F fill:#e8f0d0,stroke:#90a060
```

</a>

<sub>Reviews (1): Last reviewed commit: ["style: soften light mode warmth"](https://github.com/calicastle/cali.so/commit/b1ef9b964c9cca5dabc5c10f9602f4be4081cb80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44724762)</sub>

<!-- /greptile_comment -->