### PR TITLE
ci: automate Neon branch deployments

### DIFF
--- a/.github/actions/deploy-neon-vercel/action.yml
+++ b/.github/actions/deploy-neon-vercel/action.yml
@@ -46,6 +46,15 @@ inputs:
   vercel-token:
     description: Vercel deployment token.
     required: true
+  working-directory:
+    description: Checked-out application directory to install, migrate, and deploy.
+    required: false
+    default: "."
+
+outputs:
+  deployment-url:
+    description: URL of the Vercel deployment.
+    value: ${{ steps.vercel.outputs.url }}
 
 runs:
   using: composite
@@ -58,9 +67,11 @@ runs:
       with:
         node-version: 24
         cache: pnpm
+        cache-dependency-path: ${{ inputs.working-directory }}/pnpm-lock.yaml
 
     - name: Install dependencies
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: pnpm install --frozen-lockfile
 
     - name: Create or reuse Neon branch for migrations
@@ -90,6 +101,7 @@ runs:
 
     - name: Run database migrations
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       env:
         MIGRATION_DATABASE_URL: ${{ steps.reset-branch.outputs.db_url || steps.migration-branch.outputs.db_url }}
       run: pnpm db:migrate
@@ -105,7 +117,9 @@ runs:
         database: ${{ inputs.database }}
 
     - name: Deploy to Vercel
+      id: vercel
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       env:
         DEPLOY_COMMIT_SHA: ${{ inputs.commit-sha }}
         DEPLOY_GIT_REF: ${{ inputs.git-ref }}
@@ -114,12 +128,22 @@ runs:
         VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}
         VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
         VERCEL_TOKEN: ${{ inputs.vercel-token }}
