### PR TITLE
Fix admin sessions and compact the shell

### DIFF
--- a/app/_components/site-document.tsx
+++ b/app/_components/site-document.tsx
@@ -40,11 +40,32 @@ export async function SiteDocument({
   locale: Locale
   restoreLocale?: boolean
 }>) {
-  // Live-but-cached social numbers (ISR via the fetch data cache) keep the
-  // shared chrome fresh without making any page request-bound.
-  const [social, github] = await Promise.all([getSocial(), getGitHub()])
   const english = locale === 'en'
-  const isPublicSite = !isAdmin
+
+  if (isAdmin) {
+    return (
+      <html
+        lang={english ? 'en' : 'zh-CN'}
+        data-locale={english ? 'en' : undefined}
+        suppressHydrationWarning
+        className={cn('font-sans', fontVariables)}
+      >
+        <head>
+          <script dangerouslySetInnerHTML={{ __html: PREPAINT_SCRIPT }} />
+        </head>
+        <body className="antialiased">
+          <ThemeProvider>
+            {restoreLocale && <LocaleRestorer />}
+            {children}
+          </ThemeProvider>
+        </body>
+      </html>
+    )
+  }
+
+  // Live-but-cached social numbers (ISR via the fetch data cache) keep the
+  // shared public chrome fresh without making any page request-bound.
+  const [social, github] = await Promise.all([getSocial(), getGitHub()])
 
   return (
     <html
@@ -52,7 +73,7 @@ export async function SiteDocument({
       data-locale={english ? 'en' : undefined}
       data-route-motion="none"
       suppressHydrationWarning
-      className={cn('font-sans', fontVariables, isPublicSite && 'public-site')}
+      className={cn('font-sans', fontVariables, 'public-site')}
     >
       <head>
         {/* Pre-paint handles the visited flag and theme. Locale restoration
@@ -76,7 +97,7 @@ export async function SiteDocument({
             <Dock />
           </Suspense>
         </ThemeProvider>
-        {isPublicSite && <Analytics />}
+        <Analytics />
       </body>
     </html>
   )

--- a/app/admin/(protected)/AdminShell.test.tsx
+++ b/app/admin/(protected)/AdminShell.test.tsx
@@ -14,7 +14,11 @@ describe('AdminShell', () => {
     })
     const sections = Children.toArray(shell.props.children).filter(
       isValidElement,
-    ) as ReactElement<{ className: string; children?: React.ReactNode }>[]
+    ) as ReactElement<{
+      className: string
+      children?: React.ReactNode
+      style?: React.CSSProperties
+    }>[]
     const nav = sections.find((section) => section.type === 'nav')
     const main = sections.find((section) => section.type === 'main')
     const links = Children.toArray(nav?.props.children).filter(
@@ -28,7 +32,11 @@ describe('AdminShell', () => {
     expect(shell.props.className).toContain('grid')
     expect(shell.props.className).toContain('lg:grid-cols-[11rem_minmax(0,1fr)]')
     expect(nav?.props.className).toContain('grid')
+    expect(nav?.props.className).toContain(
+      'grid-cols-[repeat(var(--admin-nav-columns),minmax(0,1fr))]',
+    )
     expect(nav?.props.className).toContain('lg:grid-cols-1')
+    expect(nav?.props.style).toMatchObject({ '--admin-nav-columns': 3 })
     expect(main?.props.className).toContain('min-w-0')
     expect(main?.props.children).toEqual(<section>Media content</section>)
     expect(links).toHaveLength(3)

--- a/app/admin/(protected)/AdminShell.test.tsx
+++ b/app/admin/(protected)/AdminShell.test.tsx
@@ -1,0 +1,42 @@
+import { Children, isValidElement, type ReactElement } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/admin/media',
+}))
+
+import { AdminShell } from './AdminShell'
+
+describe('AdminShell', () => {
+  it('uses compact grid chrome with a responsive sidebar', () => {
+    const shell = AdminShell({
+      children: <section>Media content</section>,
+    })
+    const sections = Children.toArray(shell.props.children).filter(
+      isValidElement,
+    ) as ReactElement<{ className: string; children?: React.ReactNode }>[]
+    const nav = sections.find((section) => section.type === 'nav')
+    const main = sections.find((section) => section.type === 'main')
+    const links = Children.toArray(nav?.props.children).filter(
+      isValidElement,
+    ) as ReactElement<{
+      href: string
+      prefetch: boolean
+      'aria-current'?: string
+    }>[]
+
+    expect(shell.props.className).toContain('grid')
+    expect(shell.props.className).toContain('lg:grid-cols-[11rem_minmax(0,1fr)]')
+    expect(nav?.props.className).toContain('grid')
+    expect(nav?.props.className).toContain('lg:grid-cols-1')
+    expect(main?.props.className).toContain('min-w-0')
+    expect(main?.props.children).toEqual(<section>Media content</section>)
+    expect(links).toHaveLength(3)
+    expect(links.every((link) => link.props.prefetch === false)).toBe(true)
+    expect(
+      links
+        .find((link) => link.props.href === '/admin/media')
+        ?.props['aria-current'],
+    ).toBe('page')
+  })
+})

--- a/app/admin/(protected)/AdminShell.tsx
+++ b/app/admin/(protected)/AdminShell.tsx
@@ -34,7 +34,12 @@ export function AdminShell({ children }: { children: React.ReactNode }) {
       </header>
       <nav
         aria-label="Admin"
-        className="grid grid-cols-3 gap-1 border-b border-dashed border-border py-3 lg:grid-cols-1 lg:content-start lg:border-b-0 lg:border-r lg:py-6 lg:pr-4"
+        style={
+          {
+            '--admin-nav-columns': navigation.length,
+          } as React.CSSProperties
+        }
+        className="grid grid-cols-[repeat(var(--admin-nav-columns),minmax(0,1fr))] gap-1 border-b border-dashed border-border py-3 lg:grid-cols-1 lg:content-start lg:border-b-0 lg:border-r lg:py-6 lg:pr-4"
       >
         {navigation.map((item) => {
           const selected =

--- a/app/admin/(protected)/AdminShell.tsx
+++ b/app/admin/(protected)/AdminShell.tsx
@@ -15,40 +15,15 @@ export function AdminShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
 
   return (
-    <div className="mx-auto min-h-dvh w-full max-w-[80rem] px-6 pb-16 pt-6 sm:px-8">
-      <header className="flex min-h-11 flex-wrap items-center justify-between gap-x-8 gap-y-3 border-b border-dashed border-border pb-5">
+    <div className="mx-auto grid min-h-dvh w-full max-w-[90rem] grid-cols-1 grid-rows-[auto_auto_1fr] px-4 sm:px-6 lg:grid-cols-[11rem_minmax(0,1fr)] lg:grid-rows-[auto_1fr] lg:px-8">
+      <header className="grid min-h-16 grid-cols-[minmax(0,1fr)_auto] items-center gap-4 border-b border-dashed border-border lg:col-span-2">
         <Link
           href="/admin"
           className="text-sm font-medium tracking-[-0.011em] text-muted-foreground outline-none focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
         >
           CALI / ADMIN
         </Link>
-        <nav
-          aria-label="Admin"
-          className="order-3 flex w-full items-center gap-1 sm:order-none sm:w-auto"
-        >
-          {navigation.map((item) => {
-            const selected =
-              item.href === '/admin'
-                ? pathname === item.href
-                : pathname.startsWith(item.href)
-            return (
-              <Link
-                key={item.href}
-                href={item.href}
-                aria-current={selected ? 'page' : undefined}
-                className={`flex min-h-11 items-center rounded-md px-3 text-sm outline-none focus-visible:ring-1 focus-visible:ring-foreground ${
-                  selected
-                    ? 'bg-foreground text-background'
-                    : 'text-muted-foreground hover:bg-hover hover:text-foreground'
-                }`}
-              >
-                <T zh={item.zh} en={item.en} />
-              </Link>
-            )
-          })}
-        </nav>
-        <form action="/api/admin/auth/logout" method="post" className="ml-auto">
+        <form action="/api/admin/auth/logout" method="post">
           <button
             type="submit"
             className="min-h-11 touch-manipulation px-2 text-sm text-muted-foreground outline-none transition-transform duration-100 active:scale-[0.97] focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground motion-reduce:transform-none"
@@ -57,7 +32,33 @@ export function AdminShell({ children }: { children: React.ReactNode }) {
           </button>
         </form>
       </header>
-      <div className="pt-8">{children}</div>
+      <nav
+        aria-label="Admin"
+        className="grid grid-cols-3 gap-1 border-b border-dashed border-border py-3 lg:grid-cols-1 lg:content-start lg:border-b-0 lg:border-r lg:py-6 lg:pr-4"
+      >
+        {navigation.map((item) => {
+          const selected =
+            item.href === '/admin'
+              ? pathname === item.href
+              : pathname.startsWith(item.href)
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              prefetch={false}
+              aria-current={selected ? 'page' : undefined}
+              className={`flex min-h-11 min-w-0 items-center justify-center rounded-md px-3 text-sm outline-none focus-visible:ring-1 focus-visible:ring-foreground lg:justify-start ${
+                selected
+                  ? 'bg-foreground text-background'
+                  : 'text-muted-foreground hover:bg-hover hover:text-foreground'
+              }`}
+            >
+              <T zh={item.zh} en={item.en} />
+            </Link>
+          )
+        })}
+      </nav>
+      <main className="min-w-0 py-6 lg:px-8 lg:py-8">{children}</main>
     </div>
   )
 }

--- a/app/admin/(protected)/media/page.tsx
+++ b/app/admin/(protected)/media/page.tsx
@@ -13,10 +13,10 @@ export const metadata: Metadata = {
 
 export default async function AdminMediaPage() {
   const owner = await requireOwnerPage('/admin/media')
-  const { review } = getMediaAdminPageServices()
+  const { listAssets } = getMediaAdminPageServices()
   const [active, archived] = await Promise.all([
-    review.listAssets({ ownerUserId: owner.id, view: 'active' }),
-    review.listAssets({ ownerUserId: owner.id, view: 'archived' }),
+    listAssets({ ownerUserId: owner.id, view: 'active' }),
+    listAssets({ ownerUserId: owner.id, view: 'archived' }),
   ])
   return <MediaLibrary initialActive={active} initialArchived={archived} />
 }

--- a/app/admin/(protected)/media/page.tsx
+++ b/app/admin/(protected)/media/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 
 import { requireOwnerPage } from '~/lib/admin/server'
-import { getMediaAdminServices } from '~/lib/media/admin/server'
+import { getMediaAdminPageServices } from '~/lib/media/admin/server'
 import { nonPublicRobots } from '~/lib/non-public-metadata'
 
 import { MediaLibrary } from './MediaLibrary'
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 
 export default async function AdminMediaPage() {
   const owner = await requireOwnerPage('/admin/media')
-  const { review } = getMediaAdminServices()
+  const { review } = getMediaAdminPageServices()
   const [active, archived] = await Promise.all([
     review.listAssets({ ownerUserId: owner.id, view: 'active' }),
     review.listAssets({ ownerUserId: owner.id, view: 'archived' }),

--- a/app/admin/(protected)/photos/page.tsx
+++ b/app/admin/(protected)/photos/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 
 import { requireOwnerPage } from '~/lib/admin/server'
-import { getMediaAdminServices } from '~/lib/media/admin/server'
+import { getMediaAdminPageServices } from '~/lib/media/admin/server'
 import { nonPublicRobots } from '~/lib/non-public-metadata'
 
 import { PhotoSelectionEditor } from './PhotoSelectionEditor'
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
 export default async function AdminPhotosPage() {
   const owner = await requireOwnerPage('/admin/photos')
 
-  const { review, selection } = getMediaAdminServices()
+  const { review, selection } = getMediaAdminPageServices()
   const [draft, assets] = await Promise.all([
     selection.getDraft(owner.id),
     review.listAssets({ ownerUserId: owner.id, view: 'active' }),

--- a/app/admin/(protected)/photos/page.tsx
+++ b/app/admin/(protected)/photos/page.tsx
@@ -14,10 +14,10 @@ export const metadata: Metadata = {
 export default async function AdminPhotosPage() {
   const owner = await requireOwnerPage('/admin/photos')
 
-  const { review, selection } = getMediaAdminPageServices()
+  const { getDraft, listAssets } = getMediaAdminPageServices()
   const [draft, assets] = await Promise.all([
-    selection.getDraft(owner.id),
-    review.listAssets({ ownerUserId: owner.id, view: 'active' }),
+    getDraft(owner.id),
+    listAssets({ ownerUserId: owner.id, view: 'active' }),
   ])
 
   return <PhotoSelectionEditor initialDraft={draft} initialAssets={assets} />

--- a/app/site-document.test.tsx
+++ b/app/site-document.test.tsx
@@ -1,5 +1,5 @@
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('react', async (importOriginal) => {
   const react = await importOriginal<typeof import('react')>()
@@ -18,14 +18,14 @@ vi.mock('~/components/ambient-background', () => ({
   AmbientBackground: () => null,
 }))
 vi.mock('~/components/dock', () => ({
-  Dock: () => null,
-  DockFallback: () => null,
+  Dock: () => <span data-public-dock="" />,
+  DockFallback: () => <span data-public-dock-fallback="" />,
 }))
 vi.mock('~/components/locale-restorer', () => ({
   LocaleRestorer: () => null,
 }))
 vi.mock('~/components/site-footer', () => ({
-  SiteFooter: () => null,
+  SiteFooter: () => <span data-public-footer="" />,
 }))
 vi.mock('~/components/theme-provider', () => ({
   ThemeProvider: ({ children }: { children: React.ReactNode }) => children,
@@ -37,11 +37,22 @@ vi.mock('~/lib/social-live', () => ({
   getGitHub: vi.fn().mockResolvedValue({}),
   getSocial: vi.fn().mockResolvedValue({}),
 }))
+vi.mock('~/components/route-motion-controller', () => ({
+  RouteMotionController: () => <span data-public-route-motion="" />,
+  RouteViewTransition: ({ children }: { children: React.ReactNode }) => (
+    <div data-public-route-transition="">{children}</div>
+  ),
+}))
 vi.mock('./fonts', () => ({
   fontVariables: '',
 }))
 
 import { SiteDocument } from './_components/site-document'
+import { getGitHub, getSocial } from '~/lib/social-live'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
 
 describe('SiteDocument analytics', () => {
   it('collects page views across the public route families', async () => {
@@ -54,10 +65,13 @@ describe('SiteDocument analytics', () => {
       )
 
       expect(html).toContain('data-vercel-analytics')
+      expect(html).toContain('data-public-dock')
+      expect(html).toContain('data-public-footer')
+      expect(html).toContain('data-public-route-transition')
     }
   })
 
-  it('keeps owner-admin routes outside public analytics', async () => {
+  it('keeps owner-admin routes outside public chrome and social reads', async () => {
     const html = renderToStaticMarkup(
       await SiteDocument({
         children: <p>Owner admin</p>,
@@ -67,5 +81,12 @@ describe('SiteDocument analytics', () => {
     )
 
     expect(html).not.toContain('data-vercel-analytics')
+    expect(html).not.toContain('data-public-dock')
+    expect(html).not.toContain('data-public-footer')
+    expect(html).not.toContain('data-public-route-motion')
+    expect(html).not.toContain('data-public-route-transition')
+    expect(html).toContain('Owner admin')
+    expect(getSocial).not.toHaveBeenCalled()
+    expect(getGitHub).not.toHaveBeenCalled()
   })
 })

--- a/lib/media/admin/server.test.ts
+++ b/lib/media/admin/server.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import { getMediaAdminPageServices } from './server'
+
+const mediaEnvironmentNames = [
+  'BUNNY_MEDIA_REGION',
+  'BUNNY_ORIGINALS_ZONE',
+  'BUNNY_ORIGINALS_PASSWORD',
+  'BUNNY_RENDITIONS_ZONE',
+  'BUNNY_RENDITIONS_PASSWORD',
+  'BUNNY_RENDITIONS_CDN_URL',
+  'BUNNY_CDN_API_KEY',
+  'MEDIA_ENCRYPTION_KEY',
+] as const
+
+const previousEnvironment = Object.fromEntries(
+  mediaEnvironmentNames.map((name) => [name, process.env[name]]),
+)
+
+afterEach(() => {
+  for (const name of mediaEnvironmentNames) {
+    const value = previousEnvironment[name]
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+  }
+})
+
+describe('Media admin page services', () => {
+  it('does not initialize write-only secrets while listing assets', () => {
+    for (const name of mediaEnvironmentNames) delete process.env[name]
+    process.env.BUNNY_RENDITIONS_CDN_URL = 'https://media.cali.so'
+
+    expect(() => getMediaAdminPageServices()).not.toThrow()
+  })
+})

--- a/lib/media/admin/server.test.ts
+++ b/lib/media/admin/server.test.ts
@@ -32,6 +32,13 @@ describe('Media admin page services', () => {
     for (const name of mediaEnvironmentNames) delete process.env[name]
     process.env.BUNNY_RENDITIONS_CDN_URL = 'https://media.cali.so'
 
-    expect(() => getMediaAdminPageServices()).not.toThrow()
+    const services = getMediaAdminPageServices()
+
+    expect(services).toEqual({
+      getDraft: expect.any(Function),
+      listAssets: expect.any(Function),
+    })
+    expect(services).not.toHaveProperty('review')
+    expect(services).not.toHaveProperty('selection')
   })
 })

--- a/lib/media/admin/server.ts
+++ b/lib/media/admin/server.ts
@@ -33,20 +33,44 @@ import { createMediaPurgeRepository } from '../purge/repository'
 import { createMediaPurgeService } from '../purge/service'
 import { createMediaReconciliationRepository } from '../reconciliation/repository'
 import { createMediaReconciliationService } from '../reconciliation/service'
+import { createPublicRenditionUrl } from '../storage/bunny'
+import { parseBunnyRenditionCdnEnv } from '../storage/config'
 import { getMediaStorage } from '../storage/server'
 
 let services: ReturnType<typeof createServices> | undefined
+let pageServices: ReturnType<typeof createPageServices> | undefined
+
+function createCatalogServices(publicRenditionUrl: (key: string) => string) {
+  const database = () => getDatabase()
+  const review = createMediaAssetReviewService({
+    repository: createMediaAssetReviewRepository(database, publicRenditionUrl),
+  })
+  const selection = createPhotoSelectionService({
+    repository: createPhotoSelectionRepository(database),
+    invalidatePublicSelection: async () => {
+      // Next 16.3 requires a cache-life profile or expire object here;
+      // updateTag is restricted to Server Actions and this runs in a Route Handler.
+      revalidateTag(PUBLIC_PHOTO_SELECTION_CACHE_TAG, { expire: 0 })
+    },
+  })
+
+  return { database, review, selection }
+}
+
+function createPageServices() {
+  const cdnBaseUrl = parseBunnyRenditionCdnEnv(process.env)
+  const { review, selection } = createCatalogServices(
+    createPublicRenditionUrl(cdnBaseUrl),
+  )
+  return { review, selection }
+}
 
 function createServices() {
   const environment = getServerEnv()
   const storage = getMediaStorage()
-  const database = () => getDatabase()
-  const review = createMediaAssetReviewService({
-    repository: createMediaAssetReviewRepository(
-      database,
-      storage.publicRenditionUrl,
-    ),
-  })
+  const { database, review, selection } = createCatalogServices(
+    storage.publicRenditionUrl,
+  )
   const ingestionRepository = createMediaIngestionRepository(database)
   const mediaEncryptionKey = process.env.MEDIA_ENCRYPTION_KEY
   if (!mediaEncryptionKey) {
@@ -62,15 +86,6 @@ function createServices() {
     repository: createMediaPurgeRepository(database),
     storage,
   })
-  const selection = createPhotoSelectionService({
-    repository: createPhotoSelectionRepository(database),
-    invalidatePublicSelection: async () => {
-      // Next 16.3 requires a cache-life profile or expire object here;
-      // updateTag is restricted to Server Actions and this runs in a Route Handler.
-      revalidateTag(PUBLIC_PHOTO_SELECTION_CACHE_TAG, { expire: 0 })
-    },
-  })
-
   const altTextConfig = parseMediaAltTextEnv(process.env)
   const altText = altTextConfig.enabled
     ? createMediaAltTextService({
@@ -121,6 +136,11 @@ function createServices() {
 export function getMediaAdminServices() {
   services ??= createServices()
   return services
+}
+
+export function getMediaAdminPageServices() {
+  pageServices ??= createPageServices()
+  return pageServices
 }
 
 export { ownerHighImpactReverifier, ownerRequestAuthenticator }

--- a/lib/media/admin/server.ts
+++ b/lib/media/admin/server.ts
@@ -62,7 +62,10 @@ function createPageServices() {
   const { review, selection } = createCatalogServices(
     createPublicRenditionUrl(cdnBaseUrl),
   )
-  return { review, selection }
+  return {
+    getDraft: selection.getDraft,
+    listAssets: review.listAssets,
+  }
 }
 
 function createServices() {

--- a/lib/media/storage/bunny.ts
+++ b/lib/media/storage/bunny.ts
@@ -84,6 +84,14 @@ function assertObjectKey(key: string) {
   }
 }
 
+export function createPublicRenditionUrl(cdnBaseUrl: URL) {
+  return function publicRenditionUrl(key: string) {
+    assertObjectKey(key)
+    const encodedKey = key.split('/').map(encodeURIComponent).join('/')
+    return new URL(encodedKey, cdnBaseUrl).toString()
+  }
+}
+
 function checksumBase64(checksumSha256: string) {
   if (!/^[a-f0-9]{64}$/.test(checksumSha256)) {
     throw new TypeError('Invalid SHA-256 checksum')
@@ -123,11 +131,9 @@ export function createBunnyStorage(
     dependencies.renditionsClient ?? createClient(config.region, config.renditions)
   const request = dependencies.fetch ?? fetch
 
-  function publicRenditionUrl(key: string) {
-    assertObjectKey(key)
-    const encodedKey = key.split('/').map(encodeURIComponent).join('/')
-    return new URL(encodedKey, config.renditions.cdnBaseUrl).toString()
-  }
+  const publicRenditionUrl = createPublicRenditionUrl(
+    config.renditions.cdnBaseUrl,
+  )
 
   async function deleteObject(client: S3Client, bucket: string, key: string) {
     assertObjectKey(key)

--- a/lib/security/admin-proxy.test.ts
+++ b/lib/security/admin-proxy.test.ts
@@ -42,6 +42,27 @@ afterAll(() => {
 })
 
 describe('admin CSP proxy', () => {
+  it('allows Clerk to keep the browser session synchronized', () => {
+    const previousPublishableKey =
+      process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY =
+      'pk_live_Y2xlcmsuY2FsaS5zbyQ'
+
+    try {
+      const policy = siteProxy(
+        new NextRequest('https://cali.so/admin/media'),
+      ).headers.get('content-security-policy')
+
+      expect(policy).toContain("connect-src 'self' https://clerk.cali.so")
+    } finally {
+      if (previousPublishableKey === undefined) {
+        delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+      } else {
+        process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = previousPublishableKey
+      }
+    }
+  })
+
   it('uses a fresh strict nonce policy for each admin render', () => {
     const request = new NextRequest('https://cali.so/admin/login')
     const first = siteProxy(request).headers.get('content-security-policy')

--- a/lib/security/headers.ts
+++ b/lib/security/headers.ts
@@ -21,7 +21,29 @@ function optionalMediaImageSource() {
   }
 }
 
-function contentSecurityPolicy(scriptSources: string, styleSources: string) {
+function clerkFrontendApiSource() {
+  const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+  const encodedHost = publishableKey?.match(/^pk_(?:test|live)_(.+)$/)?.[1]
+  if (!encodedHost) return ''
+
+  try {
+    const decodedHost = Buffer.from(encodedHost, 'base64url')
+      .toString('utf8')
+      .replace(/\$$/, '')
+    const url = new URL(`https://${decodedHost}`)
+    return url.protocol === 'https:' && url.hostname === decodedHost
+      ? ` ${url.origin}`
+      : ''
+  } catch {
+    return ''
+  }
+}
+
+function contentSecurityPolicy(
+  scriptSources: string,
+  styleSources: string,
+  connectSources = '',
+) {
   return [
     "default-src 'self'",
     "base-uri 'self'",
@@ -33,7 +55,7 @@ function contentSecurityPolicy(scriptSources: string, styleSources: string) {
     `style-src ${styleSources}`,
     `img-src 'self' data: blob: https://og.zolplay.com${optionalMediaImageSource()}`,
     "font-src 'self' data:",
-    "connect-src 'self'",
+    `connect-src 'self'${connectSources}`,
     "media-src 'self' blob:",
     "worker-src 'self' blob:",
     "frame-src 'none'",
@@ -51,6 +73,7 @@ export function adminContentSecurityPolicy(nonce: string) {
   return contentSecurityPolicy(
     `'self' ${nonceSource} ${prepaintScriptHash} 'strict-dynamic'${isDevelopment ? " 'unsafe-eval'" : ''}`,
     "'self' 'unsafe-inline'",
+    clerkFrontendApiSource(),
   )
 }
 


### PR DESCRIPTION
Admin now owns a compact shell and a narrower runtime boundary. Protected navigation keeps the Clerk session active, while Media and Photos can render without initializing upload and purge dependencies.

## Implementation

- Allow the exact Clerk frontend API origin in the strict admin `connect-src` policy so the client session can stay synchronized after the initial server render.
- Keep admin outside the public route-transition, social-data, dock, and footer chrome.
- Split read-only Media and Photos page services from the write-capable storage graph. Mutation routes still require the full Bunny and encryption configuration.
- Replace the stretched header with a compact responsive grid: three-column navigation on small screens and an 11rem sidebar on desktop.
- Disable prefetching on protected admin links and preserve 44px controls, neutral focus states, and the existing bilingual labels.

## Root cause

The admin CSP allowed only same-origin connections, which blocked Clerk's frontend API after authentication. Media and Photos also constructed the complete storage service graph during ordinary page reads, so unavailable write-only secrets surfaced as a 500. The shared public document chrome made both failures harder to isolate and produced the broken layout.

## Verification

- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm exec vitest run app/admin lib/admin lib/ama/admin/dashboard.test.tsx`
- `pnpm test:media:admin`
- `pnpm test:security`
- `pnpm exec vitest run lib/security/admin-proxy.test.ts app/site-document.test.tsx app/admin/'(protected)'/AdminShell.test.tsx lib/media/admin/server.test.ts lib/media/storage/bunny.test.ts lib/media/storage/config.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two root causes: the admin CSP blocked Clerk's frontend API after authentication (fixed by decoding the publishable key to derive the exact `connect-src` origin), and Media/Photos pages crashed with a 500 when write-only storage secrets were absent (fixed by splitting a lightweight `getMediaAdminPageServices` that only requires `BUNNY_RENDITIONS_CDN_URL`). The admin shell is also extracted from the public document chrome, removing social data fetches, analytics, dock, and footer from every admin render.

- **CSP fix** – `clerkFrontendApiSource()` base64url-decodes the Clerk publishable key to extract the frontend API hostname, validates it is a bare HTTPS hostname (no path, credentials, or port), and appends it to `connect-src` only for admin responses.
- **Service split** – `createPageServices` initialises only the CDN-URL-based rendition factory and the catalog/selection services needed for listing; mutation routes keep the full `createServices` path that requires encryption keys and storage credentials.
- **Admin shell** – replaces the stretched full-width header with a responsive CSS grid (mobile top-nav bar, desktop 11 rem sidebar) and moves the admin document into a separate early-return branch of `SiteDocument`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three bug fixes (Clerk CSP, storage 500, admin chrome) are narrowly scoped with matching tests, and no regressions were introduced to the public document path.

The CSP change adds only a validated, read-only env-var-derived origin to connect-src, with the hostname equality guard preventing paths, credentials, or ports from slipping through. The service split is clean: createPageServices cannot reach any write-capable method, and the singleton caching pattern matches the existing services module convention. The SiteDocument early-return for admin is straightforward and the new tests confirm both that public chrome is absent from admin renders and that social APIs are never called.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/security/headers.ts | Adds clerkFrontendApiSource() to decode the publishable key into a validated HTTPS origin and appends it to connect-src in adminContentSecurityPolicy; validation guards against paths, credentials, and ports correctly. |
| lib/media/admin/server.ts | Extracts createCatalogServices (shared review/selection graph) and createPageServices (CDN-URL-only path); getMediaAdminPageServices exposes only { getDraft, listAssets } eliminating the need for write-only secrets on read pages. |
| lib/media/storage/bunny.ts | Promotes publicRenditionUrl into an exported createPublicRenditionUrl factory so createPageServices can build a URL constructor from only the CDN base URL, without instantiating any S3 clients. |
| app/_components/site-document.tsx | Admin branch returns early with a minimal html/body shell (no social fetches, analytics, dock, or footer); public branch unconditionally adds public-site class and Analytics since it is now always the non-admin path. |
| app/admin/(protected)/AdminShell.tsx | Replaces stretched full-width header with a CSS-grid shell (mobile: top nav bar, desktop: 11 rem sidebar); uses CSS custom property --admin-nav-columns set to navigation.length so grid columns scale with the array. |
| app/admin/(protected)/media/page.tsx | Switches from getMediaAdminServices to getMediaAdminPageServices and calls listAssets directly, removing the dependency on write-only storage secrets for the listing page. |
| app/admin/(protected)/photos/page.tsx | Switches from getMediaAdminServices to getMediaAdminPageServices and destructs getDraft / listAssets directly; no write-capable surface is reachable from this page. |
| app/admin/(protected)/AdminShell.test.tsx | New test that directly invokes AdminShell and asserts the responsive grid classes, CSS custom property, link count, prefetch=false, and aria-current attribution. |
| app/site-document.test.tsx | Extended with sentinel elements for dock, footer, and route-transition to assert that public chrome is rendered for public routes and fully suppressed for admin routes, including social API call guards. |
| lib/media/admin/server.test.ts | New test verifying that getMediaAdminPageServices succeeds with only BUNNY_RENDITIONS_CDN_URL set and exposes exactly { getDraft, listAssets } without leaking write-capable service references. |
| lib/security/admin-proxy.test.ts | Adds a test that decodes a known Clerk publishable key and asserts the resulting connect-src directive includes the expected clerk.cali.so origin. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Admin Media / Photos page request] --> B[requireOwnerPage]
    B --> C{Route type}
    C -- Read-only listing --> D[getMediaAdminPageServices]
    C -- Mutation route --> E[getMediaAdminServices]
    D --> F[parseBunnyRenditionCdnEnv]
    F --> G[createCatalogServices]
    G --> H[getDraft + listAssets only]
    E --> I[getMediaStorage full credentials]
    I --> J[createCatalogServices]
    J --> K[review + selection + ingestion + purge]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Admin Media / Photos page request] --> B[requireOwnerPage]
    B --> C{Route type}
    C -- Read-only listing --> D[getMediaAdminPageServices]
    C -- Mutation route --> E[getMediaAdminServices]
    D --> F[parseBunnyRenditionCdnEnv]
    F --> G[createCatalogServices]
    G --> H[getDraft + listAssets only]
    E --> I[getMediaStorage full credentials]
    I --> J[createCatalogServices]
    J --> K[review + selection + ingestion + purge]
```

</a>

<sub>Reviews (3): Last reviewed commit: ["fix(admin): address review feedback"](https://github.com/calicastle/cali.so/commit/ae96ac84148d69017013c1067e285530c9f061c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44971974)</sub>

<!-- /greptile_comment -->