### PR TITLE
Fix mobile article map motion

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3622,7 +3622,7 @@ html[data-locale='en'] [data-en-block] {
     isolation: isolate;
     opacity: 0;
     pointer-events: none;
-    transform: translate(-50%, -0.75rem) scale(0.97);
+    transform: translate(-50%, -1rem) scale(0.96);
     transition:
       opacity 180ms var(--ease-swift),
       transform 200ms var(--ease-swift);
@@ -3648,7 +3648,7 @@ html[data-locale='en'] [data-en-block] {
     visibility: hidden;
     overflow: hidden;
     pointer-events: none;
-    transform: translateY(-0.375rem) scale(0.98);
+    transform: translateY(-0.75rem) scale(0.96);
     transform-origin: top center;
     transition:
       opacity 180ms var(--ease-swift),

--- a/components/post-toc.tsx
+++ b/components/post-toc.tsx
@@ -13,6 +13,10 @@ const DESKTOP_QUERY = '(min-width: 64rem)'
 const DESKTOP_EXIT_DURATION = 0.2
 const DESKTOP_EXIT_STAGGER_WINDOW = 0.06
 const EASE_SWIFT = [0.2, 0.8, 0.2, 1] as const
+const PHONE_ENTER_DURATION = 0.2
+const PHONE_ENTER_STAGGER_WINDOW = 0.06
+const PHONE_EXIT_DURATION = 0.16
+const PHONE_EXIT_STAGGER_WINDOW = 0.04
 const PHONE_QUERY = '(max-width: 39.99rem)'
 const TARGET_OFFSET = 100
 const RAIL_ID = 'post-document-minimap'
@@ -82,7 +86,7 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
     setActive(first)
   }, [landmarks])
 
-  function animateOpenState(nextOpen: boolean, pinRenderedState = false) {
+  function animateOpenState(nextOpen: boolean) {
     if (nextOpen === open) return
 
     const items = rootRef.current?.querySelectorAll<HTMLElement>('.post-minimap-node')
@@ -108,13 +112,21 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
       furthestCenterIndex > 0
         ? Math.min(0.01, DESKTOP_EXIT_STAGGER_WINDOW / furthestCenterIndex)
         : 0
+    const phoneStaggerWindow = nextOpen
+      ? PHONE_ENTER_STAGGER_WINDOW
+      : PHONE_EXIT_STAGGER_WINDOW
+    const phoneStagger =
+      furthestCenterIndex > 0
+        ? Math.min(0.01, phoneStaggerWindow / furthestCenterIndex)
+        : 0
 
-    if (closingDesktop || pinRenderedState) {
-      for (const item of items) {
-        const style = window.getComputedStyle(item)
-        item.style.opacity = style.opacity
-        item.style.transform = style.transform
-      }
+    // Motion otherwise resolves the first open against the incoming React
+    // state, so phone items jump directly to their final styles. Pinning the
+    // rendered frame also keeps rapid direction changes interruptible.
+    for (const item of items) {
+      const style = window.getComputedStyle(item)
+      item.style.opacity = style.opacity
+      item.style.transform = style.transform
     }
 
     const animation = animate(
@@ -126,11 +138,20 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
           : 'translateY(-8px) rotate(2deg)',
       },
       {
-        duration: closingDesktop ? DESKTOP_EXIT_DURATION : nextOpen ? 0.26 : 0.2,
-        delay: stagger(closingDesktop ? desktopExitStagger : nextOpen ? 0.012 : 0.01, {
-          from: 'center',
-        }),
-        ease: closingDesktop ? EASE_SWIFT : [0.23, 0.88, 0.26, 0.92],
+        duration: closingDesktop
+          ? DESKTOP_EXIT_DURATION
+          : phone
+            ? nextOpen
+              ? PHONE_ENTER_DURATION
+              : PHONE_EXIT_DURATION
+            : nextOpen
+              ? 0.26
+              : 0.2,
+        delay: stagger(
+          closingDesktop ? desktopExitStagger : phone ? phoneStagger : nextOpen ? 0.012 : 0.01,
+          { from: 'center' },
+        ),
+        ease: EASE_SWIFT,
       },
     )
     nodeAnimationRef.current = animation
@@ -169,7 +190,7 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
         frame = window.requestAnimationFrame(() => {
           frame = 0
           desktopEntrancePlayedRef.current = true
-          animateOpenState(true, true)
+          animateOpenState(true)
         })
         return
       }

--- a/e2e/instant-navigation.spec.ts
+++ b/e2e/instant-navigation.spec.ts
@@ -702,6 +702,83 @@ test('keyboard controls restore focus across public overlays', async ({ page }) 
   )
 })
 
