### PR TITLE
Fix admin Clerk session context

### DIFF
--- a/app/admin/layout.test.tsx
+++ b/app/admin/layout.test.tsx
@@ -1,0 +1,25 @@
+import { ClerkProvider } from '@clerk/nextjs'
+import { describe, expect, it, vi } from 'vitest'
+
+import { SiteDocument } from '../_components/site-document'
+import AdminRootLayout from './layout'
+
+vi.mock('@clerk/nextjs', () => ({
+  ClerkProvider: vi.fn(),
+}))
+
+vi.mock('../_components/site-document', () => ({
+  rootMetadata: {},
+  SiteDocument: vi.fn(),
+}))
+
+describe('admin root layout', () => {
+  it('provides Clerk session context inside the document body', () => {
+    const children = <div>Admin</div>
+    const layout = AdminRootLayout({ children })
+
+    expect(layout.type).toBe(SiteDocument)
+    expect(layout.props.children.type).toBe(ClerkProvider)
+    expect(layout.props.children.props).toMatchObject({ children, dynamic: true })
+  })
+})

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,5 +1,7 @@
 import '../globals.css'
 
+import { ClerkProvider } from '@clerk/nextjs'
+
 import { rootMetadata, SiteDocument } from '../_components/site-document'
 
 export const metadata = rootMetadata
@@ -11,7 +13,7 @@ export const prefetch = 'force-disabled'
 export default function AdminRootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <SiteDocument isAdmin locale="zh" restoreLocale>
-      {children}
+      <ClerkProvider dynamic>{children}</ClerkProvider>
     </SiteDocument>
   )
 }


### PR DESCRIPTION
The admin route now owns a dynamic `ClerkProvider` inside the document body. This keeps Clerk client session context limited to `/admin` while preserving the public site's existing static and analytics boundaries.

The authenticated admin dashboard calls `useSession()` through the passkey reverification hook. Server-side authorization succeeded, but the client tree had no provider, causing the dashboard to fail with a 500 after sign-in. The added layout regression test locks down the provider boundary and its dynamic rendering contract.

The strict admin `frame-src 'none'` CSP remains unchanged. The blocked `vercel.live` toolbar frame is unrelated to the Clerk render failure.

## Verification

- `pnpm typecheck`
- `pnpm exec vitest run app/admin/layout.test.tsx lib/admin lib/ama/admin/dashboard.test.tsx lib/media/admin/ui.test.tsx lib/media/admin/photo-selection-ui.test.tsx` (47 passed)
- `pnpm test:security` (5 passed)
- `pnpm build` compiled successfully, then stopped during page generation because the local checkout does not have the required server environment variables

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a client-side 500 error in the admin dashboard by adding a `ClerkProvider dynamic` wrapper inside `app/admin/layout.tsx`. Without it, the admin client tree had no Clerk session context provider, so any hook calling `useSession()` (e.g., the passkey reverification hook) would throw at runtime.

- `app/admin/layout.tsx`: Wraps the admin layout's children in `<ClerkProvider dynamic>`, scoping Clerk session context to the `/admin` route while keeping the public site's rendering boundaries unaffected.
- `app/admin/layout.test.tsx`: Adds a new unit test that asserts the exact provider nesting (`SiteDocument → ClerkProvider → children`) and verifies the `dynamic` prop is set.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge — it adds a single provider wrapper to the admin root layout and a matching regression test, with no impact on the public site's rendering boundaries.

The fix is minimal and precisely targeted: one extra JSX wrapper in the admin-only layout and a new test that locks down the provider nesting. The `dynamic` prop correctly opts Clerk out of static rendering, consistent with the existing `instant = false` and `prefetch = 'force-disabled'` directives on the same file. No other layouts or rendering paths are touched.

No files require special attention — both changed files are straightforward and consistent with the rest of the admin routing structure.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/admin/layout.tsx | Adds `ClerkProvider dynamic` as the sole child of `SiteDocument` in the admin root layout, fixing the missing Clerk session context that caused a 500 on the authenticated dashboard. |
| app/admin/layout.test.tsx | New regression test verifying that `AdminRootLayout` renders `SiteDocument` with a `ClerkProvider dynamic` child; correctly mocks both imports and checks the JSX element structure directly. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant AdminLayout as app/admin/layout.tsx
    participant SiteDocument as SiteDocument (async RSC)
    participant ClerkProvider as ClerkProvider (dynamic)
    participant ProtectedLayout as (protected)/layout.tsx
    participant Dashboard as Admin Dashboard

    Browser->>AdminLayout: "GET /admin/*"
    AdminLayout->>SiteDocument: "render (isAdmin, locale="zh")"
    SiteDocument->>ClerkProvider: "render (dynamic=true)"
    Note over ClerkProvider: Provides Clerk session context<br/>to all /admin client components
    ClerkProvider->>ProtectedLayout: render children
    ProtectedLayout->>ProtectedLayout: requireOwnerPage() [server auth]
    ProtectedLayout->>Dashboard: render AdminShell + page
    Note over Dashboard: useSession() now works —<br/>ClerkProvider is in tree
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant AdminLayout as app/admin/layout.tsx
    participant SiteDocument as SiteDocument (async RSC)
    participant ClerkProvider as ClerkProvider (dynamic)
    participant ProtectedLayout as (protected)/layout.tsx
    participant Dashboard as Admin Dashboard

    Browser->>AdminLayout: "GET /admin/*"
    AdminLayout->>SiteDocument: "render (isAdmin, locale="zh")"
    SiteDocument->>ClerkProvider: "render (dynamic=true)"
    Note over ClerkProvider: Provides Clerk session context<br/>to all /admin client components
    ClerkProvider->>ProtectedLayout: render children
    ProtectedLayout->>ProtectedLayout: requireOwnerPage() [server auth]
    ProtectedLayout->>Dashboard: render AdminShell + page
    Note over Dashboard: useSession() now works —<br/>ClerkProvider is in tree
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(admin): provide Clerk session contex..."](https://github.com/calicastle/cali.so/commit/a9fead0913896e200ebdc750ffeef951b6b4d266) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44836622)</sub>

<!-- /greptile_comment -->