### PR TITLE
Harden post transition motion

### DIFF
--- a/app/_components/site-document.tsx
+++ b/app/_components/site-document.tsx
@@ -1,11 +1,15 @@
 import type { Metadata } from 'next'
 // Experimental React channel export — available because next.config.ts sets
 // experimental.viewTransition (see docs/design-language.md, page transitions)
-import { Suspense, ViewTransition } from 'react'
+import { Suspense } from 'react'
 
 import { AmbientBackground } from '~/components/ambient-background'
 import { Dock, DockFallback } from '~/components/dock'
 import { LocaleRestorer } from '~/components/locale-restorer'
+import {
+  RouteMotionController,
+  RouteViewTransition,
+} from '~/components/route-motion-controller'
 import { SiteFooter } from '~/components/site-footer'
 import { ThemeProvider } from '~/components/theme-provider'
 import { getGitHub, getSocial } from '~/lib/social-live'
@@ -42,6 +46,7 @@ export async function SiteDocument({
     <html
       lang={english ? 'en' : 'zh-CN'}
       data-locale={english ? 'en' : undefined}
+      data-route-motion="none"
       suppressHydrationWarning
       className={cn('font-sans', fontVariables, !restoreLocale && 'public-site')}
     >
@@ -52,14 +57,14 @@ export async function SiteDocument({
       </head>
       <body className="antialiased">
         <ThemeProvider>
+          <RouteMotionController />
           {restoreLocale && <LocaleRestorer />}
           <AmbientBackground />
           <div className="flex min-h-screen flex-col pb-20">
             <main className="flex-1 pt-14">
-              {/* Intentionally untyped: post covers and titles morph through
-                  list → loading shell → article. default="none" suppresses
-                  those CSS-named groups in this React/Next version. */}
-              <ViewTransition>{children}</ViewTransition>
+              {/* The non-none default isolates route content while keeping the
+                  CSS-named list → loading shell → article groups active. */}
+              <RouteViewTransition>{children}</RouteViewTransition>
             </main>
             <SiteFooter social={social} github={github} locale={locale} />
           </div>

--- a/app/_views/blog-post-page.tsx
+++ b/app/_views/blog-post-page.tsx
@@ -77,6 +77,7 @@ function BlogPostLoadingShell({ locale }: { locale: Locale }) {
   return (
     <article
       aria-busy="true"
+      data-post-loading-shell
       className="post-article mx-auto min-h-[calc(100svh-3.5rem)] w-full max-w-[37.5rem] px-6"
     >
       <div role="status" aria-label={label}>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1420,17 +1420,37 @@ html[data-visited] .enter-polaroid .polaroid {
   }
 }
 
+::view-transition-group(root) {
+  animation: none;
+}
+
 ::view-transition-old(root) {
-  animation: vt-defocus 250ms var(--ease-swift) both;
+  display: none;
 }
 
 ::view-transition-new(root) {
+  animation: none;
+}
+
+::view-transition-old(.route-content) {
+  animation: vt-defocus 250ms var(--ease-swift) both;
+}
+
+::view-transition-new(.route-content) {
   animation: vt-focus 300ms var(--ease-swift) both;
 }
 
 ::view-transition-group(*) {
   animation-duration: var(--duration-route-morph);
   animation-timing-function: var(--ease-swift);
+}
+
+html[data-route-motion='none']::view-transition-group(*),
+html[data-route-motion='none']::view-transition-image-pair(*),
+html[data-route-motion='none']::view-transition-old(*),
+html[data-route-motion='none']::view-transition-new(*) {
+  animation-duration: 0s !important;
+  animation-delay: 0s !important;
 }
 
 /* The shared title owns the morph. Its supporting metadata develops once the

--- a/components/post-transition-link.test.tsx
+++ b/components/post-transition-link.test.tsx
@@ -8,12 +8,15 @@ vi.mock('next/link', () => ({
   default: ({
     children,
     onClick,
+    'data-post-transition-link': postTransitionLink,
   }: {
     children: ReactNode
     onClick?: MouseEventHandler<HTMLAnchorElement>
+    'data-post-transition-link'?: boolean
   }) => (
     <a
       href="/blog/a-post"
+      data-post-transition-link={postTransitionLink}
       onClick={(event) => {
         onClick?.(event)
         if (
@@ -39,6 +42,7 @@ import { PostTransitionLink } from './post-transition-link'
 describe('PostTransitionLink', () => {
   afterEach(() => {
     cleanup()
+    document.documentElement.removeAttribute('data-route-motion')
     document.documentElement.style.removeProperty(
       '--post-cover-transition-name',
     )
@@ -47,7 +51,26 @@ describe('PostTransitionLink', () => {
     )
   })
 
+  it('marks the rendered anchor as a post transition link', () => {
+    render(
+      <PostTransitionLink
+        href="/blog/a-post"
+        coverTransitionName="cover-p01"
+        titleTransitionName="title-p01"
+      >
+        Marked post
+      </PostTransitionLink>,
+    )
+
+    expect(
+      screen
+        .getByRole('link', { name: 'Marked post' })
+        .hasAttribute('data-post-transition-link'),
+    ).toBe(true)
+  })
+
   it('carries the clicked row transition names into the destination shell', () => {
+    document.documentElement.setAttribute('data-route-motion', 'none')
     render(
       <PostTransitionLink
         href="/blog/a-post"
@@ -72,9 +95,13 @@ describe('PostTransitionLink', () => {
         '--post-title-transition-name',
       ),
     ).toBe('title-p01')
+    expect(document.documentElement.hasAttribute('data-route-motion')).toBe(
+      false,
+    )
   })
 
   it('navigates without a morph when activated from the keyboard', () => {
+    document.documentElement.setAttribute('data-route-motion', 'none')
     document.documentElement.style.setProperty(
       '--post-cover-transition-name',
       'stale-cover',
@@ -106,6 +133,7 @@ describe('PostTransitionLink', () => {
         '--post-title-transition-name',
       ),
     ).toBe('')
+    expect(document.documentElement.dataset.routeMotion).toBe('none')
   })
 
   it.each([

--- a/components/post-transition-link.tsx
+++ b/components/post-transition-link.tsx
@@ -30,11 +30,13 @@ export function PostTransitionLink({
 
     const root = document.documentElement
     if (event.detail === 0) {
+      root.setAttribute('data-route-motion', 'none')
       root.style.removeProperty('--post-cover-transition-name')
       root.style.removeProperty('--post-title-transition-name')
       return
     }
 
+    root.removeAttribute('data-route-motion')
     root.style.setProperty('--post-cover-transition-name', coverTransitionName)
     root.style.setProperty('--post-title-transition-name', titleTransitionName)
   }
@@ -43,6 +45,7 @@ export function PostTransitionLink({
     <Link
       href={href}
       className={className}
+      data-post-transition-link
       onClick={preparePointerMorph}
     >
       {children}

--- a/components/route-motion-controller.test.tsx
+++ b/components/route-motion-controller.test.tsx
@@ -1,0 +1,204 @@
+/** @vitest-environment jsdom */
+
+import type { ReactNode } from 'react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const viewTransitionHarness = vi.hoisted(() => ({
+  defaultClass: undefined as string | undefined,
+  onUpdate: undefined as undefined | (() => void | (() => void)),
+}))
+
+vi.mock('react', async (importOriginal) => {
+  const react = await importOriginal<typeof import('react')>()
+  return {
+    ...react,
+    ViewTransition: ({
+      children,
+      default: defaultClass,
+      onUpdate,
+    }: {
+      children: ReactNode
+      default?: string
+      onUpdate?: () => void | (() => void)
+    }) => {
+      viewTransitionHarness.defaultClass = defaultClass
+      viewTransitionHarness.onUpdate = onUpdate
+      return <>{children}</>
+    },
+  }
+})
+
+import {
+  RouteMotionController,
+  RouteViewTransition,
+} from './route-motion-controller'
+
+describe('RouteMotionController', () => {
+  beforeEach(() => {
+    document.documentElement.setAttribute('data-route-motion', 'none')
+    viewTransitionHarness.defaultClass = undefined
+    viewTransitionHarness.onUpdate = undefined
+  })
+
+  afterEach(() => {
+    cleanup()
+    document.documentElement.removeAttribute('data-route-motion')
+    vi.restoreAllMocks()
+  })
+
+  it('waits for a validated click before enabling post route motion', () => {
+    render(
+      <>
+        <RouteMotionController />
+        <a href="/blog/a-post" data-post-transition-link>
+          <span>Read post</span>
+        </a>
+      </>,
+    )
+
+    fireEvent.pointerDown(screen.getByText('Read post'), {
+      button: 0,
+      isPrimary: true,
+    })
+
+    expect(document.documentElement.dataset.routeMotion).toBe('none')
+  })
+
+  it.each([
+    ['an ordinary link', false, { button: 0, isPrimary: true }],
+    [
+      'a Command-clicked post link',
+      true,
+      { button: 0, isPrimary: true, metaKey: true },
+    ],
+    [
+      'a Control-clicked post link',
+      true,
+      { button: 0, isPrimary: true, ctrlKey: true },
+    ],
+    [
+      'a Shift-clicked post link',
+      true,
+      { button: 0, isPrimary: true, shiftKey: true },
+    ],
+    [
+      'an Alt-clicked post link',
+      true,
+      { button: 0, isPrimary: true, altKey: true },
+    ],
+    ['a non-primary pointer', true, { button: 0, isPrimary: false }],
+    ['a non-primary button', true, { button: 1, isPrimary: true }],
+  ] satisfies Array<[string, boolean, PointerEventInit]>)(
+    'keeps route motion disabled for %s',
+    (_label, marked, eventInit) => {
+      document.documentElement.removeAttribute('data-route-motion')
+      render(
+        <>
+          <RouteMotionController />
+          <a
+            href="/blog/a-post"
+            data-post-transition-link={marked || undefined}
+          >
+            Open link
+          </a>
+        </>,
+      )
+
+      fireEvent.pointerDown(
+        screen.getByRole('link', { name: 'Open link' }),
+        eventInit,
+      )
+
+      expect(document.documentElement.dataset.routeMotion).toBe('none')
+    },
+  )
+
+  it('restores instant route motion on keydown', () => {
+    render(<RouteMotionController />)
+    document.documentElement.removeAttribute('data-route-motion')
+
+    fireEvent.keyDown(document, { key: 'Enter' })
+
+    expect(document.documentElement.dataset.routeMotion).toBe('none')
+  })
+
+  it('restores instant route motion on browser history navigation', () => {
+    render(<RouteMotionController />)
+    document.documentElement.removeAttribute('data-route-motion')
+
+    fireEvent.popState(window)
+
+    expect(document.documentElement.dataset.routeMotion).toBe('none')
+  })
+
+  it('removes every input and history listener on unmount', () => {
+    const addDocumentListener = vi.spyOn(document, 'addEventListener')
+    const removeDocumentListener = vi.spyOn(document, 'removeEventListener')
+    const addWindowListener = vi.spyOn(window, 'addEventListener')
+    const removeWindowListener = vi.spyOn(window, 'removeEventListener')
+    const { unmount } = render(<RouteMotionController />)
+    const pointerListener = addDocumentListener.mock.calls.find(
+      ([type]) => type === 'pointerdown',
+    )?.[1]
+    const keyboardListener = addDocumentListener.mock.calls.find(
+      ([type]) => type === 'keydown',
+    )?.[1]
+    const popstateListener = addWindowListener.mock.calls.find(
+      ([type]) => type === 'popstate',
+    )?.[1]
+
+    expect(pointerListener).toBeTypeOf('function')
+    expect(keyboardListener).toBeTypeOf('function')
+    expect(popstateListener).toBeTypeOf('function')
+
+    unmount()
+
+    expect(removeDocumentListener).toHaveBeenCalledWith(
+      'pointerdown',
+      pointerListener,
+      true,
+    )
+    expect(removeDocumentListener).toHaveBeenCalledWith(
+      'keydown',
+      keyboardListener,
+      true,
+    )
+    expect(removeWindowListener).toHaveBeenCalledWith(
+      'popstate',
+      popstateListener,
+    )
+  })
+
+  it('restores instant motion only after the final post transition finishes', () => {
+    const { rerender } = render(
+      <RouteViewTransition>
+        <article data-post-loading-shell>Loading article</article>
+      </RouteViewTransition>,
+    )
+    document.documentElement.removeAttribute('data-route-motion')
+
+    expect(viewTransitionHarness.defaultClass).toBe('route-content')
+    const finishShellTransition = viewTransitionHarness.onUpdate?.()
+    expect(finishShellTransition).toBeTypeOf('function')
+    finishShellTransition?.()
+    expect(document.documentElement.hasAttribute('data-route-motion')).toBe(
+      false,
+    )
+
+    rerender(
+      <RouteViewTransition>
+        <article>Article content</article>
+      </RouteViewTransition>,
+    )
+    const finishArticleTransition = viewTransitionHarness.onUpdate?.()
+    expect(finishArticleTransition).toBeTypeOf('function')
+    expect(document.documentElement.hasAttribute('data-route-motion')).toBe(
+      false,
+    )
+
+    finishArticleTransition?.()
+
+    expect(document.documentElement.dataset.routeMotion).toBe('none')
+  })
+})

--- a/components/route-motion-controller.tsx
+++ b/components/route-motion-controller.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useEffect, ViewTransition } from 'react'
+import type { ReactNode } from 'react'
+
+const POST_LINK_SELECTOR = '[data-post-transition-link]'
+const POST_LOADING_SHELL_SELECTOR = '[data-post-loading-shell]'
+const ROUTE_MOTION_ATTRIBUTE = 'data-route-motion'
+
+export function RouteMotionController() {
+  useEffect(() => {
+    const root = document.documentElement
+
+    function disableRouteMotion() {
+      root.setAttribute(ROUTE_MOTION_ATTRIBUTE, 'none')
+    }
+
+    function preparePointerRoute(event: PointerEvent) {
+      const target = event.target
+      const opensPost =
+        event.isPrimary &&
+        event.button === 0 &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.shiftKey &&
+        !event.altKey &&
+        target instanceof Element &&
+        target.closest(POST_LINK_SELECTOR) !== null
+
+      if (!opensPost) {
+        disableRouteMotion()
+      }
+    }
+
+    document.addEventListener('pointerdown', preparePointerRoute, true)
+    document.addEventListener('keydown', disableRouteMotion, true)
+    window.addEventListener('popstate', disableRouteMotion)
+
+    return () => {
+      document.removeEventListener('pointerdown', preparePointerRoute, true)
+      document.removeEventListener('keydown', disableRouteMotion, true)
+      window.removeEventListener('popstate', disableRouteMotion)
+    }
+  }, [])
+
+  return null
+}
+
+export function RouteViewTransition({ children }: { children: ReactNode }) {
+  function handleUpdate() {
+    return () => {
+      if (document.querySelector(POST_LOADING_SHELL_SELECTOR) === null) {
+        document.documentElement.setAttribute(ROUTE_MOTION_ATTRIBUTE, 'none')
+      }
+    }
+  }
+
+  return (
+    <ViewTransition default="route-content" onUpdate={handleUpdate}>
+      {children}
+    </ViewTransition>
+  )
+}

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -56,9 +56,11 @@ Hard rules:
 - Route changes keep the ambient guides, dock, and other global chrome fixed.
   The route content defocuses by 2px while fading, then the destination focuses
   into place. Shared post covers and titles remain separate morph elements.
-  Pointer-initiated post links prepare those identities before navigation;
-  keyboard navigation omits the shared morph. Reduced motion swaps every route
-  instantly.
+  Only a primary pointer or touch activation on a post link enables this route
+  motion and prepares those identities. Keyboard, dock, settings, ordinary
+  links, browser history, and reduced-motion navigation swap instantly. The
+  pointer opt-in resets after the loading shell finishes handing off to the
+  article.
 - Scroll reveals are allowed only as gentle arrivals: below-fold long-form
   blocks may sharpen in (blur 2px → 0 + fade, 300ms `--ease-swift`, ≤45ms
   stagger within a batch) as they enter the viewport. Never parallax, never
@@ -521,10 +523,11 @@ generated, and the transition plays over already-available content.
 
 Implementation: `experimental.viewTransition` + `view-transition-name` pairs
 (`cover-<slug>` via PolaroidCover's `morph` prop, `title-<slug>` on row
-title/post h1). Root: old page 250ms fade + `blur(2px)` defocus, new page
-300ms focus-in; shared groups 320ms `--ease-swift`. The shared h1 remains
-unanimated, metadata develops from 320–570ms, and the prose starts at 520ms.
-This overlap hands the title card into reading without delaying navigation.
+title/post h1). The document root remains static; the named route-content group
+uses a 250ms fade + `blur(2px)` defocus and a 300ms focus-in. Shared groups use
+320ms `--ease-swift`. The shared h1 remains unanimated, metadata develops from
+320–570ms, and the prose starts at 520ms. This overlap hands the title card
+into reading without delaying navigation.
 
 ## Instant-photo cover treatment
 

