### PR TITLE
Fix Preview mutation origin checks

### DIFF
--- a/docs/ama-booking-operations.md
+++ b/docs/ama-booking-operations.md
@@ -18,7 +18,7 @@ startup with field names only. `.env.example` mirrors this table.
 | `ADMIN_EMAIL` | always | Owner data namespace and Google Calendar owner. |
 | `AMA_ENCRYPTION_KEY` | always | 32-byte base64 key: Google refresh-token envelopes and Manage Link token derivation. |
 | `RATE_LIMIT_HASH_KEY` | always | 32-byte base64 key pseudonymizing rate-limit and audit actors, including public booking clients. |
-| `SITE_URL` | always | Canonical public origin. Anchors same-origin mutation checks, Stripe return URLs, and Manage Link URLs. |
+| `SITE_URL` | always | Canonical public origin for Production links and provider return URLs. Vercel Preview and Staging mutation checks use Vercel's system-provided deployment URL so same-origin writes work on ephemeral deployment hosts. |
 | `CRON_SECRET` | scheduled work | Bearer secret for `/api/internal/ama/work` (and media reconcile). Vercel injects it for cron invocations. |
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | availability + calendar | OAuth client for free/busy and calendar event writes. Slots and meeting creation are unavailable until configured. |
 | `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` | payments | Checkout Session and refund API access; the webhook secret signs `/api/ama/stripe/webhook` (the webhook, never the return URL, is authoritative for payment). Checkout and webhook routes return 503 until configured. |

