### PR TITLE
Defer portrait reveal until client paint

### DIFF
--- a/app/_views/home-page.tsx
+++ b/app/_views/home-page.tsx
@@ -46,10 +46,7 @@ export async function HomePageView({ locale }: { locale: Locale }) {
             <HomeIntroduction social={social.x} github={github} />
           </div>
         </div>
-        <div
-          className="enter w-[9.35rem] shrink-0 sm:w-60"
-          style={{ '--enter-delay': '80ms' } as React.CSSProperties}
-        >
+        <div className="w-[9.35rem] shrink-0 sm:w-60">
           <HalftonePortrait
             srcLight="/images/headshot.jpg"
             srcDark="/images/portrait-square.jpg"

--- a/app/globals.css
+++ b/app/globals.css
@@ -2031,60 +2031,34 @@ a:focus-visible .external-label .external-mark {
   user-select: none;
 }
 
-/* the raw photo carries layout and serves as the no-JS fallback,
-   printed-down so it still sits quietly on the paper */
-.halftone-source {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  filter: grayscale(1) contrast(1.05);
-  opacity: 1;
-}
-
-.halftone-source[data-theme='light'] {
-  filter: contrast(1.12) saturate(1.05);
-}
-
-.halftone-source[data-theme='dark'] {
-  position: absolute;
-  inset: 0;
-  opacity: 0;
-}
-
-@media (prefers-color-scheme: dark) {
-  .halftone-source[data-theme='light'] {
-    opacity: 0;
-  }
-
-  .halftone-source[data-theme='dark'] {
-    opacity: 0.85;
-  }
-}
-
-html.light .halftone-source[data-theme='light'] {
-  opacity: 1;
-}
-
-html.dark .halftone-source[data-theme='dark'] {
-  opacity: 0.85;
-}
-
-html.light .halftone-source[data-theme='dark'],
-html.dark .halftone-source[data-theme='light'] {
-  opacity: 0;
-}
-
-[data-halftone][data-ready] .halftone-source[data-theme] {
-  opacity: 0;
-}
-
 .halftone-canvas {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
   color: var(--foreground);
+  opacity: 0;
+}
+
+@keyframes halftone-reveal {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+[data-halftone][data-ready] .halftone-canvas {
+  animation: halftone-reveal 400ms var(--ease-swift) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-halftone][data-ready] .halftone-canvas {
+    animation: none;
+    opacity: 1;
+  }
 }
 
 /* center-out list reveal with a tiny swing (rotate −2° → 0) */

--- a/components/halftone-portrait.test.tsx
+++ b/components/halftone-portrait.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+import { HalftonePortrait } from './halftone-portrait'
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}))
+
+describe('HalftonePortrait', () => {
+  it('keeps the server-rendered portrait visually empty', () => {
+    const container = document.createElement('div')
+    container.innerHTML = renderToStaticMarkup(
+      <HalftonePortrait
+        srcLight="/light.jpg"
+        srcDark="/dark.jpg"
+        alt="肖像"
+        altEn="Portrait"
+      />,
+    )
+
+    const shell = container.querySelector('[data-halftone]')
+    const sources = container.querySelectorAll('img')
+
+    expect(shell?.hasAttribute('data-ready')).toBe(false)
+    expect(sources).toHaveLength(2)
+    expect(Array.from(sources).every((source) => source.hidden)).toBe(true)
+    expect(container.querySelector('canvas')?.getAttribute('aria-label')).toBe('肖像')
+  })
+})

--- a/components/halftone-portrait.test.tsx
+++ b/components/halftone-portrait.test.tsx
@@ -5,12 +5,18 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { HalftonePortrait } from './halftone-portrait'
 
