### PR TITLE
Fix Staging custom mutation origin

### DIFF
--- a/docs/ama-booking-operations.md
+++ b/docs/ama-booking-operations.md
@@ -18,7 +18,7 @@ startup with field names only. `.env.example` mirrors this table.
 | `ADMIN_EMAIL` | always | Owner data namespace and Google Calendar owner. |
 | `AMA_ENCRYPTION_KEY` | always | 32-byte base64 key: Google refresh-token envelopes and Manage Link token derivation. |
 | `RATE_LIMIT_HASH_KEY` | always | 32-byte base64 key pseudonymizing rate-limit and audit actors, including public booking clients. |
-| `SITE_URL` | always | Canonical public origin for Production links and provider return URLs. Vercel Preview and Staging mutation checks use Vercel's system-provided deployment URL so same-origin writes work on ephemeral deployment hosts. |
+| `SITE_URL` | Production and custom aliases | Canonical public origin for links, provider return URLs, and same-origin mutation checks. Ordinary Vercel Previews derive it from Vercel's system deployment URL; custom environments such as Staging must set it to their stable alias. |
 | `CRON_SECRET` | scheduled work | Bearer secret for `/api/internal/ama/work` (and media reconcile). Vercel injects it for cron invocations. |
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | availability + calendar | OAuth client for free/busy and calendar event writes. Slots and meeting creation are unavailable until configured. |
 | `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` | payments | Checkout Session and refund API access; the webhook secret signs `/api/ama/stripe/webhook` (the webhook, never the return URL, is authoritative for payment). Checkout and webhook routes return 503 until configured. |

--- a/docs/v3-cutover-ops-runbook.md
+++ b/docs/v3-cutover-ops-runbook.md
@@ -39,9 +39,11 @@ changing either Neon project.
    those roles and grants are copied into every Preview.
 3. Keep Production in a separate Neon project. Its API key and migration URL
    must never be stored in the Preview or Staging GitHub environments.
-4. Create a Vercel custom environment named `staging`. Copy only approved
-   non-production application settings into it; database URLs are supplied per
-   deployment by GitHub Actions.
+4. Create a Vercel custom environment named `staging`. Set `SITE_URL` to its
+   stable custom alias (currently `https://beta.cali.so`) so browser mutation
+   checks match the URL maintainers use. Copy only approved non-production
+   application settings into it; database URLs are supplied per deployment by
+   GitHub Actions.
 5. Create these GitHub deployment environments:
 
 | Environment | Variables | Secrets | Protection |

--- a/lib/ama/server-env-schema.ts
+++ b/lib/ama/server-env-schema.ts
@@ -303,7 +303,7 @@ const serverEnvironmentSchema = z
       SITE_URL: SITE_URL ?? new URL(`https://${VERCEL_URL!}`),
       browserMutationBaseUrl:
         VERCEL_ENV === 'preview'
-          ? new URL(`https://${VERCEL_URL!}`)
+          ? (SITE_URL ?? new URL(`https://${VERCEL_URL!}`))
           : SITE_URL!,
       rateLimitBackend:
         VERCEL_ENV === 'production'

--- a/lib/ama/server-env.test.ts
+++ b/lib/ama/server-env.test.ts
@@ -58,16 +58,17 @@ describe('AMA server environment', () => {
     })
   })
 
