### PR TITLE
Refine mobile article map expansion

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -266,9 +266,8 @@
   --guide-opacity: 0.4;
 }
 
-/* The warm working-paper palette. Public pages and the owner admin share
-   it (maintainer decision, July 2026) — the neutral ramp above remains
-   only as the pre-hydration fallback. */
+/* Public pages use warm paper and ink. Admin keeps the neutral product
+   palette above so editorial refinements cannot change operational UI. */
 .public-site {
   --gray-1: oklch(0.99 0.001 95);
   --gray-2: oklch(0.975 0.0015 95);
@@ -3663,13 +3662,17 @@ html[data-locale='en'] [data-en-block] {
     max-height: calc(100dvh - 10.25rem - env(safe-area-inset-bottom));
     flex-direction: column;
     padding: 2.75rem 1rem 0;
+    border-radius: 1rem;
+    box-shadow:
+      0 0 0 var(--border-hairline) color-mix(in oklab, var(--foreground) 14%, transparent),
+      0 16px 40px -18px rgb(0 0 0 / 0.42);
     opacity: 0;
     visibility: hidden;
     overflow: hidden;
     pointer-events: none;
     transform: translateY(-0.75rem) scale(0.96);
     transform-origin: top center;
-    transition: visibility 1ms linear 200ms;
+    transition: visibility 1ms linear 280ms;
   }
 
   .post-minimap-root[data-open] .post-minimap {
@@ -3687,10 +3690,11 @@ html[data-locale='en'] [data-en-block] {
     display: block;
     border-radius: 1rem;
     background: color-mix(in oklab, var(--popover) 94%, transparent);
-    box-shadow:
-      0 0 0 var(--border-hairline) color-mix(in oklab, var(--foreground) 14%, transparent),
-      0 16px 40px -18px rgb(0 0 0 / 0.42);
     pointer-events: none;
+  }
+
+  .post-minimap-root:not([data-open]) .post-minimap-node {
+    filter: blur(2px);
   }
 
   .post-minimap-clip {
@@ -3779,11 +3783,12 @@ html[data-locale='en'] [data-en-block] {
     stroke-linecap: round;
     stroke-linejoin: round;
     transform-origin: center;
-    transition: transform 200ms var(--ease-swift);
+    transition: transform 260ms var(--ease-swift);
   }
 
   .post-minimap-root[data-open] .post-minimap-island-chevron {
     transform: rotate(180deg);
+    transition-duration: 280ms;
   }
 }
 
@@ -4286,51 +4291,6 @@ html[data-locale='en'] [data-en-block] {
 .prefs-panel [role='tab'][aria-selected='true'] svg,
 .prefs-panel [role='tab'][aria-selected='true'] [data-tab-label] {
   color: var(--background) !important;
-}
-
-/* The owner's way in: a quiet link row below a hairline, present only once
-   the owner probe has confirmed the session. Hover deepens the label to
-   full ink; the chord hint reuses the dock tooltip's key chips. */
-.prefs-admin {
-  margin-top: 0.25rem;
-  padding-top: 0.375rem;
-  min-height: 2.75rem;
-  border-top: var(--border-hairline) solid var(--border);
-  text-decoration: none;
-}
-
-@media (hover: hover) and (pointer: fine) {
-  .prefs-admin {
-    min-height: 2rem;
-  }
-
-  .prefs-admin:hover .prefs-row-label {
-    color: var(--foreground);
-  }
-}
-
-.prefs-admin .prefs-row-label {
-  transition: color 150ms ease;
-}
-
-.prefs-admin:focus-visible .prefs-row-label {
-  color: var(--foreground);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .prefs-admin .prefs-row-label {
-    transition: none;
-  }
-}
-
-/* Sign-out inside the owner dock's panel: the same quiet row, as a button. */
-.prefs-signout {
-  width: 100%;
-  background: none;
-  border-left: 0;
-  border-right: 0;
-  border-bottom: 0;
-  text-align: left;
 }
 
 /* ── Home nav cards: analog vignettes on soft surfaces ────────────── */

--- a/app/globals.css
+++ b/app/globals.css
@@ -266,8 +266,9 @@
   --guide-opacity: 0.4;
 }
 
-/* Public pages use warm paper and ink. Admin keeps the neutral product
-   palette above so editorial refinements cannot change operational UI. */
+/* The warm working-paper palette. Public pages and the owner admin share
+   it (maintainer decision, July 2026) — the neutral ramp above remains
+   only as the pre-hydration fallback. */
 .public-site {
   --gray-1: oklch(0.99 0.001 95);
   --gray-2: oklch(0.975 0.0015 95);
@@ -4291,6 +4292,51 @@ html[data-locale='en'] [data-en-block] {
 .prefs-panel [role='tab'][aria-selected='true'] svg,
 .prefs-panel [role='tab'][aria-selected='true'] [data-tab-label] {
   color: var(--background) !important;
+}
+
+/* The owner's way in: a quiet link row below a hairline, present only once
+   the owner probe has confirmed the session. Hover deepens the label to
+   full ink; the chord hint reuses the dock tooltip's key chips. */
+.prefs-admin {
+  margin-top: 0.25rem;
+  padding-top: 0.375rem;
+  min-height: 2.75rem;
+  border-top: var(--border-hairline) solid var(--border);
+  text-decoration: none;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .prefs-admin {
+    min-height: 2rem;
+  }
+
+  .prefs-admin:hover .prefs-row-label {
+    color: var(--foreground);
+  }
+}
+
+.prefs-admin .prefs-row-label {
+  transition: color 150ms ease;
+}
+
+.prefs-admin:focus-visible .prefs-row-label {
+  color: var(--foreground);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .prefs-admin .prefs-row-label {
+    transition: none;
+  }
+}
+
+/* Sign-out inside the owner dock's panel: the same quiet row, as a button. */
+.prefs-signout {
+  width: 100%;
+  background: none;
+  border-left: 0;
+  border-right: 0;
+  border-bottom: 0;
+  text-align: left;
 }
 
 /* ── Home nav cards: analog vignettes on soft surfaces ────────────── */

--- a/components/post-toc.tsx
+++ b/components/post-toc.tsx
@@ -13,14 +13,17 @@ const DESKTOP_QUERY = '(min-width: 64rem)'
 const DESKTOP_EXIT_DURATION = 0.2
 const DESKTOP_EXIT_STAGGER_WINDOW = 0.06
 const EASE_SWIFT = [0.2, 0.8, 0.2, 1] as const
-const PHONE_ENTER_DURATION = 0.2
-const PHONE_ENTER_STAGGER_WINDOW = 0.06
-const PHONE_EXIT_DURATION = 0.16
-const PHONE_EXIT_STAGGER_WINDOW = 0.04
+const PHONE_ENTER_STAGGER_WINDOW = 0.1
+const PHONE_EXIT_STAGGER_WINDOW = 0.1
 const PHONE_ISLAND_ENTER_DURATION = 0.28
 const PHONE_ISLAND_EXIT_DURATION = 0.26
 const PHONE_ISLAND_HIDDEN_TRANSFORM = 'translate(-50%, -16px) scale(0.96)'
 const PHONE_ISLAND_VISIBLE_TRANSFORM = 'translate(-50%, 0px) scale(1)'
+const PHONE_NODE_ENTER_DURATION = 0.18
+const PHONE_NODE_EXIT_DURATION = 0.16
+const PHONE_NODE_HIDDEN_FILTER = 'blur(2px)'
+const PHONE_PANEL_ENTER_DURATION = 0.28
+const PHONE_PANEL_EXIT_DURATION = 0.26
 const PHONE_PANEL_HIDDEN_TRANSFORM = 'translateY(-12px) scale(0.96)'
 const PHONE_PANEL_VISIBLE_TRANSFORM = 'translateY(0px) scale(1)'
 const PHONE_QUERY = '(max-width: 39.99rem)'
@@ -132,6 +135,7 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
       panelAnimationRef.current?.cancel()
       panelAnimationRef.current = null
       for (const item of items ?? []) {
+        item.style.removeProperty('filter')
         item.style.removeProperty('opacity')
         item.style.removeProperty('transform')
       }
@@ -160,16 +164,16 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
     const phoneStaggerWindow = nextOpen
       ? PHONE_ENTER_STAGGER_WINDOW
       : PHONE_EXIT_STAGGER_WINDOW
+    const phoneFurthestIndex = items.length - 1
     const phoneStagger =
-      furthestCenterIndex > 0
-        ? Math.min(0.01, phoneStaggerWindow / furthestCenterIndex)
-        : 0
+      phoneFurthestIndex > 0 ? phoneStaggerWindow / phoneFurthestIndex : 0
 
     // Motion otherwise resolves the first open against the incoming React
     // state, so phone items jump directly to their final styles. Pinning the
     // rendered frame also keeps rapid direction changes interruptible.
     for (const item of items) {
       const style = window.getComputedStyle(item)
+      if (phone) item.style.filter = style.filter
       item.style.opacity = style.opacity
       item.style.transform = style.transform
     }
@@ -190,7 +194,7 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
           transform: nextOpen ? PHONE_PANEL_VISIBLE_TRANSFORM : PHONE_PANEL_HIDDEN_TRANSFORM,
         },
         {
-          duration: nextOpen ? PHONE_ENTER_DURATION : PHONE_EXIT_DURATION,
+          duration: nextOpen ? PHONE_PANEL_ENTER_DURATION : PHONE_PANEL_EXIT_DURATION,
           ease: EASE_SWIFT,
         },
       )
@@ -207,27 +211,35 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
         .catch(() => undefined)
     }
 
+    const itemTransform = nextOpen
+      ? 'translateY(0) rotate(0deg)'
+      : 'translateY(-8px) rotate(2deg)'
+    const itemKeyframes = phone
+      ? {
+          filter: nextOpen ? 'blur(0px)' : PHONE_NODE_HIDDEN_FILTER,
+          opacity: nextOpen ? 1 : 0,
+          transform: itemTransform,
+        }
+      : {
+          opacity: nextOpen ? 1 : 0,
+          transform: itemTransform,
+        }
     const animation = animate(
       items,
-      {
-        opacity: nextOpen ? 1 : 0,
-        transform: nextOpen
-          ? 'translateY(0) rotate(0deg)'
-          : 'translateY(-8px) rotate(2deg)',
-      },
+      itemKeyframes,
       {
         duration: closingDesktop
           ? DESKTOP_EXIT_DURATION
           : phone
             ? nextOpen
-              ? PHONE_ENTER_DURATION
-              : PHONE_EXIT_DURATION
+              ? PHONE_NODE_ENTER_DURATION
+              : PHONE_NODE_EXIT_DURATION
             : nextOpen
               ? 0.26
               : 0.2,
         delay: stagger(
           closingDesktop ? desktopExitStagger : phone ? phoneStagger : nextOpen ? 0.012 : 0.01,
-          { from: 'center' },
+          { from: phone ? (nextOpen ? 'first' : 'last') : 'center' },
         ),
         ease: EASE_SWIFT,
       },
@@ -240,6 +252,7 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
         animation.cancel()
         nodeAnimationRef.current = null
         for (const item of items) {
+          item.style.removeProperty('filter')
           item.style.removeProperty('opacity')
           item.style.removeProperty('transform')
         }


### PR DESCRIPTION
## Summary

- stagger the mobile article-map landmarks from top to bottom on expansion and reverse the order on collapse
- fade and sharpen each landmark with a subtle 2px blur while keeping rapid direction changes interruptible
- synchronize the panel and chevron around a 280ms entrance and 260ms exit
- keep the expanded panel shadow on the animated shell so overflow clipping no longer removes its depth

## Why

This follows up on #170. The panel motion was smoother, but its inner landmarks still appeared as one group and the expanded shadow was attached to a clipped child surface. Moving the shadow to the animated shell and matching the landmark stagger window to the full panel duration makes the state change read as one continuous interaction.

## Validation

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run components --exclude='**/*.live.test.ts'` (60 tests passed)
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refines the mobile article-map animation by staggering landmark nodes top-to-bottom on expand and bottom-to-top on collapse, adding a subtle blur effect to nodes that resolves as they appear, and moving the panel shadow from the clipped child surface to the animated shell so it is no longer cut off by `overflow: hidden`.

- **Shadow relocation**: `box-shadow` moved from `.post-minimap-phone-surface` (inside `overflow: hidden` parent) to `.post-minimap` itself, so the shadow renders correctly without clipping.
- **Directional stagger**: Phone node stagger now uses `from: 'first'` on open and `from: 'last'` on close, with a fixed 100 ms window spread across all items so the last node always finishes at exactly the panel duration (0.28 s / 0.26 s).
- **Blur transition**: A CSS `filter: blur(2px)` baseline is applied to collapsed nodes and pinned as an inline style before `flushSync` so the WAAPI animation interpolates cleanly from blurred to sharp without a frame jump.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are self-contained to CSS transitions and JavaScript Web Animation API calls with no data-layer or routing impact.

All three cleanup paths correctly remove the new filter property in every exit scenario. The stagger math is consistent: fixed 0.1 s window divided by items.length - 1 guarantees the last node always completes at exactly the panel duration. Shadow relocation to the animated shell is the correct fix for the overflow hidden clipping.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| components/post-toc.tsx | Animation logic refactored to separate panel and node duration constants, add filter pinning for phone mode, and change stagger direction/calculation; cleanup paths correctly remove the new filter property in all code paths. |
| app/globals.css | Shadow moved from clipped child surface to animated shell; new CSS-baseline blur added for closed nodes; chevron transition durations asymmetrically adjusted to 260 ms (close) / 280 ms (open) to match panel timings. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User tap
    participant JS as animateOpenState()
    participant DOM as DOM / flushSync
    participant PA as Panel WAAPI
    participant NA as Nodes WAAPI
    participant CSS as CSS transitions

    U->>JS: toggle (nextOpen)
    JS->>JS: stop previous animations
    JS->>DOM: pin filter/opacity/transform inline (phone only)
    JS->>DOM: flushSync setOpen(nextOpen)
    Note over DOM: data-open attr added/removed

    JS->>PA: animate panel opacity+transform (280ms / 260ms)
    JS->>NA: "animate nodes filter+opacity+transform stagger(from first|last, window=100ms) duration 180ms / 160ms"
    JS->>CSS: chevron rotate via CSS transition (280ms / 260ms)

    PA-->>DOM: finished - remove inline opacity/transform/will-change
    NA-->>DOM: finished - remove inline filter/opacity/transform

    Note over CSS: visibility hidden after 280ms delay (close path)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User tap
    participant JS as animateOpenState()
    participant DOM as DOM / flushSync
    participant PA as Panel WAAPI
    participant NA as Nodes WAAPI
    participant CSS as CSS transitions

    U->>JS: toggle (nextOpen)
    JS->>JS: stop previous animations
    JS->>DOM: pin filter/opacity/transform inline (phone only)
    JS->>DOM: flushSync setOpen(nextOpen)
    Note over DOM: data-open attr added/removed

    JS->>PA: animate panel opacity+transform (280ms / 260ms)
    JS->>NA: "animate nodes filter+opacity+transform stagger(from first|last, window=100ms) duration 180ms / 160ms"
    JS->>CSS: chevron rotate via CSS transition (280ms / 260ms)

    PA-->>DOM: finished - remove inline opacity/transform/will-change
    NA-->>DOM: finished - remove inline filter/opacity/transform

    Note over CSS: visibility hidden after 280ms delay (close path)
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(site): preserve latest dev styles"](https://github.com/calicastle/cali.so/commit/f6f89f38f269304cae6c3ee9377f1753fc58c5c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45302576)</sub>

<!-- /greptile_comment -->