### PR TITLE
Add a hidden topographic portrait stage

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,3 @@
+[mcp_servers.shaders]
+type = "http"
+url = "https://shaders.com/mcp"

--- a/app/_views/home-page.tsx
+++ b/app/_views/home-page.tsx
@@ -7,6 +7,7 @@ import { HalftonePortrait } from '~/components/halftone-portrait'
 import { HomeIntroduction } from '~/components/home-introduction'
 import { NavCards, PhotoNavCard } from '~/components/nav-cards'
 import { PostRow } from '~/components/post-row'
+import { PortraitHiddenStage } from '~/components/portrait-hidden-stage'
 import { VinylShelf } from '~/components/vinyl-shelf'
 import { getAllPosts } from '~/lib/content'
 import { T } from '~/lib/i18n'
@@ -44,12 +45,20 @@ export async function HomePageView({ locale }: { locale: Locale }) {
           </div>
         </div>
         <div className="w-[9.35rem] shrink-0 sm:w-60">
-          <HalftonePortrait
-            srcLight="/images/headshot.jpg"
-            srcDark="/images/portrait-square.jpg"
-            alt="Cali 的半调网点肖像"
-            altEn="Cali's halftone portrait"
-          />
+          <PortraitHiddenStage
+            label={
+              locale === 'en'
+                ? "Cali's halftone portrait. Reveal the hidden topographic field"
+                : 'Cali 的半调网点肖像。显现隐藏的等高线场'
+            }
+          >
+            <HalftonePortrait
+              srcLight="/images/headshot.jpg"
+              srcDark="/images/portrait-square.jpg"
+              alt="Cali 的半调网点肖像"
+              altEn="Cali's halftone portrait"
+            />
+          </PortraitHiddenStage>
         </div>
       </div>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -2118,6 +2118,9 @@ a:focus-visible .external-label .external-mark {
 [data-portrait-stage][data-active='true'] .portrait-hidden-stage-field {
   opacity: 1;
   transform: scale(1);
+}
+
+[data-portrait-stage][data-motion='true'] .portrait-hidden-stage-field {
   will-change: transform, opacity;
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -2056,10 +2056,126 @@ a:focus-visible .external-label .external-mark {
   animation: halftone-reveal 400ms var(--ease-swift) both;
 }
 
+/* The homepage portrait keeps its halftone print at rest. A bounded
+   topographic field develops behind it only after deliberate attention. */
+[data-portrait-stage] {
+  position: relative;
+  isolation: isolate;
+  display: block;
+  aspect-ratio: 1;
+}
+
+.portrait-hidden-stage-trigger {
+  position: relative;
+  z-index: 1;
+  display: block;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 2px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: default;
+  touch-action: manipulation;
+  appearance: none;
+}
+
+.portrait-hidden-stage-trigger:focus-visible {
+  outline: 1px solid var(--foreground);
+  outline-offset: 4px;
+}
+
+.portrait-hidden-stage-field {
+  position: absolute;
+  z-index: 0;
+  inset: -28% -36% -28% -20%;
+  contain: layout paint;
+  pointer-events: none;
+  user-select: none;
+  opacity: 0;
+  transform: scale(0.94);
+  mask-image: radial-gradient(
+    ellipse at 45% 49%,
+    transparent 0 25%,
+    rgb(0 0 0 / 0.38) 36%,
+    black 48%,
+    rgb(0 0 0 / 0.82) 61%,
+    transparent 78%
+  );
+  transition:
+    opacity 320ms var(--ease-swift),
+    transform 320ms var(--ease-swift);
+}
+
+[data-portrait-stage][data-motion='false'] .portrait-hidden-stage-field,
+[data-portrait-stage][data-motion='false'] .portrait-hidden-stage-shader-shell {
+  transition: none;
+}
+
+[data-portrait-stage][data-active='true'] .portrait-hidden-stage-field {
+  opacity: 1;
+  transform: scale(1);
+  will-change: transform, opacity;
+}
+
+.portrait-hidden-stage-fallback,
+.portrait-hidden-stage-shader,
+.portrait-hidden-stage-shader-shell,
+.portrait-hidden-stage-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.portrait-hidden-stage-fallback {
+  overflow: visible;
+  color: var(--foreground);
+  opacity: 0.028;
+  transform: rotate(-5deg);
+}
+
+.portrait-hidden-stage-fallback path {
+  vector-effect: non-scaling-stroke;
+  stroke: currentColor;
+  stroke-width: 1.35;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.portrait-hidden-stage-shader {
+  opacity: 0.1;
+}
+
+.portrait-hidden-stage-shader-shell {
+  opacity: 0;
+  transition: opacity 180ms var(--ease-swift);
+}
+
+.portrait-hidden-stage-shader-shell[data-ready='true'] {
+  opacity: 1;
+}
+
+.dark .portrait-hidden-stage-fallback {
+  opacity: 0.026;
+}
+
+.dark .portrait-hidden-stage-shader {
+  opacity: 0.09;
+}
+
 @media (prefers-reduced-motion: reduce) {
   [data-halftone][data-ready] .halftone-canvas {
     animation: none;
     opacity: 1;
+  }
+
+  .portrait-hidden-stage-field,
+  .portrait-hidden-stage-shader-shell {
+    transition: none;
   }
 }
 

--- a/components/portrait-hidden-stage.test.tsx
+++ b/components/portrait-hidden-stage.test.tsx
@@ -42,12 +42,14 @@ function setMediaPreference(initialReducedMotion: boolean) {
 }
 
 function enableWebGpu(adapter: unknown | null = {}) {
+  const requestAdapter = vi.fn().mockResolvedValue(adapter)
   Object.defineProperty(navigator, 'gpu', {
     configurable: true,
     value: {
-      requestAdapter: vi.fn().mockResolvedValue(adapter),
+      requestAdapter,
     },
   })
+  return requestAdapter
 }
 
 afterEach(() => {
@@ -92,7 +94,7 @@ describe('PortraitHiddenStage', () => {
 
   it('keeps reduced-motion reveals static even when WebGPU is available', () => {
     setMediaPreference(true)
-    enableWebGpu()
+    const requestAdapter = enableWebGpu()
 
     render(
       <PortraitHiddenStage label="Reveal hidden topographic field">
@@ -105,7 +107,7 @@ describe('PortraitHiddenStage', () => {
 
     expect(trigger.closest('[data-portrait-stage]')?.getAttribute('data-active')).toBe('true')
     expect(trigger.closest('[data-portrait-stage]')?.getAttribute('data-motion')).toBe('false')
-    expect(document.querySelector('[data-hidden-stage-fallback]')).not.toBeNull()
+    expect(requestAdapter).not.toHaveBeenCalled()
     expect(document.querySelector('[data-shader-stage]')).toBeNull()
   })
 
@@ -191,7 +193,7 @@ describe('PortraitHiddenStage', () => {
 
   it('falls back when WebGPU exposes no adapter', async () => {
     setMediaPreference(false)
-    enableWebGpu(null)
+    const requestAdapter = enableWebGpu(null)
 
     render(
       <PortraitHiddenStage label="Reveal hidden topographic field">
@@ -206,7 +208,7 @@ describe('PortraitHiddenStage', () => {
 
     expect(trigger.closest('[data-portrait-stage]')?.getAttribute('data-active')).toBe('true')
     expect(trigger.closest('[data-portrait-stage]')?.getAttribute('data-motion')).toBe('false')
-    expect(document.querySelector('[data-hidden-stage-fallback]')).not.toBeNull()
+    expect(requestAdapter).toHaveBeenCalledOnce()
     expect(document.querySelector('[data-shader-stage]')).toBeNull()
   })
 

--- a/components/portrait-hidden-stage.test.tsx
+++ b/components/portrait-hidden-stage.test.tsx
@@ -1,0 +1,235 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { PortraitHiddenStage } from './portrait-hidden-stage'
+
+vi.mock('next/dynamic', () => ({
+  default: () => function ShaderFieldBoundary() {
+    return <span data-shader-stage />
+  },
+}))
+
+function setMediaPreference(initialReducedMotion: boolean) {
+  let reducedMotion = initialReducedMotion
+  const listeners = new Set<() => void>()
+
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((query: string) => ({
+      get matches() {
+        return query === '(prefers-reduced-motion: reduce)' && reducedMotion
+      },
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn((_type: string, listener: () => void) => listeners.add(listener)),
+      removeEventListener: vi.fn((_type: string, listener: () => void) =>
+        listeners.delete(listener),
+      ),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  )
+
+  return {
+    setReducedMotion(value: boolean) {
+      reducedMotion = value
+      listeners.forEach((listener) => listener())
+    },
+  }
+}
+
+function enableWebGpu(adapter: unknown | null = {}) {
+  Object.defineProperty(navigator, 'gpu', {
+    configurable: true,
+    value: {
+      requestAdapter: vi.fn().mockResolvedValue(adapter),
+    },
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  Reflect.deleteProperty(navigator, 'gpu')
+})
+
+describe('PortraitHiddenStage', () => {
+  it('mounts lazily and waits for the exit fade before unmounting', async () => {
+    vi.useFakeTimers()
+    setMediaPreference(false)
+    enableWebGpu()
+
+    render(
+      <PortraitHiddenStage label="Reveal hidden topographic field">
+        <span>Portrait</span>
+      </PortraitHiddenStage>,
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Reveal hidden topographic field' })
+    expect(document.querySelector('[data-shader-stage]')).toBeNull()
+
+    await act(async () => {
+      fireEvent.pointerEnter(trigger, { pointerType: 'mouse' })
+    })
+
+    expect(trigger.closest('[data-portrait-stage]')?.getAttribute('data-active')).toBe('true')
+    expect(document.querySelector('[data-shader-stage]')).not.toBeNull()
+
+    fireEvent.pointerLeave(trigger, { pointerType: 'mouse' })
+    fireEvent.blur(trigger)
+    expect(document.querySelector('[data-shader-stage]')).not.toBeNull()
+
+    act(() => vi.advanceTimersByTime(319))
+    expect(document.querySelector('[data-shader-stage]')).not.toBeNull()
+
+    act(() => vi.advanceTimersByTime(1))
+    expect(document.querySelector('[data-shader-stage]')).toBeNull()
+  })
+
+  it('keeps reduced-motion reveals static even when WebGPU is available', () => {
+    setMediaPreference(true)
+    enableWebGpu()
+
+    render(
+      <PortraitHiddenStage label="Reveal hidden topographic field">
+        <span>Portrait</span>
+      </PortraitHiddenStage>,
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Reveal hidden topographic field' })
+    fireEvent.pointerEnter(trigger, { pointerType: 'mouse' })
+
+    expect(trigger.closest('[data-portrait-stage]')?.getAttribute('data-active')).toBe('true')
+    expect(trigger.closest('[data-portrait-stage]')?.getAttribute('data-motion')).toBe('false')
+    expect(document.querySelector('[data-hidden-stage-fallback]')).not.toBeNull()
+    expect(document.querySelector('[data-shader-stage]')).toBeNull()
+  })
+
+  it('keeps the first touch reveal open when touch focus arrives before pointerup', async () => {
+    vi.useFakeTimers()
+    setMediaPreference(false)
+    enableWebGpu()
+
+    render(
+      <PortraitHiddenStage label="Reveal hidden topographic field">
+        <span>Portrait</span>
+      </PortraitHiddenStage>,
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Reveal hidden topographic field' })
+    fireEvent.pointerDown(trigger, { pointerType: 'touch' })
+    fireEvent.focus(trigger)
+    await act(async () => {
+      fireEvent.pointerUp(trigger, { pointerType: 'touch' })
+    })
+
+    expect(trigger.closest('[data-portrait-stage]')?.getAttribute('data-active')).toBe('true')
+    expect(document.querySelector('[data-shader-stage]')).not.toBeNull()
+
+    act(() => vi.advanceTimersByTime(3000))
+
+    expect(trigger.closest('[data-portrait-stage]')?.getAttribute('data-active')).toBe('false')
+    expect(document.querySelector('[data-shader-stage]')).toBeNull()
+  })
+
+  it('does not mistake focus after touch pointerup for keyboard focus', async () => {
+    vi.useFakeTimers()
+    setMediaPreference(false)
+    enableWebGpu()
+
+    render(
+      <PortraitHiddenStage label="Reveal hidden topographic field">
+        <span>Portrait</span>
+      </PortraitHiddenStage>,
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Reveal hidden topographic field' })
+    fireEvent.pointerDown(trigger, { pointerType: 'touch' })
+    await act(async () => {
+      fireEvent.pointerUp(trigger, { pointerType: 'touch' })
+    })
+    fireEvent.focus(trigger)
+
+    expect(trigger.closest('[data-portrait-stage]')?.getAttribute('data-active')).toBe('true')
+
+    act(() => vi.advanceTimersByTime(3000))
+
+    expect(trigger.closest('[data-portrait-stage]')?.getAttribute('data-active')).toBe('false')
+    expect(document.querySelector('[data-shader-stage]')).toBeNull()
+  })
+
+  it('keeps keyboard focus static and composed with pointer hover', async () => {
+    setMediaPreference(false)
+    enableWebGpu()
+
+    render(
+      <PortraitHiddenStage label="Reveal hidden topographic field">
+        <span>Portrait</span>
+      </PortraitHiddenStage>,
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Reveal hidden topographic field' })
+    fireEvent.focus(trigger)
+
+    expect(trigger.closest('[data-portrait-stage]')?.getAttribute('data-active')).toBe('true')
+    expect(trigger.closest('[data-portrait-stage]')?.getAttribute('data-motion')).toBe('false')
+    expect(document.querySelector('[data-shader-stage]')).toBeNull()
+
+    await act(async () => {
+      fireEvent.pointerEnter(trigger, { pointerType: 'mouse' })
+    })
+    expect(document.querySelector('[data-shader-stage]')).not.toBeNull()
+
+    fireEvent.pointerLeave(trigger, { pointerType: 'mouse' })
+    expect(trigger.closest('[data-portrait-stage]')?.getAttribute('data-active')).toBe('true')
+    expect(document.querySelector('[data-shader-stage]')).toBeNull()
+  })
+
+  it('falls back when WebGPU exposes no adapter', async () => {
+    setMediaPreference(false)
+    enableWebGpu(null)
+
+    render(
+      <PortraitHiddenStage label="Reveal hidden topographic field">
+        <span>Portrait</span>
+      </PortraitHiddenStage>,
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Reveal hidden topographic field' })
+    await act(async () => {
+      fireEvent.pointerEnter(trigger, { pointerType: 'mouse' })
+    })
+
+    expect(trigger.closest('[data-portrait-stage]')?.getAttribute('data-active')).toBe('true')
+    expect(trigger.closest('[data-portrait-stage]')?.getAttribute('data-motion')).toBe('false')
+    expect(document.querySelector('[data-hidden-stage-fallback]')).not.toBeNull()
+    expect(document.querySelector('[data-shader-stage]')).toBeNull()
+  })
+
+  it('removes an active shader when reduced motion turns on', async () => {
+    const preference = setMediaPreference(false)
+    enableWebGpu()
+
+    render(
+      <PortraitHiddenStage label="Reveal hidden topographic field">
+        <span>Portrait</span>
+      </PortraitHiddenStage>,
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Reveal hidden topographic field' })
+    await act(async () => {
+      fireEvent.pointerEnter(trigger, { pointerType: 'mouse' })
+    })
+    expect(document.querySelector('[data-shader-stage]')).not.toBeNull()
+
+    act(() => preference.setReducedMotion(true))
+
+    expect(trigger.closest('[data-portrait-stage]')?.getAttribute('data-active')).toBe('true')
+    expect(trigger.closest('[data-portrait-stage]')?.getAttribute('data-motion')).toBe('false')
+    expect(document.querySelector('[data-shader-stage]')).toBeNull()
+  })
+})

--- a/components/portrait-hidden-stage.tsx
+++ b/components/portrait-hidden-stage.tsx
@@ -1,0 +1,263 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const PortraitShaderField = dynamic(
+  () => import('./portrait-shader-field').then((module) => module.PortraitShaderField),
+  { ssr: false },
+)
+
+const EXIT_MS = 320
+const TOUCH_REVEAL_MS = 2600
+
+type WebGpuNavigator = Navigator & {
+  gpu?: {
+    requestAdapter: () => Promise<unknown | null>
+  }
+}
+
+export function PortraitHiddenStage({
+  children,
+  label,
+}: Readonly<{
+  children: React.ReactNode
+  label: string
+}>) {
+  const [active, setActive] = useState(false)
+  const [motionEnabled, setMotionEnabled] = useState(false)
+  const [shaderMounted, setShaderMounted] = useState(false)
+  const exitTimer = useRef<number | undefined>(undefined)
+  const touchTimer = useRef<number | undefined>(undefined)
+  const pointerType = useRef<string | null>(null)
+  const pointerFocusSuppressed = useRef(false)
+  const hovered = useRef(false)
+  const keyboardFocused = useRef(false)
+  const touchActive = useRef(false)
+  const animatedRef = useRef(false)
+  const mounted = useRef(true)
+  const reducedMotion = useRef(false)
+  const webGpuSupported = useRef<boolean | null>(null)
+  const webGpuRequest = useRef<Promise<boolean> | null>(null)
+
+  const clearExitTimer = useCallback(() => {
+    if (exitTimer.current !== undefined) window.clearTimeout(exitTimer.current)
+    exitTimer.current = undefined
+  }, [])
+
+  const clearTouchTimer = useCallback(() => {
+    if (touchTimer.current !== undefined) window.clearTimeout(touchTimer.current)
+    touchTimer.current = undefined
+  }, [])
+
+  const checkWebGpu = useCallback(() => {
+    if (webGpuSupported.current !== null) {
+      return Promise.resolve(webGpuSupported.current)
+    }
+
+    if (webGpuRequest.current === null) {
+      const gpu = (navigator as WebGpuNavigator).gpu
+      webGpuRequest.current = (async () => {
+        if (!gpu?.requestAdapter) return false
+        try {
+          return Boolean(await gpu.requestAdapter())
+        } catch {
+          return false
+        }
+      })().then((supported) => {
+        webGpuSupported.current = supported
+        return supported
+      })
+    }
+
+    return webGpuRequest.current
+  }, [])
+
+  const syncStage = useCallback(() => {
+    const nextActive = hovered.current || keyboardFocused.current || touchActive.current
+    const wantsAnimation =
+      nextActive && !reducedMotion.current && (hovered.current || touchActive.current)
+    const nextAnimated = wantsAnimation && webGpuSupported.current === true
+    const wasAnimated = animatedRef.current
+
+    animatedRef.current = nextAnimated
+
+    if (wantsAnimation && webGpuSupported.current === null) {
+      clearExitTimer()
+      setActive(keyboardFocused.current)
+      setMotionEnabled(false)
+      setShaderMounted(false)
+
+      void checkWebGpu().then((supported) => {
+        if (!mounted.current) return
+
+        const stillActive = hovered.current || keyboardFocused.current || touchActive.current
+        const canAnimate =
+          supported &&
+          stillActive &&
+          !reducedMotion.current &&
+          (hovered.current || touchActive.current)
+
+        animatedRef.current = canAnimate
+        setActive(stillActive)
+        setMotionEnabled(canAnimate)
+        setShaderMounted(canAnimate)
+      })
+      return
+    }
+
+    setActive(nextActive)
+
+    if (!nextActive) {
+      if (exitTimer.current !== undefined && !reducedMotion.current) return
+
+      clearExitTimer()
+      if (!wasAnimated || reducedMotion.current) {
+        setShaderMounted(false)
+        setMotionEnabled(false)
+        return
+      }
+
+      setMotionEnabled(true)
+      exitTimer.current = window.setTimeout(() => {
+        setShaderMounted(false)
+        setMotionEnabled(false)
+      }, EXIT_MS)
+      return
+    }
+
+    clearExitTimer()
+    setMotionEnabled(nextAnimated)
+
+    if (!nextAnimated) {
+      setShaderMounted(false)
+      return
+    }
+
+    setShaderMounted(true)
+  }, [checkWebGpu, clearExitTimer])
+
+  const revealForTouch = useCallback(() => {
+    clearTouchTimer()
+    if (touchActive.current) {
+      touchActive.current = false
+      syncStage()
+      return
+    }
+
+    touchActive.current = true
+    syncStage()
+    touchTimer.current = window.setTimeout(() => {
+      touchActive.current = false
+      pointerFocusSuppressed.current = false
+      syncStage()
+    }, TOUCH_REVEAL_MS)
+  }, [clearTouchTimer, syncStage])
+
+  const markShaderUnavailable = useCallback(() => {
+    webGpuSupported.current = false
+    animatedRef.current = false
+    setShaderMounted(false)
+    setMotionEnabled(false)
+  }, [])
+
+  useEffect(() => {
+    const preference = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const updatePreference = () => {
+      reducedMotion.current = preference.matches
+      syncStage()
+    }
+
+    updatePreference()
+    preference.addEventListener('change', updatePreference)
+    return () => preference.removeEventListener('change', updatePreference)
+  }, [syncStage])
+
+  useEffect(() => {
+    mounted.current = true
+    return () => {
+      mounted.current = false
+      animatedRef.current = false
+      clearExitTimer()
+      clearTouchTimer()
+    }
+  }, [clearExitTimer, clearTouchTimer])
+
+  return (
+    <span
+      data-portrait-stage
+      data-active={active ? 'true' : 'false'}
+      data-motion={motionEnabled ? 'true' : 'false'}
+    >
+      <span className="portrait-hidden-stage-field" aria-hidden>
+        <svg
+          data-hidden-stage-fallback
+          className="portrait-hidden-stage-fallback"
+          viewBox="0 0 120 120"
+          fill="none"
+        >
+          <path d="M15 72C8 49 23 23 48 14c24-8 52 2 62 25 9 21 1 49-19 62-21 14-53 10-68-9-5-6-7-13-8-20Z" />
+          <path d="M24 68c-4-18 8-38 26-45 19-7 41 1 50 18 8 17 1 38-15 48-17 11-41 8-53-7-4-4-6-9-8-14Z" />
+          <path d="M34 65c-2-13 6-27 19-32 14-5 31 1 37 13 6 12 1 27-11 35-12 8-29 6-38-5-3-3-5-7-7-11Z" />
+          <path d="M44 61c0-8 5-17 13-20 9-3 19 1 23 9 3 7 0 16-7 21-8 5-18 3-24-3-3-2-4-4-5-7Z" />
+          <path d="M53 58c1-4 4-8 8-9 5-2 10 0 12 4 2 4 0 9-4 11-4 3-10 2-13-1-2-1-3-3-3-5Z" />
+        </svg>
+        {shaderMounted && (
+          <span className="portrait-hidden-stage-shader" data-shader-stage>
+            <PortraitShaderField onUnavailable={markShaderUnavailable} />
+          </span>
+        )}
+      </span>
+
+      <button
+        type="button"
+        className="portrait-hidden-stage-trigger"
+        aria-label={label}
+        onPointerEnter={(event) => {
+          if (event.pointerType === 'mouse') {
+            hovered.current = true
+            syncStage()
+          }
+        }}
+        onPointerDown={(event) => {
+          pointerType.current = event.pointerType
+          pointerFocusSuppressed.current = event.pointerType !== 'mouse'
+        }}
+        onPointerLeave={(event) => {
+          if (event.pointerType === 'mouse') {
+            hovered.current = false
+            syncStage()
+          }
+        }}
+        onPointerUp={(event) => {
+          if (event.pointerType !== 'mouse') revealForTouch()
+          pointerType.current = null
+        }}
+        onPointerCancel={() => {
+          pointerType.current = null
+          pointerFocusSuppressed.current = false
+        }}
+        onFocus={() => {
+          if (pointerType.current === null && !pointerFocusSuppressed.current) {
+            keyboardFocused.current = true
+            syncStage()
+          }
+        }}
+        onKeyDown={() => {
+          if (pointerFocusSuppressed.current) {
+            pointerFocusSuppressed.current = false
+            keyboardFocused.current = true
+            syncStage()
+          }
+        }}
+        onBlur={() => {
+          pointerFocusSuppressed.current = false
+          keyboardFocused.current = false
+          syncStage()
+        }}
+      >
+        {children}
+      </button>
+    </span>
+  )
+}

--- a/components/portrait-shader-field.tsx
+++ b/components/portrait-shader-field.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { ContourLines, PerlinNoise, Shader } from 'shaders/react'
+
+const SHADER_READY_TIMEOUT_MS = 2000
+
+function readForegroundInk() {
+  return getComputedStyle(document.body).color
+}
+
+export function PortraitShaderField({ onUnavailable }: { onUnavailable: () => void }) {
+  const [ink, setInk] = useState(readForegroundInk)
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    const root = document.documentElement
+    const observer = new MutationObserver(() => setInk(readForegroundInk()))
+    observer.observe(root, { attributes: true, attributeFilter: ['class'] })
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    if (ready) return
+    const timer = window.setTimeout(onUnavailable, SHADER_READY_TIMEOUT_MS)
+    return () => window.clearTimeout(timer)
+  }, [onUnavailable, ready])
+
+  return (
+    <span className="portrait-hidden-stage-shader-shell" data-ready={ready ? 'true' : 'false'}>
+      <Shader
+        className="portrait-hidden-stage-canvas"
+        colorSpace="srgb"
+        disableTelemetry
+        onReady={() => setReady(true)}
+      >
+        <ContourLines
+          levels={5}
+          lineWidth={0.7}
+          softness={0.1}
+          gamma={0.72}
+          colorMode="custom"
+          lineColor={ink}
+          backgroundColor="transparent"
+        >
+          <PerlinNoise
+            colorA="#ffffff"
+            colorB="#000000"
+            colorSpace="oklch"
+            scale={2.7}
+            contrast={0.08}
+            balance={-0.06}
+            seed={19}
+            speed={0.06}
+          />
+        </ContourLines>
+      </Shader>
+    </span>
+  )
+}

--- a/components/portrait-shader-field.tsx
+++ b/components/portrait-shader-field.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { ContourLines, PerlinNoise, Shader } from 'shaders/react'
 
 const SHADER_READY_TIMEOUT_MS = 2000
@@ -12,6 +12,7 @@ function readForegroundInk() {
 export function PortraitShaderField({ onUnavailable }: { onUnavailable: () => void }) {
   const [ink, setInk] = useState(readForegroundInk)
   const [ready, setReady] = useState(false)
+  const handleReady = useCallback(() => setReady(true), [])
 
   useEffect(() => {
     const root = document.documentElement
@@ -32,7 +33,7 @@ export function PortraitShaderField({ onUnavailable }: { onUnavailable: () => vo
         className="portrait-hidden-stage-canvas"
         colorSpace="srgb"
         disableTelemetry
-        onReady={() => setReady(true)}
+        onReady={handleReady}
       >
         <ContourLines
           levels={5}

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -288,7 +288,14 @@ typewriter/ascii textures, measuring ticks, registration marks. Rules:
   reveals it instantly, while no-JS leaves the reserved square empty. Its
   wrapper is 149.6px wide on mobile (15% below the original 176px
   presentation) and returns to the fixed 240px size from the 40rem breakpoint
-  onward.
+  onward. The portrait also hides one bounded **topographic stage**: deliberate
+  hover, keyboard focus, or touch develops low-contrast contour lines behind
+  the print. Fine-pointer hover and touch use Shaders `ContourLines` over slowly
+  evolving `PerlinNoise`; it is never mounted at rest, unmounts after the field
+  recedes, and disables vendor telemetry. Keyboard focus, reduced motion, or
+  missing WebGPU reveals only the static hand-drawn contour plate, without a
+  transition. The portrait itself never moves and its reserved square never
+  changes size.
 - **Rulers**: measuring ticks (48px major / 12px minor) ride top and
   bottom as arcs of an enormous circle (fixed 40px rise at the viewport
   edge, so R = w²/8s at any width) — a bent steel rule whose ends bow away

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "rss": "^1.2.2",
     "server-only": "^0.0.1",
     "shadcn": "^4.13.0",
+    "shaders": "3.0.440",
     "sharp": "^0.34.5",
     "shiki": "^4.3.1",
     "subset-font": "^2.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       shadcn:
         specifier: ^4.13.0
         version: 4.13.0(typescript@5.9.3)
+      shaders:
+        specifier: 3.0.440
+        version: 3.0.440(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -3555,6 +3558,30 @@ packages:
     engines: {node: '>=20.18.1'}
     hasBin: true
 
+  shaders@3.0.440:
+    resolution: {integrity: sha512-erDztfeue5VXhd1/ef8XFABfKdJcQjoDpYYHsTTpi8fdZQa1vfEfy/6ydZSgb8GVS6QB+T+Bi6jisNNj4rgphw==}
+    hasBin: true
+    peerDependencies:
+      pixi.js: ^8.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      solid-js: ^1.8.0
+      svelte: ^5
+      vue: ^3.5.0
+    peerDependenciesMeta:
+      pixi.js:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -3724,6 +3751,10 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
+  tinyest@0.3.2:
+    resolution: {integrity: sha512-1wqSt97RLezWzeogLSVXHr+E3jpYO8jxyaK2AIdJeGoZZTCubwNxQ9IqU5gbQpJVcxlbPugPAsII+m9/gqpPSA==}
+    engines: {node: '>=12.20.0'}
+
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
@@ -3775,6 +3806,9 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsover-runtime@0.0.7:
+    resolution: {integrity: sha512-FHHwMJzZbnP23+fU1PxXljy7j0RRRosL2r1/CRUNTqfW+l7m35JsUkM615x/cAzw4GqRdXPIl3axKMj9qzpZtQ==}
+
   tsx@4.23.1:
     resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
     engines: {node: '>=18.0.0'}
@@ -3786,6 +3820,14 @@ packages:
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
+
+  typed-binary@4.3.3:
+    resolution: {integrity: sha512-W2hLsSzt3k/tg38gDE4Fn/QiwcoqGuUHBc2cb3mXuH7KcYxe/GM57vzW14s2/bawB4R5knGgGq8Xb57vsaJ4Sg==}
+
+  typegpu@0.11.9:
+    resolution: {integrity: sha512-AqBV6P9lW2jA7pEVDeiMD7Qoza9doPgueQbwyUyf09u4ndb9jOttHwpZ18c+BEzwLHaPlV50jw0hx5QsmVJGNg==}
+    engines: {node: '>=12.20.0'}
+    hasBin: true
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -7594,6 +7636,13 @@ snapshots:
       - supports-color
       - typescript
 
+  shaders@3.0.440(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      typegpu: 0.11.9
+    optionalDependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   sharp@0.34.5:
     dependencies:
       '@img/colour': 1.1.0
@@ -7777,6 +7826,8 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinyest@0.3.2: {}
+
   tinyexec@1.2.4: {}
 
   tinyglobby@0.2.17:
@@ -7823,6 +7874,8 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsover-runtime@0.0.7: {}
+
   tsx@4.23.1:
     dependencies:
       esbuild: 0.28.1
@@ -7836,6 +7889,14 @@ snapshots:
       content-type: 2.0.0
       media-typer: 1.1.0
       mime-types: 3.0.2
+
+  typed-binary@4.3.3: {}
+
+  typegpu@0.11.9:
+    dependencies:
+      tinyest: 0.3.2
+      tsover-runtime: 0.0.7
+      typed-binary: 4.3.3
 
   typescript@5.9.3: {}
 


### PR DESCRIPTION
The homepage keeps its existing halftone portrait unchanged at rest and reveals a bounded topographic field only after deliberate interaction.

## Implementation

- Lazy-loads Shaders `ContourLines` over slowly evolving `PerlinNoise` for fine-pointer hover and touch.
- Keeps keyboard focus, reduced motion, missing WebGPU, and initialization failures on a static hand-drawn contour plate.
- Preserves the 320ms exit before unmounting and the 2600ms touch reveal across browser focus-order differences.
- Uses the foreground token in light and dark appearances, preserves the fixed portrait dimensions, and keeps contours quiet through the face and introduction copy.
- Disables vendor telemetry, pins `shaders@3.0.440`, and adds the project Shaders MCP configuration.
- Documents the interaction contract and adds focused lifecycle tests.

## Verification

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run app components db lib --exclude='**/*.live.test.ts'` (108 files, 1,014 tests)
- `node scripts/audit-production-dependencies.mjs`
- `npx -y pnpm@10.12.1 audit --prod`
- `npx -y pnpm@10.12.1 run build` with the repository's non-secret CI placeholders
- Real WebGPU browser checks in light and dark appearances, reduced motion, keyboard focus, 240px desktop, and 149.6px mobile layouts
- Repository standards and feature-spec review passes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wraps the homepage portrait in a `PortraitHiddenStage` component that reveals a WebGPU topographic contour field (`ContourLines` over `PerlinNoise` via `shaders@3.0.440`) on deliberate hover or touch, while preserving the static halftone experience for keyboard focus, reduced-motion, and missing-WebGPU users.

- The hidden field is lazy-loaded via `next/dynamic` (SSR disabled), only mounted after interaction, and unmounted after a 320 ms exit fade — the WebGPU adapter check is deduped so it runs at most once per component lifetime.
- Input-type disambiguation tracks pointer type, touch active state, and a `pointerFocusSuppressed` flag to keep the 2600 ms touch reveal and keyboard-focus static mode mutually correct across the browser's async focus-delivery order.
- CSS layering (`isolation: isolate`, `z-index`, `contain: layout paint`, and `will-change` held on `data-motion='true'` through the full exit window) and the `data-portrait-stage` / `data-active` / `data-motion` attribute contract keep the three visual states composable without layout shift.

<h3>Confidence Score: 5/5</h3>

Safe to merge — new code is self-contained, lazy-loaded, and falls back gracefully on every unsupported path.

The WebGPU adapter check is correctly deduplicated with a ref-guarded promise, all timers are cleaned up on unmount, and the syncStage reducer is idempotent under rapid or concurrent inputs. The CSS will-change is correctly scoped to data-motion='true' so it persists through the full 320 ms exit window. The shaders package is lazy-loaded via next/dynamic with ssr: false, so it has no impact on initial page load or SSR. No data path, authentication boundary, or layout is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| components/portrait-hidden-stage.tsx | Core stage orchestrator — handles WebGPU async deduplication, exit timer, touch/keyboard/hover state machines, and syncStage reducer. Logic is correct and edge cases are all handled idempotently. |
| components/portrait-shader-field.tsx | Thin WebGPU shader wrapper with a 2s onUnavailable guard, stable handleReady callback, and MutationObserver for dark-mode ink sync. Clean and correct. |
| components/portrait-hidden-stage.test.tsx | Seven lifecycle tests covering lazy-mount/exit timing, reduced-motion suppression, touch reveal with pre-/post-pointerUp focus ordering, keyboard-only compositing, WebGPU fallback, and live preference change. |
| app/globals.css | New portrait-stage CSS block with correct will-change scoped to data-motion='true', contain: layout paint, mask gradient, and reduced-motion override. |
| app/_views/home-page.tsx | Wraps HalftonePortrait in PortraitHiddenStage with locale-aware aria-label. Container sizing is unchanged. |
| package.json | Adds shaders@3.0.440 pinned at an exact version. The package is lazy-loaded at runtime so it does not affect the initial bundle. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant B as Button (trigger)
    participant S as syncStage
    participant W as checkWebGpu
    participant R as React State
    participant SF as PortraitShaderField

    U->>B: pointerEnter (mouse)
    B->>S: "hovered=true"
    S->>W: "webGpuSupported===null?"
    W-->>S: Promise (async)
    S->>R: setActive(false) during check
    W-->>S: "supported=true"
    S->>R: setActive(true), setMotionEnabled(true), setShaderMounted(true)
    R-->>SF: mount
    SF->>SF: onReady → setReady(true) / 2s timeout → onUnavailable

    U->>B: pointerLeave (mouse)
    B->>S: "hovered=false"
    S->>R: setActive(false), setMotionEnabled(true)
    Note over S,R: EXIT_MS=320ms timer starts
    S-->>R: [after 320ms] setShaderMounted(false), setMotionEnabled(false)
    R-->>SF: unmount

    Note over U,SF: Touch path
    U->>B: pointerDown (touch)
    B->>B: "pointerFocusSuppressed=true"
    U->>B: pointerUp (touch)
    B->>S: revealForTouch()
    S->>R: "touchActive=true, syncStage"
    Note over S,R: TOUCH_REVEAL_MS=2600ms timer
    S-->>R: "[after 2600ms] touchActive=false, syncStage → unmount"

    Note over U,SF: Reduced motion / no WebGPU
    U->>B: any interaction
    B->>S: syncStage
    S->>R: "setActive(true), motionEnabled=false, shaderMounted=false"
    Note over R: Only static fallback SVG visible
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant B as Button (trigger)
    participant S as syncStage
    participant W as checkWebGpu
    participant R as React State
    participant SF as PortraitShaderField

    U->>B: pointerEnter (mouse)
    B->>S: "hovered=true"
    S->>W: "webGpuSupported===null?"
    W-->>S: Promise (async)
    S->>R: setActive(false) during check
    W-->>S: "supported=true"
    S->>R: setActive(true), setMotionEnabled(true), setShaderMounted(true)
    R-->>SF: mount
    SF->>SF: onReady → setReady(true) / 2s timeout → onUnavailable

    U->>B: pointerLeave (mouse)
    B->>S: "hovered=false"
    S->>R: setActive(false), setMotionEnabled(true)
    Note over S,R: EXIT_MS=320ms timer starts
    S-->>R: [after 320ms] setShaderMounted(false), setMotionEnabled(false)
    R-->>SF: unmount

    Note over U,SF: Touch path
    U->>B: pointerDown (touch)
    B->>B: "pointerFocusSuppressed=true"
    U->>B: pointerUp (touch)
    B->>S: revealForTouch()
    S->>R: "touchActive=true, syncStage"
    Note over S,R: TOUCH_REVEAL_MS=2600ms timer
    S-->>R: "[after 2600ms] touchActive=false, syncStage → unmount"

    Note over U,SF: Reduced motion / no WebGPU
    U->>B: any interaction
    B->>S: syncStage
    S->>R: "setActive(true), motionEnabled=false, shaderMounted=false"
    Note over R: Only static fallback SVG visible
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(site): address shader review feedbac..."](https://github.com/calicastle/cali.so/commit/8b49ee8637d3b9dbf52682c25d2d079e7332554f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45312483)</sub>

<!-- /greptile_comment -->