+const navigation = vi.hoisted(() => ({ pathname: '/' }))
+
 vi.mock('next/navigation', () => ({
-  usePathname: () => '/',
+  usePathname: () => navigation.pathname,
 }))
 
 describe('HalftonePortrait', () => {
-  it('keeps the server-rendered portrait visually empty', () => {
+  it.each([
+    { pathname: '/', label: '肖像' },
+    { pathname: '/en', label: 'Portrait' },
+  ])('keeps the $pathname server-rendered portrait visually empty', ({ pathname, label }) => {
+    navigation.pathname = pathname
     const container = document.createElement('div')
     container.innerHTML = renderToStaticMarkup(
       <HalftonePortrait
@@ -27,6 +33,6 @@ describe('HalftonePortrait', () => {
     expect(shell?.hasAttribute('data-ready')).toBe(false)
     expect(sources).toHaveLength(2)
     expect(Array.from(sources).every((source) => source.hidden)).toBe(true)
-    expect(container.querySelector('canvas')?.getAttribute('aria-label')).toBe('肖像')
+    expect(container.querySelector('canvas')?.getAttribute('aria-label')).toBe(label)
   })
 })

--- a/components/halftone-portrait.tsx
+++ b/components/halftone-portrait.tsx
@@ -138,10 +138,11 @@ export function HalftonePortrait({
     }
 
     function drawField(field: Field, alpha: number) {
-      if (alpha <= 0.01) return
+      if (alpha <= 0.01) return false
       ctx.globalAlpha = alpha
       ctx.fillStyle = field.ink
       const maxR = CELL * 0.52
+      let painted = false
       for (const cell of field.cells) {
         let { x, y } = cell
         let r = cell.tone * maxR
@@ -162,8 +163,10 @@ export function HalftonePortrait({
         ctx.beginPath()
         ctx.arc(x, y, r, 0, Math.PI * 2)
         ctx.fill()
+        painted = true
       }
       ctx.globalAlpha = 1
+      return painted
     }
 
     function draw() {
@@ -178,19 +181,16 @@ export function HalftonePortrait({
         const fromField = fields[fade.from]
         const toField = fields[fade.to]
         if (fromField) {
-          drawField(fromField, 1 - ease)
-          painted = true
+          painted = drawField(fromField, 1 - ease) || painted
         }
         if (toField) {
-          drawField(toField, ease)
-          painted = true
+          painted = drawField(toField, ease) || painted
         }
         if (t >= 1) fade = null
       } else {
         const field = fields[active]
         if (field) {
-          drawField(field, 1)
-          painted = true
+          painted = drawField(field, 1)
         }
       }
       if (painted && !wrapper.hasAttribute('data-ready')) {

--- a/components/halftone-portrait.tsx
+++ b/components/halftone-portrait.tsx
@@ -171,17 +171,30 @@ export function HalftonePortrait({
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
       ctx.clearRect(0, 0, cssW, cssH)
       const active: 'light' | 'dark' = isDark() ? 'dark' : 'light'
+      let painted = false
       if (fade) {
         const t = Math.min(1, (performance.now() - fade.start) / FADE_MS)
         const ease = t * t * (3 - 2 * t)
         const fromField = fields[fade.from]
         const toField = fields[fade.to]
-        if (fromField) drawField(fromField, 1 - ease)
-        if (toField) drawField(toField, ease)
+        if (fromField) {
+          drawField(fromField, 1 - ease)
+          painted = true
+        }
+        if (toField) {
+          drawField(toField, ease)
+          painted = true
+        }
         if (t >= 1) fade = null
       } else {
         const field = fields[active]
-        if (field) drawField(field, 1)
+        if (field) {
+          drawField(field, 1)
+          painted = true
+        }
+      }
+      if (painted && !wrapper.hasAttribute('data-ready')) {
+        wrapper.dataset.ready = ''
       }
     }
 
@@ -208,7 +221,6 @@ export function HalftonePortrait({
       canvas.height = Math.round(cssH * dpr)
       buildField('light')
       buildField('dark')
-      wrapper.dataset.ready = ''
       draw()
     }
 
@@ -267,8 +279,8 @@ export function HalftonePortrait({
 
   return (
     <span ref={wrapperRef} className={className} data-halftone>
-      {/* Keep both no-JS fallbacks in the document so CSS can select the
-          pre-paint-resolved theme before the canvas is ready. */}
+      {/* Warm both source images from the server HTML without exposing a
+          raw-photo frame before the client paints the halftone field. */}
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         src={srcLight}
@@ -276,8 +288,7 @@ export function HalftonePortrait({
         width={1000}
         height={1000}
         crossOrigin="anonymous"
-        className="halftone-source"
-        data-theme="light"
+        hidden
         aria-hidden
       />
       {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -287,8 +298,7 @@ export function HalftonePortrait({
         width={1000}
         height={1000}
         crossOrigin="anonymous"
-        className="halftone-source"
-        data-theme="dark"
+        hidden
         aria-hidden
       />
       <canvas

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -281,9 +281,12 @@ typewriter/ascii textures, measuring ticks, registration marks. Rules:
   below a 6% floor so the figure emerges from nothing. A fine pointer swells
   (+8%) and repels (≤3px) dots within ~150px, smoothed per-frame (0.16
   lerp, rAF only while active). Touch and reduced motion get the static
-  print; no-JS gets the photo printed down (grayscale, 85%). Its wrapper is
-  149.6px wide on mobile (15% below the original 176px presentation) and
-  returns to the fixed 240px size from the 40rem breakpoint onward.
+  print. The server-rendered shell is visually empty; once the client paints
+  the first valid dot field, the portrait fades in over 400ms. Reduced motion
+  reveals it instantly, while no-JS leaves the reserved square empty. Its
+  wrapper is 149.6px wide on mobile (15% below the original 176px
+  presentation) and returns to the fixed 240px size from the 40rem breakpoint
+  onward.
 - **Rulers**: measuring ticks (48px major / 12px minor) ride top and
   bottom as arcs of an enormous circle (fixed 40px rise at the viewport
   edge, so R = w²/8s at any width) — a bent steel rule whose ends bow away


### PR DESCRIPTION
The halftone portrait now reserves its layout on the server without exposing a raw-photo frame. The canvas becomes visible only after the client has painted a valid dot field.

## Implementation

- Keep both portrait source images hidden while preserving their server-side preload behavior.
- Mark the portrait ready only after a drawable field exists.
- Fade the canvas in over 400ms using opacity, with an instant reveal for reduced motion.
- Remove the independent server-driven entrance animation from the portrait wrapper.
- Document and test the empty server-rendered state.

## Verification

- `pnpm typecheck`
- `pnpm exec vitest run components/halftone-portrait.test.tsx`
- Headless first-paint check: server state had no ready marker, hidden sources, and canvas opacity `0`; hydrated state reached the ready marker and canvas opacity `1`.
- `pnpm exec vitest run lib/rate-limit/repository.test.ts` passed 3/3 in isolation.
- `pnpm test:unit` passed 456/457 tests; the existing PGlite rate-limit setup exceeded its 10-second hook timeout under parallel suite load.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR defers the halftone portrait's visible reveal until the client has painted a valid dot field, preventing a raw-photo flash before the halftone canvas is ready. Both source `<img>` elements are now rendered with the `hidden` attribute (preserving browser preload) while the canvas is initially invisible via `opacity: 0`; a CSS `halftone-reveal` animation is triggered only once `data-ready` lands on the wrapper.

- **Gated reveal**: `drawField` now returns a boolean, and `data-ready` is set on the wrapper only after at least one dot is actually rendered, replacing the previous unconditional set in `layout()`.
- **Reduced-motion & no-JS**: Reduced-motion users get an instant reveal via an `animation: none; opacity: 1` override; no-JS users see an empty reserved square (deliberate trade-off, documented).
- **Test coverage**: New `halftone-portrait.test.tsx` exercises both locale paths and confirms the server-rendered shell has no `data-ready`, hidden images, and a correct `aria-label`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are confined to the portrait reveal path and carry no regressions to the rest of the page.

The change is narrow and self-contained: it moves the data-ready gate from a one-time unconditional set in layout() to a per-frame check that requires actual canvas pixels, pairs it with a CSS fade-in, and tests the server-rendered shell end-to-end. The no-JS empty-square trade-off is explicitly documented. No data paths, routes, or shared state are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| components/halftone-portrait.tsx | Core change: `drawField` returns a boolean; `data-ready` is set only after a real paint; source images use `hidden` instead of CSS classes. Logic is correct and handles all ordering scenarios (image-before-layout, layout-before-image, theme-switch-after-ready). |
| app/globals.css | Removes the `.halftone-source` display/opacity rules; canvas now starts at `opacity: 0` and fades in via `halftone-reveal` animation on `[data-halftone][data-ready]`; reduced-motion override is present and correct. |
| components/halftone-portrait.test.tsx | New test file; `it.each` covers both locale paths (Chinese and English), verifying no `data-ready`, hidden images, and correct canvas `aria-label` in the server-rendered shell. |
| app/_views/home-page.tsx | Removes the `.enter` wrapper class and `--enter-delay` style from the portrait div, deferring the entrance animation entirely to the component's internal CSS reveal. |
| docs/design-language.md | Documentation updated to reflect the new deferred reveal behavior, including the no-JS empty-square trade-off and the 400ms fade with reduced-motion instant reveal. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant SSR as Server SSR
    participant DOM as DOM and CSS
    participant Effect as useEffect client
    participant Canvas as Canvas
    participant RO as ResizeObserver
    participant Img as Image loader

    SSR->>DOM: Render shell with data-halftone but no data-ready
    SSR->>DOM: hidden imgs, canvas opacity 0

    Note over DOM: First paint - portrait area empty

    Effect->>Img: loadImage light and dark
    Effect->>RO: ro.observe canvas

    RO->>Effect: layout fires, cssW and cssH measured
    Effect->>Canvas: buildField light and dark
    Effect->>Canvas: draw

    alt field has drawable dots
        Canvas->>DOM: set wrapper dataset ready
        DOM->>Canvas: CSS animation halftone-reveal 400ms opacity 0 to 1
        Note over Canvas: Portrait fades in
    else no cells or image not loaded
        Canvas-->>DOM: painted is false, data-ready withheld
    end

    Note over Effect: Theme switch via MutationObserver
    Effect->>Canvas: set fade from and to with start time then wake
    Canvas->>Canvas: drawField from and to per rAF frame
    Note over Canvas: Crossfade complete, data-ready already set
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant SSR as Server SSR
    participant DOM as DOM and CSS
    participant Effect as useEffect client
    participant Canvas as Canvas
    participant RO as ResizeObserver
    participant Img as Image loader

    SSR->>DOM: Render shell with data-halftone but no data-ready
    SSR->>DOM: hidden imgs, canvas opacity 0

    Note over DOM: First paint - portrait area empty

    Effect->>Img: loadImage light and dark
    Effect->>RO: ro.observe canvas

    RO->>Effect: layout fires, cssW and cssH measured
    Effect->>Canvas: buildField light and dark
    Effect->>Canvas: draw

    alt field has drawable dots
        Canvas->>DOM: set wrapper dataset ready
        DOM->>Canvas: CSS animation halftone-reveal 400ms opacity 0 to 1
        Note over Canvas: Portrait fades in
    else no cells or image not loaded
        Canvas-->>DOM: painted is false, data-ready withheld
    end

    Note over Effect: Theme switch via MutationObserver
    Effect->>Canvas: set fade from and to with start time then wake
    Canvas->>Canvas: drawField from and to per rAF frame
    Note over Canvas: Crossfade complete, data-ready already set
```

</a>

<sub>Reviews (3): Last reviewed commit: ["fix(site): tighten portrait readiness ch..."](https://github.com/calicastle/cali.so/commit/eba2ffb5bbb5fdac29c08bfb9014c0d4198bdc9b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44775562)</sub>

<!-- /greptile_comment -->