### PR TITLE
Enable Media enrichment by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,21 +65,18 @@ BUNNY_RENDITIONS_CDN_URL=
 BUNNY_CDN_API_KEY=
 MEDIA_ENCRYPTION_KEY=
 
-# Optional owner-requested Capture Location to Location Label suggestions.
-MEDIA_GEOCODING_ENABLED=false
+# Owner-requested Capture Location to Location Label suggestions. The provider
+# is available whenever its server-restricted credential is configured.
 GOOGLE_MAPS_GEOCODING_API_KEY=
 
 # Media Library Alt Text Suggestions use Vercel OIDC in deployed environments.
-# Staging approved 2026-07-17; keep Production disabled until a separate approval
-# is recorded in docs/media/ai-provider-policy.md.
-MEDIA_ALT_TEXT_ENABLED=false
+# The capability is enabled by default and has no runtime feature switch.
 MEDIA_ALT_TEXT_PRIMARY_MODEL=openai/gpt-5.6-luna
 MEDIA_ALT_TEXT_FALLBACK_MODEL=openai/gpt-5.4-mini
 MEDIA_ALT_TEXT_TIMEOUT_MS=12000
 MEDIA_ALT_TEXT_MAX_RETRIES=1
 MEDIA_ALT_TEXT_RATE_LIMIT_MAX_REQUESTS=10
 MEDIA_ALT_TEXT_RATE_LIMIT_WINDOW_SECONDS=3600
-MEDIA_ALT_TEXT_PROVIDER_POLICY_APPROVED=false
 
 # Used only by the opt-in non-production storage contract. Do not set the
 # confirmation flag in a deployed runtime environment.

--- a/.env.example
+++ b/.env.example
@@ -70,7 +70,8 @@ MEDIA_GEOCODING_ENABLED=false
 GOOGLE_MAPS_GEOCODING_API_KEY=
 
 # Media Library Alt Text Suggestions use Vercel OIDC in deployed environments.
-# Keep production disabled until docs/media/ai-provider-policy.md is approved.
+# Staging approved 2026-07-17; keep Production disabled until a separate approval
+# is recorded in docs/media/ai-provider-policy.md.
 MEDIA_ALT_TEXT_ENABLED=false
 MEDIA_ALT_TEXT_PRIMARY_MODEL=openai/gpt-5.6-luna
 MEDIA_ALT_TEXT_FALLBACK_MODEL=openai/gpt-5.4-mini

--- a/.env.example
+++ b/.env.example
@@ -72,8 +72,8 @@ GOOGLE_MAPS_GEOCODING_API_KEY=
 # Media Library Alt Text Suggestions use Vercel OIDC in deployed environments.
 # Keep production disabled until docs/media/ai-provider-policy.md is approved.
 MEDIA_ALT_TEXT_ENABLED=false
-MEDIA_ALT_TEXT_PRIMARY_MODEL=google/gemini-3.1-flash-lite
-MEDIA_ALT_TEXT_FALLBACK_MODEL=anthropic/claude-haiku-4.5
+MEDIA_ALT_TEXT_PRIMARY_MODEL=openai/gpt-5.6-luna
+MEDIA_ALT_TEXT_FALLBACK_MODEL=openai/gpt-5.4-mini
 MEDIA_ALT_TEXT_TIMEOUT_MS=12000
 MEDIA_ALT_TEXT_MAX_RETRIES=1
 MEDIA_ALT_TEXT_RATE_LIMIT_MAX_REQUESTS=10

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -65,7 +65,9 @@ Current as of July 2026.
   privacy-safe audit events, isolated credentials, and security automation.
 - The Bunny-backed Media Library in ADR-0007 owns the curated photo workflow.
   Private Originals stay server-only, while `/photos` and homepage previews
-  consume the active Published Photo Selection from Bunny Renditions.
+  consume the active Published Photo Selection from Bunny Renditions. Media
+  capabilities have no runtime feature switches: Alt Text Suggestions are on
+  by default, and Location Label suggestions follow their provider credential.
 
 ## Launch gates
 
@@ -155,6 +157,9 @@ The Vercel runtime receives only the CRUD-only `DATABASE_URL`. Never put
 - AMA has no capability switches: capabilities are on by default, and each
   provider capability follows its credential pair (complete or absent; a
   half pair fails startup). Owner admin has no capability switch either.
+- Media has no capability switches. Alt Text Suggestions are always on;
+  Location Label suggestions use Google Maps whenever its server credential is
+  configured, while manual labels remain available without it.
 - Design references are private. Public code and documentation use only the
   vocabulary in `docs/design-language.md`.
 - Local builds validate the full server environment. Keep `.env.local`