--- a/lib/ama/booking/server.ts
+++ b/lib/ama/booking/server.ts
@@ -204,7 +204,7 @@ function createServices() {
     clock,
   })
   const guard = createPublicRequestGuard({
-    baseUrl: environment.SITE_URL,
+    baseUrl: environment.browserMutationBaseUrl,
     rateLimiter: createRateLimiter(environment.rateLimitBackend, {
       prefix: 'cali:ama:public-mutation',
       maxRequests: environment.AMA_PUBLIC_RATE_LIMIT_MAX_REQUESTS,

--- a/lib/ama/security/server.ts
+++ b/lib/ama/security/server.ts
@@ -18,7 +18,7 @@ export function getAmaSecurity() {
   })
 
   security = createAmaSecurity({
-    baseUrl: environment.SITE_URL,
+    baseUrl: environment.browserMutationBaseUrl,
     features: environment.features,
     pseudonymKey: Buffer.from(environment.RATE_LIMIT_HASH_KEY, 'base64'),
     rateLimiter: limiter,

--- a/lib/ama/server-env-schema.ts
+++ b/lib/ama/server-env-schema.ts
@@ -136,13 +136,19 @@ const serverEnvironmentSchema = z
     VERCEL_URL: blankAsUndefined(
       z.string().trim().refine(isVercelDeploymentHost).optional(),
     ),
-    SITE_URL: z
-      .url()
-      .refine((value) => {
-        const url = new URL(value)
-        return url.protocol === 'https:' || ['localhost', '127.0.0.1'].includes(url.hostname)
-      })
-      .transform((value) => new URL(value)),
+    SITE_URL: blankAsUndefined(
+      z
+        .url()
+        .refine((value) => {
+          const url = new URL(value)
+          return (
+            url.protocol === 'https:' ||
+            ['localhost', '127.0.0.1'].includes(url.hostname)
+          )
+        })
+        .transform((value) => new URL(value))
+        .optional(),
+    ),
     ADMIN_MUTATION_RATE_LIMIT_MAX_REQUESTS: z.coerce
       .number()
       .int()
@@ -173,6 +179,7 @@ const serverEnvironmentSchema = z
         KV_REST_API_TOKEN,
         VERCEL_ENV,
         VERCEL_URL,
+        SITE_URL,
         GOOGLE_CLIENT_ID,
         GOOGLE_CLIENT_SECRET,
         STRIPE_SECRET_KEY,
@@ -189,6 +196,13 @@ const serverEnvironmentSchema = z
           code: 'custom',
           path: ['VERCEL_URL'],
           message: 'Vercel Preview requires its trusted deployment hostname',
+        })
+      }
+      if (VERCEL_ENV !== 'preview' && !SITE_URL) {
+        context.addIssue({
+          code: 'custom',
+          path: ['SITE_URL'],
+          message: 'The canonical site URL is required outside Vercel Preview',
         })
       }
 
@@ -282,13 +296,15 @@ const serverEnvironmentSchema = z
       REDIS_URL: _redisUrl,
       VERCEL_ENV,
       VERCEL_URL,
+      SITE_URL,
       ...environment
     }) => ({
       ...environment,
+      SITE_URL: SITE_URL ?? new URL(`https://${VERCEL_URL!}`),
       browserMutationBaseUrl:
         VERCEL_ENV === 'preview'
           ? new URL(`https://${VERCEL_URL!}`)
-          : environment.SITE_URL,
+          : SITE_URL!,
       rateLimitBackend:
         VERCEL_ENV === 'production'
           ? {

--- a/lib/ama/server-env-schema.ts
+++ b/lib/ama/server-env-schema.ts
@@ -25,6 +25,21 @@ function isHttpsUrl(value: string) {
   }
 }
 
+function isVercelDeploymentHost(value: string) {
+  try {
+    const url = new URL(`https://${value}`)
+    return (
+      url.hostname === value &&
+      url.hostname.endsWith('.vercel.app') &&
+      url.pathname === '/' &&
+      url.search === '' &&
+      url.hash === ''
+    )
+  } catch {
+    return false
+  }
+}
+
 function configured(value: string | undefined) {
   return typeof value === 'string' && value.trim() !== ''
 }
@@ -118,6 +133,9 @@ const serverEnvironmentSchema = z
     KV_URL: z.string().trim().min(1).optional(),
     REDIS_URL: z.string().trim().min(1).optional(),
     VERCEL_ENV: z.enum(['development', 'preview', 'production']).optional(),
+    VERCEL_URL: blankAsUndefined(
+      z.string().trim().refine(isVercelDeploymentHost).optional(),
+    ),
     SITE_URL: z
       .url()
       .refine((value) => {
@@ -254,9 +272,14 @@ const serverEnvironmentSchema = z
       KV_URL: _kvUrl,
       REDIS_URL: _redisUrl,
       VERCEL_ENV,
+      VERCEL_URL,
       ...environment
     }) => ({
       ...environment,
+      browserMutationBaseUrl:
+        VERCEL_ENV === 'preview' && VERCEL_URL
+          ? new URL(`https://${VERCEL_URL}`)
+          : environment.SITE_URL,
       rateLimitBackend:
         VERCEL_ENV === 'production'
           ? {

--- a/lib/ama/server-env-schema.ts
+++ b/lib/ama/server-env-schema.ts
@@ -172,6 +172,7 @@ const serverEnvironmentSchema = z
         KV_REST_API_URL,
         KV_REST_API_TOKEN,
         VERCEL_ENV,
+        VERCEL_URL,
         GOOGLE_CLIENT_ID,
         GOOGLE_CLIENT_SECRET,
         STRIPE_SECRET_KEY,
@@ -183,6 +184,14 @@ const serverEnvironmentSchema = z
       },
       context,
     ) => {
+      if (VERCEL_ENV === 'preview' && !VERCEL_URL) {
+        context.addIssue({
+          code: 'custom',
+          path: ['VERCEL_URL'],
+          message: 'Vercel Preview requires its trusted deployment hostname',
+        })
+      }
+
       const upstashPairComplete = Boolean(
         UPSTASH_REDIS_REST_URL && UPSTASH_REDIS_REST_TOKEN,
       )
@@ -277,8 +286,8 @@ const serverEnvironmentSchema = z
     }) => ({
       ...environment,
       browserMutationBaseUrl:
-        VERCEL_ENV === 'preview' && VERCEL_URL
-          ? new URL(`https://${VERCEL_URL}`)
+        VERCEL_ENV === 'preview'
+          ? new URL(`https://${VERCEL_URL!}`)
           : environment.SITE_URL,
       rateLimitBackend:
         VERCEL_ENV === 'production'

--- a/lib/ama/server-env.test.ts
+++ b/lib/ama/server-env.test.ts
@@ -84,6 +84,28 @@ describe('AMA server environment', () => {
     },
   )
 
+  it('derives the Preview site URL when no canonical URL is configured', () => {
+    const { SITE_URL: _siteUrl, ...withoutSiteUrl } = validEnvironment
+    const environment = parseServerEnv({
+      ...withoutSiteUrl,
+      VERCEL_ENV: 'preview',
+      VERCEL_URL: 'cali-preview-cali.vercel.app',
+    })
+
+    expect(environment.SITE_URL.href).toBe(
+      'https://cali-preview-cali.vercel.app/',
+    )
+    expect(environment.browserMutationBaseUrl.href).toBe(
+      environment.SITE_URL.href,
+    )
+  })
+
+  it('requires a canonical site URL outside Preview', () => {
+    const { SITE_URL: _siteUrl, ...withoutSiteUrl } = validEnvironment
+
+    expect(() => parseServerEnv(withoutSiteUrl)).toThrowError(/SITE_URL/)
+  })
+
   it('keeps Production mutations pinned to the canonical site', () => {
     const environment = parseServerEnv({
       ...validEnvironment,

--- a/lib/ama/server-env.test.ts
+++ b/lib/ama/server-env.test.ts
@@ -58,6 +58,38 @@ describe('AMA server environment', () => {
     })
   })
 
+  it('uses the Vercel deployment origin for Preview mutations', () => {
+    const environment = parseServerEnv({
+      ...validEnvironment,
+      VERCEL_ENV: 'preview',
+      VERCEL_URL: 'cali-preview-cali.vercel.app',
+    })
+
+    expect(environment.SITE_URL.href).toBe('https://cali.so/')
+    expect(environment.browserMutationBaseUrl.href).toBe(
+      'https://cali-preview-cali.vercel.app/',
+    )
+  })
+
+  it('keeps Production mutations pinned to the canonical site', () => {
+    const environment = parseServerEnv({
+      ...validEnvironment,
+      VERCEL_URL: 'cali-production-cali.vercel.app',
+    })
+
+    expect(environment.browserMutationBaseUrl.href).toBe('https://cali.so/')
+  })
+
+  it('rejects untrusted Vercel deployment host overrides', () => {
+    expect(() =>
+      parseServerEnv({
+        ...validEnvironment,
+        VERCEL_ENV: 'preview',
+        VERCEL_URL: 'cali-preview.vercel.app.attacker.example',
+      }),
+    ).toThrowError(/VERCEL_URL/)
+  })
+
   it('treats Google as unconfigured without its credential pair', () => {
     const {
       GOOGLE_CLIENT_ID: _clientId,

--- a/lib/ama/server-env.test.ts
+++ b/lib/ama/server-env.test.ts
@@ -71,6 +71,19 @@ describe('AMA server environment', () => {
     )
   })
 
+  it.each([undefined, ''])(
+    'rejects Preview without a trusted Vercel deployment hostname',
+    (VERCEL_URL) => {
+      expect(() =>
+        parseServerEnv({
+          ...validEnvironment,
+          VERCEL_ENV: 'preview',
+          VERCEL_URL,
+        }),
+      ).toThrowError(/VERCEL_URL/)
+    },
+  )
+
   it('keeps Production mutations pinned to the canonical site', () => {
     const environment = parseServerEnv({
       ...validEnvironment,
@@ -148,7 +161,11 @@ describe('AMA server environment', () => {
     } = validEnvironment
 
     expect(
-      parseServerEnv({ ...withoutUpstash, VERCEL_ENV: 'preview' })
+      parseServerEnv({
+        ...withoutUpstash,
+        VERCEL_ENV: 'preview',
+        VERCEL_URL: 'cali-preview-cali.vercel.app',
+      })
         .rateLimitBackend,
     ).toEqual({ kind: 'database' })
   })
@@ -162,6 +179,7 @@ describe('AMA server environment', () => {
     const previewEnvironment = parseServerEnv({
       ...withoutUpstash,
       VERCEL_ENV: 'preview',
+      VERCEL_URL: 'cali-preview-cali.vercel.app',
       KV_REST_API_URL: 'https://marketplace.upstash.io',
       KV_REST_API_TOKEN: 'marketplace-secret',
       KV_REST_API_READ_ONLY_TOKEN: 'marketplace-read-only-secret',


### PR DESCRIPTION
## Summary

- derive Preview and Staging mutation origins from Vercel's trusted deployment hostname
- keep Production mutations pinned to the canonical `SITE_URL`
- reject non-Vercel hostname overrides and document the environment behavior

## Why

Admin media uploads on Staging were denied by the browser mutation guard because the ephemeral deployment hostname could never equal the Production `SITE_URL`. Relative browser requests were genuinely same-origin, but the server compared them against the wrong environment origin.

## Validation

- `pnpm typecheck`
- `pnpm test:security`
- `pnpm test:deployment`
- `pnpm exec vitest run lib/ama/server-env.test.ts lib/ama/security/request-policy.test.ts lib/ama/security/service.test.ts lib/media/admin/http.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an admin mutation origin check failure on Vercel Preview/Staging deployments by introducing a `browserMutationBaseUrl` field that is set to the deployment's ephemeral hostname (from `VERCEL_URL`) instead of the canonical `SITE_URL` when `VERCEL_ENV === 'preview'`. The `SITE_URL` field is made optional for Preview, with a fallback to `VERCEL_URL`.

- **Schema change** (`server-env-schema.ts`): `SITE_URL` is now optional in Preview (where `VERCEL_URL` is required and validated against a `.vercel.app` allowlist), and the new `browserMutationBaseUrl` computed property drives the mutation guard instead of `SITE_URL`.
- **Consumers updated** (`lib/ama/security/server.ts`, `lib/ama/booking/server.ts`): Both the admin security singleton and the public request guard now use `browserMutationBaseUrl`, while Stripe/Manage-Link URL generation continues to use `SITE_URL`.
- **Test coverage added** (`server-env.test.ts`): Six new test cases exercise the preview-origin derivation, production pinning, missing-`VERCEL_URL` rejection, attacker-hostname rejection, and the `SITE_URL`-absent preview path.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to the mutation origin check and the non-null assertions in the transform are fully guarded by the preceding superRefine validations.

The validation invariants established in superRefine ensure the transform's non-null assertions can never be reached with undefined values. The isVercelDeploymentHost guard — checking url.hostname === value, the .vercel.app suffix, and rejecting paths/ports/credentials — is robust against the obvious injection patterns. SITE_URL continues to be used for Stripe return URLs and Manage Links. Tests cover the happy path, both missing-field cases, production-pinning, and an attacker-hostname attempt.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/ama/server-env-schema.ts | Core change: adds VERCEL_URL validation, makes SITE_URL optional in Preview, and derives browserMutationBaseUrl; non-null assertions are guarded by superRefine invariants and are safe. |
| lib/ama/server-env.test.ts | Six new test cases cover preview-origin derivation, production pin, attacker-host rejection, and VERCEL_URL-absent failure; existing tests updated to supply the now-required VERCEL_URL for preview scenarios. |
| lib/ama/security/server.ts | One-line change: admin security singleton now uses browserMutationBaseUrl instead of SITE_URL; straightforward and correct. |
| lib/ama/booking/server.ts | One-line change: public request guard now uses browserMutationBaseUrl; SITE_URL still used for Stripe/Manage-Link URL generation, which is correct. |
| docs/ama-booking-operations.md | Documentation updated to reflect the new split between SITE_URL (production links/provider returns) and environment-aware mutation origin behaviour. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[parseServerEnv input] --> B[Field validation]
    B --> C[VERCEL_ENV parsed as enum]
    B --> D[VERCEL_URL validated via isVercelDeploymentHost]
    B --> E[SITE_URL optional, https or localhost]

    C & D & E --> F[superRefine checks]
    F -->|preview and no VERCEL_URL| ERR1[Error: VERCEL_URL required]
    F -->|non-preview and no SITE_URL| ERR2[Error: SITE_URL required]
    F -->|Valid| G[transform]

    G --> H{VERCEL_ENV is preview?}
    H -->|Yes| I[browserMutationBaseUrl = new URL from VERCEL_URL]
    H -->|No| J[browserMutationBaseUrl = SITE_URL]

    G --> K{SITE_URL defined?}
    K -->|Yes| L[SITE_URL unchanged]
    K -->|No - preview only| M[SITE_URL = new URL from VERCEL_URL]

    I --> N[Mutation guard uses ephemeral preview host]
    J --> O[Mutation guard uses canonical production URL]
    L & M --> P[Stripe return URLs and Manage Links use SITE_URL]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[parseServerEnv input] --> B[Field validation]
    B --> C[VERCEL_ENV parsed as enum]
    B --> D[VERCEL_URL validated via isVercelDeploymentHost]
    B --> E[SITE_URL optional, https or localhost]

    C & D & E --> F[superRefine checks]
    F -->|preview and no VERCEL_URL| ERR1[Error: VERCEL_URL required]
    F -->|non-preview and no SITE_URL| ERR2[Error: SITE_URL required]
    F -->|Valid| G[transform]

    G --> H{VERCEL_ENV is preview?}
    H -->|Yes| I[browserMutationBaseUrl = new URL from VERCEL_URL]
    H -->|No| J[browserMutationBaseUrl = SITE_URL]

    G --> K{SITE_URL defined?}
    K -->|Yes| L[SITE_URL unchanged]
    K -->|No - preview only| M[SITE_URL = new URL from VERCEL_URL]

    I --> N[Mutation guard uses ephemeral preview host]
    J --> O[Mutation guard uses canonical production URL]
    L & M --> P[Stripe return URLs and Manage Links use SITE_URL]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(deploy): derive Preview site URL"](https://github.com/calicastle/cali.so/commit/92b3a756b70046eed641e76dde6b28b0e61dbdc7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45028577)</sub>

<!-- /greptile_comment -->