-  it('uses the Vercel deployment origin for Preview mutations', () => {
+  it('uses an explicit Preview site URL for custom deployment aliases', () => {
     const environment = parseServerEnv({
       ...validEnvironment,
       VERCEL_ENV: 'preview',
       VERCEL_URL: 'cali-preview-cali.vercel.app',
+      SITE_URL: 'https://beta.cali.so',
     })
 
-    expect(environment.SITE_URL.href).toBe('https://cali.so/')
+    expect(environment.SITE_URL.href).toBe('https://beta.cali.so/')
     expect(environment.browserMutationBaseUrl.href).toBe(
-      'https://cali-preview-cali.vercel.app/',
+      'https://beta.cali.so/',
     )
   })
 


### PR DESCRIPTION
## Summary

- honor an explicit `SITE_URL` for same-origin mutation checks in Vercel Preview custom environments
- keep `VERCEL_URL` as the fallback for ordinary ephemeral Preview deployments
- document the stable Staging alias requirement

## Root cause

Admin uploads from `https://beta.cali.so` were rejected because the server compared the browser origin with the deployment's ephemeral `*.vercel.app` hostname. Staging already provides `SITE_URL=https://beta.cali.so`, so the mutation boundary should prefer that configured origin.

## Validation

- `pnpm typecheck`
- 64 targeted security and media tests
- `pnpm test:deployment` (19/19)
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes admin upload rejections on the Staging environment (`https://beta.cali.so`) by updating `browserMutationBaseUrl` to prefer an explicit `SITE_URL` over the ephemeral `VERCEL_URL` when both are present in a Vercel Preview deployment.

- **Core fix** (`server-env-schema.ts`): single expression change — `new URL(`https://${VERCEL_URL!}`)` replaced with `(SITE_URL ?? new URL(`https://${VERCEL_URL!}`))` in the preview branch, so a configured stable alias wins over the auto-generated hostname.
- **Tests** (`server-env.test.ts`): renamed test now asserts the SITE_URL-wins behavior; the pre-existing fallback test ("derives the Preview site URL when no canonical URL is configured") continues to cover the no-SITE_URL path, giving full branch coverage.
- **Docs** (`ama-booking-operations.md`, `v3-cutover-ops-runbook.md`): updated to document the two-tier rule and add an explicit step to set `SITE_URL` in the Vercel staging custom environment.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is minimal, well-tested, and limited to the environment schema transform.

The diff touches a single expression in the schema transform, has direct test coverage for both the new SITE_URL-wins path and the existing VERCEL_URL fallback, and all non-preview and security-validation branches are unchanged. The non-null assertion on SITE_URL! in the non-preview branch was already safe before this PR and remains so.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/ama/server-env-schema.ts | One-line change: browserMutationBaseUrl in preview mode now prefers SITE_URL over VERCEL_URL, correctly fixing the Staging origin mismatch. The non-null assertion on SITE_URL! in the non-preview branch remains safe because the schema already rejects non-preview environments without SITE_URL. |
| lib/ama/server-env.test.ts | Test renamed and updated to assert the new SITE_URL-wins behavior; the pre-existing fallback test covers the no-SITE_URL path. Both happy paths are now tested. |
| docs/ama-booking-operations.md | Documentation updated to accurately reflect the new two-tier SITE_URL rule: required for Production and custom aliases, derived from VERCEL_URL for ordinary ephemeral previews. |
| docs/v3-cutover-ops-runbook.md | Runbook updated to include the explicit instruction to set SITE_URL in the Vercel staging custom environment to its stable alias. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[parseServerEnv transform] --> B{VERCEL_ENV === 'preview'?}
    B -- Yes --> C{SITE_URL set?}
    C -- Yes --> D[browserMutationBaseUrl = SITE_URL\ne.g. https://beta.cali.so]
    C -- No --> E[browserMutationBaseUrl = new URL from VERCEL_URL\ne.g. https://abc123.vercel.app]
    B -- No\nproduction / development --> F[browserMutationBaseUrl = SITE_URL!\nRequired by schema]
    D --> G[Same-origin check passes\nfor custom alias]
    E --> H[Same-origin check passes\nfor ephemeral preview]
    F --> I[Same-origin check passes\nfor production]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[parseServerEnv transform] --> B{VERCEL_ENV === 'preview'?}
    B -- Yes --> C{SITE_URL set?}
    C -- Yes --> D[browserMutationBaseUrl = SITE_URL\ne.g. https://beta.cali.so]
    C -- No --> E[browserMutationBaseUrl = new URL from VERCEL_URL\ne.g. https://abc123.vercel.app]
    B -- No\nproduction / development --> F[browserMutationBaseUrl = SITE_URL!\nRequired by schema]
    D --> G[Same-origin check passes\nfor custom alias]
    E --> H[Same-origin check passes\nfor ephemeral preview]
    F --> I[Same-origin check passes\nfor production]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(security): support Staging custom or..."](https://github.com/calicastle/cali.so/commit/29d87c0fa4370f4d0670159774d3ad7d419933e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45038452)</sub>

<!-- /greptile_comment -->