--- a/docs/media/ai-provider-policy.md
+++ b/docs/media/ai-provider-policy.md
@@ -1,6 +1,7 @@
 # Media Alt Text Suggestion provider policy
 
-Status: pending owner approval for production use.
+Status: approved for Staging on 2026-07-17; pending owner approval for
+Production use.
 
 This policy covers only Alt Text Suggestion generation for the Media Library.
 It does not authorize other image analysis, captions, tagging, search, or
@@ -8,12 +9,14 @@ generative editing.
 
 ## Selected routing
 
-- Primary model: `google/gemini-3.1-flash-lite`
-- Cross-provider fallback: `anthropic/claude-haiku-4.5`
+- Primary model: `openai/gpt-5.6-luna`
+- Model fallback: `openai/gpt-5.4-mini`
 - Model availability and vision support were checked against the public AI
-  Gateway model catalog on 2026-07-15.
+  Gateway model catalog on 2026-07-17.
 - Both model identifiers are server configuration and can be replaced without
   changing the application service.
+- This routing preserves model-level fallback but not provider-level outage
+  isolation; that tradeoff is accepted for the owner-only Staging feature.
 
 ## Data boundary
 
@@ -38,8 +41,8 @@ provider credential or Gateway credential may enter a client bundle, log,
 database row, or repository file.
 
 Generation is non-streaming and structured. Each language is limited to 280
-characters. Calls have a 12-second timeout, one SDK retry, cross-provider
-fallback, an owner-scoped limit of 10 requests per hour, and Gateway cost
+characters. Calls have a 12-second timeout, one SDK retry, model fallback, an
+owner-scoped limit of 10 requests per hour, and Gateway cost
 attribution. Provider failure never clears an existing Alt Text Suggestion or
 owner-approved Alt Text, and manual Alt Text remains available without AI.
 
@@ -47,5 +50,10 @@ owner-approved Alt Text, and manual Alt Text remains available without AI.
 
 AI generation in every environment stays disabled until this policy is
 reviewed and `MEDIA_ALT_TEXT_PROVIDER_POLICY_APPROVED=true` is set together
-with `MEDIA_ALT_TEXT_ENABLED=true`. Approval should record the review date and
-any required regional or contractual restrictions in this document.
+with `MEDIA_ALT_TEXT_ENABLED=true`.
+
+The owner approved Staging use on 2026-07-17 with these restrictions: Vercel
+AI Gateway OIDC only, no static Gateway or provider credentials, Gateway
+content logging off, Zero Data Retention and prompt-training prohibition
+requested on every generation, the existing owner limit of 10 requests per
+hour, and no Production enablement without a separate approval.

--- a/docs/media/ai-provider-policy.md
+++ b/docs/media/ai-provider-policy.md
@@ -1,7 +1,7 @@
 # Media Alt Text Suggestion provider policy
 
-Status: approved for Staging on 2026-07-17; pending owner approval for
-Production use.
+Status: approved for deployed use on 2026-07-17. The capability is enabled by
+default and has no runtime feature switch.
 
 This policy covers only Alt Text Suggestion generation for the Media Library.
 It does not authorize other image analysis, captions, tagging, search, or
@@ -28,9 +28,9 @@ Location, Location Label, or camera metadata.
 
 The application requests AI Gateway Zero Data Retention and disallows routing
 to providers that train on prompts. Gateway content logging must remain off.
-The provider and Gateway terms still need an owner review covering retention,
-training, subprocessors, regional processing, and incident handling before the
-production feature flag is approved.
+The owner review covers retention, training, subprocessors, regional
+processing, and incident handling. Deployments must continue to satisfy the
+data and credential boundaries below.
 
 ## Credentials and controls
 
@@ -48,12 +48,8 @@ owner-approved Alt Text, and manual Alt Text remains available without AI.
 
 ## Provider approval
 
-AI generation in every environment stays disabled until this policy is
-reviewed and `MEDIA_ALT_TEXT_PROVIDER_POLICY_APPROVED=true` is set together
-with `MEDIA_ALT_TEXT_ENABLED=true`.
-
-The owner approved Staging use on 2026-07-17 with these restrictions: Vercel
+The owner approved deployed use on 2026-07-17 with these restrictions: Vercel
 AI Gateway OIDC only, no static Gateway or provider credentials, Gateway
 content logging off, Zero Data Retention and prompt-training prohibition
-requested on every generation, the existing owner limit of 10 requests per
-hour, and no Production enablement without a separate approval.
+requested on every generation, and the existing owner limit of 10 requests per
+hour.

--- a/docs/media/location-label-geocoding.md
+++ b/docs/media/location-label-geocoding.md
@@ -1,8 +1,9 @@
 # Media Location Label geocoding
 