-      run: >-
-        pnpm dlx vercel@56.3.1 deploy
-        --yes
-        --token "$VERCEL_TOKEN"
-        --target="$DEPLOY_TARGET"
-        --build-env DATABASE_URL="$RUNTIME_DATABASE_URL"
-        --env DATABASE_URL="$RUNTIME_DATABASE_URL"
-        --meta githubCommitRef="$DEPLOY_GIT_REF"
-        --meta githubCommitSha="$DEPLOY_COMMIT_SHA"
+      run: |
+        deployment_url="$(
+          pnpm dlx vercel@56.3.1 deploy \
+            --yes \
+            --token "$VERCEL_TOKEN" \
+            --target="$DEPLOY_TARGET" \
+            --build-env DATABASE_URL="$RUNTIME_DATABASE_URL" \
+            --env DATABASE_URL="$RUNTIME_DATABASE_URL" \
+            --meta githubCommitRef="$DEPLOY_GIT_REF" \
+            --meta githubCommitSha="$DEPLOY_COMMIT_SHA"
+        )"
+        if [[ ! "$deployment_url" =~ ^https://[A-Za-z0-9.-]+\.vercel\.app$ ]]; then
+          echo "Vercel did not return a deployment URL." >&2
+          exit 1
+        fi
+        echo "url=$deployment_url" >> "$GITHUB_OUTPUT"
+        printf '### %s deployment\n[%s](%s)\n' \
+          "$DEPLOY_TARGET" "$deployment_url" "$deployment_url" \
+          >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/deploy-neon-vercel/action.yml
+++ b/.github/actions/deploy-neon-vercel/action.yml
@@ -1,0 +1,125 @@
+name: Deploy Neon-backed Vercel environment
+description: Provision or refresh a Neon branch, migrate it, and deploy the matching Vercel environment.
+
+inputs:
+  branch-name:
+    description: Neon branch name.
+    required: true
+  parent-branch:
+    description: Parent Neon branch used only when creating a new branch.
+    required: false
+    default: ""
+  reset:
+    description: Reset the existing branch from its parent before migrating.
+    required: false
+    default: "false"
+  target:
+    description: Vercel target environment.
+    required: true
+  git-ref:
+    description: Git branch recorded on the Vercel deployment.
+    required: true
+  commit-sha:
+    description: Git commit recorded on the Vercel deployment.
+    required: true
+  project-id:
+    description: Non-production Neon project ID.
+    required: true
+  api-key:
+    description: Project-scoped Neon API key.
+    required: true
+  migration-role:
+    description: Neon role allowed to run migrations.
+    required: true
+  runtime-role:
+    description: Neon role limited to application CRUD.
+    required: true
+  database:
+    description: Neon database name.
+    required: true
+  vercel-org-id:
+    description: Vercel organization ID.
+    required: true
+  vercel-project-id:
+    description: Vercel project ID.
+    required: true
+  vercel-token:
+    description: Vercel deployment token.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up pnpm
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+    - name: Set up Node.js
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: 24
+        cache: pnpm
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile
+
+    - name: Create or reuse Neon branch for migrations
+      if: inputs.reset != 'true'
+      id: migration-branch
+      uses: neondatabase/create-branch-action@fb620d43d4c565abaf088b848a4e28e5c4ea4d9c # v6
+      with:
+        project_id: ${{ inputs.project-id }}
+        api_key: ${{ inputs.api-key }}
+        branch_name: ${{ inputs.branch-name }}
+        parent_branch: ${{ inputs.parent-branch }}
+        role: ${{ inputs.migration-role }}
+        database: ${{ inputs.database }}
+        suspend_timeout: 300
+
+    - name: Reset Neon Preview branch
+      if: inputs.reset == 'true'
+      id: reset-branch
+      uses: neondatabase/reset-branch-action@470ab8101095ea33737c294d17364a72fd80761b # v1
+      with:
+        project_id: ${{ inputs.project-id }}
+        api_key: ${{ inputs.api-key }}
+        branch: ${{ inputs.branch-name }}
+        parent: true
+        cs_role_name: ${{ inputs.migration-role }}
+        cs_database: ${{ inputs.database }}
+
+    - name: Run database migrations
+      shell: bash
+      env:
+        MIGRATION_DATABASE_URL: ${{ steps.reset-branch.outputs.db_url || steps.migration-branch.outputs.db_url }}
+      run: pnpm db:migrate
+
+    - name: Get CRUD-only runtime connection
+      id: runtime-branch
+      uses: neondatabase/create-branch-action@fb620d43d4c565abaf088b848a4e28e5c4ea4d9c # v6
+      with:
+        project_id: ${{ inputs.project-id }}
+        api_key: ${{ inputs.api-key }}
+        branch_name: ${{ inputs.branch-name }}
+        role: ${{ inputs.runtime-role }}
+        database: ${{ inputs.database }}
+
+    - name: Deploy to Vercel
+      shell: bash
+      env:
+        DEPLOY_COMMIT_SHA: ${{ inputs.commit-sha }}
+        DEPLOY_GIT_REF: ${{ inputs.git-ref }}
+        DEPLOY_TARGET: ${{ inputs.target }}
+        RUNTIME_DATABASE_URL: ${{ steps.runtime-branch.outputs.db_url_pooled }}
+        VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}
+        VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
+        VERCEL_TOKEN: ${{ inputs.vercel-token }}
+      run: >-
+        pnpm dlx vercel@56.3.1 deploy
+        --yes
+        --token "$VERCEL_TOKEN"
+        --target="$DEPLOY_TARGET"
+        --build-env DATABASE_URL="$RUNTIME_DATABASE_URL"
+        --env DATABASE_URL="$RUNTIME_DATABASE_URL"
+        --meta githubCommitRef="$DEPLOY_GIT_REF"
+        --meta githubCommitSha="$DEPLOY_COMMIT_SHA"

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -23,6 +23,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
       - name: Delete Neon Preview branch
         uses: neondatabase/delete-branch-action@4468d825d5a88ef4012f1705a82f02ec3072f776 # v3
         with:

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -1,0 +1,40 @@
+name: Cleanup Preview
+
+on:
+  delete:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cleanup-preview-${{ github.event.ref }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    if: >-
+      github.event.ref_type == 'branch' &&
+      github.event.ref != 'dev' &&
+      github.event.ref != 'main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: preview
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Delete Neon Preview branch
+        uses: neondatabase/delete-branch-action@4468d825d5a88ef4012f1705a82f02ec3072f776 # v3
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+          branch: preview/${{ github.event.ref }}
+
+      - name: Delete Vercel Preview deployments
+        if: always()
+        env:
+          GIT_BRANCH: ${{ github.event.ref }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: node scripts/delete-vercel-branch-deployments.mjs

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: cleanup-preview-${{ github.event.ref }}
+  group: preview-${{ github.event.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -10,8 +10,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: deploy-preview-${{ github.ref }}
-  cancel-in-progress: true
+  group: preview-${{ github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,44 @@
+name: Deploy Preview
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - dev
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: >-
+      github.repository == 'CaliCastle/cali.so' &&
+      github.event.repository.fork == false &&
+      github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: preview
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Deploy Preview
+        uses: ./.github/actions/deploy-neon-vercel
+        with:
+          branch-name: preview/${{ github.ref_name }}
+          parent-branch: staging
+          target: preview
+          git-ref: ${{ github.ref_name }}
+          commit-sha: ${{ github.sha }}
+          project-id: ${{ vars.NEON_PROJECT_ID }}
+          api-key: ${{ secrets.NEON_API_KEY }}
+          migration-role: ${{ vars.NEON_MIGRATION_ROLE }}
+          runtime-role: ${{ vars.NEON_RUNTIME_ROLE }}
+          database: ${{ vars.NEON_DATABASE }}
+          vercel-org-id: ${{ vars.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ vars.VERCEL_PROJECT_ID }}
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -13,7 +13,16 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  migration-review:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    environment: production-migration-review
+    steps:
+      - name: Confirm Production migration review
+        run: echo "Production migration review approved."
+
   deploy:
+    needs: migration-review
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     environment: production
@@ -35,7 +44,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Reject destructive database migrations
+      - name: Enforce expand-only database migrations
         run: node scripts/check-production-migrations.mjs "${{ github.event.before }}" "${{ github.sha }}"
 
       - name: Run database migrations
@@ -45,12 +54,21 @@ jobs:
 
       - name: Deploy Vercel Production
         env:
+          DEPLOY_COMMIT_SHA: ${{ github.sha }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: >-
-          pnpm dlx vercel@56.3.1 deploy --prod
-          --yes
-          --token "$VERCEL_TOKEN"
-          --meta githubCommitRef="main"
-          --meta githubCommitSha="${{ github.sha }}"
+        run: |
+          deployment_url="$(
+            pnpm dlx vercel@56.3.1 deploy --prod \
+              --yes \
+              --token "$VERCEL_TOKEN" \
+              --meta githubCommitRef="main" \
+              --meta githubCommitSha="$DEPLOY_COMMIT_SHA"
+          )"
+          if [[ ! "$deployment_url" =~ ^https://[A-Za-z0-9.-]+\.vercel\.app$ ]]; then
+            echo "Vercel did not return a Production deployment URL." >&2
+            exit 1
+          fi
+          printf '### Production deployment\n[%s](%s)\n' \
+            "$deployment_url" "$deployment_url" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -45,7 +45,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Enforce expand-only database migrations
-        run: node scripts/check-production-migrations.mjs "${{ github.event.before }}" "${{ github.sha }}"
+        env:
+          BASE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: node scripts/check-production-migrations.mjs "$BASE_SHA" "$HEAD_SHA"
 
       - name: Run database migrations
         env:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,56 @@
+name: Deploy Production
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: production
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Reject destructive database migrations
+        run: node scripts/check-production-migrations.mjs "${{ github.event.before }}" "${{ github.sha }}"
+
+      - name: Run database migrations
+        env:
+          MIGRATION_DATABASE_URL: ${{ secrets.MIGRATION_DATABASE_URL }}
+        run: pnpm db:migrate
+
+      - name: Deploy Vercel Production
+        env:
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: >-
+          pnpm dlx vercel@56.3.1 deploy --prod
+          --yes
+          --token "$VERCEL_TOKEN"
+          --meta githubCommitRef="main"
+          --meta githubCommitSha="${{ github.sha }}"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,39 @@
+name: Deploy Staging
+
+on:
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: staging
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Deploy Staging
+        uses: ./.github/actions/deploy-neon-vercel
+        with:
+          branch-name: staging
+          target: staging
+          git-ref: dev
+          commit-sha: ${{ github.sha }}
+          project-id: ${{ vars.NEON_PROJECT_ID }}
+          api-key: ${{ secrets.NEON_API_KEY }}
+          migration-role: ${{ vars.NEON_MIGRATION_ROLE }}
+          runtime-role: ${{ vars.NEON_RUNTIME_ROLE }}
+          database: ${{ vars.NEON_DATABASE }}
+          vercel-org-id: ${{ vars.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ vars.VERCEL_PROJECT_ID }}
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.ref == 'refs/heads/dev'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     environment: staging

--- a/.github/workflows/refresh-preview.yml
+++ b/.github/workflows/refresh-preview.yml
@@ -1,0 +1,50 @@
+name: Refresh Preview
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_branch:
+        description: Internal Git branch whose Preview database should be reset from Staging.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: refresh-preview-${{ inputs.git_branch }}
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    if: inputs.git_branch != 'dev' && inputs.git_branch != 'main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: preview
+    steps:
+      - name: Check out target branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.git_branch }}
+
+      - name: Resolve target commit
+        id: target
+        shell: bash
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Refresh Preview
+        uses: ./.github/actions/deploy-neon-vercel
+        with:
+          branch-name: preview/${{ inputs.git_branch }}
+          reset: true
+          target: preview
+          git-ref: ${{ inputs.git_branch }}
+          commit-sha: ${{ steps.target.outputs.sha }}
+          project-id: ${{ vars.NEON_PROJECT_ID }}
+          api-key: ${{ secrets.NEON_API_KEY }}
+          migration-role: ${{ vars.NEON_MIGRATION_ROLE }}
+          runtime-role: ${{ vars.NEON_RUNTIME_ROLE }}
+          database: ${{ vars.NEON_DATABASE }}
+          vercel-org-id: ${{ vars.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ vars.VERCEL_PROJECT_ID }}
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/refresh-preview.yml
+++ b/.github/workflows/refresh-preview.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: refresh-preview-${{ inputs.git_branch }}
+  group: preview-${{ inputs.git_branch }}
   cancel-in-progress: false
 
 jobs:
@@ -22,14 +22,27 @@ jobs:
     timeout-minutes: 30
     environment: preview
     steps:
+      - name: Check out trusted deployment action
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: dev
+
+      - name: Validate target branch
+        shell: bash
+        env:
+          GIT_BRANCH: ${{ inputs.git_branch }}
+        run: git check-ref-format --branch "$GIT_BRANCH"
+
       - name: Check out target branch
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ inputs.git_branch }}
+          ref: refs/heads/${{ inputs.git_branch }}
+          path: target
 
       - name: Resolve target commit
         id: target
         shell: bash
+        working-directory: target
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Refresh Preview
@@ -37,6 +50,7 @@ jobs:
         with:
           branch-name: preview/${{ inputs.git_branch }}
           reset: true
+          working-directory: target
           target: preview
           git-ref: ${{ inputs.git_branch }}
           commit-sha: ${{ steps.target.outputs.sha }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,7 +3,7 @@ name: Security
 on:
   push:
     branches:
-      - v2
+      - dev
       - main
   pull_request:
   schedule:
@@ -50,6 +50,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
 
       - name: Set up pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -71,6 +73,16 @@ jobs:
 
       - name: Test AMA and migrations
         run: pnpm test:ama
+
+      - name: Test deployment workflows
+        run: pnpm test:deployment
+
+      - name: Check Production migration compatibility
+        if: github.event_name == 'pull_request' && github.base_ref == 'main'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node scripts/check-production-migrations.mjs "$BASE_SHA" "$HEAD_SHA"
 
       - name: Test security controls
         run: pnpm test:security

--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ pnpm audit:prod
 - `dev` automatically migrates and deploys persistent Staging. Internal feature
   branches receive persistent Neon `preview/<git-branch>` children of Staging;
   fork pull requests receive code-only CI.
-- Production uses a separate Neon project. A protected GitHub environment
-  approves the migration before GitHub deploys the exact `main` commit.
+- Production uses a separate Neon project. Two sequential protected GitHub
+  environments approve the migration review and database access before GitHub
+  deploys the exact `main` commit.
 - Next.js preview versions stay pinned exactly and require explicit review,
   a lockfile update, and the complete validation suite.
 - Staging and Previews use a separate non-production Neon project and disposable
@@ -106,7 +107,9 @@ pnpm audit:prod
   ordinary CI use process-local limits.
 - The Vercel runtime never receives migration credentials.
 - Production migrations are expand-only in the normal release workflow.
-  Destructive contract migrations require a later, separately approved release.
+  Reviewed migrations are hash-locked, and future SQL must match the explicit
+  allowlist. Destructive contract migrations require a later, separately
+  approved release.
 - Owner admin remains available in every environment and relies on
   Clerk authentication plus the server-checked
   `publicMetadata.siteOwner = "yes"` marker rather than an environment switch.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Source for [Cali Castle's personal site](https://cali.so). The ground-up
 rewrite is the v3 release. The 2024 site remains the historical v2 release,
-and the long-lived integration branch keeps the name `v2` until v3 is ready
-to cut over to `main`.
+Git `dev` is the long-lived Staging and integration branch, and `main` is
+Production.
 
 This repository documents and builds cali.so itself. It is not maintained as a
 general-purpose blog template.
@@ -24,7 +24,7 @@ general-purpose blog template.
   active Published Photo Selection powers `/photos` and the homepage preview
   while private Originals remain server-only
 - CSP, same-origin mutation checks, rate limits, capability kill switches,
-  security automation, and isolated Preview credentials
+  security automation, and isolated Staging, Preview, and Production credentials
 
 The public route and launch contract is tracked in
 [issue #98](https://github.com/CaliCastle/cali.so/issues/98). Merging the
@@ -64,6 +64,7 @@ pnpm test:unit
 pnpm test:localization
 pnpm test:port-post
 pnpm test:ama
+pnpm test:deployment
 pnpm test:security
 pnpm test:media:storage
 pnpm test:media:catalog
@@ -87,15 +88,25 @@ pnpm audit:prod
 
 ## Deployment constraints
 
-- `main` is the production branch. The historically named `v2` branch is the
-  v3 integration branch until cutover.
+- Feature pull requests target `dev`; reviewed releases promote `dev` to
+  `main`.
+- GitHub Actions is the sole deployment controller. Vercel Git deployments are
+  disabled so migrations finish before the matching commit is deployed.
+- `dev` automatically migrates and deploys persistent Staging. Internal feature
+  branches receive persistent Neon `preview/<git-branch>` children of Staging;
+  fork pull requests receive code-only CI.
+- Production uses a separate Neon project. A protected GitHub environment
+  approves the migration before GitHub deploys the exact `main` commit.
 - Next.js preview versions stay pinned exactly and require explicit review,
   a lockfile update, and the complete validation suite.
-- Preview and Production use separate credentials and data. Preview data must
-  be disposable or irreversibly sanitized.
-- Redis is Production-only. Preview rate limits use its isolated Neon database;
-  Local and CI use process-local limits.
+- Staging and Previews use a separate non-production Neon project and disposable
+  or irreversibly sanitized data. Production credentials cannot reach it, and
+  its automation credentials cannot reach Production.
+- Redis is Production-only. Staging and Preview rate limits use Neon; Local and
+  ordinary CI use process-local limits.
 - The Vercel runtime never receives migration credentials.
+- Production migrations are expand-only in the normal release workflow.
+  Destructive contract migrations require a later, separately approved release.
 - Owner admin remains available in every environment and relies on
   Clerk authentication plus the server-checked
   `publicMetadata.siteOwner = "yes"` marker rather than an environment switch.

--- a/docs/adr/0010-github-controlled-neon-deployments.md
+++ b/docs/adr/0010-github-controlled-neon-deployments.md
@@ -11,7 +11,8 @@ separate Production Neon project. GitHub Actions creates or reuses the database
 branch, runs migrations, then deploys the exact commit, while Vercel Git
 deployments stay disabled so code cannot race its schema. Migration credentials
 exist only in scoped GitHub deployment steps, Vercel receives CRUD-only runtime
-URLs, and Production requires protected-environment approval plus an expand-only
-migration check. This custom control plane is more involved than Neon's managed
+URLs, and Production requires two sequential protected-environment approvals
+plus a fail-closed expand-only migration check. This custom control plane is
+more involved than Neon's managed
 Vercel integration, but it preserves a non-production Staging parent and keeps
 DDL credentials out of application builds and runtimes.

--- a/docs/adr/0010-github-controlled-neon-deployments.md
+++ b/docs/adr/0010-github-controlled-neon-deployments.md
@@ -1,0 +1,17 @@
+# Let GitHub Actions control Neon-backed deployments
+
+## Status
+
+Accepted. This supersedes the integration-branch naming portion of ADR-0005.
+
+Git `dev` is the long-lived Staging branch, backed by a persistent `staging`
+branch in the non-production Neon project. Internal feature branches receive
+persistent `preview/<git-branch>` children of Staging; Git `main` deploys to a
+separate Production Neon project. GitHub Actions creates or reuses the database
+branch, runs migrations, then deploys the exact commit, while Vercel Git
+deployments stay disabled so code cannot race its schema. Migration credentials
+exist only in scoped GitHub deployment steps, Vercel receives CRUD-only runtime
+URLs, and Production requires protected-environment approval plus an expand-only
+migration check. This custom control plane is more involved than Neon's managed
+Vercel integration, but it preserves a non-production Staging parent and keeps
+DDL credentials out of application builds and runtimes.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -47,7 +47,8 @@ Current as of July 2026.
 - GitHub Actions owns deployment ordering. `dev` migrates the persistent Neon
   `staging` branch before deploying Vercel Staging. Internal feature branches
   use persistent `preview/<git-branch>` children of Staging. Production lives
-  in a separate Neon project and waits for protected-environment approval.
+  in a separate Neon project and waits for two sequential protected-environment
+  approvals before database access.
 - Security baseline controls from PR #97 remain mandatory: CSP and security
   headers, same-origin mutation policy, rate limits, kill switches,
   privacy-safe audit events, isolated credentials, and security automation.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -6,14 +6,14 @@ Current as of July 2026.
 
 - The ground-up rewrite is **v3**. The site released in 2024 remains the
   historical v2.
-- The integration branch keeps the name **`v2`** for continuity. `main` still
-  drives production; merging the completed v3 release into `main` is the
-  cutover.
+- Git **`dev`** is the long-lived Staging and integration branch. `main` drives
+  Production; a reviewed `dev` to `main` pull request is the release path.
 - Release scope and evidence are tracked by
   [#98](https://github.com/CaliCastle/cali.so/issues/98). Do not merge to
   `main` until its complete dependency chain and final proof are green.
 - Release slices #99 through #106 are merged into `v2`. Final cutover proof is
-  tracked by #107; its checked-in report is the current readiness authority.
+  tracked by #107; those `v2` references are historical evidence from before
+  the branch became `dev`.
 
 ## Current architecture
 
@@ -44,6 +44,10 @@ Current as of July 2026.
   the v3 production launch.
 - Rate limits use Upstash only in Production. Preview persists its limits in
   the isolated Neon database, while Local and CI use process-local limits.
+- GitHub Actions owns deployment ordering. `dev` migrates the persistent Neon
+  `staging` branch before deploying Vercel Staging. Internal feature branches
+  use persistent `preview/<git-branch>` children of Staging. Production lives
+  in a separate Neon project and waits for protected-environment approval.
 - Security baseline controls from PR #97 remain mandatory: CSP and security
   headers, same-origin mutation policy, rate limits, kill switches,
   privacy-safe audit events, isolated credentials, and security automation.
@@ -87,6 +91,7 @@ pnpm test:unit
 pnpm test:localization
 pnpm test:port-post
 pnpm test:ama
+pnpm test:deployment
 pnpm test:security
 pnpm test:media:storage
 pnpm test:media:catalog
@@ -109,7 +114,8 @@ pnpm verify:security-boundary
 pnpm audit:prod
 ```
 
-Run migrations only with an explicitly supplied migration credential:
+Deployment workflows run migrations before deployment with a scoped GitHub
+environment credential. For an explicitly authorized local operation:
 
 ```bash
 MIGRATION_DATABASE_URL=postgresql://... pnpm db:migrate
@@ -120,9 +126,8 @@ The Vercel runtime receives only the CRUD-only `DATABASE_URL`. Never put
 
 ## Gotchas
 
-- Product generation and branch name differ: v3 is developed on `v2`. Do not
-  rename historical tags, the integration branch, vendor APIs, or protocol
-  versions while correcting product terminology.
+- Historical product v2 tags and old readiness evidence remain v2. Do not
+  rewrite them when working on Git `dev`, the current v3 integration branch.
 - This Next.js preview has breaking changes. Read the relevant bundled guide in
   `node_modules/next/dist/docs/` before changing framework behavior.
 - `turbopack.root` supports nested worktrees and must stay configured.
@@ -131,9 +136,10 @@ The Vercel runtime receives only the CRUD-only `DATABASE_URL`. Never put
 - Raw stylesheet `backdrop-filter` is stripped by the CSS pipeline. The liquid
   dock owns its SVG filter as an inline style; ordinary blur uses Tailwind
   utilities.
-- Preview and Production credentials and data are separate. Preview data must
-  be disposable or irreversibly sanitized. Never attach Redis credentials to
-  Preview; its rate-limit windows live in the Preview Neon database.
+- Staging/Preview and Production credentials and data are isolated in separate
+  Neon projects. Non-production data must be disposable or irreversibly
+  sanitized. Never attach Redis credentials to Staging or Preview; their
+  rate-limit windows live in Neon.
 - The five optional `AMA_*_ENABLED` variables fail closed. Leave every one
   `false` for the v3 launch; owner admin has no capability switch.
 - Design references are private. Public code and documentation use only the

--- a/docs/security/baseline.md
+++ b/docs/security/baseline.md
@@ -9,7 +9,8 @@ an attacker can read the implementation.
 | Environment | Data and integrations | Secret policy |
 | --- | --- | --- |
 | Production | Production-only accounts and durable data | Available only to protected production deployments |
-| Preview | Test accounts and disposable, isolated data | Preview-scoped credentials; never production credentials |
+| Staging | Persistent non-production baseline and test accounts | Staging-scoped credentials; never production credentials |
+| Preview | Disposable child of Staging for one internal Git branch | Preview-scoped runtime credentials; never production credentials |
 | Local and CI | Local emulators, fixtures, or dedicated test accounts | Developer-local or CI-scoped credentials with the minimum privilege |
 
 - Keep production and preview credentials in separate provider projects or
@@ -41,12 +42,15 @@ Production uses separate database identities:
 - The runtime role receives only the schema usage and table or sequence
   privileges required for application CRUD. It cannot create or alter schema,
   manage roles, grant privileges, or run migrations.
-- The migration role may perform approved DDL but is never present in runtime,
-  Preview, browser, or routine CI environments.
+- The migration role may perform approved DDL only in its scoped GitHub
+  deployment step. It is never sent to Vercel, an application build or runtime,
+  a browser, or ordinary code-validation CI.
 - An owner or emergency role is break-glass only, access-controlled and
   audited. It is not an application credential.
-- Preview uses a separate database and credentials. Production snapshots are
-  not copied into Preview unless they are irreversibly sanitized first.
+- Staging and Preview use a separate non-production Neon project and
+  credentials. Production snapshots are not copied into it unless they are
+  irreversibly sanitized first. The non-production automation key has no access
+  to the Production Neon project.
 
 Review grants whenever the schema changes. Prefer explicit grants over broad
 database ownership, require encrypted connections, and revoke default/public
@@ -77,6 +81,9 @@ recording their sensitive payloads.
 - Keep Actions' repository default at read-only. Each workflow declares its
   own minimum permissions; the CodeQL upload job is allowed only
   `security-events: write` in addition to `contents: read`.
+- Database-backed deployment workflows run only for branches inside this
+  repository. Fork pull requests receive code-only checks and never receive
+  Neon or Vercel credentials.
 - Pin every action to a verified full commit SHA and retain the release tag in
   a comment so updates remain reviewable.
 - Require pull requests and required CI/security checks on the integration and

--- a/docs/security/baseline.md
+++ b/docs/security/baseline.md
@@ -8,7 +8,7 @@ an attacker can read the implementation.
 
 | Environment | Data and integrations | Secret policy |
 | --- | --- | --- |
-| Production | Production-only accounts and durable data | Available only to protected production deployments |
+| Production | Production-only accounts and durable data | Available only after two sequential protected-environment approvals |
 | Staging | Persistent non-production baseline and test accounts | Staging-scoped credentials; never production credentials |
 | Preview | Disposable child of Staging for one internal Git branch | Preview-scoped runtime credentials; never production credentials |
 | Local and CI | Local emulators, fixtures, or dedicated test accounts | Developer-local or CI-scoped credentials with the minimum privilege |
@@ -54,7 +54,9 @@ Production uses separate database identities:
 
 Review grants whenever the schema changes. Prefer explicit grants over broad
 database ownership, require encrypted connections, and revoke default/public
-privileges that are not needed.
+privileges that are not needed. The migration role's default privileges must
+grant the runtime role only the table and sequence access new application
+objects require, so automatic migrations do not create owner-only tables.
 
 ## Logging and audit events
 

--- a/docs/security/verification.md
+++ b/docs/security/verification.md
@@ -16,7 +16,10 @@ Google, and Tencent; an absent switch is deliberately equivalent to `false`.
   vulnerability reporting.
 - [x] Dependabot covers pnpm/npm dependencies and GitHub Actions.
 - [x] `.github/workflows/security.yml` runs Quality and advanced CodeQL for
-  pull requests, `v2`, `main`, and the weekly schedule.
+  pull requests, `dev`, `main`, and the weekly schedule.
+- [x] Deployment contract tests verify migration-before-deploy ordering,
+  expand-only Production migrations, fork isolation, reserved-branch cleanup,
+  and the absence of migration credentials from Vercel steps.
 - [x] Workflow permissions default to read-only. Only CodeQL adds
   `security-events: write`.
 - [x] Third-party Actions are pinned to full reviewed commit SHAs.
@@ -34,11 +37,12 @@ Local recheck:
 pnpm typecheck
 pnpm test:unit
 pnpm test:ama
+pnpm test:deployment
 pnpm test:security
 pnpm audit:prod
 pnpm verify:security-boundary
 gitleaks git --redact --no-banner --log-opts='--branches --tags' --verbose
-git grep -nE 'uses: [^#[:space:]]+@(v|main|master|[0-9a-f]{1,39})([[:space:]]|$)' -- '.github/workflows/*.yml'
+git grep -nE 'uses: [^#[:space:]]+@(v|main|master|[0-9a-f]{1,39})([[:space:]]|$)' -- '.github/workflows/*.yml' '.github/actions/*/*.yml'
 ```
 
 The production dependency audit queries OSV from the installed pnpm graph.
@@ -55,12 +59,14 @@ Repository API checks on 2026-07-16 verified:
 - [x] Default Actions workflow permissions are read-only and workflows cannot
   approve pull requests.
 - [x] Actions must be pinned to a full commit SHA.
-- [x] The `v2` ruleset requires pull requests, blocks force pushes and branch
-  deletion, and limits the audited emergency bypass to repository
+- [x] The historical `v2` ruleset requires pull requests, blocks force pushes
+  and branch deletion, and limits the audited emergency bypass to repository
   administrators. It requires no approving review while the project has one
   maintainer.
-- [x] The `v2` ruleset requires the successful GitHub Actions checks named
+- [x] The historical `v2` ruleset requires the successful GitHub Actions checks named
   `Quality` and `CodeQL`.
+- [ ] Rename the hosted `v2` branch and its ruleset target to `dev`, then verify
+  the same PR, deletion, force-push, and required-check protections.
 - [ ] Require `Quality` and `CodeQL` on `main` branch protection.
 - [x] CodeQL default setup is disabled so the committed advanced workflow is
   the single analysis source.
@@ -69,6 +75,9 @@ Repository API checks on 2026-07-16 verified:
   change.
 - [x] Fork pull requests cannot receive Vercel secrets, and the GitHub Actions
   workflow uses committed non-secret fixtures instead of repository secrets.
+- [ ] Configure `preview`, `staging`, and protected `production` GitHub
+  environments with the variables, secrets, branch restrictions, and required
+  Production reviewer documented in the cutover runbook.
 
 ## Vercel
 
@@ -79,6 +88,11 @@ Project API checks on 2026-07-16 verified:
 - [x] Production and Preview have distinct database variables. Preview uses a
   disposable Neon branch and a pooled CRUD-only runtime role; migrations use a
   separate direct credential that is absent from Vercel.
+- [ ] Rename the persistent non-production Neon branch to `staging`, configure
+  the custom Vercel Staging environment, and verify feature branches receive
+  isolated `preview/<git-branch>` children.
+- [x] Committed Vercel configuration disables Git deployments; hosted proof
+  requires a GitHub-controlled Staging and Preview deployment after setup.
 - [x] Preview explicitly sets all five optional AMA capability switches to
   `false`. Owner admin has no capability switch and remains protected by Clerk
   authentication plus the exact server-side `siteOwner: "yes"` marker.

--- a/docs/security/verification.md
+++ b/docs/security/verification.md
@@ -75,9 +75,10 @@ Repository API checks on 2026-07-16 verified:
   change.
 - [x] Fork pull requests cannot receive Vercel secrets, and the GitHub Actions
   workflow uses committed non-secret fixtures instead of repository secrets.
-- [ ] Configure `preview`, `staging`, and protected `production` GitHub
-  environments with the variables, secrets, branch restrictions, and required
-  Production reviewer documented in the cutover runbook.
+- [ ] Configure `preview`, `staging`, no-secret
+  `production-migration-review`, and protected `production` GitHub environments
+  with the variables, secrets, branch restrictions, and required Production
+  reviewers documented in the cutover runbook.
 
 ## Vercel
 

--- a/docs/v3-cutover-ops-runbook.md
+++ b/docs/v3-cutover-ops-runbook.md
@@ -31,8 +31,12 @@ changing either Neon project.
    existing ruleset now target `dev`.
 2. In the non-production Neon project, rename the persistent `preview` branch
    to `staging`. Preserve its data, migration history, migration role, and
-   SQL-created CRUD-only runtime role. Set it as the parent for disposable
-   `preview/<git-branch>` branches.
+   SQL-created CRUD-only runtime role. Configure the migration role's default
+   privileges so new tables and sequences grant only the required CRUD and
+   sequence access to the runtime role; grant the same access explicitly on
+   existing objects. The runtime role must not own objects or inherit DDL.
+   Set Staging as the parent for disposable `preview/<git-branch>` branches so
+   those roles and grants are copied into every Preview.
 3. Keep Production in a separate Neon project. Its API key and migration URL
    must never be stored in the Preview or Staging GitHub environments.
 4. Create a Vercel custom environment named `staging`. Copy only approved
@@ -44,6 +48,7 @@ changing either Neon project.
 | --- | --- | --- | --- |
 | `preview` | `NEON_PROJECT_ID`, `NEON_MIGRATION_ROLE`, `NEON_RUNTIME_ROLE`, `NEON_DATABASE`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` | project-scoped `NEON_API_KEY`, `VERCEL_TOKEN` | Internal branches only; exclude `dev` and `main` |
 | `staging` | Same non-production variables | Same non-production secrets | `dev` only; no approval |
+| `production-migration-review` | None | None | `main` only; required reviewer |
 | `production` | `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` | `MIGRATION_DATABASE_URL`, `VERCEL_TOKEN` | `main` only; required reviewer |
 
 The committed `vercel.json` disables Vercel Git deployments. Do not re-enable
@@ -59,6 +64,9 @@ Verify `/admin/media` and `/admin/photos` on Staging after the workflow is green
 Feature pushes should create `preview/<git-branch>` once, preserve it across
 subsequent pushes, and delete both Neon and Vercel Preview resources when the
 Git branch is deleted. `Refresh Preview` is the explicit destructive reset path.
+All three operations share one per-branch concurrency lock. Refresh checks out
+the trusted deployment action from `dev` and runs the requested branch only
+from the isolated `target/` working directory.
 
 ## 2. Require Quality and CodeQL on both branches
 
@@ -185,12 +193,25 @@ results in the readiness report:
 ## 6. Production database and migrations
 
 Gated by two fresh explicit confirmations immediately before access. Verify
-the separate Production Neon project and CRUD-only runtime role. A merge to
-`main` then starts `Deploy Production`, waits for the protected GitHub
-environment reviewer, rejects contract-breaking migration SQL, applies pending
-expand migrations with the GitHub-only credential, and deploys the exact commit.
-Never approve that environment until the migration diff and rollback anchor
-have been reviewed.
+the separate Production Neon project, CRUD-only runtime role, and migration-role
+default privileges for both existing and future tables and sequences. A merge
+to `main` then starts `Deploy Production`. The no-secret
+`production-migration-review` environment records the first approval. Only
+after it succeeds can the separately protected `production` environment expose
+the migration credential and record the second approval.
+
+The workflow hash-locks reviewed migrations `0001` through `0010` and rejects
+any modification or deletion. Future migrations fail closed unless every SQL
+statement is an explicitly allowed expand operation: create a new table, type,
+sequence, view, function, or non-unique index; add a nullable column; add a
+non-null column with a statically proven non-null default; validate a named
+constraint; or set a statically proven non-null column default. New constraints,
+including `NOT VALID` constraints, affect new writes and therefore require an
+explicitly reviewed digest exception. Dynamic blocks, unknown default
+expressions, and every unrecognized statement are rejected. After both
+approvals and that check, the workflow applies pending migrations with the
+GitHub-only credential and deploys the exact commit. Do not approve either
+environment until the migration diff and rollback anchor have been reviewed.
 
 ## 7. Rollback anchor
 

--- a/docs/v3-cutover-ops-runbook.md
+++ b/docs/v3-cutover-ops-runbook.md
@@ -19,26 +19,55 @@ npx vercel project inspect cali-so $SCOPE
 If the repo is not yet linked, run `npx vercel link` once and pick the team
 and the `cali-so` project.
 
-## 1. Require Quality and CodeQL on both branches
+## 1. Activate the controlled deployment topology
 
-The `v2` ruleset (`18920686`) has deletion, non-fast-forward, and PR rules but
-no required checks; `main` classic protection has none. Add the rule to the
-ruleset by round-tripping it:
+These hosted changes are shared state. Obtain an action-time confirmation
+before the Git branch rename, and two fresh confirmations before inspecting or
+changing either Neon project.
 
-```bash
-gh api repos/CaliCastle/cali.so/rulesets/18920686 > /tmp/ruleset.json
-jq '{name, target, enforcement, conditions, bypass_actors, rules: (.rules + [{
-  "type": "required_status_checks",
-  "parameters": {
-    "strict_required_status_checks_policy": false,
-    "required_status_checks": [{"context": "Quality"}, {"context": "CodeQL"}]
-  }
-}])}' /tmp/ruleset.json > /tmp/ruleset-update.json
-gh api -X PUT repos/CaliCastle/cali.so/rulesets/18920686 \
-  --input /tmp/ruleset-update.json
-```
+1. Rename the Git integration branch from `v2` to `dev` through GitHub's branch
+   rename operation. Do not create a second unrelated branch or delete `v2`
+   manually. Verify open pull requests, local tracking branches, and the
+   existing ruleset now target `dev`.
+2. In the non-production Neon project, rename the persistent `preview` branch
+   to `staging`. Preserve its data, migration history, migration role, and
+   SQL-created CRUD-only runtime role. Set it as the parent for disposable
+   `preview/<git-branch>` branches.
+3. Keep Production in a separate Neon project. Its API key and migration URL
+   must never be stored in the Preview or Staging GitHub environments.
+4. Create a Vercel custom environment named `staging`. Copy only approved
+   non-production application settings into it; database URLs are supplied per
+   deployment by GitHub Actions.
+5. Create these GitHub deployment environments:
 
-Then protect `main` (PUT replaces the whole protection object; force pushes
+| Environment | Variables | Secrets | Protection |
+| --- | --- | --- | --- |
+| `preview` | `NEON_PROJECT_ID`, `NEON_MIGRATION_ROLE`, `NEON_RUNTIME_ROLE`, `NEON_DATABASE`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` | project-scoped `NEON_API_KEY`, `VERCEL_TOKEN` | Internal branches only; exclude `dev` and `main` |
+| `staging` | Same non-production variables | Same non-production secrets | `dev` only; no approval |
+| `production` | `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` | `MIGRATION_DATABASE_URL`, `VERCEL_TOKEN` | `main` only; required reviewer |
+
+The committed `vercel.json` disables Vercel Git deployments. Do not re-enable
+them in the dashboard: GitHub must create or select the Neon branch, migrate it,
+and only then call Vercel. Configure the hosted environments and rename the
+branch before merging this automation change into `dev`. That merge is the
+first Staging workflow run and applies all pending migrations, including
+`0010`, before deploying. Use GitHub's job rerun for a failed activation; the
+manual Staging dispatch becomes available after the workflow reaches the
+default branch.
+
+Verify `/admin/media` and `/admin/photos` on Staging after the workflow is green.
+Feature pushes should create `preview/<git-branch>` once, preserve it across
+subsequent pushes, and delete both Neon and Vercel Preview resources when the
+Git branch is deleted. `Refresh Preview` is the explicit destructive reset path.
+
+## 2. Require Quality and CodeQL on both branches
+
+The historical `v2` ruleset (`18920686`) already requires `Quality` and
+`CodeQL` alongside its deletion, non-fast-forward, and pull-request rules.
+After the branch rename, inspect the ruleset and verify its ref condition now
+targets `dev`; do not append a duplicate required-check rule.
+
+Protect `main` as well (PUT replaces the whole protection object; force pushes
 and deletions stay disabled by default):
 
 ```bash
@@ -52,7 +81,7 @@ gh api -X PUT repos/CaliCastle/cali.so/branches/main/protection --input - <<'JSO
 JSON
 ```
 
-## 2. Isolate Preview and Production credentials
+## 3. Isolate Staging, Preview, and Production credentials
 
 - The v3 app no longer uses Resend. Remove the legacy key from Preview rather
   than creating another key. Keep its Production assignment only while the
@@ -66,22 +95,16 @@ JSON
   existing Upstash integration to target Production only, or remove the
   integration and reconnect it for Production only. Delete every `KV_*`,
   `REDIS_URL`, and `UPSTASH_*` variable from Preview. Do not create a Preview
-  Redis store: Preview rate limits use its isolated Neon database.
+  Redis store: Staging and Preview rate limits use their isolated Neon
+  branches.
 
-- Before deploying this runtime contract to Preview, apply migration `0010`
-  with the separately held Preview migration credential. This is sensitive
-  remote database access and requires two fresh explicit confirmations. Never
-  place the migration credential in Vercel:
-
-  ```bash
-  MIGRATION_DATABASE_URL=postgresql://... pnpm db:migrate
-  ```
-
-  Verify the Preview runtime role can only select, insert, update, and delete
+- The first successful Staging workflow applies migration `0010` with the
+  separately scoped GitHub migration role before deployment. Verify the
+  Staging runtime role can only select, insert, update, and delete
   `rate_limit_windows`; it must not own the table or receive DDL privileges.
-  Preview has no Redis fallback: if the table or grants are missing,
+  Staging and Preview have no Redis fallback: if the table or grants are missing,
   rate-limited admin mutations fail closed with 503. Because the Redis
-  variables are already absent, do not count Preview mutation checks as passed
+  variables are already absent, do not count mutation checks as passed
   until this migration and grant verification succeeds.
 
 - Add a Preview-only `CLERK_SECRET_KEY` from the non-production Clerk
@@ -93,7 +116,7 @@ JSON
   npx vercel env rm AMA_ADMIN_ENABLED preview $SCOPE
   ```
 
-## 3. Provision the Production environment
+## 4. Provision the Production environment
 
 Production currently satisfies none of the v3 contract in `.env.example`.
 Each `env add` prompts for its value; generate fresh secrets rather than
@@ -150,7 +173,7 @@ The remaining `MEDIA_ALT_TEXT_*` and `BUNNY_STORAGE_CONTRACT_*` values are
 needed only when Alt Text generation and the live storage contract are turned
 on; consult `.env.example` and `docs/media/ai-provider-policy.md` first.
 
-## 4. Dashboard-only checks
+## 5. Dashboard-only checks
 
 The CLI does not expose these; verify in the Vercel dashboard and record the
 results in the readiness report:
@@ -159,17 +182,17 @@ results in the readiness report:
 - Firewall and Attack Challenge configuration.
 - Git production-branch mapping (`main`) and the `cali.so` certificate.
 
-## 5. Production database and migrations
+## 6. Production database and migrations
 
 Gated by two fresh explicit confirmations immediately before access. Verify
-the runtime role has only CRUD grants, then apply the ten additive
-migrations with the separately held credential:
+the separate Production Neon project and CRUD-only runtime role. A merge to
+`main` then starts `Deploy Production`, waits for the protected GitHub
+environment reviewer, rejects contract-breaking migration SQL, applies pending
+expand migrations with the GitHub-only credential, and deploys the exact commit.
+Never approve that environment until the migration diff and rollback anchor
+have been reviewed.
 
-```bash
-MIGRATION_DATABASE_URL=postgresql://... pnpm db:migrate
-```
-
-## 6. Rollback anchor
+## 7. Rollback anchor
 
 The last known-good production deployment is recorded in the readiness
 report's audit baseline. Deployments can age out of plan retention, so

--- a/docs/v3-cutover-readiness.md
+++ b/docs/v3-cutover-readiness.md
@@ -2,6 +2,12 @@
 
 Last checked: 2026-07-16 (hosted-control inventory refreshed the same day).
 
+The accepted deployment architecture now renames the integration branch from
+`v2` to `dev` and the persistent non-production database branch from Preview to
+Staging. The hosted rename and environment setup are still pending. Exact `v2`
+names below remain historical evidence from the dated audit baseline until the
+next hosted verification refresh.
+
 ## Verdict
 
 **NOT READY.** The merged `v2` integration branch is green under the complete
@@ -220,10 +226,12 @@ explicit confirmations immediately before access.
 
 ## Domain and rollback expectations
 
-The intended cutover is a reviewed merge from `v2` into `main`. Vercel should
-then build `main` and retain `cali.so` and `www.cali.so` on the same project.
-No manual DNS move is expected, but current project ownership, production
-branch, aliases, certificate, and environment scopes must be verified first.
+The intended cutover is a reviewed pull request from `dev` into `main`.
+`Deploy Production` must wait for protected-environment approval, migrate the
+separate Production Neon project, and then deploy that exact commit. Vercel
+must retain `cali.so` and `www.cali.so` on the same project. No manual DNS move
+is expected, but current project ownership, aliases, certificate, and
+environment scopes must be verified first.
 
 Rollback must prefer promoting the last known-good Vercel production deployment
 or reverting the cutover merge. The ten additive database migrations should
@@ -236,27 +244,29 @@ operator before cutover.
 The maintainer-operated commands for actions 1 through 4 are collected in
 `docs/v3-cutover-ops-runbook.md`.
 
-1. Provision the Production environment for the v3 contract: replace the
+1. Rename Git `v2` to `dev`, rename the persistent non-production Neon branch
+   to `staging`, configure the three GitHub deployment environments, and create
+   the Vercel custom Staging environment.
+2. Run the GitHub-controlled Staging deployment. With two fresh confirmations,
+   verify migration `0010`, Media tables, and the runtime role's CRUD-only
+   grants. Until these pass, treat Staging admin reads and mutations as
+   unavailable rather than validated.
+3. Provision the Production environment for the v3 contract: replace the
    legacy `DATABASE_URL` with the CRUD-only Neon runtime role and add the
    missing secrets, rate limits, capability switches, and complete Bunny and
    media configuration.
-2. With two fresh confirmations, verify migration `0010` on Preview and the
-   runtime role's CRUD-only grants for `rate_limit_windows`. Until both pass,
-   treat rate-limited Preview admin mutations as potentially unavailable by
-   fail-closed 503 responses rather than as validated behavior.
-3. Add `Quality` and `CodeQL` as required checks to `main`; the `v2` ruleset is
-   already complete.
-4. In the Vercel dashboard, verify logs, drains, retention, firewall rules,
+4. Verify `Quality` and `CodeQL` are required on protected `dev` and `main`.
+5. In the Vercel dashboard, verify logs, drains, retention, firewall rules,
    the production-branch mapping, and the certificate.
-5. With two fresh confirmations, verify production runtime database grants
-   and migration state, then apply migrations `0001` through `0010` with the
-   separately supplied migration credential.
-6. Verify the production Bunny and Neon Media boundary, run the protected live
+6. With two fresh confirmations, verify Production runtime grants and the
+   reviewed initial migration baseline. Approve the protected Production
+   environment only after confirming the workflow will migrate before deploy.
+7. Verify the production Bunny and Neon Media boundary, run the protected live
    storage contract, and publish the intended two-photo Published Photo
    Selection through the owner admin.
-7. Review the recorded production-like Vercel Preview across the remaining
+8. Review the recorded production-like Vercel Preview across the remaining
    browser matrix and confirm the fresh Chinese and English Preview pageviews
    are visible in the existing `cali-so` Analytics dashboard.
-8. Confirm the rollback procedure against the recorded known-good deployment.
-9. Only after every blocker above is passed, approve the separately operated
-   merge to `main` and production cutover.
+9. Confirm the rollback procedure against the recorded known-good deployment.
+10. Only after every blocker above is passed, merge `dev` to `main`, approve
+    the protected Production deployment, and complete the cutover smoke tests.

--- a/docs/v3-cutover-readiness.md
+++ b/docs/v3-cutover-readiness.md
@@ -227,8 +227,9 @@ explicit confirmations immediately before access.
 ## Domain and rollback expectations
 
 The intended cutover is a reviewed pull request from `dev` into `main`.
-`Deploy Production` must wait for protected-environment approval, migrate the
-separate Production Neon project, and then deploy that exact commit. Vercel
+`Deploy Production` must wait for the no-secret migration-review approval and
+then the separately protected Production approval, migrate the separate
+Production Neon project, and deploy that exact commit. Vercel
 must retain `cali.so` and `www.cali.so` on the same project. No manual DNS move
 is expected, but current project ownership, aliases, certificate, and
 environment scopes must be verified first.
@@ -245,7 +246,7 @@ The maintainer-operated commands for actions 1 through 4 are collected in
 `docs/v3-cutover-ops-runbook.md`.
 
 1. Rename Git `v2` to `dev`, rename the persistent non-production Neon branch
-   to `staging`, configure the three GitHub deployment environments, and create
+   to `staging`, configure the four GitHub deployment environments, and create
    the Vercel custom Staging environment.
 2. Run the GitHub-controlled Staging deployment. With two fresh confirmations,
    verify migration `0010`, Media tables, and the runtime role's CRUD-only
@@ -259,8 +260,10 @@ The maintainer-operated commands for actions 1 through 4 are collected in
 5. In the Vercel dashboard, verify logs, drains, retention, firewall rules,
    the production-branch mapping, and the certificate.
 6. With two fresh confirmations, verify Production runtime grants and the
-   reviewed initial migration baseline. Approve the protected Production
-   environment only after confirming the workflow will migrate before deploy.
+   reviewed initial migration baseline. Configure and approve the no-secret
+   `production-migration-review` environment first, then approve the protected
+   `production` environment only after confirming the workflow will migrate
+   before deploy.
 7. Verify the production Bunny and Neon Media boundary, run the protected live
    storage contract, and publish the intended two-photo Published Photo
    Selection through the owner admin.
@@ -269,4 +272,5 @@ The maintainer-operated commands for actions 1 through 4 are collected in
    are visible in the existing `cali-so` Analytics dashboard.
 9. Confirm the rollback procedure against the recorded known-good deployment.
 10. Only after every blocker above is passed, merge `dev` to `main`, approve
-    the protected Production deployment, and complete the cutover smoke tests.
+    both Production deployment gates in order, and complete the cutover smoke
+    tests.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:validate": "node --test scripts/ama-migrations.test.mjs",
+    "test:deployment": "node --test scripts/check-production-migrations.test.mjs scripts/delete-vercel-branch-deployments.test.mjs scripts/deployment-workflows.test.mjs",
     "start": "next start",
     "test:ama": "vitest run lib/ama && pnpm db:validate",
     "test:navigation": "NEXT_INSTANT_NAVIGATION_TEST=1 next build && playwright test",
@@ -100,6 +101,7 @@
     "playwright": "^1.61.1",
     "tailwindcss": "^4.1.0",
     "typescript": "^5.8.0",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.10",
+    "yaml": "^2.9.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
 packages:
 

--- a/scripts/check-production-migrations.mjs
+++ b/scripts/check-production-migrations.mjs
@@ -370,6 +370,22 @@ function allowedCreate(tokens) {
   return tokens[1]?.value === 'MATERIALIZED' && tokens[2]?.value === 'VIEW'
 }
 
+function addColumnDefinition(action) {
+  let columnIndex = 2
+  if (
+    action[2]?.value === 'IF' &&
+    action[3]?.value === 'NOT' &&
+    action[4]?.value === 'EXISTS'
+  ) {
+    columnIndex = 5
+  }
+  if (!['word', 'identifier'].includes(action[columnIndex]?.type)) {
+    return undefined
+  }
+  const definition = action.slice(columnIndex + 1)
+  return definition.length === 0 ? undefined : definition
+}
+
 function alterTableFinding(tokens) {
   const action = tableAction(tokens)
   if (action.length === 0) return 'UNRECOGNIZED STATEMENT'
@@ -378,7 +394,8 @@ function alterTableFinding(tokens) {
   }
 
   if (action[0]?.value === 'ADD' && action[1]?.value === 'COLUMN') {
-    const definition = action.slice(3)
+    const definition = addColumnDefinition(action)
+    if (!definition) return 'UNRECOGNIZED STATEMENT'
     const hasNotNull = hasSequence(definition, ['NOT', 'NULL'], 0)
     const defaultIndex = definition.findIndex(
       (token) => token.depth === 0 && token.value === 'DEFAULT',

--- a/scripts/check-production-migrations.mjs
+++ b/scripts/check-production-migrations.mjs
@@ -1,0 +1,253 @@
+import { execFileSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { readFile, readdir } from 'node:fs/promises'
+import { pathToFileURL } from 'node:url'
+
+const destructiveOperations = [
+  ['DROP TABLE', /\bDROP\s+TABLE\b/giu],
+  ['DROP SCHEMA', /\bDROP\s+SCHEMA\b/giu],
+  ['DROP TYPE', /\bDROP\s+TYPE\b/giu],
+  ['DROP DOMAIN', /\bDROP\s+DOMAIN\b/giu],
+  ['DROP SEQUENCE', /\bDROP\s+SEQUENCE\b/giu],
+  ['DROP VIEW', /\bDROP\s+(?:MATERIALIZED\s+)?VIEW\b/giu],
+  ['DROP FUNCTION', /\bDROP\s+(?:FUNCTION|PROCEDURE)\b/giu],
+  ['TRUNCATE', /\bTRUNCATE(?:\s+TABLE)?\b/giu],
+  ['DELETE', /\bDELETE\s+FROM\b/giu],
+  ['DROP COLUMN', /\bALTER\s+TABLE\b[^;]*?\bDROP\s+COLUMN\b/gisu],
+  ['RENAME', /\bALTER\s+(?:TABLE|TYPE|DOMAIN)\b[^;]*?\bRENAME\b/gisu],
+  [
+    'ALTER COLUMN TYPE',
+    /\bALTER\s+TABLE\b[^;]*?\bALTER\s+COLUMN\b[^;]*?\bTYPE\b/gisu,
+  ],
+  [
+    'SET NOT NULL',
+    /\bALTER\s+TABLE\b[^;]*?\bALTER\s+COLUMN\b[^;]*?\bSET\s+NOT\s+NULL\b/gisu,
+  ],
+  [
+    'DROP DEFAULT',
+    /\bALTER\s+TABLE\b[^;]*?\bALTER\s+COLUMN\b[^;]*?\bDROP\s+DEFAULT\b/gisu,
+  ],
+  ['DROP CONSTRAINT', /\bALTER\s+TABLE\b[^;]*?\bDROP\s+CONSTRAINT\b/gisu],
+  ['SET SCHEMA', /\bALTER\s+TABLE\b[^;]*?\bSET\s+SCHEMA\b/gisu],
+]
+
+const reviewedInitialMigrationDigests = new Map([
+  [
+    'db/migrations/0001_ama_owner_auth.sql',
+    '839932b28e9c4bf079a03b911f93a17ee52ca9360989d57f5b9bb19dfe07885b',
+  ],
+  [
+    'db/migrations/0002_ama_availability.sql',
+    'd231874f888a5cca3808c0a9f1fb46bfd85de3ea48163e61ae1e91a49438efbe',
+  ],
+  [
+    'db/migrations/0003_ama_google_calendar.sql',
+    '2bc0a27f0aaf5bbc13f09634c6e38455be72ae32aacbe1e743477bde7695d5d9',
+  ],
+  [
+    'db/migrations/0004_ama_google_oauth.sql',
+    'b44fdb68af6b0797c45643f1399dfb9aa08eec24be09ff94cb569f7ac11f6de0',
+  ],
+  [
+    'db/migrations/0005_media_catalog.sql',
+    '59d9c19e2beea74ea071596ed71f08d4cc8f5c872c766e0fd6e5cbd05e8220c5',
+  ],
+  [
+    'db/migrations/0006_photo_selection.sql',
+    '6f0070cc9cc8baa09d573d7c1bfe5438d482c13d543cc01840268b5bf6f75da5',
+  ],
+  [
+    'db/migrations/0007_photo_publication_revision.sql',
+    '2f9e730dfa226e9abbd39b527b9d3ff6bbca540a148247ba63e4e15d7fabf3d3',
+  ],
+  [
+    'db/migrations/0008_media_purge_progress.sql',
+    '5e243a9730d4265c8c38ba021abb78aa6d3021bdc16581c4d08a9b154cfae068',
+  ],
+  [
+    'db/migrations/0009_media_catalog_state.sql',
+    '4093b49d5cbd10c5d7a856d7a259b5e7efe6086ab84c33ee1c4857cb03d700bf',
+  ],
+  [
+    'db/migrations/0010_rate_limit_windows.sql',
+    '02868db5c548947ccd50bd8fa2a84c0507128bc97d1c5932dca990fb3f7cc289',
+  ],
+])
+
+function maskRange(characters, start, end) {
+  for (let index = start; index < end; index += 1) {
+    if (characters[index] !== '\n') characters[index] = ' '
+  }
+}
+
+function sqlWithoutCommentsAndLiterals(sql) {
+  const characters = [...sql]
+  let index = 0
+
+  while (index < sql.length) {
+    if (sql.startsWith('--', index)) {
+      const end = sql.indexOf('\n', index + 2)
+      const stop = end === -1 ? sql.length : end
+      maskRange(characters, index, stop)
+      index = stop
+      continue
+    }
+    if (sql.startsWith('/*', index)) {
+      let depth = 1
+      let end = index + 2
+      while (end < sql.length && depth > 0) {
+        if (sql.startsWith('/*', end)) {
+          depth += 1
+          end += 2
+        } else if (sql.startsWith('*/', end)) {
+          depth -= 1
+          end += 2
+        } else {
+          end += 1
+        }
+      }
+      maskRange(characters, index, end)
+      index = end
+      continue
+    }
+    if (sql[index] === "'" || sql[index] === '"') {
+      const quote = sql[index]
+      let end = index + 1
+      while (end < sql.length) {
+        if (sql[end] === quote && sql[end + 1] === quote) {
+          end += 2
+        } else if (sql[end] === quote) {
+          end += 1
+          break
+        } else {
+          end += 1
+        }
+      }
+      maskRange(characters, index, end)
+      index = end
+      continue
+    }
+    if (sql[index] === '$') {
+      const delimiter = sql
+        .slice(index)
+        .match(/^\$[A-Za-z_][A-Za-z0-9_]*\$|^\$\$/u)?.[0]
+      if (delimiter) {
+        const closing = sql.indexOf(delimiter, index + delimiter.length)
+        const end = closing === -1 ? sql.length : closing + delimiter.length
+        maskRange(characters, index, end)
+        index = end
+        continue
+      }
+    }
+    index += 1
+  }
+  return characters.join('')
+}
+
+export function destructiveMigrationFindings(sql) {
+  const searchable = sqlWithoutCommentsAndLiterals(sql)
+  const findings = []
+  for (const [operation, expression] of destructiveOperations) {
+    expression.lastIndex = 0
+    for (const match of searchable.matchAll(expression)) {
+      findings.push({
+        operation,
+        line: searchable.slice(0, match.index).split('\n').length,
+        index: match.index,
+      })
+    }
+  }
+  return findings
+    .sort((left, right) => left.index - right.index)
+    .map(({ index: _index, ...finding }) => finding)
+}
+
+export function productionMigrationFindings(path, sql) {
+  const reviewedDigest = reviewedInitialMigrationDigests.get(path)
+  if (reviewedDigest) {
+    const digest = createHash('sha256').update(sql).digest('hex')
+    if (digest !== reviewedDigest) {
+      throw new Error(`Reviewed initial migration is immutable: ${path}`)
+    }
+    return []
+  }
+  return destructiveMigrationFindings(sql)
+}
+
+export function parseChangedMigrations(output) {
+  const added = []
+  for (const line of output.trim().split('\n').filter(Boolean)) {
+    const [status, ...paths] = line.split('\t')
+    const migrationPaths = paths.filter((path) =>
+      /^db\/migrations\/[^/]+\.sql$/u.test(path),
+    )
+    if (migrationPaths.length === 0) continue
+    if (status !== 'A') {
+      throw new Error(
+        `Applied migration files are immutable: ${migrationPaths.join(', ')}`,
+      )
+    }
+    added.push(...migrationPaths)
+  }
+  return added
+}
+
+export function migrationPathsInRepository(fileNames) {
+  return fileNames
+    .filter((name) => /^[^/]+\.sql$/u.test(name))
+    .sort()
+    .map((name) => `db/migrations/${name}`)
+}
+
+function assertCommit(value, name) {
+  if (!/^[0-9a-f]{40}$/iu.test(value ?? '')) {
+    throw new Error(`${name} must be a full Git commit SHA`)
+  }
+  if (/^0{40}$/u.test(value)) {
+    throw new Error(`${name} cannot be the empty Git commit SHA`)
+  }
+  return value
+}
+
+export function migrationDiffArguments(base, head) {
+  return [
+    'diff',
+    '--name-status',
+    '--diff-filter=ACDMRT',
+    `${base}..${head}`,
+    '--',
+    'db/migrations/*.sql',
+  ]
+}
+
+async function main() {
+  const base = assertCommit(process.argv[2], 'Base')
+  const head = assertCommit(process.argv[3], 'Head')
+  const changed = execFileSync('git', migrationDiffArguments(base, head), {
+    encoding: 'utf8',
+  })
+  const changedMigrations = parseChangedMigrations(changed)
+  const migrations = migrationPathsInRepository(await readdir('db/migrations'))
+  const unsafe = []
+  for (const path of migrations) {
+    const sql = await readFile(path, 'utf8')
+    for (const finding of productionMigrationFindings(path, sql)) {
+      unsafe.push(`${path}:${finding.line} ${finding.operation}`)
+    }
+  }
+  if (unsafe.length > 0) {
+    throw new Error(
+      `Production migrations must use an expand-only release:\n${unsafe.join('\n')}`,
+    )
+  }
+  console.log(
+    `Checked ${migrations.length} Production migration(s); ${changedMigrations.length} added in this release.`,
+  )
+}
+
+if (
+  process.argv[1] &&
+  pathToFileURL(process.argv[1]).href === import.meta.url
+) {
+  await main()
+}

--- a/scripts/check-production-migrations.mjs
+++ b/scripts/check-production-migrations.mjs
@@ -3,35 +3,7 @@ import { createHash } from 'node:crypto'
 import { readFile, readdir } from 'node:fs/promises'
 import { pathToFileURL } from 'node:url'
 
-const destructiveOperations = [
-  ['DROP TABLE', /\bDROP\s+TABLE\b/giu],
-  ['DROP SCHEMA', /\bDROP\s+SCHEMA\b/giu],
-  ['DROP TYPE', /\bDROP\s+TYPE\b/giu],
-  ['DROP DOMAIN', /\bDROP\s+DOMAIN\b/giu],
-  ['DROP SEQUENCE', /\bDROP\s+SEQUENCE\b/giu],
-  ['DROP VIEW', /\bDROP\s+(?:MATERIALIZED\s+)?VIEW\b/giu],
-  ['DROP FUNCTION', /\bDROP\s+(?:FUNCTION|PROCEDURE)\b/giu],
-  ['TRUNCATE', /\bTRUNCATE(?:\s+TABLE)?\b/giu],
-  ['DELETE', /\bDELETE\s+FROM\b/giu],
-  ['DROP COLUMN', /\bALTER\s+TABLE\b[^;]*?\bDROP\s+COLUMN\b/gisu],
-  ['RENAME', /\bALTER\s+(?:TABLE|TYPE|DOMAIN)\b[^;]*?\bRENAME\b/gisu],
-  [
-    'ALTER COLUMN TYPE',
-    /\bALTER\s+TABLE\b[^;]*?\bALTER\s+COLUMN\b[^;]*?\bTYPE\b/gisu,
-  ],
-  [
-    'SET NOT NULL',
-    /\bALTER\s+TABLE\b[^;]*?\bALTER\s+COLUMN\b[^;]*?\bSET\s+NOT\s+NULL\b/gisu,
-  ],
-  [
-    'DROP DEFAULT',
-    /\bALTER\s+TABLE\b[^;]*?\bALTER\s+COLUMN\b[^;]*?\bDROP\s+DEFAULT\b/gisu,
-  ],
-  ['DROP CONSTRAINT', /\bALTER\s+TABLE\b[^;]*?\bDROP\s+CONSTRAINT\b/gisu],
-  ['SET SCHEMA', /\bALTER\s+TABLE\b[^;]*?\bSET\s+SCHEMA\b/gisu],
-]
-
-const reviewedInitialMigrationDigests = new Map([
+const reviewedMigrationDigests = new Map([
   [
     'db/migrations/0001_ama_owner_auth.sql',
     '839932b28e9c4bf079a03b911f93a17ee52ca9360989d57f5b9bb19dfe07885b',
@@ -74,96 +46,428 @@ const reviewedInitialMigrationDigests = new Map([
   ],
 ])
 
-function maskRange(characters, start, end) {
-  for (let index = start; index < end; index += 1) {
-    if (characters[index] !== '\n') characters[index] = ' '
-  }
+function dollarDelimiterAt(sql, index) {
+  return sql
+    .slice(index)
+    .match(/^\$[A-Za-z_][A-Za-z0-9_]*\$|^\$\$/u)?.[0]
 }
 
-function sqlWithoutCommentsAndLiterals(sql) {
-  const characters = [...sql]
-  let index = 0
+function skipQuoted(sql, index, quote) {
+  let cursor = index + 1
+  while (cursor < sql.length) {
+    if (sql[cursor] === quote && sql[cursor + 1] === quote) {
+      cursor += 2
+    } else if (sql[cursor] === quote) {
+      return cursor + 1
+    } else {
+      cursor += 1
+    }
+  }
+  return sql.length
+}
 
+function skipBlockComment(sql, index) {
+  let cursor = index + 2
+  let depth = 1
+  while (cursor < sql.length && depth > 0) {
+    if (sql.startsWith('/*', cursor)) {
+      depth += 1
+      cursor += 2
+    } else if (sql.startsWith('*/', cursor)) {
+      depth -= 1
+      cursor += 2
+    } else {
+      cursor += 1
+    }
+  }
+  return cursor
+}
+
+function firstTokenLine(sql, initialLine) {
+  let line = initialLine
+  let index = 0
   while (index < sql.length) {
+    if (/\s/u.test(sql[index])) {
+      if (sql[index] === '\n') line += 1
+      index += 1
+      continue
+    }
     if (sql.startsWith('--', index)) {
       const end = sql.indexOf('\n', index + 2)
-      const stop = end === -1 ? sql.length : end
-      maskRange(characters, index, stop)
-      index = stop
+      index = end === -1 ? sql.length : end
       continue
     }
     if (sql.startsWith('/*', index)) {
-      let depth = 1
-      let end = index + 2
-      while (end < sql.length && depth > 0) {
-        if (sql.startsWith('/*', end)) {
-          depth += 1
-          end += 2
-        } else if (sql.startsWith('*/', end)) {
-          depth -= 1
-          end += 2
-        } else {
-          end += 1
-        }
-      }
-      maskRange(characters, index, end)
+      const end = skipBlockComment(sql, index)
+      line += sql.slice(index, end).split('\n').length - 1
+      index = end
+      continue
+    }
+    break
+  }
+  return line
+}
+
+function splitSqlStatements(sql) {
+  const statements = []
+  let start = 0
+  let startLine = 1
+  let line = 1
+  let index = 0
+
+  while (index < sql.length) {
+    if (sql[index] === '\n') {
+      line += 1
+      index += 1
+      continue
+    }
+    if (sql.startsWith('--', index)) {
+      const end = sql.indexOf('\n', index + 2)
+      index = end === -1 ? sql.length : end
+      continue
+    }
+    if (sql.startsWith('/*', index)) {
+      const end = skipBlockComment(sql, index)
+      line += sql.slice(index, end).split('\n').length - 1
       index = end
       continue
     }
     if (sql[index] === "'" || sql[index] === '"') {
-      const quote = sql[index]
-      let end = index + 1
-      while (end < sql.length) {
-        if (sql[end] === quote && sql[end + 1] === quote) {
-          end += 2
-        } else if (sql[end] === quote) {
-          end += 1
-          break
-        } else {
-          end += 1
-        }
-      }
-      maskRange(characters, index, end)
+      const end = skipQuoted(sql, index, sql[index])
+      line += sql.slice(index, end).split('\n').length - 1
       index = end
       continue
     }
     if (sql[index] === '$') {
-      const delimiter = sql
-        .slice(index)
-        .match(/^\$[A-Za-z_][A-Za-z0-9_]*\$|^\$\$/u)?.[0]
+      const delimiter = dollarDelimiterAt(sql, index)
       if (delimiter) {
         const closing = sql.indexOf(delimiter, index + delimiter.length)
         const end = closing === -1 ? sql.length : closing + delimiter.length
-        maskRange(characters, index, end)
+        line += sql.slice(index, end).split('\n').length - 1
         index = end
         continue
       }
     }
+    if (sql[index] === ';') {
+      const statementSql = sql.slice(start, index + 1)
+      statements.push({
+        sql: statementSql,
+        line: firstTokenLine(statementSql, startLine),
+      })
+      start = index + 1
+      startLine = line
+    }
     index += 1
   }
-  return characters.join('')
+
+  if (sql.slice(start).trim()) {
+    const statementSql = sql.slice(start)
+    statements.push({
+      sql: statementSql,
+      line: firstTokenLine(statementSql, startLine),
+    })
+  }
+  return statements
 }
 
-export function destructiveMigrationFindings(sql) {
-  const searchable = sqlWithoutCommentsAndLiterals(sql)
-  const findings = []
-  for (const [operation, expression] of destructiveOperations) {
-    expression.lastIndex = 0
-    for (const match of searchable.matchAll(expression)) {
-      findings.push({
-        operation,
-        line: searchable.slice(0, match.index).split('\n').length,
-        index: match.index,
-      })
+function sqlTokens(sql) {
+  const tokens = []
+  let depth = 0
+  let index = 0
+
+  while (index < sql.length) {
+    if (/\s/u.test(sql[index]) || sql[index] === ';') {
+      index += 1
+      continue
     }
+    if (sql.startsWith('--', index)) {
+      const end = sql.indexOf('\n', index + 2)
+      index = end === -1 ? sql.length : end
+      continue
+    }
+    if (sql.startsWith('/*', index)) {
+      index = skipBlockComment(sql, index)
+      continue
+    }
+    if (sql[index] === "'") {
+      tokens.push({ value: '<LITERAL>', type: 'literal', depth })
+      index = skipQuoted(sql, index, "'")
+      continue
+    }
+    if (sql[index] === '"') {
+      tokens.push({ value: '<IDENTIFIER>', type: 'identifier', depth })
+      index = skipQuoted(sql, index, '"')
+      continue
+    }
+    if (sql[index] === '$') {
+      const delimiter = dollarDelimiterAt(sql, index)
+      if (delimiter) {
+        tokens.push({ value: '<LITERAL>', type: 'literal', depth })
+        const closing = sql.indexOf(delimiter, index + delimiter.length)
+        index = closing === -1 ? sql.length : closing + delimiter.length
+        continue
+      }
+    }
+    if (sql[index] === '(') {
+      tokens.push({ value: '(', type: 'punctuation', depth })
+      depth += 1
+      index += 1
+      continue
+    }
+    if (sql[index] === ')') {
+      depth = Math.max(0, depth - 1)
+      tokens.push({ value: ')', type: 'punctuation', depth })
+      index += 1
+      continue
+    }
+    const number = sql
+      .slice(index)
+      .match(/^(?:\d+(?:\.\d*)?|\.\d+)(?:E[+-]?\d+)?/iu)?.[0]
+    if (number) {
+      tokens.push({ value: number.toUpperCase(), type: 'number', depth })
+      index += number.length
+      continue
+    }
+    if (sql[index] === '.' || sql[index] === ',') {
+      tokens.push({ value: sql[index], type: 'punctuation', depth })
+      index += 1
+      continue
+    }
+    const word = sql.slice(index).match(/^[A-Za-z_][A-Za-z0-9_$]*/u)?.[0]
+    if (word) {
+      tokens.push({ value: word.toUpperCase(), type: 'word', depth })
+      index += word.length
+      continue
+    }
+    tokens.push({ value: sql[index], type: 'operator', depth })
+    index += 1
+  }
+  return tokens
+}
+
+function hasSequence(tokens, values, depth) {
+  return tokens.some((token, index) => {
+    if (depth !== undefined && token.depth !== depth) return false
+    return values.every((value, offset) => {
+      const candidate = tokens[index + offset]
+      return candidate?.depth === token.depth && candidate.value === value
+    })
+  })
+}
+
+function withoutOuterParentheses(tokens) {
+  let expression = tokens
+  while (
+    expression[0]?.value === '(' &&
+    expression.at(-1)?.value === ')'
+  ) {
+    let balance = 0
+    let wrapsWholeExpression = true
+    for (let index = 0; index < expression.length; index += 1) {
+      if (expression[index].value === '(') balance += 1
+      if (expression[index].value === ')') balance -= 1
+      if (balance === 0 && index < expression.length - 1) {
+        wrapsWholeExpression = false
+        break
+      }
+    }
+    if (!wrapsWholeExpression || balance !== 0) break
+    expression = expression.slice(1, -1)
+  }
+  return expression
+}
+
+function isProvablyNonNullDefault(tokens) {
+  const expression = withoutOuterParentheses(tokens)
+  if (expression.length === 1) {
+    const [token] = expression
+    return (
+      token.type === 'literal' ||
+      token.type === 'number' ||
+      [
+        'CURRENT_DATE',
+        'CURRENT_TIME',
+        'CURRENT_TIMESTAMP',
+        'FALSE',
+        'LOCALTIME',
+        'LOCALTIMESTAMP',
+        'TRUE',
+      ].includes(token.value)
+    )
+  }
+  if (
+    expression.length === 2 &&
+    ['+', '-'].includes(expression[0].value) &&
+    expression[1].type === 'number'
+  ) {
+    return true
+  }
+  return (
+    expression.length === 3 &&
+    ['GEN_RANDOM_UUID', 'NOW'].includes(expression[0].value) &&
+    expression[1].value === '(' &&
+    expression[2].value === ')'
+  )
+}
+
+function tableAction(tokens) {
+  if (tokens[0]?.value !== 'ALTER' || tokens[1]?.value !== 'TABLE') return []
+  let index = 2
+  if (tokens[index]?.value === 'ONLY') index += 1
+  if (tokens[index]?.value === 'IF' && tokens[index + 1]?.value === 'EXISTS') {
+    index += 2
+  }
+  if (!['word', 'identifier'].includes(tokens[index]?.type)) return []
+  index += 1
+  while (
+    tokens[index]?.value === '.' &&
+    ['word', 'identifier'].includes(tokens[index + 1]?.type)
+  ) {
+    index += 2
+  }
+  return tokens.slice(index)
+}
+
+function specificUnsafeOperation(tokens) {
+  if (tokens[0]?.value === 'DROP' && tokens[1]?.type === 'word') {
+    return `DROP ${tokens[1].value}`
+  }
+  if (tokens[0]?.value === 'TRUNCATE') return 'TRUNCATE'
+  if (tokens[0]?.value === 'DELETE') return 'DELETE'
+
+  const action = tableAction(tokens)
+  if (action[0]?.value === 'DROP' && action[1]?.value === 'COLUMN') {
+    return 'DROP COLUMN'
+  }
+  if (action[0]?.value === 'DROP' && action[1]?.value === 'CONSTRAINT') {
+    return 'DROP CONSTRAINT'
+  }
+  if (action[0]?.value === 'RENAME') return 'RENAME'
+  if (action[0]?.value === 'SET' && action[1]?.value === 'SCHEMA') {
+    return 'SET SCHEMA'
+  }
+  if (action[0]?.value === 'ALTER' && action[1]?.value === 'COLUMN') {
+    if (hasSequence(action, ['TYPE'], 0)) return 'ALTER COLUMN TYPE'
+    if (hasSequence(action, ['SET', 'NOT', 'NULL'], 0)) return 'SET NOT NULL'
+    if (hasSequence(action, ['DROP', 'DEFAULT'], 0)) return 'DROP DEFAULT'
+  }
+  return 'UNRECOGNIZED STATEMENT'
+}
+
+function allowedCreate(tokens) {
+  if (tokens[0]?.value !== 'CREATE') return false
+  if (
+    ['TABLE', 'TYPE', 'SEQUENCE', 'VIEW', 'FUNCTION', 'INDEX'].includes(
+      tokens[1]?.value,
+    )
+  ) {
+    return true
+  }
+  return tokens[1]?.value === 'MATERIALIZED' && tokens[2]?.value === 'VIEW'
+}
+
+function alterTableFinding(tokens) {
+  const action = tableAction(tokens)
+  if (action.length === 0) return 'UNRECOGNIZED STATEMENT'
+  if (action.some((token) => token.value === ',' && token.depth === 0)) {
+    return 'UNRECOGNIZED STATEMENT'
+  }
+
+  if (action[0]?.value === 'ADD' && action[1]?.value === 'COLUMN') {
+    const definition = action.slice(3)
+    const hasNotNull = hasSequence(definition, ['NOT', 'NULL'], 0)
+    const defaultIndex = definition.findIndex(
+      (token) => token.depth === 0 && token.value === 'DEFAULT',
+    )
+    const trailingNotNullIndex = definition.findIndex((token, index) => {
+      return (
+        index > defaultIndex &&
+        token.depth === 0 &&
+        token.value === 'NOT' &&
+        definition[index + 1]?.depth === 0 &&
+        definition[index + 1]?.value === 'NULL'
+      )
+    })
+    const defaultExpression =
+      defaultIndex === -1
+        ? []
+        : definition.slice(
+            defaultIndex + 1,
+            trailingNotNullIndex === -1
+              ? definition.length
+              : trailingNotNullIndex,
+          )
+    const hasSafeDefault =
+      defaultIndex !== -1 && isProvablyNonNullDefault(defaultExpression)
+    if (hasNotNull && !hasSafeDefault) {
+      return 'ADD COLUMN NOT NULL WITHOUT SAFE DEFAULT'
+    }
+    if (defaultIndex !== -1 && !hasSafeDefault) {
+      return 'ADD COLUMN REQUIRES SAFE DEFAULT'
+    }
+    if (
+      definition.some(
+        (token) =>
+          token.depth === 0 &&
+          [
+            'CHECK',
+            'CONSTRAINT',
+            'GENERATED',
+            'IDENTITY',
+            'PRIMARY',
+            'REFERENCES',
+            'UNIQUE',
+          ].includes(token.value),
+      )
+    ) {
+      return 'UNRECOGNIZED STATEMENT'
+    }
+    return undefined
+  }
+
+  if (action[0]?.value === 'ADD' && action[1]?.value === 'CONSTRAINT') {
+    return 'ADD CONSTRAINT REQUIRES REVIEW'
+  }
+
+  if (
+    action[0]?.value === 'VALIDATE' &&
+    action[1]?.value === 'CONSTRAINT' &&
+    action.length === 3
+  ) {
+    return undefined
+  }
+
+  if (
+    action[0]?.value === 'ALTER' &&
+    action[1]?.value === 'COLUMN' &&
+    action[3]?.value === 'SET' &&
+    action[4]?.value === 'DEFAULT' &&
+    action.length > 5
+  ) {
+    return isProvablyNonNullDefault(action.slice(5))
+      ? undefined
+      : 'SET DEFAULT REQUIRES SAFE VALUE'
+  }
+
+  return specificUnsafeOperation(tokens)
+}
+
+export function expandOnlyMigrationFindings(sql) {
+  const findings = []
+  for (const statement of splitSqlStatements(sql)) {
+    const tokens = sqlTokens(statement.sql)
+    if (tokens.length === 0 || allowedCreate(tokens)) continue
+    const operation =
+      tokens[0]?.value === 'ALTER' && tokens[1]?.value === 'TABLE'
+        ? alterTableFinding(tokens)
+        : specificUnsafeOperation(tokens)
+    if (operation) findings.push({ operation, line: statement.line })
   }
   return findings
-    .sort((left, right) => left.index - right.index)
-    .map(({ index: _index, ...finding }) => finding)
 }
 
 export function productionMigrationFindings(path, sql) {
-  const reviewedDigest = reviewedInitialMigrationDigests.get(path)
+  const reviewedDigest = reviewedMigrationDigests.get(path)
   if (reviewedDigest) {
     const digest = createHash('sha256').update(sql).digest('hex')
     if (digest !== reviewedDigest) {
@@ -171,7 +475,7 @@ export function productionMigrationFindings(path, sql) {
     }
     return []
   }
-  return destructiveMigrationFindings(sql)
+  return expandOnlyMigrationFindings(sql)
 }
 
 export function parseChangedMigrations(output) {

--- a/scripts/check-production-migrations.test.mjs
+++ b/scripts/check-production-migrations.test.mjs
@@ -43,6 +43,25 @@ test('accepts only explicitly reviewed expand operations', () => {
   assert.deepEqual(expandOnlyMigrationFindings(sql), [])
 })
 
+test('parses ADD COLUMN IF NOT EXISTS before checking its definition', () => {
+  const safe = `
+    ALTER TABLE media_assets
+      ADD COLUMN IF NOT EXISTS owner_label text;
+    ALTER TABLE media_assets
+      ADD COLUMN IF NOT EXISTS sort_order bigint NOT NULL DEFAULT 0;
+  `
+  const unsafe = `
+    ALTER TABLE media_assets
+      ADD COLUMN IF NOT EXISTS sort_order bigint NOT NULL;
+  `
+
+  assert.deepEqual(expandOnlyMigrationFindings(safe), [])
+  assert.deepEqual(
+    expandOnlyMigrationFindings(unsafe).map(({ operation }) => operation),
+    ['ADD COLUMN NOT NULL WITHOUT SAFE DEFAULT'],
+  )
+})
+
 test('rejects contract-breaking and unrecognized operations', () => {
   const sql = `
     DROP TABLE old_media;

--- a/scripts/check-production-migrations.test.mjs
+++ b/scripts/check-production-migrations.test.mjs
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises'
 import { test } from 'node:test'
 
 import {
-  destructiveMigrationFindings,
+  expandOnlyMigrationFindings,
   migrationDiffArguments,
   migrationPathsInRepository,
   parseChangedMigrations,
@@ -18,15 +18,32 @@ test('accepts additive expand migrations', () => {
     );
     ALTER TABLE media_assets ADD COLUMN label_id uuid;
     CREATE INDEX media_assets_label_id_idx ON media_assets (label_id);
-    ALTER TABLE media_assets
-      ADD CONSTRAINT media_assets_label_id_fk
-      FOREIGN KEY (label_id) REFERENCES media_labels(id) NOT VALID;
   `
 
-  assert.deepEqual(destructiveMigrationFindings(sql), [])
+  assert.deepEqual(expandOnlyMigrationFindings(sql), [])
 })
 
-test('rejects contract-breaking schema and data operations', () => {
+test('accepts only explicitly reviewed expand operations', () => {
+  const sql = `
+    CREATE TYPE media_label_source AS ENUM ('owner', 'suggested');
+    CREATE SEQUENCE media_label_order_seq;
+    CREATE VIEW visible_media_labels AS SELECT id FROM media_labels;
+    CREATE FUNCTION visible_media_label_count() RETURNS bigint
+      LANGUAGE SQL AS 'SELECT count(*) FROM visible_media_labels';
+    ALTER TABLE media_assets ADD COLUMN sort_order bigint NOT NULL DEFAULT 0;
+    ALTER TABLE media_assets ADD COLUMN visible boolean NOT NULL DEFAULT true;
+    ALTER TABLE media_assets
+      ADD COLUMN created_at timestamptz NOT NULL DEFAULT now();
+    ALTER TABLE media_assets
+      ADD COLUMN public_id uuid NOT NULL DEFAULT gen_random_uuid();
+    ALTER TABLE media_assets ALTER COLUMN sort_order SET DEFAULT 1;
+    ALTER TABLE media_assets VALIDATE CONSTRAINT media_assets_label_id_fk;
+  `
+
+  assert.deepEqual(expandOnlyMigrationFindings(sql), [])
+})
+
+test('rejects contract-breaking and unrecognized operations', () => {
   const sql = `
     DROP TABLE old_media;
     ALTER TABLE media_assets DROP COLUMN legacy_caption;
@@ -39,7 +56,7 @@ test('rejects contract-breaking schema and data operations', () => {
   `
 
   assert.deepEqual(
-    destructiveMigrationFindings(sql).map(({ operation }) => operation),
+    expandOnlyMigrationFindings(sql).map(({ operation }) => operation),
     [
       'DROP TABLE',
       'DROP COLUMN',
@@ -53,15 +70,64 @@ test('rejects contract-breaking schema and data operations', () => {
   )
 })
 
-test('ignores destructive words inside SQL comments and string literals', () => {
+test('rejects unsafe column, constraint, and dynamic SQL forms', () => {
+  const sql = `
+    ALTER TABLE media_assets ADD COLUMN owner_label text NOT NULL;
+    ALTER TABLE media_assets
+      ADD CONSTRAINT media_assets_width_check CHECK (width > 0);
+    ALTER TABLE media_assets
+      ADD CONSTRAINT media_assets_sha_unique UNIQUE (sha256);
+    ALTER TABLE media_assets
+      ADD CONSTRAINT media_assets_hidden_check CHECK (NOT valid);
+    ALTER TABLE media_assets
+      ADD CONSTRAINT media_assets_label_fk
+      FOREIGN KEY (label_id) REFERENCES media_labels(id) NOT VALID;
+    ALTER TABLE media_assets
+      ADD CONSTRAINT media_assets_no_writes CHECK (false) NOT VALID;
+    ALTER TABLE media_assets
+      ADD COLUMN null_owner_label text NOT NULL DEFAULT (NULL);
+    ALTER TABLE media_assets
+      ADD COLUMN computed_owner_label text NOT NULL
+      DEFAULT (NULLIF('x', 'x'));
+    ALTER TABLE media_assets
+      ADD COLUMN computed_caption text DEFAULT COALESCE(NULL, 'caption');
+    ALTER TABLE media_assets ALTER COLUMN sort_order SET DEFAULT NULL;
+    CREATE UNIQUE INDEX media_assets_sha_idx ON media_assets (sha256);
+    DO $$
+    BEGIN
+      EXECUTE 'DROP TABLE media_assets';
+    END
+    $$;
+  `
+
+  assert.deepEqual(
+    expandOnlyMigrationFindings(sql).map(({ operation }) => operation),
+    [
+      'ADD COLUMN NOT NULL WITHOUT SAFE DEFAULT',
+      'ADD CONSTRAINT REQUIRES REVIEW',
+      'ADD CONSTRAINT REQUIRES REVIEW',
+      'ADD CONSTRAINT REQUIRES REVIEW',
+      'ADD CONSTRAINT REQUIRES REVIEW',
+      'ADD CONSTRAINT REQUIRES REVIEW',
+      'ADD COLUMN NOT NULL WITHOUT SAFE DEFAULT',
+      'ADD COLUMN NOT NULL WITHOUT SAFE DEFAULT',
+      'ADD COLUMN REQUIRES SAFE DEFAULT',
+      'SET DEFAULT REQUIRES SAFE VALUE',
+      'UNRECOGNIZED STATEMENT',
+      'UNRECOGNIZED STATEMENT',
+    ],
+  )
+})
+
+test('ignores operation words inside SQL comments and string literals', () => {
   const sql = `
     -- DROP TABLE media_assets;
     /* ALTER TABLE media_assets DROP COLUMN width; */
-    INSERT INTO audit_events (event_type, detail)
-      VALUES ('DELETE FROM media_assets', $$TRUNCATE media_assets$$);
+    CREATE FUNCTION migration_example() RETURNS text
+      LANGUAGE SQL AS $$SELECT 'DROP TABLE media_assets'::text$$;
   `
 
-  assert.deepEqual(destructiveMigrationFindings(sql), [])
+  assert.deepEqual(expandOnlyMigrationFindings(sql), [])
 })
 
 test('allows only newly added migration files in a Production release', () => {

--- a/scripts/check-production-migrations.test.mjs
+++ b/scripts/check-production-migrations.test.mjs
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { test } from 'node:test'
+
+import {
+  destructiveMigrationFindings,
+  migrationDiffArguments,
+  migrationPathsInRepository,
+  parseChangedMigrations,
+  productionMigrationFindings,
+} from './check-production-migrations.mjs'
+
+test('accepts additive expand migrations', () => {
+  const sql = `
+    CREATE TABLE media_labels (
+      id uuid PRIMARY KEY,
+      label text NOT NULL
+    );
+    ALTER TABLE media_assets ADD COLUMN label_id uuid;
+    CREATE INDEX media_assets_label_id_idx ON media_assets (label_id);
+    ALTER TABLE media_assets
+      ADD CONSTRAINT media_assets_label_id_fk
+      FOREIGN KEY (label_id) REFERENCES media_labels(id) NOT VALID;
+  `
+
+  assert.deepEqual(destructiveMigrationFindings(sql), [])
+})
+
+test('rejects contract-breaking schema and data operations', () => {
+  const sql = `
+    DROP TABLE old_media;
+    ALTER TABLE media_assets DROP COLUMN legacy_caption;
+    ALTER TABLE media_assets RENAME COLUMN label TO location_label;
+    ALTER TABLE media_assets ALTER COLUMN width TYPE bigint;
+    ALTER TABLE media_assets ALTER COLUMN height SET NOT NULL;
+    ALTER TABLE media_assets ALTER COLUMN catalog_state DROP DEFAULT;
+    TRUNCATE media_upload_intents;
+    DELETE FROM media_assets WHERE catalog_state = 'archived';
+  `
+
+  assert.deepEqual(
+    destructiveMigrationFindings(sql).map(({ operation }) => operation),
+    [
+      'DROP TABLE',
+      'DROP COLUMN',
+      'RENAME',
+      'ALTER COLUMN TYPE',
+      'SET NOT NULL',
+      'DROP DEFAULT',
+      'TRUNCATE',
+      'DELETE',
+    ],
+  )
+})
+
+test('ignores destructive words inside SQL comments and string literals', () => {
+  const sql = `
+    -- DROP TABLE media_assets;
+    /* ALTER TABLE media_assets DROP COLUMN width; */
+    INSERT INTO audit_events (event_type, detail)
+      VALUES ('DELETE FROM media_assets', $$TRUNCATE media_assets$$);
+  `
+
+  assert.deepEqual(destructiveMigrationFindings(sql), [])
+})
+
+test('allows only newly added migration files in a Production release', () => {
+  assert.deepEqual(
+    parseChangedMigrations(
+      'A\tdb/migrations/0011_add_media_labels.sql\nA\tdocs/note.md\n',
+    ),
+    ['db/migrations/0011_add_media_labels.sql'],
+  )
+  assert.throws(
+    () =>
+      parseChangedMigrations('M\tdb/migrations/0010_rate_limit_windows.sql\n'),
+    /immutable/,
+  )
+  assert.throws(
+    () =>
+      parseChangedMigrations('D\tdb/migrations/0009_media_catalog_state.sql\n'),
+    /immutable/,
+  )
+  assert.ok(
+    migrationDiffArguments('a'.repeat(40), 'b'.repeat(40)).includes(
+      '--diff-filter=ACDMRT',
+    ),
+  )
+})
+
+test('admits the exact reviewed initial migration baseline without weakening future checks', async () => {
+  const path = 'db/migrations/0009_media_catalog_state.sql'
+  const sql = await readFile(path, 'utf8')
+  assert.deepEqual(productionMigrationFindings(path, sql), [])
+  assert.throws(
+    () =>
+      productionMigrationFindings(path, `${sql}\n-- changed after review\n`),
+    /immutable/,
+  )
+  assert.deepEqual(
+    productionMigrationFindings(
+      'db/migrations/0011_remove_legacy.sql',
+      'DROP TABLE legacy;',
+    ).map(({ operation }) => operation),
+    ['DROP TABLE'],
+  )
+})
+
+test('checks every migration still present, not only files in the latest push', () => {
+  assert.deepEqual(
+    migrationPathsInRepository([
+      'meta',
+      '0011_expand.sql',
+      'README.md',
+      '0001_baseline.sql',
+    ]),
+    [
+      'db/migrations/0001_baseline.sql',
+      'db/migrations/0011_expand.sql',
+    ],
+  )
+})

--- a/scripts/delete-vercel-branch-deployments.mjs
+++ b/scripts/delete-vercel-branch-deployments.mjs
@@ -1,0 +1,100 @@
+import { pathToFileURL } from 'node:url'
+
+const reservedBranches = new Set(['dev', 'main'])
+
+function required(value, name) {
+  if (!value?.trim()) throw new Error(`Missing ${name}`)
+  return value.trim()
+}
+
+async function vercelRequest(fetchImpl, url, token, init = {}) {
+  const response = await fetchImpl(url, {
+    ...init,
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+      ...init.headers,
+    },
+  })
+  if (response.ok || (init.method === 'DELETE' && response.status === 404)) {
+    return response.status === 404 ? null : response.json()
+  }
+  throw new Error(
+    `Vercel deployment request failed with HTTP ${response.status}`,
+  )
+}
+
+export async function deleteVercelBranchDeployments({
+  branch,
+  projectId,
+  teamId,
+  token,
+  fetchImpl = fetch,
+}) {
+  const gitBranch = required(branch, 'GIT_BRANCH')
+  if (reservedBranches.has(gitBranch)) {
+    throw new Error(`Refusing to clean reserved branch: ${gitBranch}`)
+  }
+  if (/[\u0000-\u001f\u007f]/.test(gitBranch)) {
+    throw new Error('Git branch contains control characters')
+  }
+
+  const project = required(projectId, 'VERCEL_PROJECT_ID')
+  const team = required(teamId, 'VERCEL_ORG_ID')
+  const accessToken = required(token, 'VERCEL_TOKEN')
+  const deployments = []
+  let until
+
+  for (let page = 0; page < 100; page += 1) {
+    const url = new URL('https://api.vercel.com/v7/deployments')
+    url.searchParams.set('projectId', project)
+    url.searchParams.set('teamId', team)
+    url.searchParams.set('target', 'preview')
+    url.searchParams.set('branch', gitBranch)
+    url.searchParams.set('limit', '100')
+    if (until !== undefined) url.searchParams.set('until', String(until))
+
+    const result = await vercelRequest(fetchImpl, url, accessToken)
+    for (const deployment of result.deployments ?? []) {
+      if (deployment.meta?.githubCommitRef !== gitBranch) {
+        throw new Error(
+          `Vercel deployment ${deployment.uid ?? 'without id'} did not match Git branch`,
+        )
+      }
+      deployments.push(deployment.uid)
+    }
+
+    until = result.pagination?.next
+    if (until === null || until === undefined) break
+    if (page === 99)
+      throw new Error('Vercel deployment pagination exceeded 100 pages')
+  }
+
+  await Promise.all(
+    deployments.map((deploymentId) => {
+      const url = new URL(
+        `https://api.vercel.com/v13/deployments/${encodeURIComponent(deploymentId)}`,
+      )
+      url.searchParams.set('teamId', team)
+      return vercelRequest(fetchImpl, url, accessToken, { method: 'DELETE' })
+    }),
+  )
+  return deployments
+}
+
+async function main() {
+  const deleted = await deleteVercelBranchDeployments({
+    branch: process.env.GIT_BRANCH,
+    projectId: process.env.VERCEL_PROJECT_ID,
+    teamId: process.env.VERCEL_ORG_ID,
+    token: process.env.VERCEL_TOKEN,
+  })
+  console.log(`Deleted ${deleted.length} Vercel Preview deployment(s).`)
+}
+
+if (
+  process.argv[1] &&
+  pathToFileURL(process.argv[1]).href === import.meta.url
+) {
+  await main()
+}

--- a/scripts/delete-vercel-branch-deployments.test.mjs
+++ b/scripts/delete-vercel-branch-deployments.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { deleteVercelBranchDeployments } from './delete-vercel-branch-deployments.mjs'
+
+function response(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+test('deletes every paginated Preview deployment for one Git branch', async () => {
+  const requests = []
+  const fetchImpl = async (url, init = {}) => {
+    requests.push({ url: String(url), method: init.method ?? 'GET' })
+    if (init.method === 'DELETE') {
+      return response({ state: 'DELETED' })
+    }
+
+    const cursor = new URL(url).searchParams.get('until')
+    if (!cursor) {
+      return response({
+        deployments: [
+          {
+            uid: 'dpl_first',
+            meta: { githubCommitRef: 'feat/media-fix' },
+          },
+        ],
+        pagination: { next: 1234 },
+      })
+    }
+    return response({
+      deployments: [
+        {
+          uid: 'dpl_second',
+          meta: { githubCommitRef: 'feat/media-fix' },
+        },
+      ],
+      pagination: { next: null },
+    })
+  }
+
+  const deleted = await deleteVercelBranchDeployments({
+    branch: 'feat/media-fix',
+    projectId: 'prj_cali',
+    teamId: 'team_cali',
+    token: 'token',
+    fetchImpl,
+  })
+
+  assert.deepEqual(deleted, ['dpl_first', 'dpl_second'])
+  const listUrls = requests
+    .filter(({ method }) => method === 'GET')
+    .map(({ url }) => new URL(url))
+  assert.equal(listUrls.length, 2)
+  assert.equal(listUrls[0].searchParams.get('branch'), 'feat/media-fix')
+  assert.equal(listUrls[0].searchParams.get('target'), 'preview')
+  assert.equal(listUrls[1].searchParams.get('until'), '1234')
+  assert.deepEqual(
+    requests
+      .filter(({ method }) => method === 'DELETE')
+      .map(({ url }) => new URL(url).pathname),
+    ['/v13/deployments/dpl_first', '/v13/deployments/dpl_second'],
+  )
+})
+
+test('refuses reserved and mismatched branches before deleting deployments', async () => {
+  const unexpectedFetch = () => {
+    throw new Error('fetch should not run')
+  }
+  await assert.rejects(
+    deleteVercelBranchDeployments({
+      branch: 'main',
+      projectId: 'prj_cali',
+      teamId: 'team_cali',
+      token: 'token',
+      fetchImpl: unexpectedFetch,
+    }),
+    /reserved branch/,
+  )
+
+  await assert.rejects(
+    deleteVercelBranchDeployments({
+      branch: 'feat/media-fix',
+      projectId: 'prj_cali',
+      teamId: 'team_cali',
+      token: 'token',
+      fetchImpl: async () =>
+        response({
+          deployments: [{ uid: 'dpl_wrong', meta: { githubCommitRef: 'dev' } }],
+          pagination: { next: null },
+        }),
+    }),
+    /did not match Git branch/,
+  )
+})

--- a/scripts/deployment-workflows.test.mjs
+++ b/scripts/deployment-workflows.test.mjs
@@ -90,6 +90,13 @@ test('main uses protected Production credentials and deploys only after migratio
     'Run database migrations',
     'Deploy Vercel Production',
   )
+  const compatibility = job.steps.find(
+    (step) => step.name === 'Enforce expand-only database migrations',
+  )
+  assert.equal(compatibility.env.BASE_SHA, '${{ github.event.before }}')
+  assert.equal(compatibility.env.HEAD_SHA, '${{ github.sha }}')
+  assert.match(compatibility.run, /"\$BASE_SHA" "\$HEAD_SHA"/)
+  assert.doesNotMatch(compatibility.run, /\$\{\{/)
   const migrate = job.steps.find(
     (step) => step.name === 'Run database migrations',
   )
@@ -143,6 +150,17 @@ test('branch deletion cleans only ephemeral Neon and Vercel Previews', async () 
     'neondatabase/delete-branch-action@4468d825d5a88ef4012f1705a82f02ec3072f776',
   )
   assert.match(removeNeon.with.branch, /^preview\//)
+  const setupNode = job.steps.find((step) => step.name === 'Set up Node.js')
+  assert.equal(
+    setupNode.uses,
+    'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020',
+  )
+  assert.equal(setupNode.with['node-version'], 24)
+  assertOrdered(
+    job.steps,
+    'Set up Node.js',
+    'Delete Vercel Preview deployments',
+  )
   assert.ok(
     job.steps.some((step) => {
       return (

--- a/scripts/deployment-workflows.test.mjs
+++ b/scripts/deployment-workflows.test.mjs
@@ -1,0 +1,193 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { test } from 'node:test'
+
+import { parse } from 'yaml'
+
+const root = new URL('../', import.meta.url)
+
+async function text(path) {
+  return readFile(new URL(path, root), 'utf8')
+}
+
+async function workflow(name) {
+  return parse(await text(`.github/workflows/${name}.yml`))
+}
+
+async function action(name) {
+  return parse(await text(`.github/actions/${name}/action.yml`))
+}
+
+function stepIndex(steps, name) {
+  return steps.findIndex((step) => step.name === name)
+}
+
+function assertOrdered(steps, before, after) {
+  const beforeIndex = stepIndex(steps, before)
+  const afterIndex = stepIndex(steps, after)
+  assert.notEqual(beforeIndex, -1, `Missing workflow step: ${before}`)
+  assert.notEqual(afterIndex, -1, `Missing workflow step: ${after}`)
+  assert.ok(beforeIndex < afterIndex, `${before} must run before ${after}`)
+}
+
+test('Vercel Git integration cannot race the deployment workflows', async () => {
+  const config = JSON.parse(await text('vercel.json'))
+  assert.equal(config.git?.deploymentEnabled, false)
+})
+
+test('feature pushes branch from Staging, migrate, then deploy Preview', async () => {
+  const config = await workflow('deploy-preview')
+  assert.deepEqual(config.on.push['branches-ignore'], ['main', 'dev'])
+  assert.equal(config.on.pull_request, undefined)
+  assert.equal(config.on.pull_request_target, undefined)
+
+  const job = config.jobs.deploy
+  assert.equal(job.environment, 'preview')
+  assert.match(job.if, /CaliCastle\/cali\.so/)
+  assert.match(job.if, /dependabot/)
+  assert.match(
+    job.concurrency?.group ?? config.concurrency?.group,
+    /github\.ref/,
+  )
+
+  const deploy = job.steps.find((step) => step.name === 'Deploy Preview')
+  assert.equal(deploy.uses, './.github/actions/deploy-neon-vercel')
+  assert.equal(deploy.with['parent-branch'], 'staging')
+  assert.match(deploy.with['branch-name'], /^preview\//)
+  assert.equal(deploy.with.target, 'preview')
+})
+
+test('dev continuously migrates and deploys the persistent Staging environment', async () => {
+  const config = await workflow('deploy-staging')
+  assert.deepEqual(config.on.push.branches, ['dev'])
+
+  const job = config.jobs.deploy
+  assert.equal(job.environment, 'staging')
+  const deploy = job.steps.find((step) => step.name === 'Deploy Staging')
+  assert.equal(deploy.uses, './.github/actions/deploy-neon-vercel')
+  assert.equal(deploy.with['branch-name'], 'staging')
+  assert.equal(deploy.with.target, 'staging')
+})
+
+test('main uses protected Production credentials and deploys only after migration', async () => {
+  const config = await workflow('deploy-production')
+  assert.deepEqual(config.on.push.branches, ['main'])
+
+  const job = config.jobs.deploy
+  assert.equal(job.environment, 'production')
+  assert.equal(job.env, undefined)
+  assertOrdered(
+    job.steps,
+    'Reject destructive database migrations',
+    'Run database migrations',
+  )
+  assertOrdered(
+    job.steps,
+    'Run database migrations',
+    'Deploy Vercel Production',
+  )
+  const migrate = job.steps.find(
+    (step) => step.name === 'Run database migrations',
+  )
+  assert.equal(
+    migrate.env.MIGRATION_DATABASE_URL,
+    '${{ secrets.MIGRATION_DATABASE_URL }}',
+  )
+  const deploy = job.steps.find(
+    (step) => step.name === 'Deploy Vercel Production',
+  )
+  assert.match(deploy.run, /vercel@56\.3\.1 deploy --prod/)
+  assert.equal(deploy.env.MIGRATION_DATABASE_URL, undefined)
+  assert.equal(deploy.env.DATABASE_URL, undefined)
+  assert.equal(deploy.env.NEON_API_KEY, undefined)
+})
+
+test('release pull requests reject unsafe migrations before merging to main', async () => {
+  const config = await workflow('security')
+  const job = config.jobs.quality
+  const checkout = job.steps.find((step) => step.name === 'Check out repository')
+  assert.equal(checkout.with['fetch-depth'], 0)
+
+  const check = job.steps.find(
+    (step) => step.name === 'Check Production migration compatibility',
+  )
+  assert.match(check.if, /github\.base_ref == 'main'/)
+  assert.match(check.run, /check-production-migrations\.mjs/)
+  assert.equal(check.env.BASE_SHA, '${{ github.event.pull_request.base.sha }}')
+  assert.equal(check.env.HEAD_SHA, '${{ github.event.pull_request.head.sha }}')
+})
+
+test('branch deletion cleans only ephemeral Neon and Vercel Previews', async () => {
+  const config = await workflow('cleanup-preview')
+  assert.ok(Object.hasOwn(config.on, 'delete'))
+  assert.equal(config.on.pull_request_target, undefined)
+
+  const job = config.jobs.cleanup
+  assert.equal(job.environment, 'preview')
+  assert.match(job.if, /ref_type == 'branch'/)
+  assert.match(job.if, /github\.event\.ref != 'dev'/)
+  assert.match(job.if, /github\.event\.ref != 'main'/)
+
+  const removeNeon = job.steps.find(
+    (step) => step.name === 'Delete Neon Preview branch',
+  )
+  assert.equal(
+    removeNeon.uses,
+    'neondatabase/delete-branch-action@4468d825d5a88ef4012f1705a82f02ec3072f776',
+  )
+  assert.match(removeNeon.with.branch, /^preview\//)
+  assert.ok(
+    job.steps.some((step) => {
+      return (
+        step.name === 'Delete Vercel Preview deployments' &&
+        step.if === 'always()'
+      )
+    }),
+  )
+})
+
+test('manual refresh resets a feature database from Staging before redeploying', async () => {
+  const config = await workflow('refresh-preview')
+  assert.ok(config.on.workflow_dispatch.inputs.git_branch.required)
+
+  const job = config.jobs.refresh
+  assert.equal(job.environment, 'preview')
+  const reset = job.steps.find((step) => step.name === 'Refresh Preview')
+  assert.equal(reset.uses, './.github/actions/deploy-neon-vercel')
+  assert.equal(reset.with.reset, true)
+  assert.match(reset.with['branch-name'], /^preview\//)
+  assert.equal(reset.with.target, 'preview')
+})
+
+test('shared non-production action keeps migration credentials out of Vercel', async () => {
+  const config = await action('deploy-neon-vercel')
+  const steps = config.runs.steps
+
+  const create = steps.find((step) => step.id === 'migration-branch')
+  assert.equal(
+    create.uses,
+    'neondatabase/create-branch-action@fb620d43d4c565abaf088b848a4e28e5c4ea4d9c',
+  )
+  assert.match(create.with.role, /migration-role/)
+
+  const reset = steps.find((step) => step.id === 'reset-branch')
+  assert.equal(
+    reset.uses,
+    'neondatabase/reset-branch-action@470ab8101095ea33737c294d17364a72fd80761b',
+  )
+  assert.equal(reset.with.parent, true)
+
+  const runtime = steps.find((step) => step.id === 'runtime-branch')
+  assert.match(runtime.with.role, /runtime-role/)
+  assertOrdered(steps, 'Run database migrations', 'Deploy to Vercel')
+
+  const deploy = steps.find((step) => step.name === 'Deploy to Vercel')
+  assert.match(deploy.run, /vercel@56\.3\.1 deploy/)
+  assert.match(deploy.run, /--target=/)
+  assert.match(deploy.run, /--build-env DATABASE_URL=/)
+  assert.match(deploy.run, /--env DATABASE_URL=/)
+  assert.doesNotMatch(deploy.run, /MIGRATION_DATABASE_URL/)
+  assert.doesNotMatch(deploy.run, /\$\{\{ inputs\.(?:git-ref|target) \}\}/)
+  assert.equal(deploy.env.DEPLOY_GIT_REF, '${{ inputs.git-ref }}')
+  assert.equal(deploy.env.DEPLOY_TARGET, '${{ inputs.target }}')
+})

--- a/scripts/deployment-workflows.test.mjs
+++ b/scripts/deployment-workflows.test.mjs
@@ -40,15 +40,13 @@ test('feature pushes branch from Staging, migrate, then deploy Preview', async (
   assert.deepEqual(config.on.push['branches-ignore'], ['main', 'dev'])
   assert.equal(config.on.pull_request, undefined)
   assert.equal(config.on.pull_request_target, undefined)
+  assert.equal(config.concurrency['cancel-in-progress'], false)
 
   const job = config.jobs.deploy
   assert.equal(job.environment, 'preview')
   assert.match(job.if, /CaliCastle\/cali\.so/)
   assert.match(job.if, /dependabot/)
-  assert.match(
-    job.concurrency?.group ?? config.concurrency?.group,
-    /github\.ref/,
-  )
+  assert.equal(config.concurrency.group, 'preview-${{ github.ref_name }}')
 
   const deploy = job.steps.find((step) => step.name === 'Deploy Preview')
   assert.equal(deploy.uses, './.github/actions/deploy-neon-vercel')
@@ -63,6 +61,7 @@ test('dev continuously migrates and deploys the persistent Staging environment',
 
   const job = config.jobs.deploy
   assert.equal(job.environment, 'staging')
+  assert.equal(job.if, "github.ref == 'refs/heads/dev'")
   const deploy = job.steps.find((step) => step.name === 'Deploy Staging')
   assert.equal(deploy.uses, './.github/actions/deploy-neon-vercel')
   assert.equal(deploy.with['branch-name'], 'staging')
@@ -73,12 +72,17 @@ test('main uses protected Production credentials and deploys only after migratio
   const config = await workflow('deploy-production')
   assert.deepEqual(config.on.push.branches, ['main'])
 
+  const review = config.jobs['migration-review']
+  assert.equal(review.environment, 'production-migration-review')
+  assert.equal(review.env, undefined)
+
   const job = config.jobs.deploy
+  assert.equal(job.needs, 'migration-review')
   assert.equal(job.environment, 'production')
   assert.equal(job.env, undefined)
   assertOrdered(
     job.steps,
-    'Reject destructive database migrations',
+    'Enforce expand-only database migrations',
     'Run database migrations',
   )
   assertOrdered(
@@ -97,6 +101,7 @@ test('main uses protected Production credentials and deploys only after migratio
     (step) => step.name === 'Deploy Vercel Production',
   )
   assert.match(deploy.run, /vercel@56\.3\.1 deploy --prod/)
+  assert.match(deploy.run, /GITHUB_STEP_SUMMARY/)
   assert.equal(deploy.env.MIGRATION_DATABASE_URL, undefined)
   assert.equal(deploy.env.DATABASE_URL, undefined)
   assert.equal(deploy.env.NEON_API_KEY, undefined)
@@ -123,6 +128,8 @@ test('branch deletion cleans only ephemeral Neon and Vercel Previews', async () 
   assert.equal(config.on.pull_request_target, undefined)
 
   const job = config.jobs.cleanup
+  assert.equal(config.concurrency.group, 'preview-${{ github.event.ref }}')
+  assert.equal(config.concurrency['cancel-in-progress'], false)
   assert.equal(job.environment, 'preview')
   assert.match(job.if, /ref_type == 'branch'/)
   assert.match(job.if, /github\.event\.ref != 'dev'/)
@@ -151,10 +158,27 @@ test('manual refresh resets a feature database from Staging before redeploying',
   assert.ok(config.on.workflow_dispatch.inputs.git_branch.required)
 
   const job = config.jobs.refresh
+  assert.equal(config.concurrency.group, 'preview-${{ inputs.git_branch }}')
+  assert.equal(config.concurrency['cancel-in-progress'], false)
   assert.equal(job.environment, 'preview')
+  const trustedCheckout = job.steps.find(
+    (step) => step.name === 'Check out trusted deployment action',
+  )
+  assert.equal(trustedCheckout.with.ref, 'dev')
+  assert.equal(trustedCheckout.with.path, undefined)
+
+  const targetCheckout = job.steps.find(
+    (step) => step.name === 'Check out target branch',
+  )
+  assert.match(targetCheckout.with.ref, /refs\/heads/)
+  assert.equal(targetCheckout.with.path, 'target')
+
+  const resolve = job.steps.find((step) => step.name === 'Resolve target commit')
+  assert.equal(resolve['working-directory'], 'target')
   const reset = job.steps.find((step) => step.name === 'Refresh Preview')
   assert.equal(reset.uses, './.github/actions/deploy-neon-vercel')
   assert.equal(reset.with.reset, true)
+  assert.equal(reset.with['working-directory'], 'target')
   assert.match(reset.with['branch-name'], /^preview\//)
   assert.equal(reset.with.target, 'preview')
 })
@@ -162,6 +186,11 @@ test('manual refresh resets a feature database from Staging before redeploying',
 test('shared non-production action keeps migration credentials out of Vercel', async () => {
   const config = await action('deploy-neon-vercel')
   const steps = config.runs.steps
+  assert.equal(
+    config.outputs['deployment-url'].value,
+    '${{ steps.vercel.outputs.url }}',
+  )
+  assert.equal(config.inputs['working-directory'].default, '.')
 
   const create = steps.find((step) => step.id === 'migration-branch')
   assert.equal(
@@ -182,6 +211,7 @@ test('shared non-production action keeps migration credentials out of Vercel', a
   assertOrdered(steps, 'Run database migrations', 'Deploy to Vercel')
 
   const deploy = steps.find((step) => step.name === 'Deploy to Vercel')
+  assert.equal(deploy.id, 'vercel')
   assert.match(deploy.run, /vercel@56\.3\.1 deploy/)
   assert.match(deploy.run, /--target=/)
   assert.match(deploy.run, /--build-env DATABASE_URL=/)
@@ -190,4 +220,13 @@ test('shared non-production action keeps migration credentials out of Vercel', a
   assert.doesNotMatch(deploy.run, /\$\{\{ inputs\.(?:git-ref|target) \}\}/)
   assert.equal(deploy.env.DEPLOY_GIT_REF, '${{ inputs.git-ref }}')
   assert.equal(deploy.env.DEPLOY_TARGET, '${{ inputs.target }}')
+  assert.match(deploy.run, /GITHUB_STEP_SUMMARY/)
+  for (const stepName of [
+    'Install dependencies',
+    'Run database migrations',
+    'Deploy to Vercel',
+  ]) {
+    const step = steps.find((candidate) => candidate.name === stepName)
+    assert.equal(step['working-directory'], '${{ inputs.working-directory }}')
+  }
 })

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,8 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": false
+  },
   "crons": [
     {
       "path": "/api/internal/media/reconcile",


### PR DESCRIPTION
## Summary

- make GitHub Actions the sole controller for Preview, Staging, and Production deployments
- create persistent Neon Preview branches from Staging and clean them up with their Vercel deployments
- migrate each database before deploying the matching commit
- require two sequential approvals before Production database access
- enforce a fail-closed expand-only Production migration policy
- document the hosted `v2` to `dev` and Neon `preview` to `staging` rollout

## Why

Vercel Git deployments could race schema changes, Preview databases had no branch lifecycle, and Production database access lacked the agreed approval and migration compatibility gates. The new workflows serialize each Preview branch lifecycle and keep migration credentials out of Vercel runtimes.

## Safety

- internal branches only receive database-backed Previews
- forks and Dependabot receive code-only checks
- manual refresh executes the trusted `dev` deployment action while running target code from an isolated working directory
- reviewed migrations `0001` through `0011` are hash-locked
- unknown SQL, dynamic blocks, unsafe defaults, and unreviewed constraints fail closed
- Vercel receives only CRUD-only pooled runtime URLs

## Validation

- `pnpm test:deployment` (18/18)
- `pnpm test:security`
- `pnpm typecheck`
- Actionlint
- Production migration baseline check (11 migrations)
- repository standards review
- release specification review
- `git diff --check`

## Rollout

Hosted branch renames, GitHub environment configuration, Neon branch changes, and database access remain explicit operator steps in the runbook. No hosted database or Production resource was changed by this branch.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes GitHub Actions the sole controller for all Neon/Vercel deployments by disabling Vercel's built-in Git integration and introducing five new workflows and one composite action that serialize branch lifecycle, migration, and deployment. The change also adds a bespoke production migration safety checker (`check-production-migrations.mjs`) that hash-locks reviewed migrations and enforces an expand-only SQL policy for all new ones.

- **New workflows** (`deploy-preview`, `deploy-staging`, `deploy-production`, `cleanup-preview`, `refresh-preview`) replace implicit Vercel Git deploys, pairing each environment with its own Neon branch lifecycle and keeping migration credentials out of the Vercel runtime.
- **`check-production-migrations.mjs`** enforces hash immutability on migrations 0001–0011, rejects any non-additive diff status, and applies a conservative expand-only allowlist (fail-closed on unrecognized SQL).
- **`deployment-workflows.test.mjs`** parses the actual YAML files at test time and asserts security-critical properties such as step ordering, credential isolation, and absence of GitHub expression interpolation inside shell strings.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive, disables a racing Vercel integration, and brings migration gates and credential isolation that were previously absent.

All five workflows and the composite action correctly serialize migration before deployment, keep migration credentials out of the Vercel runtime, and exclude forks and Dependabot from database-backed previews. The checker is well-tested and fails closed on any unrecognized SQL. The two observations raised do not affect correctness or safety of this change.

No files require special attention. `deploy-staging.yml` has a minor `workflow_dispatch` UX quirk; `check-production-migrations.mjs` intentionally rejects `CREATE OR REPLACE` as unrecognized SQL, worth documenting for future migration authors.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/actions/deploy-neon-vercel/action.yml | New composite action that provisions/reuses a Neon branch (migration role), migrates, then fetches a CRUD-only pooled runtime URL before deploying to Vercel. Migration credentials are never forwarded to the Vercel runtime. |
| .github/workflows/deploy-production.yml | New production workflow: requires a mandatory approval job, runs the expand-only migration check (via env-bound SHAs), migrates the production database, then deploys Vercel — all with migration credentials absent from the deploy step. |
| .github/workflows/deploy-staging.yml | New staging workflow triggered on push to dev and workflow_dispatch; job-level if-guard silently skips when manually triggered on any branch other than dev. |
| .github/workflows/deploy-preview.yml | New preview workflow that creates a Neon branch from staging, migrates, and deploys to Vercel preview; correctly excludes forks, Dependabot, and the dev/main branches. |
| .github/workflows/refresh-preview.yml | Manual preview refresh workflow: checks out trusted action from dev, validates branch input via git check-ref-format, checks out target code into an isolated path, then resets the Neon branch from staging before redeploying. |
| .github/workflows/cleanup-preview.yml | Cleanup workflow on branch deletion: deletes the Neon preview branch, then always attempts Vercel deployment cleanup even if Neon deletion fails. |
| scripts/check-production-migrations.mjs | New migration safety checker: hash-locks reviewed migrations 0001–0011, enforces expand-only SQL for all others (fail-closed on UNRECOGNIZED statements), and detects non-additive diff status for existing migration files. |
| scripts/delete-vercel-branch-deployments.mjs | New script that paginates Vercel's deployment API, validates each deployment's githubCommitRef before deleting, and guards against reserved branches and control-character injection. |
| scripts/deployment-workflows.test.mjs | 18-test suite that parses actual workflow YAML files and asserts security-critical properties: step ordering, credential isolation, concurrency settings, and absence of direct GitHub expression interpolation in shell commands. |
| vercel.json | Adds `"git": {"deploymentEnabled": false}` to disable Vercel's built-in Git integration and prevent deployment races with the new GitHub Actions workflows. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer push
    participant GHA as GitHub Actions
    participant Neon as Neon (non-prod)
    participant Drizzle as drizzle-kit migrate
    participant Vercel as Vercel

    Note over Dev,Vercel: Feature branch push
    Dev->>GHA: push to feature branch
    GHA->>Neon: "create-branch-action (preview/branch, parent=staging, migration-role)"
    Neon-->>GHA: migration db_url
    GHA->>Drizzle: pnpm db:migrate (MIGRATION_DATABASE_URL)
    GHA->>Neon: create-branch-action (same branch, runtime-role)
    Neon-->>GHA: pooled db_url_pooled
    GHA->>Vercel: "vercel deploy --target=preview"
    Vercel-->>GHA: deployment URL

    Note over Dev,Vercel: Branch deletion
    Dev->>GHA: delete branch event
    GHA->>Neon: delete-branch-action (preview/branch)
    GHA->>Vercel: delete branch deployments

    Note over Dev,Vercel: Push to main
    Dev->>GHA: push to main
    GHA->>GHA: migration-review job (approval gate)
    GHA->>GHA: check-production-migrations.mjs
    GHA->>Drizzle: pnpm db:migrate (MIGRATION_DATABASE_URL secret)
    GHA->>Vercel: vercel deploy --prod
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer push
    participant GHA as GitHub Actions
    participant Neon as Neon (non-prod)
    participant Drizzle as drizzle-kit migrate
    participant Vercel as Vercel

    Note over Dev,Vercel: Feature branch push
    Dev->>GHA: push to feature branch
    GHA->>Neon: "create-branch-action (preview/branch, parent=staging, migration-role)"
    Neon-->>GHA: migration db_url
    GHA->>Drizzle: pnpm db:migrate (MIGRATION_DATABASE_URL)
    GHA->>Neon: create-branch-action (same branch, runtime-role)
    Neon-->>GHA: pooled db_url_pooled
    GHA->>Vercel: "vercel deploy --target=preview"
    Vercel-->>GHA: deployment URL

    Note over Dev,Vercel: Branch deletion
    Dev->>GHA: delete branch event
    GHA->>Neon: delete-branch-action (preview/branch)
    GHA->>Vercel: delete branch deployments

    Note over Dev,Vercel: Push to main
    Dev->>GHA: push to main
    GHA->>GHA: migration-review job (approval gate)
    GHA->>GHA: check-production-migrations.mjs
    GHA->>Drizzle: pnpm db:migrate (MIGRATION_DATABASE_URL secret)
    GHA->>Vercel: vercel deploy --prod
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(deploy): address review feedback"](https://github.com/calicastle/cali.so/commit/e9781eada047807d257c7803e1e8f3e726098e6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44998005)</sub>

<!-- /greptile_comment -->