### PR TITLE
Restore Vercel Web Analytics

### DIFF
--- a/app/_components/site-document.tsx
+++ b/app/_components/site-document.tsx
@@ -27,10 +27,12 @@ export const rootMetadata: Metadata = {
 
 export async function SiteDocument({
   children,
+  isAdmin = false,
   locale,
   restoreLocale = false,
 }: Readonly<{
   children: React.ReactNode
+  isAdmin?: boolean
   locale: Locale
   restoreLocale?: boolean
 }>) {
@@ -38,7 +40,7 @@ export async function SiteDocument({
   // shared chrome fresh without making any page request-bound.
   const [social, github] = await Promise.all([getSocial(), getGitHub()])
   const english = locale === 'en'
-  const isPublicSite = !restoreLocale
+  const isPublicSite = !isAdmin
 
   return (
     <html

--- a/app/_components/site-document.tsx
+++ b/app/_components/site-document.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { Analytics } from '@vercel/analytics/next'
 // Experimental React channel export — available because next.config.ts sets
 // experimental.viewTransition (see docs/design-language.md, page transitions)
 import { Suspense, ViewTransition } from 'react'
@@ -37,13 +38,14 @@ export async function SiteDocument({
   // shared chrome fresh without making any page request-bound.
   const [social, github] = await Promise.all([getSocial(), getGitHub()])
   const english = locale === 'en'
+  const isPublicSite = !restoreLocale
 
   return (
     <html
       lang={english ? 'en' : 'zh-CN'}
       data-locale={english ? 'en' : undefined}
       suppressHydrationWarning
-      className={cn('font-sans', fontVariables, !restoreLocale && 'public-site')}
+      className={cn('font-sans', fontVariables, isPublicSite && 'public-site')}
     >
       <head>
         {/* Pre-paint handles the visited flag and theme. Locale restoration
@@ -67,6 +69,7 @@ export async function SiteDocument({
             <Dock />
           </Suspense>
         </ThemeProvider>
+        {isPublicSite && <Analytics />}
       </body>
     </html>
   )

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -10,7 +10,7 @@ export const prefetch = 'force-disabled'
 
 export default function AdminRootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <SiteDocument locale="zh" restoreLocale>
+    <SiteDocument isAdmin locale="zh" restoreLocale>
       {children}
     </SiteDocument>
   )

--- a/app/site-document.test.tsx
+++ b/app/site-document.test.tsx
@@ -61,8 +61,8 @@ describe('SiteDocument analytics', () => {
     const html = renderToStaticMarkup(
       await SiteDocument({
         children: <p>Owner admin</p>,
+        isAdmin: true,
         locale: 'zh',
-        restoreLocale: true,
       }),
     )
 

--- a/app/site-document.test.tsx
+++ b/app/site-document.test.tsx
@@ -1,0 +1,71 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('react', async (importOriginal) => {
+  const react = await importOriginal<typeof import('react')>()
+
+  return {
+    ...react,
+    ViewTransition: ({ children }: { children: React.ReactNode }) => children,
+  }
+})
+
+vi.mock('@vercel/analytics/next', () => ({
+  Analytics: () => <span data-vercel-analytics="" />,
+}))
+
+vi.mock('~/components/ambient-background', () => ({
+  AmbientBackground: () => null,
+}))
+vi.mock('~/components/dock', () => ({
+  Dock: () => null,
+  DockFallback: () => null,
+}))
+vi.mock('~/components/locale-restorer', () => ({
+  LocaleRestorer: () => null,
+}))
+vi.mock('~/components/site-footer', () => ({
+  SiteFooter: () => null,
+}))
+vi.mock('~/components/theme-provider', () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => children,
+}))
+vi.mock('~/lib/security/inline-scripts', () => ({
+  PREPAINT_SCRIPT: '',
+}))
+vi.mock('~/lib/social-live', () => ({
+  getGitHub: vi.fn().mockResolvedValue({}),
+  getSocial: vi.fn().mockResolvedValue({}),
+}))
+vi.mock('./fonts', () => ({
+  fontVariables: '',
+}))
+
+import { SiteDocument } from './_components/site-document'
+
+describe('SiteDocument analytics', () => {
+  it('collects page views across the public route families', async () => {
+    for (const locale of ['zh', 'en'] as const) {
+      const html = renderToStaticMarkup(
+        await SiteDocument({
+          children: <p>Public page</p>,
+          locale,
+        }),
+      )
+
+      expect(html).toContain('data-vercel-analytics')
+    }
+  })
+
+  it('keeps owner-admin routes outside public analytics', async () => {
+    const html = renderToStaticMarkup(
+      await SiteDocument({
+        children: <p>Owner admin</p>,
+        locale: 'zh',
+        restoreLocale: true,
+      }),
+    )
+
+    expect(html).not.toContain('data-vercel-analytics')
+  })
+})

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -27,6 +27,9 @@ Current as of July 2026.
   route, not browser-local state.
 - Public pages are static where possible. GitHub and YouTube social values use
   ISR-backed fetches with committed JSON snapshots as outage fallbacks.
+- Vercel Web Analytics is instrumented to collect first-party page views
+  across the public Chinese and English route families. Owner-admin routes
+  stay excluded from public analytics.
 - External-link cards keep metadata in a committed snapshot refreshed through
   `og.zolplay.com`; the same first-party service proxies fixed-slot favicons and
   Open Graph images, and missing media remains a non-blocking presentation

--- a/docs/v3-cutover-readiness.md
+++ b/docs/v3-cutover-readiness.md
@@ -11,7 +11,9 @@ that the Production environment is not yet provisioned for v3: its runtime
 database credential predates the rewrite and the v3 server-environment
 contract — including every media provider value — is unmet. Required GitHub
 checks, credential isolation, and the production database and media
-verifications also remain open.
+verifications also remain open. Vercel Web Analytics has been restored to the
+public v3 route families, but final Preview injection and dashboard-ingestion
+proof still remain.
 
 Unknown hosted state is not counted as passed. This report does not authorize
 merging to `main`, changing production settings, accessing production data, or
@@ -22,7 +24,7 @@ running production migrations.
 | Item | Value |
 | --- | --- |
 | Production branch | `main` at `8c258834af538dd501486a5fd319b3e96a2ff5bc` |
-| Integration branch | `v2` at `12fb6df` (post `#136` and `#138`) |
+| Integration branch | `v2` at `f184977` (post `#151`; this report's Web Analytics restoration is on top) |
 | Vercel project | `cali-so` (`prj_oIl5…`) on team `team_r1Mln…`; full IDs live in the local `.vercel/project.json` link state |
 | Production deployment | `dpl_A29CV…`, created 2026-07-11, status Ready at inventory time |
 | Release issue | [#98](https://github.com/CaliCastle/cali.so/issues/98) |
@@ -48,6 +50,7 @@ Renditions. The retired static photo fallback has been removed.
 | Complete diff Standards review | PASS | Portal layering and admin typography findings were fixed. The Media `lifecycle` vocabulary breach was resolved by PR #138 (issue #134 closed): Catalog State is the glossary term, and additive migration `0009` renames the column. |
 | Complete diff Spec review | PASS | No scope creep, incorrect PASS treatment, or missing local evidence was found; the unresolved hosted and production requirements below correctly keep the verdict at NOT READY. |
 | Production-like PR Preview | AWAITING CONFIRMATION | The #107 PR is merged; review a current `v2` Preview across the full release matrix once Production provisioning lands, and record its URL here. |
+| Vercel Web Analytics | AWAITING CONFIRMATION | The public site document mounts `@vercel/analytics` for both route families and excludes owner-admin routes. Deploy the final candidate, confirm the first-party Insights script loads, and record a fresh pageview in the existing `cali-so` Analytics dashboard. |
 | GitHub security settings | PASS | Secret scanning, push protection, Dependabot security updates, read-only Actions defaults, and full-SHA action policy are enabled. |
 | Required GitHub checks | FAIL | Neither the `v2` ruleset nor `main` branch protection requires `Quality` and `CodeQL`. The maintainer-operated commands are in `docs/v3-cutover-ops-runbook.md`. |
 | Current Vercel project settings | PASS | Project inspection succeeds with the explicit team scope. The earlier `Not authorized` was a CLI quirk: the team slug `cali` resolves to the personal account, so commands must pass the team ID as `--scope` (see the runbook). |
@@ -250,8 +253,10 @@ The maintainer-operated commands for actions 1 through 4 are collected in
 6. Verify the production Bunny and Neon Media boundary, run the protected live
    storage contract, and publish the intended two-photo Published Photo
    Selection through the owner admin.
-7. Review a production-like Vercel Preview across the remaining browser matrix
-   and update this report with its URL and result.
+7. Review a production-like Vercel Preview across the remaining browser matrix,
+   confirm public routes load the first-party Insights script while owner-admin
+   routes do not, record a fresh pageview in the existing `cali-so` Analytics
+   dashboard, and update this report with the Preview URL and result.
 8. Confirm the rollback procedure against the recorded known-good deployment.
 9. Only after every blocker above is passed, approve the separately operated
    merge to `main` and production cutover.

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@untitledui/icons": "^0.0.22",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.38.0",
+    "@vercel/analytics": "^2.0.1",
     "ai": "^6.0.226",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@upstash/redis':
         specifier: ^1.38.0
         version: 1.38.0
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(next@16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       ai:
         specifier: ^6.0.226
         version: 6.0.226(zod@4.4.3)
@@ -1674,6 +1677,35 @@ packages:
 
   '@upstash/redis@1.38.0':
     resolution: {integrity: sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
@@ -5307,6 +5339,11 @@ snapshots:
   '@upstash/redis@1.38.0':
     dependencies:
       uncrypto: 0.1.3
+
+  '@vercel/analytics@2.0.1(next@16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+    optionalDependencies:
+      next: 16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
 
   '@vercel/oidc@3.2.0': {}
 


### PR DESCRIPTION
Part of [#107](https://github.com/CaliCastle/cali.so/issues/107)

The v3 rewrite dropped the production site's `@vercel/analytics` integration. This restores first-party pageview instrumentation across the public Chinese and English route families while keeping owner-admin routes outside public analytics.

## Implementation

- add `@vercel/analytics` and mount `Analytics` once at the shared public document boundary
- derive an explicit `isPublicSite` policy so `/admin` remains excluded
- cover both public locale families and the owner-admin exclusion in a focused render test
- update the handoff and cutover readiness report without treating hosted ingestion as verified
- require final Preview script injection and a fresh pageview in the existing `cali-so` dashboard before cutover

## Verification

- `pnpm typecheck`
- `pnpm vitest run app/site-document.test.tsx` - 2 passed
- `pnpm vitest run lib/rate-limit/repository.test.ts` - 3 passed
- Standards review - passed
- Spec review - passed

## Local validation limits

- `pnpm test:unit` reached 444 passing tests, then hit the existing PGlite startup timeout in `lib/rate-limit/repository.test.ts`; that file passes by itself
- `pnpm build` deadlocks locally at the current v2 Turbopack compile stage, including with the Analytics import removed; GitHub CI remains the release check for this branch

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores `@vercel/analytics` to the v3 rewrite by mounting the `<Analytics />` component at the shared public document boundary (`SiteDocument`), gated behind an explicit `isAdmin` prop that the admin layout sets to `true`.

- Adds `isAdmin?: boolean` (default `false`) to `SiteDocument`; derives `isPublicSite = !isAdmin` and uses it to conditionally render `<Analytics />` and apply the `public-site` CSS class — cleanly decoupling both from the unrelated `restoreLocale` flag.
- Both public locale layouts (`zh`, `en`) inherit analytics automatically via the default, while `AdminRootLayout` opts out by passing `isAdmin`.
- A focused render test verifies presence for both public locales and absence for the admin route.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change adds a single well-guarded analytics mount with no impact on rendering, routing, or data flow.

The implementation is minimal and correct: the default isAdmin=false means no existing callers need updating, the admin exclusion is explicit and tested, and the public-site CSS class is now tied to a semantically meaningful prop rather than an unrelated one. No logic paths are altered beyond the analytics gate.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/_components/site-document.tsx | Adds explicit isAdmin prop (defaults to false) and isPublicSite gate; mounts <Analytics /> only on public routes; decouples the public-site CSS class from the unrelated restoreLocale flag |
| app/admin/layout.tsx | Adds isAdmin to the admin SiteDocument usage to opt the admin route out of analytics |
| app/site-document.test.tsx | New focused render test covering analytics presence for both public locales (zh, en) and absence for the admin route |
| package.json | Adds @vercel/analytics@^2.0.1 dependency |
| docs/v3-cutover-readiness.md | Updates the cutover readiness report with a new AWAITING CONFIRMATION row for Vercel Web Analytics and updated step 7 requiring dashboard ingestion proof |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request] --> B{Route family}
    B -->|/zh/* or /en/*| C[ChineseRootLayout / EnglishRootLayout]
    B -->|/admin/*| D[AdminRootLayout]
    C --> E["SiteDocument(locale, isAdmin=false)"]
    D --> F["SiteDocument(locale='zh', isAdmin=true, restoreLocale=true)"]
    E --> G{isPublicSite = !isAdmin}
    F --> G
    G -->|true| H["Render Analytics + public-site class"]
    G -->|false| I["No Analytics, no public-site class"]
    H --> J[Page HTML served to browser]
    I --> J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Request] --> B{Route family}
    B -->|/zh/* or /en/*| C[ChineseRootLayout / EnglishRootLayout]
    B -->|/admin/*| D[AdminRootLayout]
    C --> E["SiteDocument(locale, isAdmin=false)"]
    D --> F["SiteDocument(locale='zh', isAdmin=true, restoreLocale=true)"]
    E --> G{isPublicSite = !isAdmin}
    F --> G
    G -->|true| H["Render Analytics + public-site class"]
    G -->|false| I["No Analytics, no public-site class"]
    H --> J[Page HTML served to browser]
    I --> J
```

</a>

<sub>Reviews (2): Last reviewed commit: ["refactor: separate admin analytics bound..."](https://github.com/calicastle/cali.so/commit/de410e45f7b8a0badcf35eb8c1ee70c38b92195c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44762214)</sub>

<!-- /greptile_comment -->