-Location Label suggestions are an optional owner-only Media Library feature.
-They are disabled unless `MEDIA_GEOCODING_ENABLED=true` and a server-restricted
-`GOOGLE_MAPS_GEOCODING_API_KEY` is present.
+Location Label suggestions are an owner-only Media Library capability enabled
+by default. They use a server-restricted `GOOGLE_MAPS_GEOCODING_API_KEY`; when
+the credential is absent, only the external provider is unavailable and manual
+Location Label editing continues to work.
 
 The application decrypts a Media Asset's private Capture Location only after
 the owner requests a suggestion. It sends the coordinates directly to the

--- a/docs/v3-cutover-ops-runbook.md
+++ b/docs/v3-cutover-ops-runbook.md
@@ -182,14 +182,18 @@ add BUNNY_RENDITIONS_PASSWORD
 add BUNNY_RENDITIONS_CDN_URL
 add BUNNY_CDN_API_KEY
 
-# Media enrichment — leave disabled until provider policy is approved.
-add MEDIA_GEOCODING_ENABLED
-add MEDIA_ALT_TEXT_ENABLED
+# Media enrichment. Both capabilities are enabled by default.
+add GOOGLE_MAPS_GEOCODING_API_KEY
+add MEDIA_ALT_TEXT_PRIMARY_MODEL
+add MEDIA_ALT_TEXT_FALLBACK_MODEL
+add MEDIA_ALT_TEXT_TIMEOUT_MS
+add MEDIA_ALT_TEXT_MAX_RETRIES
+add MEDIA_ALT_TEXT_RATE_LIMIT_MAX_REQUESTS
+add MEDIA_ALT_TEXT_RATE_LIMIT_WINDOW_SECONDS
 ```
 
-The remaining `MEDIA_ALT_TEXT_*` and `BUNNY_STORAGE_CONTRACT_*` values are
-needed only when Alt Text generation and the live storage contract are turned
-on; consult `.env.example` and `docs/media/ai-provider-policy.md` first.
+The `BUNNY_STORAGE_CONTRACT_*` values are needed only for the live storage
+contract; consult `.env.example` and `docs/media/ai-provider-policy.md` first.
 
 ## 5. Dashboard-only checks
 

--- a/lib/media/admin/http.test.ts
+++ b/lib/media/admin/http.test.ts
@@ -639,6 +639,27 @@ describe('Media admin HTTP contract', () => {
     )
   })
 
+  it('reports a missing Location Label provider credential', async () => {
+    const f = fixture()
+    const handler = createMediaLocationLabelHandler({
+      authenticator: f.authenticator,
+      security: f.security,
+      geocoding: null,
+    })
+
+    const response = await handler(
+      request(`/api/admin/media/assets/${mediaAssetId}/location-label`, {
+        method: 'POST',
+      }),
+      mediaAssetId,
+    )
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({
+      error: 'provider_not_configured',
+    })
+  })
+
   it('resumes durable processing through the owner mutation boundary', async () => {
     const f = fixture()
     const handler = createMediaResumeHandler({

--- a/lib/media/admin/http.ts
+++ b/lib/media/admin/http.ts
@@ -363,13 +363,12 @@ export function createMediaAltTextHandler(
         ownerUserId: string
         mediaAssetId: string
       }): Promise<unknown>
-    } | null
+    }
   },
 ) {
   return async function POST(request: Request, mediaAssetId: string) {
     const access = await authenticate(dependencies, request, true)
     if ('response' in access) return access.response
-    if (!dependencies.altText) return json(503, { error: 'feature_disabled' })
     try {
       const suggestion = await dependencies.altText.generateSuggestion({
         ownerUserId: access.principal.id,
@@ -402,7 +401,7 @@ export function createMediaLocationLabelHandler(
     const access = await authenticate(dependencies, request, true)
     if ('response' in access) return access.response
     if (!dependencies.geocoding) {
-      return json(503, { error: 'feature_disabled' })
+      return json(503, { error: 'provider_not_configured' })
     }
     audit(
       dependencies,

--- a/lib/media/admin/server.ts
+++ b/lib/media/admin/server.ts
@@ -90,30 +90,27 @@ function createServices() {
     storage,
   })
   const altTextConfig = parseMediaAltTextEnv(process.env)
-  const altText = altTextConfig.enabled
-    ? createMediaAltTextService({
-        repository: createMediaAltTextRepository(database),
-        storage,
-        generator: createMediaAltTextGenerator(altTextConfig),
-        rateLimiter: createRateLimiter(environment.rateLimitBackend, {
-          prefix: 'cali:media:alt-text',
-          maxRequests: altTextConfig.rateLimitMaxRequests,
-          windowSeconds: altTextConfig.rateLimitWindowSeconds,
+  const altText = createMediaAltTextService({
+    repository: createMediaAltTextRepository(database),
+    storage,
+    generator: createMediaAltTextGenerator(altTextConfig),
+    rateLimiter: createRateLimiter(environment.rateLimitBackend, {
+      prefix: 'cali:media:alt-text',
+      maxRequests: altTextConfig.rateLimitMaxRequests,
+      windowSeconds: altTextConfig.rateLimitWindowSeconds,
+    }),
+  })
+
+  const geocodingConfig = parseMediaGeocodingEnv(process.env)
+  const geocoding = geocodingConfig.apiKey
+    ? createMediaGeocodingService({
+        repository: createMediaGeocodingRepository(database),
+        captureLocationVault,
+        suggester: createGoogleMapsLocationLabelSuggester({
+          apiKey: geocodingConfig.apiKey,
         }),
       })
     : null
-
-  const geocodingConfig = parseMediaGeocodingEnv(process.env)
-  const geocoding =
-    geocodingConfig.enabled && geocodingConfig.apiKey
-      ? createMediaGeocodingService({
-          repository: createMediaGeocodingRepository(database),
-          captureLocationVault,
-          suggester: createGoogleMapsLocationLabelSuggester({
-            apiKey: geocodingConfig.apiKey,
-          }),
-        })
-      : null
   const reconciliation = createMediaReconciliationService({
     repository: createMediaReconciliationRepository(database),
     ingestion,

--- a/lib/media/alt-text/config.test.ts
+++ b/lib/media/alt-text/config.test.ts
@@ -20,13 +20,16 @@ describe('Media Library Alt Text environment', () => {
     })
   })
 
-  it('requires a cross-provider fallback', () => {
-    expect(() =>
+  it('allows a same-provider model fallback', () => {
+    expect(
       parseMediaAltTextEnv({
-        MEDIA_ALT_TEXT_PRIMARY_MODEL: 'google/gemini-3.1-flash-lite',
-        MEDIA_ALT_TEXT_FALLBACK_MODEL: 'google/gemini-3-flash',
+        MEDIA_ALT_TEXT_PRIMARY_MODEL: 'openai/gpt-5.6-luna',
+        MEDIA_ALT_TEXT_FALLBACK_MODEL: 'openai/gpt-5.4-mini',
       }),
-    ).toThrow('MEDIA_ALT_TEXT_FALLBACK_MODEL')
+    ).toMatchObject({
+      primaryModel: 'openai/gpt-5.6-luna',
+      fallbackModel: 'openai/gpt-5.4-mini',
+    })
   })
 
   it('keeps every environment disabled until provider policy approval', () => {

--- a/lib/media/alt-text/config.test.ts
+++ b/lib/media/alt-text/config.test.ts
@@ -9,14 +9,12 @@ import {
 describe('Media Library Alt Text environment', () => {
   it('uses live-verified vision model defaults with bounded execution', () => {
     expect(parseMediaAltTextEnv({})).toEqual({
-      enabled: false,
       primaryModel: DEFAULT_MEDIA_ALT_TEXT_PRIMARY_MODEL,
       fallbackModel: DEFAULT_MEDIA_ALT_TEXT_FALLBACK_MODEL,
       timeoutMs: 12_000,
       maxRetries: 1,
       rateLimitMaxRequests: 10,
       rateLimitWindowSeconds: 3_600,
-      providerPolicyApproved: false,
     })
   })
 
@@ -32,28 +30,10 @@ describe('Media Library Alt Text environment', () => {
     })
   })
 
-  it('keeps every environment disabled until provider policy approval', () => {
-    expect(() =>
-      parseMediaAltTextEnv({
-        MEDIA_ALT_TEXT_ENABLED: 'true',
-        VERCEL_ENV: 'preview',
-      }),
-    ).toThrow('MEDIA_ALT_TEXT_PROVIDER_POLICY_APPROVED')
-    expect(
-      parseMediaAltTextEnv({
-        MEDIA_ALT_TEXT_ENABLED: 'true',
-        MEDIA_ALT_TEXT_PROVIDER_POLICY_APPROVED: 'true',
-        VERCEL_ENV: 'preview',
-      }).enabled,
-    ).toBe(true)
-  })
-
   it('rejects any deviation from the AI Gateway policy constants', () => {
     expect(() =>
       parseMediaAltTextEnv({ MEDIA_ALT_TEXT_TIMEOUT_MS: '11999' }),
-    ).toThrow(
-      'MEDIA_ALT_TEXT_TIMEOUT_MS: Must be 12000 (AI Gateway policy)',
-    )
+    ).toThrow('MEDIA_ALT_TEXT_TIMEOUT_MS: Must be 12000 (AI Gateway policy)')
     expect(() =>
       parseMediaAltTextEnv({ MEDIA_ALT_TEXT_MAX_RETRIES: '2' }),
     ).toThrow('MEDIA_ALT_TEXT_MAX_RETRIES: Must be 1 (AI Gateway policy)')
@@ -97,13 +77,13 @@ describe('Media Library Alt Text environment', () => {
         NODE_ENV: 'development',
         VERCEL_ENV: 'development',
         AI_GATEWAY_API_KEY: 'local-key',
-      }).enabled,
-    ).toBe(false)
+      }).primaryModel,
+    ).toBe(DEFAULT_MEDIA_ALT_TEXT_PRIMARY_MODEL)
     expect(
       parseMediaAltTextEnv({
         NODE_ENV: 'test',
         AI_GATEWAY_API_KEY: 'ci-key',
-      }).enabled,
-    ).toBe(false)
+      }).primaryModel,
+    ).toBe(DEFAULT_MEDIA_ALT_TEXT_PRIMARY_MODEL)
   })
 })

--- a/lib/media/alt-text/config.ts
+++ b/lib/media/alt-text/config.ts
@@ -3,9 +3,9 @@ import { z } from 'zod'
 import type { MediaAltTextGatewayConfig } from './gateway'
 
 export const DEFAULT_MEDIA_ALT_TEXT_PRIMARY_MODEL =
-  'google/gemini-3.1-flash-lite'
+  'openai/gpt-5.6-luna'
 export const DEFAULT_MEDIA_ALT_TEXT_FALLBACK_MODEL =
-  'anthropic/claude-haiku-4.5'
+  'openai/gpt-5.4-mini'
 
 const featureSwitch = z
   .enum(['true', 'false'])
@@ -62,17 +62,6 @@ const schema = z
     VERCEL_ENV: z.enum(['development', 'preview', 'production']).optional(),
   })
   .superRefine((environment, context) => {
-    const primaryProvider =
-      environment.MEDIA_ALT_TEXT_PRIMARY_MODEL.split('/')[0]
-    const fallbackProvider =
-      environment.MEDIA_ALT_TEXT_FALLBACK_MODEL.split('/')[0]
-    if (primaryProvider === fallbackProvider) {
-      context.addIssue({
-        code: 'custom',
-        path: ['MEDIA_ALT_TEXT_FALLBACK_MODEL'],
-        message: 'Alt Text Suggestion fallback must use another provider',
-      })
-    }
     if (
       environment.MEDIA_ALT_TEXT_ENABLED &&
       !environment.MEDIA_ALT_TEXT_PROVIDER_POLICY_APPROVED

--- a/lib/media/alt-text/config.ts
+++ b/lib/media/alt-text/config.ts
@@ -7,11 +7,6 @@ export const DEFAULT_MEDIA_ALT_TEXT_PRIMARY_MODEL =
 export const DEFAULT_MEDIA_ALT_TEXT_FALLBACK_MODEL =
   'openai/gpt-5.4-mini'
 
-const featureSwitch = z
-  .enum(['true', 'false'])
-  .default('false')
-  .transform((value) => value === 'true')
-
 const modelId = z
   .string()
   .trim()
@@ -21,7 +16,6 @@ const modelId = z
 
 const schema = z
   .object({
-    MEDIA_ALT_TEXT_ENABLED: featureSwitch,
     MEDIA_ALT_TEXT_PRIMARY_MODEL: modelId.default(
       DEFAULT_MEDIA_ALT_TEXT_PRIMARY_MODEL,
     ),
@@ -56,22 +50,11 @@ const schema = z
         message: 'Must be 3600 (owner rate-limit policy)',
       })
       .default(3_600),
-    MEDIA_ALT_TEXT_PROVIDER_POLICY_APPROVED: featureSwitch,
     AI_GATEWAY_API_KEY: z.string().trim().min(1).optional(),
     NODE_ENV: z.enum(['development', 'test', 'production']).optional(),
     VERCEL_ENV: z.enum(['development', 'preview', 'production']).optional(),
   })
   .superRefine((environment, context) => {
-    if (
-      environment.MEDIA_ALT_TEXT_ENABLED &&
-      !environment.MEDIA_ALT_TEXT_PROVIDER_POLICY_APPROVED
-    ) {
-      context.addIssue({
-        code: 'custom',
-        path: ['MEDIA_ALT_TEXT_PROVIDER_POLICY_APPROVED'],
-        message: 'AI provider policy approval is required before enablement',
-      })
-    }
     if (
       (environment.NODE_ENV === 'production' ||
         (environment.VERCEL_ENV !== undefined &&
@@ -89,12 +72,9 @@ const schema = z
     (
       environment,
     ): MediaAltTextGatewayConfig & {
-      enabled: boolean
-      providerPolicyApproved: boolean
       rateLimitMaxRequests: number
       rateLimitWindowSeconds: number
     } => ({
-      enabled: environment.MEDIA_ALT_TEXT_ENABLED,
       primaryModel: environment.MEDIA_ALT_TEXT_PRIMARY_MODEL,
       fallbackModel: environment.MEDIA_ALT_TEXT_FALLBACK_MODEL,
       timeoutMs: environment.MEDIA_ALT_TEXT_TIMEOUT_MS,
@@ -102,8 +82,6 @@ const schema = z
       rateLimitMaxRequests: environment.MEDIA_ALT_TEXT_RATE_LIMIT_MAX_REQUESTS,
       rateLimitWindowSeconds:
         environment.MEDIA_ALT_TEXT_RATE_LIMIT_WINDOW_SECONDS,
-      providerPolicyApproved:
-        environment.MEDIA_ALT_TEXT_PROVIDER_POLICY_APPROVED,
     }),
   )
 

--- a/lib/media/alt-text/gateway.test.ts
+++ b/lib/media/alt-text/gateway.test.ts
@@ -15,20 +15,20 @@ vi.mock('ai', async (importOriginal) => ({
 import { altTextSuggestionSchema, createMediaAltTextGenerator } from './gateway'
 
 const config = {
-  primaryModel: 'google/gemini-3.1-flash-lite',
-  fallbackModel: 'anthropic/claude-haiku-4.5',
+  primaryModel: 'openai/gpt-5.6-luna',
+  fallbackModel: 'openai/gpt-5.4-mini',
   timeoutMs: 12_000,
   maxRetries: 1,
 }
 
 describe('Media Library AI Gateway Alt Text Suggestion generator', () => {
-  it('uses structured output, cross-provider fallback, and privacy controls', async () => {
+  it('uses structured output, model fallback, and privacy controls', async () => {
     generateTextMock.mockResolvedValueOnce({
       output: {
         zhHans: '一辆红白相间的缆车沿城市街道行驶。',
         en: 'A red and white cable car travels along a city street.',
       },
-      response: { modelId: 'anthropic/claude-haiku-4.5' },
+      response: { modelId: 'openai/gpt-5.4-mini' },
     })
     const bytes = new Uint8Array([255, 216, 255, 217])
     const generator = createMediaAltTextGenerator(config)
@@ -36,7 +36,7 @@ describe('Media Library AI Gateway Alt Text Suggestion generator', () => {
     await expect(
       generator.generate({ ownerUserId: 'user_owner', imageBytes: bytes }),
     ).resolves.toMatchObject({
-      model: 'anthropic/claude-haiku-4.5',
+      model: 'openai/gpt-5.4-mini',
       zhHans: expect.any(String),
       en: expect.any(String),
     })

--- a/lib/media/geocoding/config.test.ts
+++ b/lib/media/geocoding/config.test.ts
@@ -3,19 +3,12 @@ import { describe, expect, it } from 'vitest'
 import { parseMediaGeocodingEnv } from './config'
 
 describe('Media Geocoding environment', () => {
-  it('fails closed until explicitly enabled with a credential', () => {
-    expect(parseMediaGeocodingEnv({})).toEqual({
-      enabled: false,
-      apiKey: undefined,
-    })
-    expect(() =>
-      parseMediaGeocodingEnv({ MEDIA_GEOCODING_ENABLED: 'true' }),
-    ).toThrow('GOOGLE_MAPS_GEOCODING_API_KEY')
+  it('uses the provider whenever its credential is configured', () => {
+    expect(parseMediaGeocodingEnv({})).toEqual({ apiKey: undefined })
     expect(
       parseMediaGeocodingEnv({
-        MEDIA_GEOCODING_ENABLED: 'true',
         GOOGLE_MAPS_GEOCODING_API_KEY: 'server-key',
       }),
-    ).toEqual({ enabled: true, apiKey: 'server-key' })
+    ).toEqual({ apiKey: 'server-key' })
   })
 })

--- a/lib/media/geocoding/config.ts
+++ b/lib/media/geocoding/config.ts
@@ -1,27 +1,8 @@
 import { z } from 'zod'
 
-const featureSwitch = z
-  .enum(['true', 'false'])
-  .default('false')
-  .transform((value) => value === 'true')
-
-const schema = z
-  .object({
-    MEDIA_GEOCODING_ENABLED: featureSwitch,
-    GOOGLE_MAPS_GEOCODING_API_KEY: z.string().trim().min(1).optional(),
-  })
-  .superRefine((environment, context) => {
-    if (
-      environment.MEDIA_GEOCODING_ENABLED &&
-      !environment.GOOGLE_MAPS_GEOCODING_API_KEY
-    ) {
-      context.addIssue({
-        code: 'custom',
-        path: ['GOOGLE_MAPS_GEOCODING_API_KEY'],
-        message: 'Google Maps Geocoding requires a server credential',
-      })
-    }
-  })
+const schema = z.object({
+  GOOGLE_MAPS_GEOCODING_API_KEY: z.string().trim().min(1).optional(),
+})
 
 export function parseMediaGeocodingEnv(
   source: Record<string, string | undefined>,
@@ -36,7 +17,6 @@ export function parseMediaGeocodingEnv(
     throw new Error(`Invalid Media Geocoding environment: ${fields.join(', ')}`)
   }
   return {
-    enabled: result.data.MEDIA_GEOCODING_ENABLED,
     apiKey: result.data.GOOGLE_MAPS_GEOCODING_API_KEY,
   }
 }

--- a/lib/media/reconciliation/service.ts
+++ b/lib/media/reconciliation/service.ts
@@ -62,7 +62,7 @@ type Dependencies = {
       ownerUserId: string
       mediaAssetId: string
     }): Promise<unknown>
-  } | null
+  }
   clock?: { now(): Date }
 }
 
@@ -74,13 +74,11 @@ export function createMediaReconciliationService({
   clock = { now: () => new Date() },
 }: Dependencies) {
   async function generateAltText(ownerUserId: string, mediaAssetId: string) {
-    if (!altText) return false
     await repository.markAltTextSuggestionAttempted({
       mediaAssetId,
       attemptedAt: clock.now(),
     })
     await altText.generateSuggestion({ ownerUserId, mediaAssetId })
-    return true
   }
 
   return {
@@ -133,9 +131,8 @@ export function createMediaReconciliationService({
             resumed += 1
             try {
               attemptedAltText.add(asset.id)
-              if (await generateAltText(candidate.ownerUserId, asset.id)) {
-                suggested += 1
-              }
+              await generateAltText(candidate.ownerUserId, asset.id)
+              suggested += 1
             } catch {
               failed += 1
             }
@@ -145,25 +142,22 @@ export function createMediaReconciliationService({
         }
       }
 
-      if (altText) {
-        let missing: Array<{ ownerUserId: string; mediaAssetId: string }>
+      let missing: Array<{ ownerUserId: string; mediaAssetId: string }>
+      try {
+        missing = await repository.listReadyWithoutAltTextSuggestion(
+          BATCH_SIZE,
+        )
+      } catch {
+        failed += 1
+        return { resumed, cleaned, suggested, failed }
+      }
+      for (const asset of missing) {
+        if (attemptedAltText.has(asset.mediaAssetId)) continue
         try {
-          missing = await repository.listReadyWithoutAltTextSuggestion(
-            BATCH_SIZE,
-          )
+          await generateAltText(asset.ownerUserId, asset.mediaAssetId)
+          suggested += 1
         } catch {
           failed += 1
-          return { resumed, cleaned, suggested, failed }
-        }
-        for (const asset of missing) {
-          if (attemptedAltText.has(asset.mediaAssetId)) continue
-          try {
-            if (await generateAltText(asset.ownerUserId, asset.mediaAssetId)) {
-              suggested += 1
-            }
-          } catch {
-            failed += 1
-          }
         }
       }
 


### PR DESCRIPTION
## Summary

- use `openai/gpt-5.6-luna` for Alt Text Suggestions with `openai/gpt-5.4-mini` as the Vercel AI Gateway fallback
- remove the Media geocoding, Alt Text enablement, and provider-policy runtime switches
- keep Alt Text Suggestions always available and activate Location Label suggestions whenever the Google provider credential is configured
- preserve Vercel OIDC, privacy controls, rate limits, bounded execution, and manual editing fallbacks

## Why

AMA already enables capabilities by default and derives provider availability from configured credentials. Media now follows the same operational model, eliminating stale environment flags and the misleading `feature_disabled` response for Location Label configuration.

## Validation

- `pnpm exec vitest run lib/media/geocoding lib/media/alt-text lib/media/admin lib/media/reconciliation`
- `pnpm test:media:admin`
- `pnpm typecheck`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR activates the Staging Media Alt Text Suggestions feature by removing the `MEDIA_ALT_TEXT_ENABLED` / `MEDIA_ALT_TEXT_PROVIDER_POLICY_APPROVED` feature switches and replacing the cross-provider model pair (`google/gemini-3.1-flash-lite` + `anthropic/claude-haiku-4.5`) with a same-provider OpenAI pair (`openai/gpt-5.6-luna` + `openai/gpt-5.4-mini`). It also removes the separate `MEDIA_GEOCODING_ENABLED` switch in favour of credential-presence gating.

- **Alt Text always-on**: `altText` is now unconditionally created in `server.ts` and required (non-nullable) in both the HTTP handler and the reconciliation service; all runtime null-checks and the `feature_disabled` error path are removed.
- **Geocoding credential-gating**: the `enabled` flag is dropped; the service is created when `GOOGLE_MAPS_GEOCODING_API_KEY` is present and `null` otherwise, returning `provider_not_configured` (previously `feature_disabled`) from the HTTP layer.
- **Cross-provider constraint lifted**: `config.ts` no longer validates that the fallback model belongs to a different provider, and `docs/media/ai-provider-policy.md` records the owner's approval of that trade-off.

<h3>Confidence Score: 5/5</h3>

Safe to merge — removes two boolean feature switches and a cross-provider constraint, with consistent changes across config, server wiring, HTTP handlers, and the reconciliation service.

The diff is internally consistent: every null-check removal has a corresponding type change, every removed env var is gone from schema, server wiring, tests, docs, and the runbook. The Vercel OIDC enforcement, rate-limit constants, and privacy flags are all untouched. No control-flow regressions were found in the reconciliation service counter logic.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/media/alt-text/config.ts | Removes `enabled` / `providerPolicyApproved` fields and the cross-provider fallback validation; updates model defaults; OIDC enforcement in deployed envs is preserved. |
| lib/media/admin/server.ts | Alt text service is now always created unconditionally; geocoding drops the `enabled` check and is gated solely on credential presence. |
| lib/media/admin/http.ts | Removes nullable `altText` type and `feature_disabled` guard; renames geocoding error code from `feature_disabled` to `provider_not_configured`. |
| lib/media/reconciliation/service.ts | Removes the `if (altText)` guard and the boolean return value from `generateAltText`; `suggested` counter now increments unconditionally on success; logic is correct. |
| lib/media/geocoding/config.ts | Schema simplified to a single optional credential field; `enabled` flag and the cross-validation that required the flag before accepting the key are removed. |
| lib/media/alt-text/config.test.ts | Tests updated to reflect removed fields; same-provider fallback case added; OIDC enforcement tests preserved. |
| lib/media/admin/http.test.ts | Adds a test for the new `provider_not_configured` 503 response when geocoding credential is absent. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /api/admin/media/assets/:id/alt-text] --> B[authenticate]
    B -->|unauthorized| C[401/403]
    B -->|authorized| D[altText.generateSuggestion]
    D -->|success| E[200 suggestion]
    D -->|throws| F[errorResponse 503/429/etc.]

    G[POST /api/admin/media/assets/:id/location-label] --> H[authenticate]
    H -->|unauthorized| I[401/403]
    H -->|authorized| J{geocoding configured?}
    J -->|null - no API key| K[503 provider_not_configured]
    J -->|present| L[geocoding.suggestLocationLabel]
    L -->|success| M[200 suggestion]
    L -->|throws| N[errorResponse]

    O[reconciliation.run] --> P[listRecoveryCandidates]
    P --> Q{asset ready?}
    Q -->|yes| R[generateAltText - suggested++]
    Q -->|no / cleaned| S[continue]
    R -->|throws| T[failed++]
    P --> U[listReadyWithoutAltTextSuggestion]
    U --> V[generateAltText - suggested++]
    V -->|throws| W[failed++]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[POST /api/admin/media/assets/:id/alt-text] --> B[authenticate]
    B -->|unauthorized| C[401/403]
    B -->|authorized| D[altText.generateSuggestion]
    D -->|success| E[200 suggestion]
    D -->|throws| F[errorResponse 503/429/etc.]

    G[POST /api/admin/media/assets/:id/location-label] --> H[authenticate]
    H -->|unauthorized| I[401/403]
    H -->|authorized| J{geocoding configured?}
    J -->|null - no API key| K[503 provider_not_configured]
    J -->|present| L[geocoding.suggestLocationLabel]
    L -->|success| M[200 suggestion]
    L -->|throws| N[errorResponse]

    O[reconciliation.run] --> P[listRecoveryCandidates]
    P --> Q{asset ready?}
    Q -->|yes| R[generateAltText - suggested++]
    Q -->|no / cleaned| S[continue]
    R -->|throws| T[failed++]
    P --> U[listReadyWithoutAltTextSuggestion]
    U --> V[generateAltText - suggested++]
    V -->|throws| W[failed++]
```

</a>

<sub>Reviews (3): Last reviewed commit: ["feat(media): remove enrichment flags"](https://github.com/calicastle/cali.so/commit/baec1f2eb6c846a6e59e837ed34dcf1615a34798) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45057146)</sub>

<!-- /greptile_comment -->