--- a/e2e/instant-navigation.spec.ts
+++ b/e2e/instant-navigation.spec.ts
@@ -12,43 +12,185 @@ const prefetchKind = {
   runtimeShell: '3',
 } as const
 
-async function observeCoverMorph(
-  page: import('@playwright/test').Page,
-  name: string,
-) {
-  await page.evaluate((transitionName) => {
-    const state = window as typeof window & {
-      __postCoverMorphObserved?: boolean
-    }
-    state.__postCoverMorphObserved = false
-
-    let frame = 0
-    const sample = () => {
-      const animationName = getComputedStyle(
-        document.documentElement,
-        `::view-transition-group(${transitionName})`,
-      ).animationName
-      if (animationName !== 'none') state.__postCoverMorphObserved = true
-      frame += 1
-      if (frame < 120) requestAnimationFrame(sample)
-    }
-    requestAnimationFrame(sample)
-  }, name)
+type ViewTransitionLifecycleObservation = {
+  counts: Record<string, number>
+  nonZeroCounts: Record<string, number>
+  samples: number
+  stop: () => void
 }
 
-async function expectCoverMorph(page: import('@playwright/test').Page) {
+type ViewTransitionObservationWindow = typeof window & {
+  __routeMotionObservation?: ViewTransitionLifecycleObservation
+}
+
+async function observeViewTransitionLifecycles(
+  page: import('@playwright/test').Page,
+) {
+  await page.evaluate(() => {
+    const state = window as ViewTransitionObservationWindow
+    state.__routeMotionObservation?.stop()
+
+    const seen = new WeakSet<Animation>()
+    const lifecycleStarts = new Map<string, Set<number>>()
+    const nonZeroLifecycleStarts = new Map<string, Set<number>>()
+    let observing = true
+    const observation: ViewTransitionLifecycleObservation = {
+      counts: {},
+      nonZeroCounts: {},
+      samples: 0,
+      stop: () => {
+        observing = false
+      },
+    }
+    state.__routeMotionObservation = observation
+
+    function sample() {
+      for (const animation of document.documentElement.getAnimations({
+        subtree: true,
+      })) {
+        if (seen.has(animation)) continue
+
+        const effect = animation.effect
+        if (!(effect instanceof KeyframeEffect)) continue
+
+        const pseudo = effect.pseudoElement
+        if (!pseudo?.startsWith('::view-transition-')) continue
+
+        const startTime = animation.startTime
+        if (typeof startTime !== 'number') continue
+
+        seen.add(animation)
+        const starts = lifecycleStarts.get(pseudo) ?? new Set<number>()
+        starts.add(startTime)
+        lifecycleStarts.set(pseudo, starts)
+        observation.counts[pseudo] = starts.size
+
+        const duration = effect.getComputedTiming().duration
+        if (typeof duration === 'number' && duration > 0) {
+          const nonZeroStarts =
+            nonZeroLifecycleStarts.get(pseudo) ?? new Set<number>()
+          nonZeroStarts.add(startTime)
+          nonZeroLifecycleStarts.set(pseudo, nonZeroStarts)
+          observation.nonZeroCounts[pseudo] = nonZeroStarts.size
+        }
+      }
+
+      observation.samples += 1
+      if (observing) requestAnimationFrame(sample)
+    }
+
+    requestAnimationFrame(sample)
+  })
+}
+
+async function viewTransitionLifecycleCount(
+  page: import('@playwright/test').Page,
+  pseudo: string,
+  nonZero = false,
+) {
+  return page.evaluate(
+    ({ pseudoElement, onlyNonZero }) => {
+      const observation = (window as ViewTransitionObservationWindow)
+        .__routeMotionObservation
+      const counts = onlyNonZero
+        ? observation?.nonZeroCounts
+        : observation?.counts
+      return counts?.[pseudoElement] ?? 0
+    },
+    { pseudoElement: pseudo, onlyNonZero: nonZero },
+  )
+}
+
+async function expectNonZeroViewTransitionLifecycle(
+  page: import('@playwright/test').Page,
+  pseudo: string,
+) {
+  await expect
+    .poll(() => viewTransitionLifecycleCount(page, pseudo, true), {
+      message: `expected a non-zero ${pseudo} transition lifecycle`,
+    })
+    .toBeGreaterThan(0)
+}
+
+async function expectStaticRootTransition(
+  page: import('@playwright/test').Page,
+) {
+  expect(
+    await viewTransitionLifecycleCount(
+      page,
+      '::view-transition-old(root)',
+      true,
+    ),
+  ).toBe(0)
+  expect(
+    await viewTransitionLifecycleCount(
+      page,
+      '::view-transition-new(root)',
+      true,
+    ),
+  ).toBe(0)
+}
+
+async function waitForCoverTransitionToFinish(
+  page: import('@playwright/test').Page,
+  pseudo: string,
+) {
+  await page.evaluate(async (pseudoElement) => {
+    const animations = document.documentElement
+      .getAnimations({ subtree: true })
+      .filter((animation) => {
+        const effect = animation.effect
+        if (!(effect instanceof KeyframeEffect)) return false
+        if (effect.pseudoElement !== pseudoElement) return false
+
+        const duration = effect.getComputedTiming().duration
+        return typeof duration === 'number' && duration > 0
+      })
+
+    await Promise.allSettled(animations.map((animation) => animation.finished))
+  }, pseudo)
+}
+
+async function nonZeroViewTransitionLifecycleCount(
+  page: import('@playwright/test').Page,
+) {
+  return page.evaluate(() => {
+    const counts = (window as ViewTransitionObservationWindow)
+      .__routeMotionObservation?.nonZeroCounts
+    return Object.values(counts ?? {}).reduce((total, count) => total + count, 0)
+  })
+}
+
+async function waitForTransitionObserverSamples(
+  page: import('@playwright/test').Page,
+  additionalSamples = 2,
+) {
+  const firstSample = await page.evaluate(
+    () =>
+      (window as ViewTransitionObservationWindow).__routeMotionObservation
+        ?.samples ?? 0,
+  )
   await expect
     .poll(
       () =>
         page.evaluate(
           () =>
-            (window as typeof window & {
-              __postCoverMorphObserved?: boolean
-            }).__postCoverMorphObserved ?? false,
+            (window as ViewTransitionObservationWindow)
+              .__routeMotionObservation?.samples ?? 0,
         ),
-      { message: 'expected the shared post cover transition to become active' },
+      { message: 'expected the animation observer to sample committed frames' },
     )
-    .toBe(true)
+    .toBeGreaterThanOrEqual(firstSample + additionalSamples)
+}
+
+async function stopViewTransitionLifecycleObserver(
+  page: import('@playwright/test').Page,
+) {
+  await page.evaluate(() => {
+    const observation = (window as ViewTransitionObservationWindow)
+      .__routeMotionObservation
+    observation?.stop()
+  })
 }
 
 test('the Chinese post shell is prefetched from the home page', async ({ page }) => {
@@ -127,9 +269,10 @@ test('the Chinese post shell morphs from the blog index cover', async ({ page })
         getComputedStyle(element).getPropertyValue('view-transition-name'),
       ),
   ])
+  const coverPseudo = `::view-transition-group(${coverTransitionName})`
+  await observeViewTransitionLifecycles(page)
 
   await instant(page, async () => {
-    await observeCoverMorph(page, coverTransitionName)
     await postLink.click()
 
     await expect(page).toHaveURL(`/blog/${postSlug}`)
@@ -142,7 +285,10 @@ test('the Chinese post shell morphs from the blog index cover', async ({ page })
       '--post-title-transition-name',
       titleTransitionName,
     )
-    await expectCoverMorph(page)
+    await expectNonZeroViewTransitionLifecycle(page, coverPseudo)
+    await expectStaticRootTransition(page)
+    await waitForCoverTransitionToFinish(page, coverPseudo)
+    await observeViewTransitionLifecycles(page)
   })
 
   await expect(
@@ -151,6 +297,21 @@ test('the Chinese post shell morphs from the blog index cover', async ({ page })
       name: '2023 年终总结，致我不同寻常的 28',
     }),
   ).toBeVisible()
+  await expectNonZeroViewTransitionLifecycle(page, coverPseudo)
+  await expectStaticRootTransition(page)
+  await expect(page.locator('html')).toHaveAttribute('data-route-motion', 'none')
+
+  const animatedTransitionsBeforeBack =
+    await nonZeroViewTransitionLifecycleCount(page)
+  await page.goBack()
+  await expect(page).toHaveURL('/blog')
+  await expect(postLink).toBeVisible()
+  await waitForTransitionObserverSamples(page)
+  await expect(page.locator('html')).toHaveAttribute('data-route-motion', 'none')
+  expect(await nonZeroViewTransitionLifecycleCount(page)).toBe(
+    animatedTransitionsBeforeBack,
+  )
+  await stopViewTransitionLifecycleObserver(page)
 })
 
 test('the English post shell morphs from the blog index cover', async ({ page }) => {
@@ -172,11 +333,12 @@ test('the English post shell morphs from the blog index cover', async ({ page })
       .locator('.blog-row-title')
       .evaluate((element) =>
         getComputedStyle(element).getPropertyValue('view-transition-name'),
-    ),
+      ),
   ])
