### PR TITLE
fix(site): restore instant post transitions

### DIFF
--- a/app/(en)/en/blog/[slug]/page.tsx
+++ b/app/(en)/en/blog/[slug]/page.tsx
@@ -5,7 +5,6 @@ import {
 } from '../../../../_views/blog-post-page'
 
 export const generateStaticParams = generatePostStaticParams
-export const prefetch = 'allow-runtime'
 
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }) {
   return blogPostMetadata('en', (await params).slug)

--- a/app/(zh)/blog/[slug]/page.tsx
+++ b/app/(zh)/blog/[slug]/page.tsx
@@ -5,7 +5,6 @@ import {
 } from '../../../_views/blog-post-page'
 
 export const generateStaticParams = generatePostStaticParams
-export const prefetch = 'allow-runtime'
 
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }) {
   return blogPostMetadata('zh', (await params).slug)

--- a/app/_components/site-document.tsx
+++ b/app/_components/site-document.tsx
@@ -56,21 +56,7 @@ export async function SiteDocument({
           <AmbientBackground />
           <div className="flex min-h-screen flex-col pb-20">
             <main className="flex-1 pt-14">
-              <ViewTransition
-                enter={{
-                  'page-forward': 'page-forward',
-                  'page-back': 'page-back',
-                  default: 'page-sheet',
-                }}
-                exit={{
-                  'page-forward': 'page-forward',
-                  'page-back': 'page-back',
-                  default: 'page-sheet',
-                }}
-                default="none"
-              >
-                {children}
-              </ViewTransition>
+              <ViewTransition>{children}</ViewTransition>
             </main>
             <SiteFooter social={social} github={github} locale={locale} />
           </div>

--- a/app/_components/site-document.tsx
+++ b/app/_components/site-document.tsx
@@ -56,6 +56,9 @@ export async function SiteDocument({
           <AmbientBackground />
           <div className="flex min-h-screen flex-col pb-20">
             <main className="flex-1 pt-14">
+              {/* Intentionally untyped: post covers and titles morph through
+                  list → loading shell → article. default="none" suppresses
+                  those CSS-named groups in this React/Next version. */}
               <ViewTransition>{children}</ViewTransition>
             </main>
             <SiteFooter social={social} github={github} locale={locale} />

--- a/app/globals.css
+++ b/app/globals.css
@@ -1396,8 +1396,8 @@ html[data-visited] .enter-polaroid .polaroid {
   animation-delay: calc(var(--reveal-delay, 0ms) + 250ms);
 }
 
-/* Route transition: ambient guides and chrome stay fixed while the content
-   sheet lifts and settles. Shared covers/titles still own their morph. */
+/* Route transition: the origin defocuses while the destination rises.
+   Shared covers/titles morph via view-transition-name. */
 .post-loading-cover {
   view-transition-name: var(--post-cover-transition-name, none);
 }
@@ -1406,76 +1406,26 @@ html[data-visited] .enter-polaroid .polaroid {
   view-transition-name: var(--post-title-transition-name, none);
 }
 
-@keyframes page-sheet-out {
+@keyframes vt-defocus {
   to {
     opacity: 0;
-    transform: translate3d(-8px, 6px, 0) rotate(-0.2deg);
+    filter: blur(2px);
   }
 }
 
-@keyframes page-sheet-in {
+@keyframes vt-focus {
   from {
     opacity: 0;
-    transform: translate3d(14px, -10px, 0) rotate(0.45deg);
+    filter: blur(2px);
   }
 }
 
-@keyframes page-forward-out {
-  to {
-    opacity: 0;
-    transform: translate3d(-14px, 5px, 0) rotate(-0.25deg);
-  }
+::view-transition-old(root) {
+  animation: vt-defocus 250ms var(--ease-swift) both;
 }
 
-@keyframes page-forward-in {
-  from {
-    opacity: 0;
-    transform: translate3d(18px, -8px, 0) rotate(0.4deg);
-  }
-}
-
-@keyframes page-back-out {
-  to {
-    opacity: 0;
-    transform: translate3d(14px, 5px, 0) rotate(0.25deg);
-  }
-}
-
-@keyframes page-back-in {
-  from {
-    opacity: 0;
-    transform: translate3d(-18px, -8px, 0) rotate(-0.4deg);
-  }
-}
-
-::view-transition-old(.page-sheet) {
-  transform-origin: 50% 0;
-  animation: page-sheet-out 210ms var(--ease-swift) both;
-}
-
-::view-transition-new(.page-sheet) {
-  transform-origin: 50% 0;
-  animation: page-sheet-in 320ms var(--ease-swift) both;
-}
-
-::view-transition-old(.page-forward) {
-  transform-origin: 50% 0;
-  animation: page-forward-out 210ms var(--ease-swift) both;
-}
-
-::view-transition-new(.page-forward) {
-  transform-origin: 50% 0;
-  animation: page-forward-in 320ms var(--ease-swift) both;
-}
-
-::view-transition-old(.page-back) {
-  transform-origin: 50% 0;
-  animation: page-back-out 210ms var(--ease-swift) both;
-}
-
-::view-transition-new(.page-back) {
-  transform-origin: 50% 0;
-  animation: page-back-in 320ms var(--ease-swift) both;
+::view-transition-new(root) {
+  animation: vt-focus 300ms var(--ease-swift) both;
 }
 
 ::view-transition-group(*) {

--- a/components/post-toc.tsx
+++ b/components/post-toc.tsx
@@ -380,7 +380,6 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
           <div className="post-minimap-utilities post-minimap-utilities-top">
             <Link
               href={localePath(locale, '/blog')}
-              transitionTypes={['page-back']}
               className="post-minimap-utility"
               aria-label={localize(locale, '返回写作', 'Back to writing')}
             >

--- a/components/post-transition-link.test.tsx
+++ b/components/post-transition-link.test.tsx
@@ -8,17 +8,12 @@ vi.mock('next/link', () => ({
   default: ({
     children,
     onClick,
-    onNavigate,
-    transitionTypes,
   }: {
     children: ReactNode
     onClick?: MouseEventHandler<HTMLAnchorElement>
-    onNavigate?: () => void
-    transitionTypes?: string[]
   }) => (
     <a
       href="/blog/a-post"
-      data-transition-types={transitionTypes?.join(',')}
       onClick={(event) => {
         onClick?.(event)
         if (
@@ -31,7 +26,6 @@ vi.mock('next/link', () => ({
         ) {
           return
         }
-        onNavigate?.()
         event.preventDefault()
       }}
     >
@@ -67,12 +61,6 @@ describe('PostTransitionLink', () => {
     fireEvent.click(screen.getByRole('link', { name: 'Read post' }), {
       detail: 1,
     })
-
-    expect(
-      screen
-        .getByRole('link', { name: 'Read post' })
-        .getAttribute('data-transition-types'),
-    ).toBe('page-forward')
 
     expect(
       document.documentElement.style.getPropertyValue(

--- a/components/post-transition-link.tsx
+++ b/components/post-transition-link.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useRef, type MouseEvent, type ReactNode } from 'react'
+import type { MouseEvent, ReactNode } from 'react'
 
 export function PostTransitionLink({
   href,
@@ -16,15 +16,20 @@ export function PostTransitionLink({
   className?: string
   children: ReactNode
 }) {
-  const pointerNavigationRef = useRef(false)
+  function preparePointerMorph(event: MouseEvent<HTMLAnchorElement>) {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return
+    }
 
-  function recordInputModality(event: MouseEvent<HTMLAnchorElement>) {
-    pointerNavigationRef.current = event.detail !== 0
-  }
-
-  function prepareFallbackMorph() {
     const root = document.documentElement
-    if (!pointerNavigationRef.current) {
+    if (event.detail === 0) {
       root.style.removeProperty('--post-cover-transition-name')
       root.style.removeProperty('--post-title-transition-name')
       return
@@ -37,11 +42,8 @@ export function PostTransitionLink({
   return (
     <Link
       href={href}
-      prefetch={true}
-      transitionTypes={['page-forward']}
       className={className}
-      onClick={recordInputModality}
-      onNavigate={prepareFallbackMorph}
+      onClick={preparePointerMorph}
     >
       {children}
     </Link>

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -33,7 +33,7 @@ it on chrome.
 | Exit (any) | ~2/3 of its enter | `--ease-swift` |
 | Photo pick-up / settle | 300–350ms | `--ease-spring` |
 | Shared-element page transition | 300–350ms | `--ease-swift` |
-| Content-sheet page transition | 210ms exit / 320ms enter | `--ease-swift` |
+| Route defocus / focus | 250ms exit / 300ms enter | `--ease-swift` |
 
 Shadow scale (one alpha, growing throw — don't invent one-off shadows):
 
@@ -54,11 +54,11 @@ Hard rules:
 - Elements that move together share one duration and easing (card + its
   shadow, cover + its caption).
 - Route changes keep the ambient guides, dock, and other global chrome fixed.
-  Only the route content sheet moves: a small 8–18px translation, less than
-  half a degree of rotation, and opacity. Forward and explicitly tagged back
-  links reverse the horizontal direction. Browser history without a tag gets
-  the neutral sheet motion. Shared post covers and titles remain separate
-  morph elements. Reduced motion swaps every route instantly.
+  The route content defocuses by 2px while fading, then the destination focuses
+  into place. Shared post covers and titles remain separate morph elements.
+  Pointer-initiated post links prepare those identities before navigation;
+  keyboard navigation omits the shared morph. Reduced motion swaps every route
+  instantly.
 - Scroll reveals are allowed only as gentle arrivals: below-fold long-form
   blocks may sharpen in (blur 2px → 0 + fade, 300ms `--ease-swift`, ≤45ms
   stagger within a batch) as they enter the viewport. Never parallax, never

--- a/e2e/instant-navigation.spec.ts
+++ b/e2e/instant-navigation.spec.ts
@@ -3,7 +3,44 @@ import { expect, test } from '@playwright/test'
 
 const postSlug = '2023-year-in-review'
 
-test('the Chinese post is prefetched from the home page', async ({ page }) => {
+async function observeCoverMorph(
+  page: import('@playwright/test').Page,
+  name: string,
+) {
+  await page.evaluate((transitionName) => {
+    const state = window as typeof window & {
+      __postCoverMorphObserved?: boolean
+    }
+    state.__postCoverMorphObserved = false
+
+    let frame = 0
+    const sample = () => {
+      const animationName = getComputedStyle(
+        document.documentElement,
+        `::view-transition-group(${transitionName})`,
+      ).animationName
+      if (animationName !== 'none') state.__postCoverMorphObserved = true
+      frame += 1
+      if (frame < 120) requestAnimationFrame(sample)
+    }
+    requestAnimationFrame(sample)
+  }, name)
+}
+
+async function expectCoverMorph(page: import('@playwright/test').Page) {
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as typeof window & {
+            __postCoverMorphObserved?: boolean
+          }).__postCoverMorphObserved ?? false,
+      ),
+    )
+    .toBe(true)
+}
+
+test('the Chinese post shell is prefetched from the home page', async ({ page }) => {
   await page.goto('/')
   await page.waitForLoadState('networkidle')
 
@@ -14,13 +51,7 @@ test('the Chinese post is prefetched from the home page', async ({ page }) => {
       .click()
 
     await expect(page).toHaveURL(`/blog/${postSlug}`)
-    await expect(page.getByRole('status', { name: '正在加载文章' })).toHaveCount(0)
-    await expect(
-      page.getByRole('heading', {
-        level: 1,
-        name: '2023 年终总结，致我不同寻常的 28',
-      }),
-    ).toBeVisible()
+    await expect(page.getByRole('status', { name: '正在加载文章' })).toBeVisible()
     await expect(page.getByRole('navigation', { name: '主导航' })).toBeVisible()
   })
 
@@ -35,7 +66,7 @@ test('the Chinese post is prefetched from the home page', async ({ page }) => {
   ).toBeVisible()
 })
 
-test('the English post is prefetched from the home page', async ({ page }) => {
+test('the English post shell is prefetched from the home page', async ({ page }) => {
   await page.goto('/en')
   await page.waitForLoadState('networkidle')
 
@@ -46,13 +77,7 @@ test('the English post is prefetched from the home page', async ({ page }) => {
       .click()
 
     await expect(page).toHaveURL(`/en/blog/${postSlug}`)
-    await expect(page.getByRole('status', { name: 'Loading article' })).toHaveCount(0)
-    await expect(
-      page.getByRole('heading', {
-        level: 1,
-        name: '2023 Year in Review: My Unusual 28th Year',
-      }),
-    ).toBeVisible()
+    await expect(page.getByRole('status', { name: 'Loading article' })).toBeVisible()
     await expect(page.getByRole('navigation', { name: 'Main navigation' })).toBeVisible()
   })
 
@@ -70,7 +95,7 @@ test('the English post is prefetched from the home page', async ({ page }) => {
   ).toBeVisible()
 })
 
-test('the Chinese post is prefetched from the blog index', async ({ page }) => {
+test('the Chinese post shell morphs from the blog index cover', async ({ page }) => {
   await page.goto('/blog')
   await page.waitForLoadState('networkidle')
 
@@ -92,11 +117,13 @@ test('the Chinese post is prefetched from the blog index', async ({ page }) => {
       ),
   ])
 
+  await observeCoverMorph(page, coverTransitionName)
+
   await instant(page, async () => {
     await postLink.click()
 
     await expect(page).toHaveURL(`/blog/${postSlug}`)
-    await expect(page.getByRole('status', { name: '正在加载文章' })).toHaveCount(0)
+    await expect(page.getByRole('status', { name: '正在加载文章' })).toBeVisible()
     await expect(page.locator('html')).toHaveCSS(
       '--post-cover-transition-name',
       coverTransitionName,
@@ -105,16 +132,18 @@ test('the Chinese post is prefetched from the blog index', async ({ page }) => {
       '--post-title-transition-name',
       titleTransitionName,
     )
-    await expect(
-      page.getByRole('heading', {
-        level: 1,
-        name: '2023 年终总结，致我不同寻常的 28',
-      }),
-    ).toBeVisible()
+    await expectCoverMorph(page)
   })
+
+  await expect(
+    page.getByRole('heading', {
+      level: 1,
+      name: '2023 年终总结，致我不同寻常的 28',
+    }),
+  ).toBeVisible()
 })
 
-test('the English post is prefetched from the blog index', async ({ page }) => {
+test('the English post shell morphs from the blog index cover', async ({ page }) => {
   await page.goto('/en/blog')
   await page.waitForLoadState('networkidle')
 
@@ -133,14 +162,16 @@ test('the English post is prefetched from the blog index', async ({ page }) => {
       .locator('.blog-row-title')
       .evaluate((element) =>
         getComputedStyle(element).getPropertyValue('view-transition-name'),
-      ),
+    ),
   ])
+
+  await observeCoverMorph(page, coverTransitionName)
 
   await instant(page, async () => {
     await postLink.click()
 
     await expect(page).toHaveURL(`/en/blog/${postSlug}`)
-    await expect(page.getByRole('status', { name: 'Loading article' })).toHaveCount(0)
+    await expect(page.getByRole('status', { name: 'Loading article' })).toBeVisible()
     await expect(page.locator('html')).toHaveCSS(
       '--post-cover-transition-name',
       coverTransitionName,
@@ -149,13 +180,15 @@ test('the English post is prefetched from the blog index', async ({ page }) => {
       '--post-title-transition-name',
       titleTransitionName,
     )
-    await expect(
-      page.getByRole('heading', {
-        level: 1,
-        name: '2023 Year in Review: My Unusual 28th Year',
-      }),
-    ).toBeVisible()
+    await expectCoverMorph(page)
   })
+
+  await expect(
+    page.getByRole('heading', {
+      level: 1,
+      name: '2023 Year in Review: My Unusual 28th Year',
+    }),
+  ).toBeVisible()
 })
 
 test('preferences preserve theme, locale, and reduced motion', async ({ page }) => {
@@ -386,31 +419,44 @@ test('administration stays outside public prefetching and requires login', async
   }
 })
 
-test('the home page prefetches visible post content beyond the shared route shell', async ({
+test('the blog index prefetches one shared post shell without runtime article payloads', async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1280, height: 900 })
-  const prefetches: Array<{ segment?: string; url: string }> = []
+  const prefetches: Array<{ kind?: string; segment?: string; url: string }> = []
   page.on('request', (request) => {
     const headers = request.headers()
-    if (headers['next-router-prefetch'] === '1') {
+    if (headers['next-router-prefetch']) {
       prefetches.push({
+        kind: headers['next-router-prefetch'],
         segment: headers['next-router-segment-prefetch'],
         url: request.url(),
       })
     }
   })
 
-  await page.goto('/')
+  await page.goto('/blog')
   await page.waitForLoadState('networkidle')
 
   expect(prefetches.length).toBeGreaterThan(0)
   expect(
     prefetches.some(
-      ({ segment, url }) =>
-        segment !== '/_tree' &&
-        new URL(url).pathname === `/blog/${postSlug}`,
+      ({ kind, segment, url }) =>
+        kind === '1' &&
+        segment === '/_tree' &&
+        new URL(url).pathname.startsWith('/blog/'),
     ),
   ).toBe(true)
-  expect(prefetches.some(({ segment }) => segment === '/_tree')).toBe(true)
+  expect(
+    prefetches.filter(
+      ({ kind, url }) =>
+        kind === '3' && new URL(url).pathname.startsWith('/blog/'),
+    ),
+  ).toHaveLength(1)
+  expect(
+    prefetches.some(
+      ({ kind, url }) =>
+        kind === '2' && new URL(url).pathname.startsWith('/blog/'),
+    ),
+  ).toBe(false)
 })

--- a/e2e/instant-navigation.spec.ts
+++ b/e2e/instant-navigation.spec.ts
@@ -3,6 +3,15 @@ import { expect, test } from '@playwright/test'
 
 const postSlug = '2023-year-in-review'
 
+// Next 16.3 preview.6 internal wire values, defined by FetchStrategy in
+// next/dist/client/components/segment-cache/cache.js. Re-check on upgrades:
+// 1 = route tree/loading boundary, 2 = PPR runtime data, 3 = runtime shell.
+const prefetchKind = {
+  routeTree: '1',
+  runtimeData: '2',
+  runtimeShell: '3',
+} as const
+
 async function observeCoverMorph(
   page: import('@playwright/test').Page,
   name: string,
@@ -29,13 +38,15 @@ async function observeCoverMorph(
 
 async function expectCoverMorph(page: import('@playwright/test').Page) {
   await expect
-    .poll(() =>
-      page.evaluate(
-        () =>
-          (window as typeof window & {
-            __postCoverMorphObserved?: boolean
-          }).__postCoverMorphObserved ?? false,
-      ),
+    .poll(
+      () =>
+        page.evaluate(
+          () =>
+            (window as typeof window & {
+              __postCoverMorphObserved?: boolean
+            }).__postCoverMorphObserved ?? false,
+        ),
+      { message: 'expected the shared post cover transition to become active' },
     )
     .toBe(true)
 }
@@ -117,9 +128,8 @@ test('the Chinese post shell morphs from the blog index cover', async ({ page })
       ),
   ])
 
-  await observeCoverMorph(page, coverTransitionName)
-
   await instant(page, async () => {
+    await observeCoverMorph(page, coverTransitionName)
     await postLink.click()
 
     await expect(page).toHaveURL(`/blog/${postSlug}`)
@@ -165,9 +175,8 @@ test('the English post shell morphs from the blog index cover', async ({ page })
     ),
   ])
 
-  await observeCoverMorph(page, coverTransitionName)
-
   await instant(page, async () => {
+    await observeCoverMorph(page, coverTransitionName)
     await postLink.click()
 
     await expect(page).toHaveURL(`/en/blog/${postSlug}`)
@@ -442,7 +451,7 @@ test('the blog index prefetches one shared post shell without runtime article pa
   expect(
     prefetches.some(
       ({ kind, segment, url }) =>
-        kind === '1' &&
+        kind === prefetchKind.routeTree &&
         segment === '/_tree' &&
         new URL(url).pathname.startsWith('/blog/'),
     ),
@@ -450,13 +459,15 @@ test('the blog index prefetches one shared post shell without runtime article pa
   expect(
     prefetches.filter(
       ({ kind, url }) =>
-        kind === '3' && new URL(url).pathname.startsWith('/blog/'),
+        kind === prefetchKind.runtimeShell &&
+        new URL(url).pathname.startsWith('/blog/'),
     ),
   ).toHaveLength(1)
   expect(
     prefetches.some(
       ({ kind, url }) =>
-        kind === '2' && new URL(url).pathname.startsWith('/blog/'),
+        kind === prefetchKind.runtimeData &&
+        new URL(url).pathname.startsWith('/blog/'),
     ),
   ).toBe(false)
 })


### PR DESCRIPTION
## Summary

- prefetch one reusable blog post shell instead of runtime article payloads
- restore the shared cover and title morph through the localized loading shell
- prepare transition identities before navigation and keep keyboard and modified clicks native
- align the motion contract and add production browser regressions for both languages

## Root cause

The typed root `ViewTransition` used `default="none"`, which suppressed the CSS-named shared cover group. Post links also prepared their morph identities from `onNavigate`, after the browser had started capturing the transition. Forced link prefetching plus `allow-runtime` fetched more than the shared shell needed for an instant click.

## Verification

- `pnpm typecheck`
- `pnpm test:localization`
- `pnpm exec vitest run app components db lib --exclude='**/*.live.test.ts' --maxWorkers=4` (443 tests)
- production `pnpm build` with local placeholder service configuration
- 8 public instant-navigation browser tests
- measured cover morph from 64×44 to 552×337 over 320ms

The admin-only browser assertion requires a Clerk publishable key and was excluded from the local public-navigation rerun.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes broken instant post transitions by moving shared-element morph preparation from `onNavigate` (after the browser snapshot) to `onClick` (before it), removing `prefetch='allow-runtime'` so only the static loading shell is prefetched rather than full article payloads, and replacing the typed `ViewTransition` class system with a bare `<ViewTransition>` plus direct `::view-transition-old/new(root)` blur-fade animations.

- **`PostTransitionLink`** now sets `--post-cover-transition-name` / `--post-title-transition-name` synchronously in `onClick`, ensuring the names are on `<html>` before the browser captures the old-page snapshot; modifier-key and non-primary-button clicks early-return to keep those navigations native.
- **Route animations** simplify from five directional keyframe sets to two blur-fade keyframes (`vt-defocus` / `vt-focus`) targeting `::view-transition-old/new(root)`, while `::view-transition-group(*)` still controls morph duration for named cover/title pairs.
- **E2e tests** now assert the loading shell (not the full article) is visible immediately after navigation, and two new `observeCoverMorph`/`expectCoverMorph` helpers verify the shared cover `::view-transition-group` animation fires during the click.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the core click-timing fix is well-motivated and the modifier-key guards are fully unit-tested.

The onClick-before-snapshot timing fix is correct and directly addresses the root cause. Both locale routes are in sync, reduced-motion coverage is unchanged, and the new e2e helpers cover the morph path plus the keyboard no-morph path. The only open items are a minor test robustness note and a GPU cost observation on the blur animation, neither of which affects correctness.

The `e2e/instant-navigation.spec.ts` morph observer and `app/globals.css` blur-on-root animations are worth a second look for CI reliability and mobile performance respectively, but neither blocks the feature.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| components/post-transition-link.tsx | Moved morph-name preparation from `onNavigate` (post-snapshot) to `onClick` (pre-snapshot), added modifier-key guards so Cmd/Ctrl/Shift/Alt/middle clicks remain native; removed `prefetch={true}` and `transitionTypes` to align with new shell-only strategy. |
| components/post-transition-link.test.tsx | Unit tests updated to match new `onClick`-only API; removed `onNavigate`/`transitionTypes` from mock and tests; new `it.each` table covers all five modifier-key variants that should leave navigation native. |
| app/_components/site-document.tsx | Root `<ViewTransition>` simplified to bare (no props); comment explains that `default="none"` suppresses CSS-named morph groups in the current React/Next build, hence the intentional bare usage. |
| app/globals.css | Replaced the five type-keyed `page-sheet`/`page-forward`/`page-back` keyframe sets with two simpler `vt-defocus`/`vt-focus` blur-fade animations targeting `::view-transition-old(root)` and `::view-transition-new(root)`; reduced-motion override continues to set all VT durations to 0s. |
| e2e/instant-navigation.spec.ts | Four tests updated to assert the loading shell (not full article) is shown on instant nav; two tests gain `observeCoverMorph`/`expectCoverMorph` helpers to verify the shared cover animation fires; prefetch assertion now targets blog index and expects exactly one runtimeShell request. |
| app/(en)/en/blog/[slug]/page.tsx | Removed `export const prefetch = 'allow-runtime'` so the route no longer forces full article payload prefetching; only the static loading shell is prefetched. |
| app/(zh)/blog/[slug]/page.tsx | Same `prefetch = 'allow-runtime'` removal as the English route, keeping both locale routes in sync. |
| components/post-toc.tsx | Removed `transitionTypes={['page-back']}` from the 'Back to writing' link since the directional type system has been replaced by the simpler blur-fade root transition. |
| docs/design-language.md | Design doc updated to reflect the new 'defocus/focus' blur-fade contract (250ms/300ms) replacing the previous content-sheet motion spec; pointer-vs-keyboard morph distinction documented. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User pointer click
    participant PTL as PostTransitionLink onClick
    participant HTML as html CSS vars
    participant NR as Next.js Router
    participant VT as View Transition API
    participant Shell as Loading Shell
    participant Art as Article Page

    U->>PTL: "click button=0 detail>=1 no modifier"
    PTL->>HTML: set --post-cover-transition-name to cover-p01
    PTL->>HTML: set --post-title-transition-name to title-p01
    PTL->>NR: navigate to href
    NR->>VT: startViewTransition
    VT-->>VT: snapshot old page extract cover-p01 from .print-thumb
    VT->>Shell: render prefetched loading shell
    Shell->>HTML: "read var(--post-cover-transition-name) = cover-p01"
    Shell-->>VT: .post-loading-cover gets view-transition-name cover-p01
    VT-->>VT: morph cover-p01 old to new over 320ms plus blur-fade root 250/300ms
    Shell-->>Art: article streams in via Suspense

    Note over U,PTL: Keyboard Enter or modifier click takes alternate path
    Note over PTL: detail=0 removes vars modifier returns early without change
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User pointer click
    participant PTL as PostTransitionLink onClick
    participant HTML as html CSS vars
    participant NR as Next.js Router
    participant VT as View Transition API
    participant Shell as Loading Shell
    participant Art as Article Page

    U->>PTL: "click button=0 detail>=1 no modifier"
    PTL->>HTML: set --post-cover-transition-name to cover-p01
    PTL->>HTML: set --post-title-transition-name to title-p01
    PTL->>NR: navigate to href
    NR->>VT: startViewTransition
    VT-->>VT: snapshot old page extract cover-p01 from .print-thumb
    VT->>Shell: render prefetched loading shell
    Shell->>HTML: "read var(--post-cover-transition-name) = cover-p01"
    Shell-->>VT: .post-loading-cover gets view-transition-name cover-p01
    VT-->>VT: morph cover-p01 old to new over 320ms plus blur-fade root 250/300ms
    Shell-->>Art: article streams in via Suspense

    Note over U,PTL: Keyboard Enter or modifier click takes alternate path
    Note over PTL: detail=0 removes vars modifier returns early without change
```

</a>

<sub>Reviews (2): Last reviewed commit: ["test(site): harden transition regression..."](https://github.com/calicastle/cali.so/commit/f08aa6cc69e3d01b52d0553db1426204e1cfc4a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44728741)</sub>

<!-- /greptile_comment -->