+test('mobile article map animates its entrance and toggle states', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.goto(`/en/blog/${postSlug}`)
+
+  const island = page.locator('.post-minimap-island')
+  const articleMap = page.getByRole('button', { name: 'Open article map' })
+  await expect(island).toHaveCSS('opacity', '0')
+
+  const entranceDurations = await page.evaluate(async () => {
+    window.scrollTo(0, 700)
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+    )
+
+    return document
+      .querySelector('.post-minimap-island')
+      ?.getAnimations()
+      .map((animation) => animation.effect?.getComputedTiming().duration)
+  })
+  expect(entranceDurations).toEqual(expect.arrayContaining([180, 200]))
+  await expect(articleMap).toBeVisible()
+
+  const opening = await articleMap.evaluate(async (button) => {
+    if (!(button instanceof HTMLButtonElement)) {
+      throw new Error('Article map toggle is not a button')
+    }
+    button.click()
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
+    const map = document.querySelector('.post-minimap')
+    const nodes = [...document.querySelectorAll('.post-minimap-node')]
+    return {
+      expanded: button.getAttribute('aria-expanded'),
+      mapAnimations: map?.getAnimations().length ?? 0,
+      nodeAnimations: nodes.reduce(
+        (count, node) => count + node.getAnimations().length,
+        0,
+      ),
+    }
+  })
+  expect(opening.expanded).toBe('true')
+  expect(opening.mapAnimations).toBeGreaterThan(0)
+  expect(opening.nodeAnimations).toBeGreaterThan(0)
+
+  await page.waitForFunction(() =>
+    [...document.querySelectorAll('.post-minimap-node')].every(
+      (node) => node.getAnimations().length === 0,
+    ),
+  )
+
+  const closing = await page
+    .getByRole('button', { name: 'Close article map' })
+    .evaluate(async (button) => {
+      if (!(button instanceof HTMLButtonElement)) {
+        throw new Error('Article map toggle is not a button')
+      }
+      button.click()
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
+      const map = document.querySelector('.post-minimap')
+      const nodes = [...document.querySelectorAll('.post-minimap-node')]
+      return {
+        expanded: button.getAttribute('aria-expanded'),
+        mapAnimations: map?.getAnimations().length ?? 0,
+        nodeAnimations: nodes.reduce(
+          (count, node) => count + node.getAnimations().length,
+          0,
+        ),
+      }
+    })
+  expect(closing.expanded).toBe('false')
+  expect(closing.mapAnimations).toBeGreaterThan(0)
+  expect(closing.nodeAnimations).toBeGreaterThan(0)
+})
+
 test('administration stays outside public prefetching and requires login', async ({
   page,
 }) => {

--- a/e2e/instant-navigation.spec.ts
+++ b/e2e/instant-navigation.spec.ts
@@ -712,17 +712,30 @@ test('mobile article map animates its entrance and toggle states', async ({
   const articleMap = page.getByRole('button', { name: 'Open article map' })
   await expect(island).toHaveCSS('opacity', '0')
 
-  const entranceDurations = await page.evaluate(async () => {
-    window.scrollTo(0, 700)
-    await new Promise<void>((resolve) =>
-      requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
-    )
+  const entranceDurations = await island.evaluate(
+    (element) =>
+      new Promise<number[]>((resolve, reject) => {
+        const timeout = window.setTimeout(() => {
+          element.removeEventListener('transitionrun', captureTransition)
+          reject(new Error('Mobile article map entrance did not start'))
+        }, 5_000)
+        const captureTransition = (event: Event) => {
+          if (event.target !== element) return
+          const durations = element
+            .getAnimations()
+            .map((animation) => animation.effect?.getComputedTiming().duration)
+            .filter((duration): duration is number => typeof duration === 'number')
+          if (!durations.includes(180) || !durations.includes(200)) return
 
-    return document
-      .querySelector('.post-minimap-island')
-      ?.getAnimations()
-      .map((animation) => animation.effect?.getComputedTiming().duration)
-  })
+          window.clearTimeout(timeout)
+          element.removeEventListener('transitionrun', captureTransition)
+          resolve(durations)
+        }
+
+        element.addEventListener('transitionrun', captureTransition)
+        window.scrollTo(0, 700)
+      }),
+  )
   expect(entranceDurations).toEqual(expect.arrayContaining([180, 200]))
   await expect(articleMap).toBeVisible()
 


### PR DESCRIPTION
## Summary

- Preserve each rendered map item before Motion takes over so the first expansion and rapid direction changes animate from the visible frame.
- Bound the phone enter and exit stagger windows to the panel timing, use the shared swift easing, and strengthen the collapsed island and expanded panel entrance transforms.
- Cover the mobile island entrance plus both toggle directions with a browser regression.

## Verification

- `pnpm typecheck`
- `PLAYWRIGHT_BASE_URL=http://localhost:3000 pnpm exec playwright test e2e/instant-navigation.spec.ts --grep 'mobile article map animates'`
- `pnpm exec vitest run lib/rate-limit/repository.test.ts`
- `pnpm test:unit` reached 457 of 458 passing tests; the PGlite setup hook in `lib/rate-limit/repository.test.ts` timed out under full-suite load, while its isolated rerun passed all 3 tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes mobile article map animation by always pinning each node's rendered frame before Motion takes over, ensuring the first expand and rapid direction reversals animate from the visible state rather than jumping to final styles. It also adds phone-specific timing constants, unifies all easing to `EASE_SWIFT`, strengthens the collapsed island and expanded panel entrance transforms in CSS, and adds an E2E Playwright test covering the mobile entrance, open, and close animation states.

- **`components/post-toc.tsx`**: Removes the `pinRenderedState` parameter and makes rendered-frame pinning unconditional; introduces `PHONE_ENTER/EXIT_DURATION/STAGGER_WINDOW` constants and wires them into the animation options alongside the existing desktop path.
- **`app/globals.css`**: Deepens the island hidden-state offset from `-0.75rem` to `-1rem` and scale from `0.97` to `0.96`, and the panel from `-0.375rem scale(0.98)` to `-0.75rem scale(0.96)` — purely visual entrance strengthening.
- **`e2e/instant-navigation.spec.ts`**: Adds the `mobile article map animates its entrance and toggle states` test covering scroll-triggered island entrance, open expansion, and close collapse via `getAnimations()` assertions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are scoped to mobile animation timing and entrance transforms with no logic paths affecting data or server-side behavior.

The core change (unconditional rendered-frame pinning in `animateOpenState`) is a targeted fix for a well-understood Motion WAAPI issue, and the old `pinRenderedState` codepath already exercised the same mechanism for desktop. Phone-specific timing constants are isolated to animation options and cannot affect layout or state. The CSS transform tweaks are visual-only. The new E2E test meaningfully exercises the changed code path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| components/post-toc.tsx | Removes the `pinRenderedState` parameter and makes rendered-frame pinning unconditional; adds phone-specific timing constants and wires them into animation options; unifies ease to EASE_SWIFT. Logic is correct and well-commented. |
| app/globals.css | Strengthens collapsed-island hidden transform (Y offset -0.75rem→-1rem, scale 0.97→0.96) and panel entrance transform (-0.375rem scale(0.98)→-0.75rem scale(0.96)). Pure visual polish; no behavioral regressions. |
| e2e/instant-navigation.spec.ts | Adds mobile article map test: entrance via scroll + transitionrun listener, toggle open via single-rAF getAnimations check, waitForFunction for animation completion, then toggle close. Coverage is solid; entrance timing race already noted in prior review thread. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[animateOpenState called] --> B{nextOpen === open?}
    B -- yes --> Z[return early]
    B -- no --> C{reducedMotion?}
    C -- yes --> D[cancel animation\nsetOpen immediately]
    C -- no --> E{items empty?}
    E -- yes --> F[setOpen immediately]
    E -- no --> G[Stop any running animation]
    G --> H[Compute stagger values\ndesktop / phone paths]
    H --> I[Pin rendered frame\nfor ALL items\ngetComputedStyle → inline style]
    I --> J[motion animate items\nopacity + transform]
    J --> K[flushSync setOpen\ntriggers CSS transitions\non .post-minimap]
    K --> L{animation.finished}
    L -- resolved --> M[animation.cancel\nclear ref]
    L -- rejected --> N[ignore]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[animateOpenState called] --> B{nextOpen === open?}
    B -- yes --> Z[return early]
    B -- no --> C{reducedMotion?}
    C -- yes --> D[cancel animation\nsetOpen immediately]
    C -- no --> E{items empty?}
    E -- yes --> F[setOpen immediately]
    E -- no --> G[Stop any running animation]
    G --> H[Compute stagger values\ndesktop / phone paths]
    H --> I[Pin rendered frame\nfor ALL items\ngetComputedStyle → inline style]
    I --> J[motion animate items\nopacity + transform]
    J --> K[flushSync setOpen\ntriggers CSS transitions\non .post-minimap]
    K --> L{animation.finished}
    L -- resolved --> M[animation.cancel\nclear ref]
    L -- rejected --> N[ignore]
```

</a>

<sub>Reviews (3): Last reviewed commit: ["test(site): stabilize mobile toc motion ..."](https://github.com/calicastle/cali.so/commit/8825d3f0ced5b001614128628f4af487eebb7a9d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44786387)</sub>

<!-- /greptile_comment -->