+  const coverPseudo = `::view-transition-group(${coverTransitionName})`
+  await observeViewTransitionLifecycles(page)
 
   await instant(page, async () => {
-    await observeCoverMorph(page, coverTransitionName)
     await postLink.click()
 
     await expect(page).toHaveURL(`/en/blog/${postSlug}`)
@@ -189,7 +351,10 @@ test('the English post shell morphs from the blog index cover', async ({ page })
       '--post-title-transition-name',
       titleTransitionName,
     )
-    await expectCoverMorph(page)
+    await expectNonZeroViewTransitionLifecycle(page, coverPseudo)
+    await expectStaticRootTransition(page)
+    await waitForCoverTransitionToFinish(page, coverPseudo)
+    await observeViewTransitionLifecycles(page)
   })
 
   await expect(
@@ -198,6 +363,146 @@ test('the English post shell morphs from the blog index cover', async ({ page })
       name: '2023 Year in Review: My Unusual 28th Year',
     }),
   ).toBeVisible()
+  await expectNonZeroViewTransitionLifecycle(page, coverPseudo)
+  await expectStaticRootTransition(page)
+  await expect(page.locator('html')).toHaveAttribute('data-route-motion', 'none')
+  await stopViewTransitionLifecycleObserver(page)
+})
+
+test('keyboard post navigation keeps every route group instant', async ({
+  page,
+}) => {
+  await page.goto('/blog')
+  await page.waitForLoadState('networkidle')
+
+  const postLink = page
+    .getByRole('link', {
+      name: /2023 年终总结，致我不同寻常的 28/,
+    })
+    .first()
+  await observeViewTransitionLifecycles(page)
+
+  await instant(page, async () => {
+    await postLink.focus()
+    await page.keyboard.press('Enter')
+
+    await expect(page).toHaveURL(`/blog/${postSlug}`)
+    await expect(page.getByRole('status', { name: '正在加载文章' })).toBeVisible()
+    await expect(page.locator('html')).toHaveAttribute('data-route-motion', 'none')
+    await expect(page.locator('html')).toHaveCSS(
+      '--post-cover-transition-name',
+      '',
+    )
+    await expect(page.locator('html')).toHaveCSS(
+      '--post-title-transition-name',
+      '',
+    )
+    await waitForTransitionObserverSamples(page)
+    expect(await nonZeroViewTransitionLifecycleCount(page)).toBe(0)
+  })
+
+  await expect(
+    page.getByRole('heading', {
+      level: 1,
+      name: '2023 年终总结，致我不同寻常的 28',
+    }),
+  ).toBeVisible()
+  await waitForTransitionObserverSamples(page)
+  expect(await nonZeroViewTransitionLifecycleCount(page)).toBe(0)
+  await expect(page.locator('html')).toHaveAttribute('data-route-motion', 'none')
+  await stopViewTransitionLifecycleObserver(page)
+})
+
+test('reduced motion keeps pointer post navigation instant', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'reduce' })
+  await page.goto('/en/blog')
+  await page.waitForLoadState('networkidle')
+
+  const postLink = page
+    .getByRole('link', {
+      name: /2023 Year in Review: My Unusual 28th Year/,
+    })
+    .first()
+  await observeViewTransitionLifecycles(page)
+
+  await instant(page, async () => {
+    await postLink.click()
+
+    await expect(page).toHaveURL(`/en/blog/${postSlug}`)
+    await expect(page.getByRole('status', { name: 'Loading article' })).toBeVisible()
+    await expect(page.locator('html')).not.toHaveAttribute('data-route-motion')
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+        ),
+      )
+      .toBe(true)
+    await waitForTransitionObserverSamples(page)
+    expect(await nonZeroViewTransitionLifecycleCount(page)).toBe(0)
+  })
+
+  await expect(
+    page.getByRole('heading', {
+      level: 1,
+      name: '2023 Year in Review: My Unusual 28th Year',
+    }),
+  ).toBeVisible()
+  await waitForTransitionObserverSamples(page)
+  expect(await nonZeroViewTransitionLifecycleCount(page)).toBe(0)
+  await expect(page.locator('html')).toHaveAttribute('data-route-motion', 'none')
+  await stopViewTransitionLifecycleObserver(page)
+})
+
+test.describe('touch post navigation', () => {
+  test.use({ hasTouch: true })
+
+  test('a real touch tap preserves both post morph lifecycles', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 393, height: 852 })
+    await page.goto('/blog')
+    await page.waitForLoadState('networkidle')
+
+    const postLink = page
+      .getByRole('link', {
+        name: /2023 年终总结，致我不同寻常的 28/,
+      })
+      .first()
+    const coverTransitionName = await postLink
+      .locator('.print-thumb')
+      .evaluate((element) =>
+        getComputedStyle(element).getPropertyValue('view-transition-name'),
+      )
+    const coverPseudo = `::view-transition-group(${coverTransitionName})`
+    await observeViewTransitionLifecycles(page)
+
+    await instant(page, async () => {
+      await postLink.tap()
+
+      await expect(page).toHaveURL(`/blog/${postSlug}`)
+      await expect(page.getByRole('status', { name: '正在加载文章' })).toBeVisible()
+      await expect(page.locator('html')).not.toHaveAttribute('data-route-motion')
+      await expectNonZeroViewTransitionLifecycle(page, coverPseudo)
+      await expectStaticRootTransition(page)
+      await waitForCoverTransitionToFinish(page, coverPseudo)
+      await observeViewTransitionLifecycles(page)
+    })
+
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: '2023 年终总结，致我不同寻常的 28',
+      }),
+    ).toBeVisible()
+    await expectNonZeroViewTransitionLifecycle(page, coverPseudo)
+    await expectStaticRootTransition(page)
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-route-motion',
+      'none',
+    )
+    await stopViewTransitionLifecycleObserver(page)
+  })
 })
 
 test('preferences preserve theme, locale, and reduced motion', async ({ page }) => {

--- a/plans/002-limit-route-motion-to-post-pointers.md
+++ b/plans/002-limit-route-motion-to-post-pointers.md
@@ -1,0 +1,227 @@
+# 002 - Limit route motion to pointer-opened posts
+
+- **Status**: DONE
+- **Commit**: f08aa6c
+- **Severity**: HIGH
+- **Category**: Purpose and frequency
+- **Estimated scope**: 5 files, about 100 lines
+
+## Problem
+
+The public document wraps every route body in one always-active React View
+Transition. Next.js route navigations are React transitions, so this boundary
+activates for keyboard navigation, dock navigation, ordinary links, and post
+links alike.
+
+`app/_components/site-document.tsx:58` currently has no transition-type or
+input-modality gate:
+
+```tsx
+// app/_components/site-document.tsx:58 - current
+<main className="flex-1 pt-14">
+  {/* Intentionally untyped: post covers and titles morph through
+      list → loading shell → article. default="none" suppresses
+      those CSS-named groups in this React/Next version. */}
+  <ViewTransition>{children}</ViewTransition>
+</main>
+```
+
+`components/post-transition-link.tsx:31` removes shared-element identities for
+a keyboard-generated click, but it cannot stop the route/root animation:
+
+```tsx
+// components/post-transition-link.tsx:31 - current
+const root = document.documentElement
+if (event.detail === 0) {
+  root.style.removeProperty('--post-cover-transition-name')
+  root.style.removeProperty('--post-title-transition-name')
+  return
+}
+```
+
+The result violates `docs/design-language.md:51`: keyboard-initiated actions
+must never animate, and high-frequency navigation must not gain an entrance
+animation. The only route animation justified here is the pointer/touch post
+handoff, where the cover and title communicate that the selected row became
+the article.
+
+## Target
+
+Default every route transition to instant. Enable the existing staged
+transition only when a primary unmodified pointer activates a
+`PostTransitionLink`.
+
+Use one persistent document attribute:
+
+```html
+<html data-route-motion="none">
+```
+
+Use one marker on post links:
+
+```tsx
+<Link data-post-transition-link ... />
+```
+
+Add a client-only capture controller with this exact behavior:
+
+```tsx
+// components/route-motion-controller.tsx - target
+'use client'
+
+import { useEffect } from 'react'
+
+const POST_LINK_SELECTOR = '[data-post-transition-link]'
+const ROUTE_MOTION_ATTRIBUTE = 'data-route-motion'
+
+export function RouteMotionController() {
+  useEffect(() => {
+    const root = document.documentElement
+
+    function disableRouteMotion() {
+      root.setAttribute(ROUTE_MOTION_ATTRIBUTE, 'none')
+    }
+
+    function preparePointerRoute(event: PointerEvent) {
+      const target = event.target
+      const opensPost =
+        event.isPrimary &&
+        event.button === 0 &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.shiftKey &&
+        !event.altKey &&
+        target instanceof Element &&
+        target.closest(POST_LINK_SELECTOR) !== null
+
+      if (opensPost) {
+        root.removeAttribute(ROUTE_MOTION_ATTRIBUTE)
+      } else {
+        disableRouteMotion()
+      }
+    }
+
+    document.addEventListener('pointerdown', preparePointerRoute, true)
+    document.addEventListener('keydown', disableRouteMotion, true)
+
+    return () => {
+      document.removeEventListener('pointerdown', preparePointerRoute, true)
+      document.removeEventListener('keydown', disableRouteMotion, true)
+    }
+  }, [])
+
+  return null
+}
+```
+
+The controller intentionally uses capture phase. It must classify the input
+before Next starts navigation from the target link. Pointer and touch post
+activation remove the opt-out and preserve both stages of the current
+list-to-shell-to-article transition. Keyboard, dock, settings, ordinary links,
+modified clicks, and non-primary pointers leave route motion disabled.
+
+Add this exact CSS gate alongside the existing reduced-motion gate:
+
+```css
+/* app/globals.css - target */
+html[data-route-motion='none']::view-transition-group(*),
+html[data-route-motion='none']::view-transition-image-pair(*),
+html[data-route-motion='none']::view-transition-old(*),
+html[data-route-motion='none']::view-transition-new(*) {
+  animation-duration: 0s !important;
+  animation-delay: 0s !important;
+}
+```
+
+Do not type the outer `ViewTransition` with `default="none"`. In Next.js
+16.3.0-preview.6, that suppresses the CSS-named cover/title groups and breaks
+the second Suspense handoff. The document attribute controls duration without
+deactivating the React boundary.
+
+## Repo conventions to follow
+
+- `docs/design-language.md:51-60` is the authority: keyboard and high-frequency
+  navigation are instant, pointer post links may morph, and reduced motion is
+  instant.
+- `components/post-transition-link.tsx:19-39` already distinguishes normal
+  primary clicks from keyboard and modified clicks. Preserve those native-link
+  guards.
+- `app/globals.css:1504-1530` already uses `0s !important` for reduced-motion
+  View Transition pseudo-elements. Reuse that exact mechanism.
+- `components/locale-restorer.tsx` is the existing pattern for a client-only
+  document controller rendered by the server-owned `SiteDocument`.
+- The public route transition uses CSS and the browser View Transition
+  compositor. Do not introduce Framer Motion, Motion, GSAP, or timers.
+
+## Steps
+
+1. Add `components/route-motion-controller.tsx` with the exact capture-phase
+   controller above. It must return `null` and clean up both listeners.
+2. In `app/_components/site-document.tsx`, add
+   `data-route-motion="none"` to `<html>` and render
+   `<RouteMotionController />` inside `ThemeProvider`, before the route body.
+   This default also keeps admin route changes instant because admin shares
+   `SiteDocument` and has no post-transition links.
+3. In `components/post-transition-link.tsx`, add the boolean
+   `data-post-transition-link` attribute to the existing `Link`. Do not replace
+   `Link` with `router.push`; native modified-click and new-tab behavior must
+   remain owned by Next/the browser.
+4. Add `components/route-motion-controller.test.tsx` in jsdom. Prove that an
+   unmodified primary-button pointerdown inside a marked post link removes the
+   document attribute; an ordinary, modified, or non-primary pointerdown
+   restores `none`; and a keydown restores `none`. Verify unmount removes the
+   listeners.
+5. Extend `components/post-transition-link.test.tsx` to assert the rendered
+   anchor carries `data-post-transition-link` while retaining the existing
+   pointer, keyboard, and modified-click assertions.
+6. Add the exact CSS opt-out after the base View Transition rules and before
+   the existing `prefers-reduced-motion` block. Do not remove the reduced-motion
+   block; the two gates protect different inputs.
+
+## Boundaries
+
+- Do NOT change the 250ms defocus, 300ms focus, or 320ms shared morph.
+- Do NOT add `default="none"` to the outer React `ViewTransition`.
+- Do NOT change Partial Prefetching or force `prefetch={true}`.
+- Do NOT intercept navigation with `preventDefault`, `router.push`, timers, or
+  a custom history implementation.
+- Do NOT animate keyboard, dock, settings, language, theme, admin, or ordinary
+  content links.
+- Do NOT change cover/title identity generation or the loading shell.
+- Do NOT add a dependency.
+- If the cited structures have drifted from commit `f08aa6c`, STOP and report
+  the mismatch instead of improvising.
+
+## Verification
+
+- **Mechanical**: run `pnpm typecheck`,
+  `pnpm vitest run components/route-motion-controller.test.tsx components/post-transition-link.test.tsx`,
+  and `git diff --check`; all must exit 0.
+- **Feel check**: run the production navigation fixture used by
+  `pnpm test:navigation` and confirm:
+  - Pointer-click or touch-tap a covered post row. The cover and title still
+    morph list -> localized loading shell -> article.
+  - Focus the same row and press Enter. Navigation is immediate; neither the
+    route, cover, nor title animates.
+  - Click dock destinations, language/theme settings, and ordinary links.
+    Their route content swaps immediately without a page entrance.
+  - Command/Control-click and middle-click remain native and open a new tab or
+    window without changing the current page.
+  - In DevTools at 10% playback, only a primary pointer/touch post activation
+    produces route/shared groups with non-zero duration.
+  - With `prefers-reduced-motion: reduce`, pointer post navigation is also
+    instant.
+- **Done when**: only primary pointer/touch post activation enables route
+  animation; all keyboard and routine navigation is instant, native link
+  semantics remain intact, and the two-stage post morph is unchanged.
+
+## Completion
+
+Completed on `cali/fix-instant-post-navigation`. Review strengthened the plan's
+input lifetime: eligible `pointerdown` only preserves the disabled state, while
+the validated post-link `click` enables motion. `popstate`, keyboard, modified
+or non-primary pointers, and ordinary links restore instant navigation. A
+client `RouteViewTransition` uses React's `onUpdate` completion cleanup to keep
+the list -> shell stage active and reset the opt-in only after shell -> article
+finishes. This also prevents canceled touch gestures and browser Back from
+inheriting motion.

--- a/plans/003-keep-global-chrome-fixed.md
+++ b/plans/003-keep-global-chrome-fixed.md
@@ -1,0 +1,164 @@
+# 003 - Keep global chrome fixed during post transitions
+
+- **Status**: DONE
+- **Commit**: f08aa6c
+- **Severity**: MEDIUM
+- **Category**: Cohesion
+- **Estimated scope**: 2 files, about 30 lines
+
+## Problem
+
+The route focus treatment is attached to the browser's `root` View Transition
+snapshot:
+
+```css
+/* app/globals.css:1423 - current */
+::view-transition-old(root) {
+  animation: vt-defocus 250ms var(--ease-swift) both;
+}
+
+::view-transition-new(root) {
+  animation: vt-focus 300ms var(--ease-swift) both;
+}
+```
+
+`root` contains more than the changing route. In
+`app/_components/site-document.tsx:54-68`, the ambient background, footer, and
+dock sit outside the React boundary but remain part of the document snapshot:
+
+```tsx
+// app/_components/site-document.tsx:54 - current
+<ThemeProvider>
+  {restoreLocale && <LocaleRestorer />}
+  <AmbientBackground />
+  <div className="flex min-h-screen flex-col pb-20">
+    <main className="flex-1 pt-14">
+      <ViewTransition>{children}</ViewTransition>
+    </main>
+    <SiteFooter social={social} github={github} locale={locale} />
+  </div>
+  <Suspense fallback={<DockFallback locale={locale} />}>
+    <Dock />
+  </Suspense>
+</ThemeProvider>
+```
+
+Blurring and fading the `root` snapshot therefore makes the spatial anchors
+participate in the route change. That contradicts
+`docs/design-language.md:56`: ambient guides, the dock, footer, and other
+global chrome must remain fixed while only route content defocuses and focuses.
+
+## Target
+
+Keep the React boundary active and give its automatically managed group the
+stable View Transition class `route-content`:
+
+```tsx
+// app/_components/site-document.tsx - target
+<ViewTransition default="route-content">{children}</ViewTransition>
+```
+
+`default="route-content"` assigns a class to the boundary's active group. It
+must not be `default="none"`; the latter deactivates the boundary during the
+untyped Suspense reveal and breaks the existing shared cover/title handoff in
+this exact Next/React version.
+
+Make the browser root snapshot static, following the fixed-header pattern in
+the bundled Next.js 16.3 View Transition guide:
+
+```css
+/* app/globals.css - target */
+::view-transition-group(root) {
+  animation: none;
+}
+
+::view-transition-old(root) {
+  display: none;
+}
+
+::view-transition-new(root) {
+  animation: none;
+}
+
+::view-transition-old(.route-content) {
+  animation: vt-defocus 250ms var(--ease-swift) both;
+}
+
+::view-transition-new(.route-content) {
+  animation: vt-focus 300ms var(--ease-swift) both;
+}
+```
+
+The old root snapshot is hidden so identical old/new chrome cannot
+double-expose or flash. The live/new root remains static. Only the named route
+content receives the documented opacity + 2px blur treatment. Nested
+`cover-<id>` and `title-<id>` groups keep the existing 320ms
+`--ease-swift` morph through both transitions.
+
+## Repo conventions to follow
+
+- `docs/design-language.md:56-61` requires fixed global chrome and a 2px route
+  content focus treatment.
+- `app/globals.css:1409-1434` owns the settled `vt-defocus`, `vt-focus`, 250ms,
+  300ms, and shared 320ms behavior. Reuse these definitions unchanged.
+- `node_modules/next/dist/docs/01-app/02-guides/view-transitions.md` documents
+  `default="route-content"`-style View Transition classes and the fixed-header
+  pattern of hiding the old snapshot while leaving the new snapshot static.
+- The `<ViewTransition>` boundary must stay immediately inside `<main>` so the
+  footer and dock remain outside the route-content group.
+
+## Steps
+
+1. In `app/_components/site-document.tsx`, change the bare boundary to
+   `<ViewTransition default="route-content">`. Update the adjacent comment to
+   state that the non-`none` default isolates route content while keeping the
+   CSS-named list -> shell -> article groups active.
+2. In `app/globals.css`, replace the `old(root)` and `new(root)` focus
+   animations with the exact static-root rules above.
+3. Move the unchanged `vt-defocus 250ms` and `vt-focus 300ms` animations onto
+   `old(.route-content)` and `new(.route-content)` respectively.
+4. Leave `::view-transition-group(*)` at 320ms `--ease-swift`. It continues to
+   govern geometry interpolation for the cover/title shared groups; the
+   root group's explicit `animation: none` keeps it static.
+
+## Boundaries
+
+- Do NOT move `AmbientBackground`, `SiteFooter`, or `Dock` inside the React
+  View Transition boundary.
+- Do NOT change the document layout, stacking order, footer, dock, or ambient
+  rendering.
+- Do NOT replace the settled 2px blur with translation, rotation, or scale.
+- Do NOT change the 250ms, 300ms, or 320ms timings or `--ease-swift`.
+- Do NOT use `default="none"`, transition types, or a second global boundary in
+  this plan.
+- Do NOT change the post loading shell or shared transition names.
+- Do NOT add dependencies.
+- This plan depends on plan 002's input-modality gate. If the cited structures
+  have drifted from commit `f08aa6c`, STOP and report instead of improvising.
+
+## Verification
+
+- **Mechanical**: run `pnpm typecheck`, `pnpm test:localization`, and
+  `git diff --check`; all must exit 0. Then run the focused public navigation
+  cases from `pnpm test:navigation`.
+- **Feel check**: at 1440x900 and 393x852, pointer-open a covered post from
+  `/blog` and `/en/blog`:
+  - In DevTools at 10% playback, the dock, ambient guides, and footer stay
+    perfectly fixed and sharp. No duplicate old dock/footer may flash.
+  - Only the route content fades through 2px blur; the cover and title remain
+    separate morph elements above that handoff.
+  - The loading shell -> article transition still runs as the second stage.
+  - Inspect pseudo-elements: `old(root)` is not displayed, `new(root)` has no
+    animation, `old(.route-content)` runs `vt-defocus` for 250ms, and
+    `new(.route-content)` runs `vt-focus` for 300ms.
+  - Repeat with `prefers-reduced-motion: reduce`; every group swaps instantly.
+- **Done when**: global chrome never blurs, fades, moves, or double-exposes;
+  only route content receives the focus treatment; and both shared-element
+  stages remain intact.
+
+## Completion
+
+Completed on `cali/fix-instant-post-navigation`. `RouteViewTransition` assigns
+the `route-content` class, the document root stays static, and only the route
+content uses the settled 250ms/300ms focus treatment. Browser verification
+proves both cover handoffs while root old/new groups have no non-zero lifecycle.

--- a/plans/004-prove-route-motion-accessibility.md
+++ b/plans/004-prove-route-motion-accessibility.md
@@ -1,0 +1,199 @@
+# 004 - Prove route motion accessibility in the browser
+
+- **Status**: DONE
+- **Commit**: f08aa6c
+- **Severity**: MEDIUM
+- **Category**: Accessibility
+- **Estimated scope**: 1 file, about 100 lines
+
+## Problem
+
+The stylesheet correctly disables View Transition pseudo-element timing for
+reduced motion:
+
+```css
+/* app/globals.css:1524 - current */
+::view-transition-group(*),
+::view-transition-image-pair(*),
+::view-transition-old(*),
+::view-transition-new(*) {
+  animation-duration: 0s !important;
+  animation-delay: 0s !important;
+}
+```
+
+But the browser regression in `e2e/instant-navigation.spec.ts:203` only checks
+an entrance class and the Preferences control:
+
+```ts
+// e2e/instant-navigation.spec.ts:217 - current
+await expect
+  .poll(() => page.evaluate(() => window.matchMedia('(prefers-reduced-motion: reduce)').matches))
+  .toBe(true)
+await expect
+  .poll(() => page.locator('.enter').first().evaluate((element) => getComputedStyle(element).animationName))
+  .toBe('none')
+```
+
+It never opens a post under reduced motion and never inspects the route,
+cover, or title pseudo-groups. Likewise,
+`components/post-transition-link.test.tsx:77` proves that keyboard activation
+clears two CSS variables in jsdom, but no browser test proves that the actual
+React/Next View Transition is instant.
+
+These are the two highest-risk boundaries because CSS pseudo-element behavior,
+React View Transition activation, Next navigation, and input modality only
+meet in a real browser.
+
+## Target
+
+Extend `e2e/instant-navigation.spec.ts` with reusable pseudo-style sampling and
+two browser regressions after plans 002 and 003 are implemented.
+
+Add this helper near `observeCoverMorph`:
+
+```ts
+// e2e/instant-navigation.spec.ts - target
+type ViewTransitionTiming = {
+  animationDelay: string
+  animationDuration: string
+  animationName: string
+}
+
+async function viewTransitionTiming(
+  page: import('@playwright/test').Page,
+  pseudo: string,
+) {
+  return page.locator('html').evaluate((element, pseudoElement) => {
+    const style = getComputedStyle(element, pseudoElement)
+    return {
+      animationDelay: style.animationDelay,
+      animationDuration: style.animationDuration,
+      animationName: style.animationName,
+    }
+  }, pseudo) as Promise<ViewTransitionTiming>
+}
+```
+
+Add a keyboard regression that:
+
+1. Opens `/blog`, focuses the known covered post row, and presses Enter.
+2. Asserts the destination URL and localized article status/content.
+3. Asserts `<html data-route-motion="none">` remains present.
+4. Asserts `--post-cover-transition-name` and
+   `--post-title-transition-name` are empty.
+5. Asserts the computed `animationDuration` and `animationDelay` are `0s` for:
+   - `::view-transition-old(root)`
+   - `::view-transition-new(root)`
+   - `::view-transition-old(.route-content)`
+   - `::view-transition-new(.route-content)`
+   - `::view-transition-group(cover-p01)`
+   - `::view-transition-group(title-p01)`
+
+Add a reduced-motion pointer regression that:
+
+1. Calls `page.emulateMedia({ reducedMotion: 'reduce' })` before visiting
+   `/en/blog`.
+2. Pointer-clicks the same covered post so
+   `data-route-motion="none"` is removed. This isolates the media query as the
+   reason motion is disabled.
+3. Asserts the English loading shell and final article appear.
+4. Asserts `matchMedia('(prefers-reduced-motion: reduce)').matches` is true.
+5. Asserts the same six pseudo-elements report `animationDuration: '0s'` and
+   `animationDelay: '0s'`.
+
+Also extend the existing positive pointer test to prove the chrome/content
+split after plan 003:
+
+```ts
+expect((await viewTransitionTiming(page, '::view-transition-old(root)')).animationName)
+  .toBe('none')
+expect((await viewTransitionTiming(page, '::view-transition-old(.route-content)')).animationName)
+  .toContain('vt-defocus')
+expect((await viewTransitionTiming(page, '::view-transition-new(.route-content)')).animationName)
+  .toContain('vt-focus')
+```
+
+Sample the positive transition immediately after the pre-click observer is
+armed, as the existing `observeCoverMorph` helper does. Do not start a polling
+loop on page load; that was the Greptile race fixed in commit `f08aa6c`.
+
+## Repo conventions to follow
+
+- `e2e/instant-navigation.spec.ts:15-51` already samples a named pseudo-group
+  and stores only diagnostic state on `window`. Extend that pattern rather than
+  adding screenshots or arbitrary sleeps.
+- Use `instant(page, async () => { ... })` around the navigation so Next's
+  Partial Prefetching fixture exposes the localized loading shell deterministically.
+- `postSlug` and the allowlisted transition names make the expected groups
+  deterministic: `cover-p01` and `title-p01`.
+- Existing Chinese and English positive pointer cases must remain. New
+  accessibility cases supplement them; they do not replace positive morph
+  coverage.
+- The repository's reduced-motion contract intentionally uses `0s`, not a
+  gentler opacity fallback.
+
+## Steps
+
+1. Add the exact `ViewTransitionTiming` type and `viewTransitionTiming` helper
+   near the existing morph observer.
+2. Add the keyboard-activation browser test on `/blog`, using focus + Enter
+   rather than `click({ detail: 0 })`. Assert the input-modality attribute,
+   empty shared-name variables, localized shell/final article, and zero timing
+   for all six pseudo-elements.
+3. Add the English reduced-motion pointer test. Prove the post-link pointer
+   path removed the document opt-out before attributing zero timing to the
+   media query.
+4. Extend one existing positive pointer morph test with the static-root and
+   route-content animation-name assertions. Keep the observer immediately
+   before the click.
+5. Run each new test repeatedly enough to expose timing races. If pseudo-style
+   reads can miss the positive animation, integrate them into the existing
+   requestAnimationFrame observer rather than adding `waitForTimeout`.
+
+## Boundaries
+
+- Do NOT change production source in this plan; plans 002 and 003 own behavior.
+- Do NOT use fixed sleeps, screenshots as assertions, or network-idle as proof
+  that an animation ran.
+- Do NOT assert undocumented generated React View Transition names. Assert the
+  stable class `.route-content` and allowlisted cover/title names only.
+- Do NOT remove the existing Chinese or English pointer-morph tests.
+- Do NOT loosen the loading-shell assertions or prefetch contract.
+- Do NOT modify the 250ms, 300ms, or 320ms production timings.
+- If plans 002 and 003 are not complete, or the cited structures have drifted
+  from commit `f08aa6c`, STOP and report instead of improvising.
+
+## Verification
+
+- **Mechanical**: run `NEXT_INSTANT_NAVIGATION_TEST=1 pnpm exec next build`,
+  then
+  `pnpm exec playwright test e2e/instant-navigation.spec.ts --grep "keyboard|reduced motion|morphs from" --repeat-each=3`.
+  Follow with `pnpm exec playwright test e2e/instant-navigation.spec.ts`,
+  `pnpm typecheck`, and `git diff --check`; every command must exit 0. The
+  repeated focused run must expose observer races without rebuilding between
+  repetitions.
+- **Feel check**:
+  - At 10% playback, pointer-open the covered post and confirm the static root,
+    250/300ms route-content focus, and 320ms cover/title morph match the
+    assertions.
+  - Focus the row and press Enter. The page must swap with no visible fade,
+    blur, cover movement, or title movement.
+  - Emulate reduced motion and pointer-open the row. The result must also be an
+    immediate swap even though the post-pointer path is otherwise eligible for
+    motion.
+  - Repeat Chinese and English cases in Chromium. Verify unsupported View
+    Transition browsers still navigate without a JS fallback animation.
+- **Done when**: browser tests prove pointer motion remains positive, keyboard
+  and reduced-motion navigation are instant at every pseudo-group, global
+  chrome stays static, and the focused test is race-free across three runs.
+
+## Completion
+
+Completed on `cali/fix-instant-post-navigation` with stronger browser proof than
+the original pseudo-style proposal. The suite observes real `Animation`
+lifecycles by `KeyframeEffect.pseudoElement`, holds the localized loading shell
+with `instant()`, awaits the exact stage-one cover animations' `finished`
+promises, and rearms before proving shell -> article independently. It covers
+Chinese, English, keyboard, reduced motion, browser Back, and a real `hasTouch`
+tap without fixed sleeps.

--- a/plans/README.md
+++ b/plans/README.md
@@ -3,7 +3,19 @@
 | # | Plan | Severity | Status |
 | --- | --- | --- | --- |
 | 001 | [Let the desktop TOC finish closing](001-desktop-toc-close.md) | MEDIUM | DONE |
+| 002 | [Limit route motion to pointer-opened posts](002-limit-route-motion-to-post-pointers.md) | HIGH | DONE |
+| 003 | [Keep global chrome fixed during post transitions](003-keep-global-chrome-fixed.md) | MEDIUM | DONE |
+| 004 | [Prove route motion accessibility in the browser](004-prove-route-motion-accessibility.md) | MEDIUM | DONE |
 
 ## Recommended execution order
 
-Plan 001 is complete. There are no pending animation plans.
+Plan 001 is complete.
+
+Plans 002 through 004 were completed in this order:
+
+1. **002** establishes the input-modality contract: only primary pointer/touch
+   post navigation may animate.
+2. **003** depends on 002 and moves the settled route focus treatment from the
+   document root to route content while keeping global chrome fixed.
+3. **004** depends on 002 and 003. It adds real-browser proof for positive
+   pointer motion, keyboard navigation, reduced motion, and fixed chrome.


### PR DESCRIPTION
Follow-up to #151 after it merged.

## Summary

- limit route animation to deliberate primary pointer and touch post opens
- keep the document root, dock, footer, and ambient chrome static while route content transitions
- preserve both cover and title morph stages through the localized loading shell
- keep keyboard, ordinary links, modified clicks, browser history, admin, and reduced-motion navigation instant
- add lifecycle-level unit and browser coverage and document the final motion contract

## Verification

- focused Vitest: 20 tests passed
- `pnpm typecheck`
- `pnpm test:localization`: 148 tests passed
- focused Playwright coverage passed for Chinese, English, keyboard, reduced motion, Back, and touch
- `git diff --check`

## Local environment note

The local production build stalled during Turbopack compilation while machine load was above 35. The full unit suite timed out only while initializing the unrelated PGlite rate-limit test under the same load; that test file passed 3/3 when run alone. CI is the production-build and full-suite verdict for this PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the post route transition system by limiting the cover/title morph animation to deliberate primary pointer and touch activations of post links, while keeping all other navigation (keyboard, history, modified clicks, admin) instant. It also migrates the existing defocus/focus animation from the document `root` view transition to a named `route-content` group so that ambient chrome, the dock, and the footer remain static during route changes.

- **`RouteMotionController`** adds a capture-phase `pointerdown` listener that leaves `data-route-motion` untouched (motion still disabled) for qualifying post-link pointers, and explicitly sets it to `"none"` for everything else; `PostTransitionLink`'s `click` handler then removes the attribute only for full, unmodified pointer activations.
- **`RouteViewTransition`** wraps route content in `<ViewTransition default="route-content">` and uses the `onUpdate` cleanup to reset motion back to instant only after the shell-to-article hand-off completes, preserving both morph stages through the loading shell phase.
- The CSS moves the 250ms/300ms defocus-focus pair onto `::view-transition-old/new(.route-content)` and adds a `data-route-motion="none"` selector block to zero all animation durations instantly alongside the existing `prefers-reduced-motion` gate.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge. The motion gating, CSS re-targeting, and lifecycle cleanup all behave correctly, and the test suite exercises the critical edge cases at both the unit and browser level.

The controller never removes the attribute on a qualifying pointerdown — it only prevents disabling it — while PostTransitionLink's click handler is the sole point that activates motion. This makes canceled gestures and dragged touches safe by default. The CSS migration from root to route-content is correct: display:none on the old root snapshot prevents double-exposure, and the specificity ordering ensures the instant-mode selector overrides both the base and named group rules. The onUpdate cleanup pattern correctly distinguishes the shell stage from the article stage by querying the live DOM at cleanup time.

No files require special attention. The e2e test suite relies on a default of 2 rAF samples for its race guard in waitForTransitionObserverSamples, which is light but consistent with the author's note that CI is the production-build verdict.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| components/route-motion-controller.tsx | New client component: RouteMotionController guards data-route-motion via capture-phase listeners; RouteViewTransition wraps content in ViewTransition default=route-content and resets motion state via onUpdate cleanup after the article phase. |
| components/post-transition-link.tsx | Adds data-post-transition-link marker and, on click, removes data-route-motion for normal pointer activations or sets it to none for keyboard (detail===0). |
| app/_components/site-document.tsx | Adds data-route-motion=none to the server-rendered html element, mounts RouteMotionController, and swaps bare ViewTransition for RouteViewTransition with default=route-content. |
| app/globals.css | Moves defocus/focus animations from root to .route-content group, freezes the root snapshot, and adds the data-route-motion=none instant suppression block. |
| e2e/instant-navigation.spec.ts | Replaces the rAF-based cover-morph observer with a full Animation lifecycle observer. Adds keyboard, reduced-motion, Back, and touch test cases. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User Input
    participant RMC as RouteMotionController
    participant PTL as PostTransitionLink
    participant RVT as RouteViewTransition
    participant DOM as html data-route-motion

    Note over DOM: SSR: data-route-motion=none
    U->>RMC: pointerdown on post link (primary, unmodified)
    RMC->>RMC: "opensPost=true, does nothing"
    Note over DOM: still none
    U->>PTL: "click (detail > 0)"
    PTL->>DOM: removeAttribute data-route-motion
    Note over DOM: absent, motion enabled
    Note over RVT: shell appears
    RVT->>RVT: onUpdate cleanup, shell present, no-op
    Note over RVT: article replaces shell
    RVT->>RVT: onUpdate cleanup, no shell, set none
    Note over DOM: data-route-motion=none
    alt keyboard or popstate
        U->>RMC: keydown or popstate
        RMC->>DOM: setAttribute none
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User Input
    participant RMC as RouteMotionController
    participant PTL as PostTransitionLink
    participant RVT as RouteViewTransition
    participant DOM as html data-route-motion

    Note over DOM: SSR: data-route-motion=none
    U->>RMC: pointerdown on post link (primary, unmodified)
    RMC->>RMC: "opensPost=true, does nothing"
    Note over DOM: still none
    U->>PTL: "click (detail > 0)"
    PTL->>DOM: removeAttribute data-route-motion
    Note over DOM: absent, motion enabled
    Note over RVT: shell appears
    RVT->>RVT: onUpdate cleanup, shell present, no-op
    Note over RVT: article replaces shell
    RVT->>RVT: onUpdate cleanup, no shell, set none
    Note over DOM: data-route-motion=none
    alt keyboard or popstate
        U->>RMC: keydown or popstate
        RMC->>DOM: setAttribute none
    end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(site): harden post transition motion"](https://github.com/calicastle/cali.so/commit/a057271186e82940fc373f4d02c1d485baf2e8dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44752328)</sub>

<!-- /greptile_comment -->