### PR TITLE
Improve vinyl shelf realism

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2301,7 +2301,23 @@ a:focus-visible .external-label .external-mark {
 /* ── Room shelves: records and books rest on a real wooden plank ──── */
 
 .room-shelf {
+  --room-shelf-shadow-rgb: 27 22 17;
+  --room-shelf-wood-front-bottom: oklch(0.61 0.065 64);
+  --room-shelf-wood-front-top: oklch(0.79 0.05 74);
+  --room-shelf-wood-grain: rgb(71 42 17 / 0.08);
+  --room-shelf-wood-top-back: oklch(0.77 0.045 75);
+  --room-shelf-wood-top-front: oklch(0.84 0.04 78);
+
   position: relative;
+}
+
+.dark .room-shelf {
+  --room-shelf-shadow-rgb: 0 0 0;
+  --room-shelf-wood-front-bottom: oklch(0.29 0.035 49);
+  --room-shelf-wood-front-top: oklch(0.43 0.04 59);
+  --room-shelf-wood-grain: rgb(0 0 0 / 0.15);
+  --room-shelf-wood-top-back: oklch(0.38 0.035 56);
+  --room-shelf-wood-top-front: oklch(0.47 0.035 62);
 }
 
 .shelf-annotation {
@@ -2343,47 +2359,68 @@ a:focus-visible .external-label .external-mark {
   outline-offset: 3px;
 }
 
-/* the plank's front face: edge grain drawn with layered streaks over an
-   oak tone; a wall shadow hangs beneath */
+/* One wooden material and upper-left light source ground both collections. */
 .room-shelf-plank {
   display: block;
   position: relative;
+  z-index: 1;
   height: 12px;
-  border-radius: 2px;
+  border-radius: 1px 1px 2px 2px;
   background:
-    repeating-linear-gradient(0deg, rgb(60 34 12 / 0.09) 0 1px, transparent 1px 4px),
-    repeating-linear-gradient(0deg, transparent 0 5px, rgb(60 34 12 / 0.06) 5px 6px, transparent 6px 13px),
-    linear-gradient(180deg, oklch(0.8 0.055 75), oklch(0.7 0.065 70) 45%, oklch(0.62 0.07 65));
+    radial-gradient(ellipse 22% 38% at 12% 22%, transparent 0 92%, var(--room-shelf-wood-grain) 93% 95%, transparent 96%),
+    radial-gradient(ellipse 32% 42% at 67% 70%, transparent 0 93%, var(--room-shelf-wood-grain) 94% 96%, transparent 97%),
+    linear-gradient(92deg, transparent 0 8%, var(--room-shelf-wood-grain) 14%, transparent 22% 54%, var(--room-shelf-wood-grain) 61%, transparent 72%),
+    linear-gradient(180deg, var(--room-shelf-wood-front-top), var(--room-shelf-wood-front-bottom));
   box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.35),
-    inset 0 -1px 0 rgb(0 0 0 / 0.18),
-    0 7px 14px -4px rgb(0 0 0 / 0.25),
-    0 2px 3px rgb(0 0 0 / 0.12);
+    inset 0 1px 0 rgb(255 255 255 / 0.28),
+    inset 0 -1px 0 rgb(51 28 10 / 0.2),
+    1px 3px 3px -2px rgb(var(--room-shelf-shadow-rgb) / 0.24),
+    3px 10px 16px -8px rgb(var(--room-shelf-shadow-rgb) / 0.34),
+    6px 24px 34px -18px rgb(var(--room-shelf-shadow-rgb) / 0.28);
+}
+
+.room-shelf-plank::before,
+.room-shelf-plank::after {
+  content: '';
+  position: absolute;
+  right: 0;
+  left: 0;
+  pointer-events: none;
+}
+
+.room-shelf-plank::before {
+  top: -6px;
+  height: 6px;
+  clip-path: polygon(0.8% 0, 99.2% 0, 100% 100%, 0 100%);
+  background:
+    radial-gradient(ellipse 28% 70% at 23% 45%, transparent 0 90%, var(--room-shelf-wood-grain) 91% 93%, transparent 94%),
+    linear-gradient(91deg, transparent 0 16%, var(--room-shelf-wood-grain) 25%, transparent 34% 67%, var(--room-shelf-wood-grain) 75%, transparent 83%),
+    linear-gradient(180deg, var(--room-shelf-wood-top-front), var(--room-shelf-wood-top-back));
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.32),
+    inset 0 -1px 0 rgb(52 29 11 / 0.18);
+}
+
+.room-shelf-plank::after {
+  bottom: -2px;
+  height: 2px;
+  border-radius: 0 0 2px 2px;
+  background: linear-gradient(180deg, rgb(var(--room-shelf-shadow-rgb) / 0.24), rgb(var(--room-shelf-shadow-rgb) / 0.08));
 }
 
 .dark .room-shelf-plank {
-  /* walnut after dark */
-  background:
-    repeating-linear-gradient(0deg, rgb(0 0 0 / 0.22) 0 1px, transparent 1px 4px),
-    repeating-linear-gradient(0deg, transparent 0 5px, rgb(0 0 0 / 0.16) 5px 6px, transparent 6px 13px),
-    linear-gradient(180deg, oklch(0.44 0.045 60), oklch(0.36 0.045 55) 45%, oklch(0.3 0.04 50));
   box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.09),
-    inset 0 -1px 0 rgb(0 0 0 / 0.45),
-    0 7px 14px -4px rgb(0 0 0 / 0.55),
-    0 2px 3px rgb(0 0 0 / 0.3);
+    inset 0 1px 0 rgb(255 255 255 / 0.1),
+    inset 0 -1px 0 rgb(0 0 0 / 0.48),
+    1px 3px 3px -2px rgb(var(--room-shelf-shadow-rgb) / 0.45),
+    3px 10px 16px -8px rgb(var(--room-shelf-shadow-rgb) / 0.62),
+    6px 24px 34px -18px rgb(var(--room-shelf-shadow-rgb) / 0.5);
 }
 
-/* bookshelf contact shadows stay on their translated book elements */
-.room-shelf .book3::after {
-  content: '';
-  position: absolute;
-  left: 7%;
-  right: 7%;
-  bottom: -2px;
-  height: 5px;
-  background: radial-gradient(50% 100% at 50% 100%, rgb(0 0 0 / 0.3), transparent 78%);
-  pointer-events: none;
+.dark .room-shelf-plank::before {
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.1),
+    inset 0 -1px 0 rgb(0 0 0 / 0.4);
 }
 
 /* ── Post images: scattered prints that straighten on attention ───── */
@@ -2475,12 +2512,7 @@ a:focus-visible .external-label .external-mark {
 .vinyl-room {
   --vinyl-depth: 3px;
   --vinyl-motion-duration: 330ms;
-  --vinyl-shadow-rgb: 27 22 17;
-  --vinyl-wood-front-bottom: oklch(0.61 0.065 64);
-  --vinyl-wood-front-top: oklch(0.79 0.05 74);
-  --vinyl-wood-grain: rgb(71 42 17 / 0.08);
-  --vinyl-wood-top-back: oklch(0.77 0.045 75);
-  --vinyl-wood-top-front: oklch(0.84 0.04 78);
+  --vinyl-shadow-rgb: var(--room-shelf-shadow-rgb);
 
   left: 50%;
   width: min(37.5rem, calc(100vw - 2rem));
@@ -2488,77 +2520,8 @@ a:focus-visible .external-label .external-mark {
   transform: translateX(-50%);
 }
 
-.vinyl-room > .room-shelf-plank {
-  z-index: 1;
-  border-radius: 1px 1px 2px 2px;
-  background:
-    radial-gradient(ellipse 22% 38% at 12% 22%, transparent 0 92%, var(--vinyl-wood-grain) 93% 95%, transparent 96%),
-    radial-gradient(ellipse 32% 42% at 67% 70%, transparent 0 93%, var(--vinyl-wood-grain) 94% 96%, transparent 97%),
-    linear-gradient(92deg, transparent 0 8%, var(--vinyl-wood-grain) 14%, transparent 22% 54%, var(--vinyl-wood-grain) 61%, transparent 72%),
-    linear-gradient(180deg, var(--vinyl-wood-front-top), var(--vinyl-wood-front-bottom));
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.28),
-    inset 0 -1px 0 rgb(51 28 10 / 0.2),
-    1px 3px 3px -2px rgb(var(--vinyl-shadow-rgb) / 0.24),
-    3px 10px 16px -8px rgb(var(--vinyl-shadow-rgb) / 0.34),
-    6px 24px 34px -18px rgb(var(--vinyl-shadow-rgb) / 0.28);
-}
-
-.vinyl-room > .room-shelf-plank::before,
-.vinyl-room > .room-shelf-plank::after {
-  content: '';
-  position: absolute;
-  right: 0;
-  left: 0;
-  pointer-events: none;
-}
-
-.vinyl-room > .room-shelf-plank::before {
-  top: -6px;
-  height: 6px;
-  clip-path: polygon(0.8% 0, 99.2% 0, 100% 100%, 0 100%);
-  background:
-    radial-gradient(ellipse 28% 70% at 23% 45%, transparent 0 90%, var(--vinyl-wood-grain) 91% 93%, transparent 94%),
-    linear-gradient(91deg, transparent 0 16%, var(--vinyl-wood-grain) 25%, transparent 34% 67%, var(--vinyl-wood-grain) 75%, transparent 83%),
-    linear-gradient(180deg, var(--vinyl-wood-top-front), var(--vinyl-wood-top-back));
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.32),
-    inset 0 -1px 0 rgb(52 29 11 / 0.18);
-}
-
-.vinyl-room > .room-shelf-plank::after {
-  bottom: -2px;
-  height: 2px;
-  border-radius: 0 0 2px 2px;
-  background: linear-gradient(180deg, rgb(var(--vinyl-shadow-rgb) / 0.24), rgb(var(--vinyl-shadow-rgb) / 0.08));
-}
-
 .vinyl-annotation {
   z-index: 2;
-}
-
-.dark .vinyl-room {
-  --vinyl-shadow-rgb: 0 0 0;
-  --vinyl-wood-front-bottom: oklch(0.29 0.035 49);
-  --vinyl-wood-front-top: oklch(0.43 0.04 59);
-  --vinyl-wood-grain: rgb(0 0 0 / 0.15);
-  --vinyl-wood-top-back: oklch(0.38 0.035 56);
-  --vinyl-wood-top-front: oklch(0.47 0.035 62);
-}
-
-.dark .vinyl-room > .room-shelf-plank {
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.1),
-    inset 0 -1px 0 rgb(0 0 0 / 0.48),
-    1px 3px 3px -2px rgb(var(--vinyl-shadow-rgb) / 0.45),
-    3px 10px 16px -8px rgb(var(--vinyl-shadow-rgb) / 0.62),
-    6px 24px 34px -18px rgb(var(--vinyl-shadow-rgb) / 0.5);
-}
-
-.dark .vinyl-room > .room-shelf-plank::before {
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.1),
-    inset 0 -1px 0 rgb(0 0 0 / 0.4);
 }
 
 .vinyl-viewport {
@@ -2905,6 +2868,8 @@ a:focus-visible .external-label .external-mark {
 /* ── Bookshelf: 3D accordion (components/bookshelf.tsx) ───────────── */
 
 .bookshelf-viewport {
+  position: relative;
+  z-index: 2;
   width: 100%;
   height: 216px;
   overflow: clip;
@@ -2929,8 +2894,30 @@ a:focus-visible .external-label .external-mark {
   flex-shrink: 0;
 }
 
+.book3-contact-shadow {
+  position: absolute;
+  z-index: 0;
+  bottom: -3px;
+  left: 0;
+  width: var(--book-contact-width);
+  height: 9px;
+  border-radius: 50%;
+  background: radial-gradient(
+    ellipse at center,
+    rgb(var(--room-shelf-shadow-rgb) / 0.38) 0%,
+    rgb(var(--room-shelf-shadow-rgb) / 0.16) 48%,
+    transparent 84%
+  );
+  opacity: 0.9;
+  pointer-events: none;
+  transform: scaleX(var(--book-contact-scale));
+  transform-origin: left center;
+  will-change: transform;
+}
+
 .book3 {
   position: relative;
+  z-index: 1;
   display: block;
   width: 100%;
   height: 100%;
@@ -2986,7 +2973,10 @@ a:focus-visible .external-label .external-mark {
   backface-visibility: hidden;
   overflow: hidden;
   border-radius: 2px 4px 4px 2px;
-  filter: drop-shadow(2px 4px 15px rgb(0 0 0 / 0.14));
+  box-shadow:
+    0 0 0 var(--border-hairline) rgb(0 0 0 / 0.09),
+    1px 2px 3px -1px rgb(var(--room-shelf-shadow-rgb) / 0.2),
+    4px 9px 16px -9px rgb(var(--room-shelf-shadow-rgb) / 0.3);
   user-select: none;
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -2613,7 +2613,7 @@ a:focus-visible .external-label .external-mark {
     rotateZ(calc(var(--vinyl-rest-tilt) * 1deg))
     rotateY(calc(var(--vinyl-direction) * var(--vinyl-inward-angle) * -1deg))
     scale(var(--vinyl-scale));
-  transform-origin: bottom center;
+  transform-origin: var(--vinyl-origin-x) bottom;
   transform-style: preserve-3d;
   transition: transform var(--vinyl-motion-duration) var(--ease-spring);
   will-change: transform;
@@ -2649,14 +2649,6 @@ a:focus-visible .external-label .external-mark {
 .vinyl-hit-corner[data-corner='bottom-left'] {
   bottom: 0;
   left: 0;
-}
-
-.vinyl[data-position='before'] .vinyl-trigger {
-  transform-origin: right bottom;
-}
-
-.vinyl[data-position='after'] .vinyl-trigger {
-  transform-origin: left bottom;
 }
 
 .vinyl-object {

--- a/app/globals.css
+++ b/app/globals.css
@@ -2374,8 +2374,7 @@ a:focus-visible .external-label .external-mark {
     0 2px 3px rgb(0 0 0 / 0.3);
 }
 
-/* contact shadows where things meet the wood */
-.room-shelf .vinyl::after,
+/* bookshelf contact shadows stay on their translated book elements */
 .room-shelf .book3::after {
   content: '';
   position: absolute;
@@ -2474,13 +2473,97 @@ a:focus-visible .external-label .external-mark {
 /* ── Vinyl shelf (components/vinyl-shelf.tsx) ─────────────────────── */
 
 .vinyl-room {
+  --vinyl-depth: 3px;
+  --vinyl-motion-duration: 330ms;
+  --vinyl-shadow-rgb: 27 22 17;
+  --vinyl-wood-front-bottom: oklch(0.61 0.065 64);
+  --vinyl-wood-front-top: oklch(0.79 0.05 74);
+  --vinyl-wood-grain: rgb(71 42 17 / 0.08);
+  --vinyl-wood-top-back: oklch(0.77 0.045 75);
+  --vinyl-wood-top-front: oklch(0.84 0.04 78);
+
   left: 50%;
   width: min(37.5rem, calc(100vw - 2rem));
+  isolation: isolate;
   transform: translateX(-50%);
+}
+
+.vinyl-room > .room-shelf-plank {
+  z-index: 1;
+  border-radius: 1px 1px 2px 2px;
+  background:
+    radial-gradient(ellipse 22% 38% at 12% 22%, transparent 0 92%, var(--vinyl-wood-grain) 93% 95%, transparent 96%),
+    radial-gradient(ellipse 32% 42% at 67% 70%, transparent 0 93%, var(--vinyl-wood-grain) 94% 96%, transparent 97%),
+    linear-gradient(92deg, transparent 0 8%, var(--vinyl-wood-grain) 14%, transparent 22% 54%, var(--vinyl-wood-grain) 61%, transparent 72%),
+    linear-gradient(180deg, var(--vinyl-wood-front-top), var(--vinyl-wood-front-bottom));
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.28),
+    inset 0 -1px 0 rgb(51 28 10 / 0.2),
+    1px 3px 3px -2px rgb(var(--vinyl-shadow-rgb) / 0.24),
+    3px 10px 16px -8px rgb(var(--vinyl-shadow-rgb) / 0.34),
+    6px 24px 34px -18px rgb(var(--vinyl-shadow-rgb) / 0.28);
+}
+
+.vinyl-room > .room-shelf-plank::before,
+.vinyl-room > .room-shelf-plank::after {
+  content: '';
+  position: absolute;
+  right: 0;
+  left: 0;
+  pointer-events: none;
+}
+
+.vinyl-room > .room-shelf-plank::before {
+  top: -6px;
+  height: 6px;
+  clip-path: polygon(0.8% 0, 99.2% 0, 100% 100%, 0 100%);
+  background:
+    radial-gradient(ellipse 28% 70% at 23% 45%, transparent 0 90%, var(--vinyl-wood-grain) 91% 93%, transparent 94%),
+    linear-gradient(91deg, transparent 0 16%, var(--vinyl-wood-grain) 25%, transparent 34% 67%, var(--vinyl-wood-grain) 75%, transparent 83%),
+    linear-gradient(180deg, var(--vinyl-wood-top-front), var(--vinyl-wood-top-back));
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.32),
+    inset 0 -1px 0 rgb(52 29 11 / 0.18);
+}
+
+.vinyl-room > .room-shelf-plank::after {
+  bottom: -2px;
+  height: 2px;
+  border-radius: 0 0 2px 2px;
+  background: linear-gradient(180deg, rgb(var(--vinyl-shadow-rgb) / 0.24), rgb(var(--vinyl-shadow-rgb) / 0.08));
+}
+
+.vinyl-annotation {
+  z-index: 2;
+}
+
+.dark .vinyl-room {
+  --vinyl-shadow-rgb: 0 0 0;
+  --vinyl-wood-front-bottom: oklch(0.29 0.035 49);
+  --vinyl-wood-front-top: oklch(0.43 0.04 59);
+  --vinyl-wood-grain: rgb(0 0 0 / 0.15);
+  --vinyl-wood-top-back: oklch(0.38 0.035 56);
+  --vinyl-wood-top-front: oklch(0.47 0.035 62);
+}
+
+.dark .vinyl-room > .room-shelf-plank {
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.1),
+    inset 0 -1px 0 rgb(0 0 0 / 0.48),
+    1px 3px 3px -2px rgb(var(--vinyl-shadow-rgb) / 0.45),
+    3px 10px 16px -8px rgb(var(--vinyl-shadow-rgb) / 0.62),
+    6px 24px 34px -18px rgb(var(--vinyl-shadow-rgb) / 0.5);
+}
+
+.dark .vinyl-room > .room-shelf-plank::before {
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.1),
+    inset 0 -1px 0 rgb(0 0 0 / 0.4);
 }
 
 .vinyl-viewport {
   position: relative;
+  z-index: 2;
   overflow: clip;
   cursor: grab;
 }
@@ -2495,7 +2578,7 @@ a:focus-visible .external-label .external-mark {
   display: grid;
   place-items: end center;
   margin: 0;
-  padding: 2.5rem 0 0;
+  padding: 2.5rem 0 4px;
   list-style: none;
   overflow: visible;
   isolation: isolate;
@@ -2525,11 +2608,14 @@ a:focus-visible .external-label .external-mark {
   pointer-events: none;
   touch-action: manipulation;
   transform: translateX(calc(var(--vinyl-offset) * var(--vinyl-spread)))
+    translateY(calc(var(--vinyl-rest-offset) * 1px))
+    translateZ(calc(var(--vinyl-forward) * 1px))
+    rotateZ(calc(var(--vinyl-rest-tilt) * 1deg))
     rotateY(calc(var(--vinyl-direction) * var(--vinyl-inward-angle) * -1deg))
     scale(var(--vinyl-scale));
   transform-origin: bottom center;
   transform-style: preserve-3d;
-  transition: transform 330ms var(--ease-spring);
+  transition: transform var(--vinyl-motion-duration) var(--ease-spring);
   will-change: transform;
 }
 
@@ -2575,23 +2661,60 @@ a:focus-visible .external-label .external-mark {
 
 .vinyl-object {
   position: relative;
+  z-index: 1;
   display: block;
   width: 100%;
   transform: translate(0, 0);
   transform-style: preserve-3d;
-  transition: transform 300ms var(--ease-spring);
+  transition: transform var(--vinyl-motion-duration) var(--ease-spring);
+}
+
+.vinyl-contact-shadow {
+  position: absolute;
+  z-index: 0;
+  top: calc(100% - 5px);
+  right: 8%;
+  left: 8%;
+  height: 10px;
+  border-radius: 50%;
+  background: radial-gradient(
+    ellipse at center,
+    rgb(var(--vinyl-shadow-rgb) / 0.4) 0%,
+    rgb(var(--vinyl-shadow-rgb) / 0.18) 46%,
+    transparent 84%
+  );
+  opacity: var(--vinyl-contact-opacity);
+  pointer-events: none;
+  transform: translateZ(-1px)
+    rotateY(calc(var(--vinyl-direction) * var(--vinyl-inward-angle) * 1deg))
+    rotateX(62deg)
+    scaleX(var(--vinyl-contact-scale));
+  transform-origin: center;
+  transition:
+    transform var(--vinyl-motion-duration) var(--ease-spring),
+    opacity var(--vinyl-motion-duration) var(--ease-spring);
 }
 
 .vinyl-room[data-vinyl-interaction='panning'] .vinyl-trigger,
 .vinyl-room[data-vinyl-interaction='panning'] .vinyl-object,
+.vinyl-room[data-vinyl-interaction='panning'] .vinyl-contact-shadow,
 .vinyl-room[data-vinyl-interaction='instant'] .vinyl-trigger,
-.vinyl-room[data-vinyl-interaction='instant'] .vinyl-object {
+.vinyl-room[data-vinyl-interaction='instant'] .vinyl-object,
+.vinyl-room[data-vinyl-interaction='instant'] .vinyl-contact-shadow {
   transition: none;
 }
 
 @media (hover: hover) and (pointer: fine) {
   .vinyl-trigger:not([data-active])[data-pointer-owned] .vinyl-object {
-    transform: translateX(calc(var(--vinyl-direction) * 2px)) translateY(-5px);
+    transform: translateX(calc(var(--vinyl-direction) * 2px)) translateY(-4px);
+  }
+
+  .vinyl-trigger:not([data-active])[data-pointer-owned] .vinyl-contact-shadow {
+    opacity: calc(var(--vinyl-contact-opacity) * 0.55);
+    transform: translateZ(-1px)
+      rotateY(calc(var(--vinyl-direction) * var(--vinyl-inward-angle) * 1deg))
+      rotateX(62deg)
+      scaleX(calc(var(--vinyl-contact-scale) * 1.08));
   }
 }
 
@@ -2608,15 +2731,24 @@ a:focus-visible .external-label .external-mark {
   aspect-ratio: 1;
   background: var(--paper);
   box-shadow:
-    0 0 0 1px rgb(0 0 0 / 0.08),
-    0 2px 4px -1px rgb(0 0 0 / 0.16),
-    0 9px 16px -9px rgb(0 0 0 / 0.28);
+    0 0 0 var(--border-hairline) rgb(0 0 0 / 0.09),
+    1px 2px 3px -1px rgb(var(--vinyl-shadow-rgb) / 0.2),
+    4px 9px 16px -9px rgb(var(--vinyl-shadow-rgb) / 0.3);
   overflow: hidden;
   backface-visibility: hidden;
-  transform: translateZ(7px);
+  transform: translateZ(var(--vinyl-depth));
 }
 
-/* Real 3D side faces: the cover sits 7px forward and these planes bridge
+.vinyl-sleeve::after {
+  content: '';
+  position: absolute;
+  z-index: 4;
+  inset: 0;
+  background: linear-gradient(118deg, rgb(255 255 255 / 0.12), transparent 28% 70%, rgb(25 16 9 / 0.11));
+  pointer-events: none;
+}
+
+/* Real 3D side faces: the cover sits forward and these planes bridge
    the depth. The face revealed by each inward turn becomes the sleeve spine. */
 .vinyl-spine {
   position: absolute;
@@ -2624,15 +2756,13 @@ a:focus-visible .external-label .external-mark {
   top: 0;
   bottom: 0;
   left: 0;
-  width: 7px;
+  width: var(--vinyl-depth);
   display: flex;
   align-items: center;
   justify-content: center;
   overflow: hidden;
   color: var(--vinyl-spine-ink, oklch(0.28 0.012 95));
-  background:
-    linear-gradient(to right, rgb(0 0 0 / 0.18), transparent 35%, rgb(255 255 255 / 0.14) 70%, rgb(0 0 0 / 0.12)),
-    var(--vinyl-spine-color, var(--paper));
+  background: var(--vinyl-spine-color, var(--paper));
   box-shadow:
     inset 1px 0 rgb(255 255 255 / 0.16),
     inset -1px 0 rgb(0 0 0 / 0.18);
@@ -2644,7 +2774,7 @@ a:focus-visible .external-label .external-mark {
   max-height: calc(100% - 10px);
   overflow: hidden;
   font-family: var(--font-geist-mono), ui-monospace, monospace;
-  font-size: 5px;
+  font-size: 4px;
   line-height: 1;
   letter-spacing: 0.04em;
   text-overflow: ellipsis;
@@ -2653,6 +2783,9 @@ a:focus-visible .external-label .external-mark {
 }
 
 .vinyl-spine-left {
+  background:
+    linear-gradient(to right, rgb(255 255 255 / 0.16), transparent 45%, rgb(0 0 0 / 0.16)),
+    var(--vinyl-spine-color, var(--paper));
   transform: rotateY(-90deg);
   transform-origin: left center;
 }
@@ -2660,6 +2793,9 @@ a:focus-visible .external-label .external-mark {
 .vinyl-spine-right {
   right: 0;
   left: auto;
+  background:
+    linear-gradient(to right, rgb(0 0 0 / 0.24), transparent 55%, rgb(255 255 255 / 0.08)),
+    var(--vinyl-spine-color, var(--paper));
   transform: rotateY(90deg);
   transform-origin: right center;
 }
@@ -2678,16 +2814,39 @@ a:focus-visible .external-label .external-mark {
 /* seeded crease streaks (inline background) + paper grain overlay */
 .vinyl-creases {
   position: absolute;
+  z-index: 2;
   inset: 0;
+  background-image: var(--vinyl-crease-image);
+  background-position: var(--vinyl-crease-position);
+  background-repeat: no-repeat;
+  background-size: var(--vinyl-crease-size);
+  opacity: 0.55;
+  pointer-events: none;
 }
 
 .vinyl-paper {
   position: absolute;
+  z-index: 3;
   inset: 0;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='96' height='96'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0'/%3E%3C/filter%3E%3Crect width='96' height='96' filter='url(%23n)'/%3E%3C/svg%3E");
-  background-size: 96px 96px;
-  mix-blend-mode: overlay;
-  opacity: 0.55;
+  background-image:
+    radial-gradient(circle at var(--vinyl-wear-x) var(--vinyl-wear-y), rgb(70 42 20 / 0.24) 0 0.5px, rgb(70 42 20 / 0.08) 1px 4%, transparent 9%),
+    linear-gradient(118deg, rgb(255 255 255 / 0.15), transparent 24% 72%, rgb(30 18 10 / 0.12)),
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='108' height='108'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.72' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0.55 0 0 0 0 0.52 0 0 0 0 0.46 0.06 0.06 0.06 0 -0.03'/%3E%3C/filter%3E%3Crect width='108' height='108' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-position:
+    center,
+    center,
+    var(--vinyl-paper-x) var(--vinyl-paper-y);
+  background-repeat: no-repeat, no-repeat, repeat;
+  background-size:
+    100% 100%,
+    100% 100%,
+    var(--vinyl-paper-size) var(--vinyl-paper-size);
+  box-shadow:
+    inset 1px 1px 0 rgb(255 255 255 / 0.22),
+    inset -1px -1px 0 rgb(45 27 13 / 0.14);
+  mix-blend-mode: soft-light;
+  opacity: var(--vinyl-wear-opacity);
+  pointer-events: none;
 }
 
 .vinyl-sleeve-raster {
@@ -2733,12 +2892,21 @@ a:focus-visible .external-label .external-mark {
 @media (prefers-reduced-motion: reduce) {
   .vinyl-trigger,
   .vinyl-sleeve,
-  .vinyl-object {
+  .vinyl-object,
+  .vinyl-contact-shadow {
     transition: none;
   }
 
   .vinyl-trigger:not([data-active])[data-pointer-owned] .vinyl-object {
     transform: none;
+  }
+
+  .vinyl-trigger:not([data-active])[data-pointer-owned] .vinyl-contact-shadow {
+    opacity: var(--vinyl-contact-opacity);
+    transform: translateZ(-1px)
+      rotateY(calc(var(--vinyl-direction) * var(--vinyl-inward-angle) * 1deg))
+      rotateX(62deg)
+      scaleX(var(--vinyl-contact-scale));
   }
 }
 

--- a/components/bookshelf.test.tsx
+++ b/components/bookshelf.test.tsx
@@ -4,6 +4,8 @@ import { forwardRef } from 'react'
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { books } from '~/lib/personal'
+
 import { Bookshelf } from './bookshelf'
 
 vi.mock('next/image', () => ({
@@ -40,6 +42,29 @@ afterEach(() => {
 })
 
 describe('Bookshelf', () => {
+  it('grounds every book on one decorative wooden shelf', () => {
+    const { container } = render(<Bookshelf />)
+    const room = container.querySelector<HTMLElement>('.bookshelf-room')
+    const viewport = container.querySelector<HTMLElement>('.bookshelf-viewport')
+    const plank = container.querySelector<HTMLElement>('.room-shelf-plank')
+    const frames = [...container.querySelectorAll<HTMLElement>('.book3-frame')]
+    const shadows = [...container.querySelectorAll<HTMLElement>('.book3-contact-shadow')]
+
+    expect(frames).toHaveLength(books.length)
+    expect(shadows).toHaveLength(books.length)
+    expect(viewport?.parentElement).toBe(room)
+    expect(plank?.parentElement).toBe(room)
+    expect(shadows.every((shadow) => shadow.getAttribute('aria-hidden') === 'true')).toBe(true)
+    expect(shadows.every((shadow) => !shadow.matches('a, button, [tabindex]'))).toBe(true)
+    expect(
+      frames.every(
+        (frame) =>
+          frame.style.getPropertyValue('--book-contact-width') !== '' &&
+          frame.style.getPropertyValue('--book-contact-scale') !== '',
+      ),
+    ).toBe(true)
+  })
+
   it('waits for the selected cover to decode before opening it', async () => {
     let finishDecode: (() => void) | undefined
     const decode = vi.fn(

--- a/components/bookshelf.tsx
+++ b/components/bookshelf.tsx
@@ -67,6 +67,8 @@ function coverWidth(book: (typeof books)[number]) {
   return (BOOK_H * book.coverWidth) / book.coverHeight
 }
 
+const BOOK_COVER_WIDTHS = books.map(coverWidth)
+
 function projectBookBounds(
   spine: number,
   nativeCoverWidth: number,
@@ -120,7 +122,7 @@ function shelfPoses(progress: number[], tilts: number[]) {
 
   return books.map((book, i) => {
     const spine = book.spine ?? 24
-    const next = pose(progress[i], tilts[i], spine, coverWidth(book))
+    const next = pose(progress[i], tilts[i], spine, BOOK_COVER_WIDTHS[i])
     const frameX = projectedX - baseX
 
     baseX += spine + SHELF_GAP
@@ -249,6 +251,10 @@ export function Bookshelf() {
 
       frame.style.zIndex = progress[i] > 0.01 ? '2' : '1'
       frame.style.transform = `translateX(${next.frameX.toFixed(2)}px)`
+      frame.style.setProperty(
+        '--book-contact-scale',
+        (next.width / BOOK_COVER_WIDTHS[i]).toFixed(4),
+      )
       inner.style.transform = `translateX(${next.offsetX.toFixed(2)}px) rotate(${next.tilt.toFixed(3)}deg) rotateY(${next.rotateY.toFixed(3)}deg)`
     })
 
@@ -487,7 +493,7 @@ export function Bookshelf() {
         {books.map((book, i) => {
           const isOpen = i === open
           const spine = book.spine ?? 24
-          const nativeCoverWidth = coverWidth(book)
+          const nativeCoverWidth = BOOK_COVER_WIDTHS[i]
           const initialPose = renderedPoses[i]
           const content = (
             <span
@@ -542,12 +548,17 @@ export function Bookshelf() {
                 bookRefs.current[i] = node
               }}
               className="book3-frame"
-              style={{
-                width: spine,
-                zIndex: progressRef.current[i] > 0.01 ? 2 : 1,
-                transform: `translateX(${initialPose.frameX.toFixed(2)}px)`,
-              }}
+              style={
+                {
+                  width: spine,
+                  zIndex: progressRef.current[i] > 0.01 ? 2 : 1,
+                  transform: `translateX(${initialPose.frameX.toFixed(2)}px)`,
+                  '--book-contact-width': `${nativeCoverWidth.toFixed(2)}px`,
+                  '--book-contact-scale': (initialPose.width / nativeCoverWidth).toFixed(4),
+                } as React.CSSProperties
+              }
             >
+              <span className="book3-contact-shadow" aria-hidden />
               <button
                 ref={(node) => {
                   controlRefs.current[i] = node

--- a/components/vinyl-shelf.test.tsx
+++ b/components/vinyl-shelf.test.tsx
@@ -58,7 +58,17 @@ describe('VinylShelf', () => {
     const finishSeeds = records.map(
       (record) => `${record.artist}, ${record.album} (${record.year})`,
     )
-    expect(finishSeeds.map(sleeveFinish)).toEqual(finishSeeds.map(sleeveFinish))
+    const finishes = finishSeeds.map(sleeveFinish)
+    const creaseImages = finishes.map(
+      (finish) =>
+        (finish.creaseStyle as unknown as Record<string, string>)[
+          '--vinyl-crease-image'
+        ],
+    )
+
+    expect(finishes).toEqual(finishSeeds.map(sleeveFinish))
+    expect(creaseImages).toContain('none')
+    expect(creaseImages.some((image) => image !== 'none')).toBe(true)
 
     const { container, rerender } = render(<VinylShelf />)
     const room = container.querySelector<HTMLElement>('.vinyl-room')

--- a/components/vinyl-shelf.test.tsx
+++ b/components/vinyl-shelf.test.tsx
@@ -1,6 +1,7 @@
 /** @vitest-environment jsdom */
 
 import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { Profiler } from 'react'
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { records } from '~/lib/personal'
@@ -90,13 +91,14 @@ describe('VinylShelf', () => {
 
     const finishTuple = (sleeve: HTMLElement) => {
       const crease = sleeve.querySelector<HTMLElement>('.vinyl-creases')
+      const trigger = sleeve.querySelector<HTMLElement>('.vinyl-trigger')
       const fields = [
-        sleeve.style.getPropertyValue('--vinyl-contact-scale'),
+        trigger?.style.getPropertyValue('--vinyl-contact-scale') ?? '',
         sleeve.style.getPropertyValue('--vinyl-paper-size'),
         sleeve.style.getPropertyValue('--vinyl-paper-x'),
         sleeve.style.getPropertyValue('--vinyl-paper-y'),
-        sleeve.style.getPropertyValue('--vinyl-rest-offset'),
-        sleeve.style.getPropertyValue('--vinyl-rest-tilt'),
+        trigger?.style.getPropertyValue('--vinyl-rest-offset') ?? '',
+        trigger?.style.getPropertyValue('--vinyl-rest-tilt') ?? '',
         sleeve.style.getPropertyValue('--vinyl-wear-opacity'),
         sleeve.style.getPropertyValue('--vinyl-wear-x'),
         sleeve.style.getPropertyValue('--vinyl-wear-y'),
@@ -236,7 +238,9 @@ describe('VinylShelf', () => {
 
       pivots.push(
         Number.parseFloat(
-          crossingSleeve?.style.getPropertyValue('--vinyl-origin-x') ?? '',
+          crossingSleeve
+            ?.querySelector<HTMLElement>('.vinyl-trigger')
+            ?.style.getPropertyValue('--vinyl-origin-x') ?? '',
         ),
       )
     }
@@ -246,6 +250,53 @@ describe('VinylShelf', () => {
 
     fireEvent.pointerUp(viewport!, {
       clientX: 235,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: 'mouse',
+    })
+  })
+
+  it('keeps continuous panning outside the React render loop', async () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({ matches: false }) as MediaQueryList),
+    )
+    const onRender = vi.fn()
+    const { container } = render(
+      <Profiler id="vinyl-shelf" onRender={onRender}>
+        <VinylShelf />
+      </Profiler>,
+    )
+    const viewport = container.querySelector<HTMLElement>('.vinyl-viewport')
+    const initialRenderCount = onRender.mock.calls.length
+
+    fireEvent.pointerDown(viewport!, {
+      button: 0,
+      clientX: 300,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: 'mouse',
+    })
+
+    for (const clientX of [280, 260, 240, 220]) {
+      fireEvent.pointerMove(viewport!, {
+        clientX,
+        clientY: 100,
+        isPrimary: true,
+        pointerId: 1,
+        pointerType: 'mouse',
+      })
+      await act(
+        () => new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve())),
+      )
+    }
+
+    expect(onRender.mock.calls.length - initialRenderCount).toBeLessThanOrEqual(2)
+
+    fireEvent.pointerUp(viewport!, {
+      clientX: 220,
       clientY: 100,
       isPrimary: true,
       pointerId: 1,

--- a/components/vinyl-shelf.test.tsx
+++ b/components/vinyl-shelf.test.tsx
@@ -3,7 +3,9 @@
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
-import { VinylShelf } from './vinyl-shelf'
+import { records } from '~/lib/personal'
+
+import { sleeveFinish, VinylShelf } from './vinyl-shelf'
 
 vi.mock('next/image', () => ({
   default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
@@ -52,6 +54,90 @@ afterAll(() => {
 })
 
 describe('VinylShelf', () => {
+  it('keeps every physical finish deterministic and decorative', () => {
+    const finishSeeds = records.map(
+      (record) => `${record.artist}, ${record.album} (${record.year})`,
+    )
+    expect(finishSeeds.map(sleeveFinish)).toEqual(finishSeeds.map(sleeveFinish))
+
+    const { container, rerender } = render(<VinylShelf />)
+    const room = container.querySelector<HTMLElement>('.vinyl-room')
+    const viewport = container.querySelector<HTMLElement>('.vinyl-viewport')
+    const plank = container.querySelector<HTMLElement>('.room-shelf-plank')
+    const sleeves = [...container.querySelectorAll<HTMLElement>('.vinyl')]
+    const shadows = [...container.querySelectorAll<HTMLElement>('.vinyl-contact-shadow')]
+
+    expect(sleeves).toHaveLength(records.length)
+    expect(shadows).toHaveLength(records.length)
+    expect(room?.contains(viewport)).toBe(true)
+    expect(room?.contains(plank)).toBe(true)
+    expect(viewport?.parentElement).toBe(room)
+    expect(plank?.parentElement).toBe(room)
+    expect(shadows.every((shadow) => shadow.getAttribute('aria-hidden') === 'true')).toBe(true)
+    expect(shadows.every((shadow) => !shadow.matches('a, button, [tabindex]'))).toBe(true)
+    expect(shadows.every((shadow) => shadow.querySelector('a, button, [tabindex]') === null)).toBe(true)
+    expect(shadows.every((shadow) => shadow.tabIndex === -1)).toBe(true)
+
+    const finishTuple = (sleeve: HTMLElement) => {
+      const crease = sleeve.querySelector<HTMLElement>('.vinyl-creases')
+      const fields = [
+        sleeve.style.getPropertyValue('--vinyl-contact-scale'),
+        sleeve.style.getPropertyValue('--vinyl-paper-size'),
+        sleeve.style.getPropertyValue('--vinyl-paper-x'),
+        sleeve.style.getPropertyValue('--vinyl-paper-y'),
+        sleeve.style.getPropertyValue('--vinyl-rest-offset'),
+        sleeve.style.getPropertyValue('--vinyl-rest-tilt'),
+        sleeve.style.getPropertyValue('--vinyl-wear-opacity'),
+        sleeve.style.getPropertyValue('--vinyl-wear-x'),
+        sleeve.style.getPropertyValue('--vinyl-wear-y'),
+        crease?.style.getPropertyValue('--vinyl-crease-image') ?? '',
+        crease?.style.getPropertyValue('--vinyl-crease-position') ?? '',
+        crease?.style.getPropertyValue('--vinyl-crease-size') ?? '',
+      ]
+
+      expect(fields.every((field) => field !== '')).toBe(true)
+      return fields.join('|')
+    }
+    const initialFinishes = sleeves.map(finishTuple)
+
+    expect(new Set(initialFinishes).size).toBeGreaterThan(1)
+
+    rerender(<VinylShelf />)
+
+    expect([...container.querySelectorAll<HTMLElement>('.vinyl')].map(finishTuple)).toEqual(initialFinishes)
+  })
+
+  it('preserves roving keyboard selection through the decorative layers', () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({ matches: false }) as MediaQueryList),
+    )
+    const { container } = render(<VinylShelf />)
+    const shelf = container.querySelector<HTMLElement>('.vinyl-shelf')
+    const triggers = [...container.querySelectorAll<HTMLButtonElement>('.vinyl-trigger')]
+    const initialIndex = Math.floor(records.length / 2)
+    const nextIndex = (initialIndex + 1) % records.length
+
+    expect(shelf?.dataset.activeIndex).toBe(String(initialIndex))
+    expect(triggers[initialIndex].ariaPressed).toBe('true')
+    expect(triggers[initialIndex].tabIndex).toBe(0)
+
+    fireEvent.keyDown(triggers[initialIndex], { key: 'ArrowRight' })
+
+    expect(shelf?.dataset.activeIndex).toBe(String(nextIndex))
+    expect(triggers[initialIndex].ariaPressed).toBe('false')
+    expect(triggers[initialIndex].hasAttribute('aria-current')).toBe(false)
+    expect(triggers[initialIndex].tabIndex).toBe(-1)
+    expect(triggers[nextIndex].ariaPressed).toBe('true')
+    expect(triggers[nextIndex].getAttribute('aria-current')).toBe('true')
+    expect(triggers[nextIndex].tabIndex).toBe(0)
+    expect(document.activeElement).toBe(triggers[nextIndex])
+
+    const annotation = container.querySelector<HTMLAnchorElement>('.vinyl-annotation')
+    expect(annotation?.getAttribute('href')).toBe(records[nextIndex].url)
+    expect(annotation?.textContent).toContain(records[nextIndex].album)
+  })
+
   it('keeps a mobile horizontal swipe and snaps to the next sleeve', () => {
     vi.stubGlobal(
       'matchMedia',
@@ -60,10 +146,18 @@ describe('VinylShelf', () => {
     const { container } = render(<VinylShelf />)
     const viewport = container.querySelector<HTMLElement>('.vinyl-viewport')
     const shelf = container.querySelector<HTMLElement>('.vinyl-shelf')
+    const initialIndex = Math.floor(records.length / 2)
+    const nextIndex = Math.min(records.length - 1, initialIndex + 1)
+    const triggers = [...container.querySelectorAll<HTMLButtonElement>('.vinyl-trigger')]
+    const annotation = container.querySelector<HTMLAnchorElement>('.vinyl-annotation')
 
     expect(viewport).not.toBeNull()
-    expect(shelf?.dataset.activeIndex).toBe('4')
+    expect(shelf?.dataset.activeIndex).toBe(String(initialIndex))
     expect(viewport?.style.touchAction).toBe('pan-y')
+    expect(annotation?.getAttribute('href')).toBe(records[initialIndex].url)
+
+    triggers[initialIndex].focus()
+    expect(document.activeElement).toBe(triggers[initialIndex])
 
     fireEvent.pointerDown(viewport!, {
       button: 0,
@@ -83,6 +177,18 @@ describe('VinylShelf', () => {
       pointerId: 1,
       pointerType: 'touch',
     })
+
+    expect(shelf?.dataset.activeIndex).toBe(String(initialIndex))
+    expect(triggers[initialIndex].ariaPressed).toBe('true')
+    expect(triggers[initialIndex].getAttribute('aria-current')).toBe('true')
+    expect(triggers[initialIndex].tabIndex).toBe(0)
+    expect(triggers[nextIndex].ariaPressed).toBe('false')
+    expect(triggers[nextIndex].hasAttribute('aria-current')).toBe(false)
+    expect(triggers[nextIndex].tabIndex).toBe(-1)
+    expect(annotation?.getAttribute('href')).toBe(records[initialIndex].url)
+    expect(annotation?.textContent).toContain(records[initialIndex].album)
+    expect(document.activeElement).toBe(triggers[initialIndex])
+
     fireEvent.pointerUp(viewport!, {
       clientX: 236,
       clientY: 100,
@@ -91,6 +197,15 @@ describe('VinylShelf', () => {
       pointerType: 'touch',
     })
 
-    expect(shelf?.dataset.activeIndex).toBe('5')
+    expect(shelf?.dataset.activeIndex).toBe(String(nextIndex))
+    expect(triggers[initialIndex].ariaPressed).toBe('false')
+    expect(triggers[initialIndex].hasAttribute('aria-current')).toBe(false)
+    expect(triggers[initialIndex].tabIndex).toBe(-1)
+    expect(triggers[nextIndex].ariaPressed).toBe('true')
+    expect(triggers[nextIndex].getAttribute('aria-current')).toBe('true')
+    expect(triggers[nextIndex].tabIndex).toBe(0)
+    expect(annotation?.getAttribute('href')).toBe(records[nextIndex].url)
+    expect(annotation?.textContent).toContain(records[nextIndex].album)
+    expect(document.activeElement).toBe(triggers[nextIndex])
   })
 })

--- a/components/vinyl-shelf.test.tsx
+++ b/components/vinyl-shelf.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 
-import { cleanup, fireEvent, render } from '@testing-library/react'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { records } from '~/lib/personal'
@@ -146,6 +146,56 @@ describe('VinylShelf', () => {
     const annotation = container.querySelector<HTMLAnchorElement>('.vinyl-annotation')
     expect(annotation?.getAttribute('href')).toBe(records[nextIndex].url)
     expect(annotation?.textContent).toContain(records[nextIndex].album)
+  })
+
+  it('keeps the centered sleeve on top during a held mouse drag', async () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({ matches: false }) as MediaQueryList),
+    )
+    const { container } = render(<VinylShelf />)
+    const viewport = container.querySelector<HTMLElement>('.vinyl-viewport')
+    const shelf = container.querySelector<HTMLElement>('.vinyl-shelf')
+    const sleeves = [...container.querySelectorAll<HTMLElement>('.vinyl')]
+    const annotation = container.querySelector<HTMLAnchorElement>('.vinyl-annotation')
+    const initialIndex = Math.floor(records.length / 2)
+    const centeredIndex = Math.min(records.length - 1, initialIndex + 2)
+    const stackOrder = (index: number) =>
+      Number(sleeves[index].style.getPropertyValue('--vinyl-stack-order'))
+
+    fireEvent.pointerDown(viewport!, {
+      button: 0,
+      clientX: 300,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: 'mouse',
+    })
+    fireEvent.pointerMove(viewport!, {
+      clientX: 172,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: 'mouse',
+    })
+
+    await act(
+      () => new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve())),
+    )
+
+    expect(shelf?.dataset.activeIndex).toBe(String(initialIndex))
+    expect(annotation?.textContent).toContain(records[initialIndex].album)
+    expect(stackOrder(centeredIndex)).toBeGreaterThan(stackOrder(initialIndex))
+
+    fireEvent.pointerUp(viewport!, {
+      clientX: 172,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: 'mouse',
+    })
+
+    expect(shelf?.dataset.activeIndex).toBe(String(centeredIndex))
   })
 
   it('keeps a mobile horizontal swipe and snaps to the next sleeve', () => {

--- a/components/vinyl-shelf.test.tsx
+++ b/components/vinyl-shelf.test.tsx
@@ -198,6 +198,61 @@ describe('VinylShelf', () => {
     expect(shelf?.dataset.activeIndex).toBe(String(centeredIndex))
   })
 
+  it('keeps the sleeve pivot continuous while a held drag crosses center', async () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({ matches: false }) as MediaQueryList),
+    )
+    const { container } = render(<VinylShelf />)
+    const viewport = container.querySelector<HTMLElement>('.vinyl-viewport')
+    const initialIndex = Math.floor(records.length / 2)
+    const crossingIndex = Math.min(records.length - 1, initialIndex + 1)
+    const crossingSleeve = container.querySelector<HTMLElement>(
+      `.vinyl[data-index="${crossingIndex}"]`,
+    )
+    const pivots: number[] = []
+
+    fireEvent.pointerDown(viewport!, {
+      button: 0,
+      clientX: 300,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: 'mouse',
+    })
+
+    for (const clientX of [237, 236, 235]) {
+      fireEvent.pointerMove(viewport!, {
+        clientX,
+        clientY: 100,
+        isPrimary: true,
+        pointerId: 1,
+        pointerType: 'mouse',
+      })
+
+      await act(
+        () => new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve())),
+      )
+
+      pivots.push(
+        Number.parseFloat(
+          crossingSleeve?.style.getPropertyValue('--vinyl-origin-x') ?? '',
+        ),
+      )
+    }
+
+    expect(pivots.every(Number.isFinite)).toBe(true)
+    expect(Math.max(...pivots) - Math.min(...pivots)).toBeLessThan(2)
+
+    fireEvent.pointerUp(viewport!, {
+      clientX: 235,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: 'mouse',
+    })
+  })
+
   it('keeps a mobile horizontal swipe and snaps to the next sleeve', () => {
     vi.stubGlobal(
       'matchMedia',

--- a/components/vinyl-shelf.tsx
+++ b/components/vinyl-shelf.tsx
@@ -548,6 +548,7 @@ export function VinylShelf() {
             const activeAmount = Math.max(0, 1 - distance)
             const restingAmount = Math.min(distance, 1)
             const scale = Math.max(0.92, 1 - distance * 0.012 + activeAmount * 0.04)
+            const originX = 50 - Math.max(-1, Math.min(1, offset)) * 50
             const contactScale = Math.max(0.38, Math.cos(inwardAngle * Math.PI / 180))
             const projectedContactScale = Number(
               (contactScale * (0.96 + activeAmount * 0.04)).toFixed(4),
@@ -560,7 +561,6 @@ export function VinylShelf() {
                 className="vinyl"
                 data-active={isActive ? '' : undefined}
                 data-index={index}
-                data-position={Math.abs(offset) < 0.001 ? 'active' : offset < 0 ? 'before' : 'after'}
                 style={
                   {
                     '--vinyl-index': index,
@@ -577,6 +577,7 @@ export function VinylShelf() {
                     '--vinyl-rest-offset': finish.restOffset * restingAmount,
                     '--vinyl-rest-tilt': finish.restTilt * restingAmount,
                     '--vinyl-scale': scale,
+                    '--vinyl-origin-x': `${originX}%`,
                     '--vinyl-spine-tone': spineTone,
                     '--vinyl-spine-color':
                       record.spineColor ??

--- a/components/vinyl-shelf.tsx
+++ b/components/vinyl-shelf.tsx
@@ -17,6 +17,18 @@ type Point = { x: number; y: number }
 type InteractionPhase = 'idle' | 'instant' | 'panning' | 'settling'
 type PointerIntent = 'pending' | 'horizontal' | 'vertical'
 
+interface SleeveFinish {
+  creaseStyle: React.CSSProperties
+  paperSize: number
+  paperX: number
+  paperY: number
+  restOffset: number
+  restTilt: number
+  wearOpacity: number
+  wearX: number
+  wearY: number
+}
+
 interface PointerSession {
   pointerId: number
   startX: number
@@ -33,22 +45,51 @@ function hashOf(s: string): number {
   return Math.abs(h)
 }
 
-// 2–3 seeded crease streaks per sleeve — worn paper, unique per album
-function creases(seed: string): string {
-  const h = hashOf(seed)
-  const layers: string[] = []
-  for (let i = 0; i < 3; i++) {
-    const angle = 15 + ((h >> (i * 7)) % 150)
-    const pos = 18 + ((h >> (i * 5)) % 64)
-    const ink = i % 2 === 0
-    layers.push(
-      `linear-gradient(${angle}deg, transparent ${pos - 1.4}%, ${
-        ink ? 'rgb(0 0 0 / 0.09)' : 'rgb(255 255 255 / 0.18)'
-      } ${pos}%, transparent ${pos + 1.6}%)`,
+// A deterministic finish keeps the jackets imperfect without introducing
+// hydration drift. Creases stay local to an edge or corner instead of drawing
+// full-cover stripes, while the other channels offset the shared paper grain.
+export function sleeveFinish(seed: string): SleeveFinish {
+  const h = hashOf(seed) >>> 0
+  const creaseCount = (h >>> 3) % 3
+  const creaseImages: string[] = []
+  const creasePositions: string[] = []
+  const creaseSizes: string[] = []
+
+  for (let index = 0; index < creaseCount; index++) {
+    const creaseSeed = hashOf(`${seed}:${index}`) >>> 0
+    const angle = 22 + (creaseSeed % 137)
+    const width = 34 + ((creaseSeed >>> 5) % 31)
+    const height = 22 + ((creaseSeed >>> 11) % 23)
+    const x = 6 + ((creaseSeed >>> 17) % 85)
+    const y = 6 + ((creaseSeed >>> 23) % 85)
+
+    creaseImages.push(
+      `linear-gradient(${angle}deg, transparent 47%, rgb(0 0 0 / 0.08) 49%, rgb(255 255 255 / 0.14) 50%, transparent 52%)`,
     )
+    creaseSizes.push(`${width}% ${height}%`)
+    creasePositions.push(`${x}% ${y}%`)
   }
-  return layers.join(', ')
+
+  return {
+    creaseStyle: {
+      '--vinyl-crease-image': creaseImages.length > 0 ? creaseImages.join(', ') : 'none',
+      '--vinyl-crease-position': creasePositions.length > 0 ? creasePositions.join(', ') : '0 0',
+      '--vinyl-crease-size': creaseSizes.length > 0 ? creaseSizes.join(', ') : '0 0',
+    } as React.CSSProperties,
+    paperSize: 84 + ((h >>> 20) % 3) * 12,
+    paperX: (h >>> 8) % 108,
+    paperY: (h >>> 16) % 192,
+    restOffset: ((h >>> 5) % 3) * 0.55,
+    restTilt: ((h % 9) - 4) * 0.085,
+    wearOpacity: 0.13 + ((h >>> 10) % 5) * 0.01,
+    wearX: (h & 1) === 0 ? 8 : 92,
+    wearY: (h & 2) === 0 ? 10 : 90,
+  }
 }
+
+const sleeveFinishes = records.map((record) =>
+  sleeveFinish(`${record.artist}, ${record.album} (${record.year})`),
+)
 
 // Favorite records as an overlapping horizontal stack of worn-paper
 // sleeves. Every interaction selects a sleeve; the separate annotation is
@@ -56,6 +97,7 @@ function creases(seed: string): string {
 export function VinylShelf() {
   const locale = useLocale()
   const initialIndex = Math.floor(records.length / 2)
+  const [activeIndex, setActiveIndex] = useState(initialIndex)
   const [selectionPosition, setSelectionPosition] = useState(initialIndex)
   const [interactionPhase, setInteractionPhaseState] = useState<InteractionPhase>('idle')
   const [pointerOwnerIndex, setPointerOwnerIndex] = useState<number | null>(null)
@@ -78,7 +120,6 @@ export function VinylShelf() {
   const wheelSelectionStepRef = useRef(64)
   const pointerFocusWasInsideRef = useRef(false)
 
-  const activeIndex = Math.round(selectionPosition)
   const activeRecord = records[activeIndex]
 
   function clampPosition(position: number) {
@@ -186,6 +227,7 @@ export function VinylShelf() {
 
     clearSettleTimer()
     clearInstantFrame()
+    setActiveIndex(nextIndex)
 
     if (mode === 'instant' && !prefersReducedMotion) {
       setInteractionPhase('instant')
@@ -495,8 +537,15 @@ export function VinylShelf() {
             const distance = Math.abs(offset)
             const isActive = index === activeIndex
             const inwardAngle = Math.min(68, 16 * Math.min(distance, 1) + distance * 13)
-            const scale = 1 - distance * 0.025 + Math.max(0, 1 - distance) * 0.08
             const accessibleName = `${record.artist}, ${record.album} (${record.year})`
+            const finish = sleeveFinishes[index]
+            const activeAmount = Math.max(0, 1 - distance)
+            const restingAmount = Math.min(distance, 1)
+            const scale = Math.max(0.92, 1 - distance * 0.012 + activeAmount * 0.04)
+            const contactScale = Math.max(0.38, Math.cos(inwardAngle * Math.PI / 180))
+            const projectedContactScale = Number(
+              (contactScale * (0.96 + activeAmount * 0.04)).toFixed(4),
+            )
             const spineTone = hashOf(accessibleName) % 5
 
             return (
@@ -505,20 +554,31 @@ export function VinylShelf() {
                 className="vinyl"
                 data-active={isActive ? '' : undefined}
                 data-index={index}
-                data-position={isActive ? 'active' : offset < 0 ? 'before' : 'after'}
+                data-position={Math.abs(offset) < 0.001 ? 'active' : offset < 0 ? 'before' : 'after'}
                 style={
                   {
                     '--vinyl-index': index,
                     '--vinyl-offset': offset,
                     '--vinyl-distance': distance,
                     '--vinyl-direction': Math.sign(offset),
+                    '--vinyl-contact-opacity': Math.max(0.16, 0.34 - distance * 0.035),
+                    '--vinyl-contact-scale': projectedContactScale,
+                    '--vinyl-forward': activeAmount * 4,
                     '--vinyl-inward-angle': inwardAngle,
+                    '--vinyl-paper-size': `${finish.paperSize}px`,
+                    '--vinyl-paper-x': `${finish.paperX}px`,
+                    '--vinyl-paper-y': `${finish.paperY}px`,
+                    '--vinyl-rest-offset': finish.restOffset * restingAmount,
+                    '--vinyl-rest-tilt': finish.restTilt * restingAmount,
                     '--vinyl-scale': scale,
                     '--vinyl-spine-tone': spineTone,
                     '--vinyl-spine-color':
                       record.spineColor ??
                       'color-mix(in oklab, var(--paper) calc(94% - var(--vinyl-spine-tone) * 5%), var(--paper-ink))',
                     '--vinyl-spine-ink': record.spineInk ?? 'oklch(0.28 0.012 95)',
+                    '--vinyl-wear-opacity': finish.wearOpacity,
+                    '--vinyl-wear-x': `${finish.wearX}%`,
+                    '--vinyl-wear-y': `${finish.wearY}%`,
                     '--vinyl-stack-order': isActive
                       ? records.length * 100 + 100
                       : Math.max(1, Math.round((records.length - distance) * 100)),
@@ -557,6 +617,7 @@ export function VinylShelf() {
                       aria-hidden
                     />
                   ))}
+                  <span className="vinyl-contact-shadow" aria-hidden />
                   <span className="vinyl-object">
                     <span className="vinyl-sleeve" aria-hidden>
                       {record.art ? (
@@ -579,7 +640,7 @@ export function VinylShelf() {
                       )}
                       <span
                         className="vinyl-creases"
-                        style={{ backgroundImage: creases(record.album + record.artist) }}
+                        style={finish.creaseStyle}
                       />
                       <span className="vinyl-paper" />
                     </span>

--- a/components/vinyl-shelf.tsx
+++ b/components/vinyl-shelf.tsx
@@ -125,6 +125,7 @@ export function VinylShelf() {
   const pointerFocusWasInsideRef = useRef(false)
 
   const activeRecord = records[activeIndex]
+  const visualFrontIndex = Math.round(selectionPosition)
 
   function clampPosition(position: number) {
     return Math.min(records.length - 1, Math.max(0, position))
@@ -540,6 +541,7 @@ export function VinylShelf() {
             const offset = index - selectionPosition
             const distance = Math.abs(offset)
             const isActive = index === activeIndex
+            const isVisualFront = index === visualFrontIndex
             const inwardAngle = Math.min(68, 16 * Math.min(distance, 1) + distance * 13)
             const accessibleName = `${record.artist}, ${record.album} (${record.year})`
             const finish = sleeveFinishes[index]
@@ -583,9 +585,11 @@ export function VinylShelf() {
                     '--vinyl-wear-opacity': finish.wearOpacity,
                     '--vinyl-wear-x': `${finish.wearX}%`,
                     '--vinyl-wear-y': `${finish.wearY}%`,
-                    '--vinyl-stack-order': isActive
-                      ? records.length * 100 + 100
-                      : Math.max(1, Math.round((records.length - distance) * 100)),
+                    '--vinyl-stack-order': Math.max(
+                      1,
+                      Math.round((records.length - distance) * 100) +
+                        (isVisualFront ? 1 : 0),
+                    ),
                   } as React.CSSProperties
                 }
               >

--- a/components/vinyl-shelf.tsx
+++ b/components/vinyl-shelf.tsx
@@ -50,6 +50,8 @@ function hashOf(s: string): number {
 // full-cover stripes, while the other channels offset the shared paper grain.
 export function sleeveFinish(seed: string): SleeveFinish {
   const h = hashOf(seed) >>> 0
+  // Some jackets intentionally stay crease-free so the wear does not become
+  // a repeated visual requirement across the whole collection.
   const creaseCount = (h >>> 3) % 3
   const creaseImages: string[] = []
   const creasePositions: string[] = []
@@ -57,11 +59,13 @@ export function sleeveFinish(seed: string): SleeveFinish {
 
   for (let index = 0; index < creaseCount; index++) {
     const creaseSeed = hashOf(`${seed}:${index}`) >>> 0
+    const xSeed = hashOf(`horizontal:${index}:${seed}`) >>> 0
+    const ySeed = hashOf(`${seed}:vertical:${index}`) >>> 0
     const angle = 22 + (creaseSeed % 137)
     const width = 34 + ((creaseSeed >>> 5) % 31)
     const height = 22 + ((creaseSeed >>> 11) % 23)
-    const x = 6 + ((creaseSeed >>> 17) % 85)
-    const y = 6 + ((creaseSeed >>> 23) % 85)
+    const x = 6 + (xSeed % 85)
+    const y = 6 + (ySeed % 85)
 
     creaseImages.push(
       `linear-gradient(${angle}deg, transparent 47%, rgb(0 0 0 / 0.08) 49%, rgb(255 255 255 / 0.14) 50%, transparent 52%)`,

--- a/components/vinyl-shelf.tsx
+++ b/components/vinyl-shelf.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image'
 import { useEffect, useRef, useState } from 'react'
+import { flushSync } from 'react-dom'
 
 import { ExternalLabel } from '~/components/external-mark'
 import { localize, useLocale } from '~/lib/locale-client'
@@ -37,6 +38,20 @@ interface PointerSession {
   selectionStep: number
   intent: PointerIntent
   focusWasInside: boolean
+}
+
+interface SleeveMotion {
+  contactOpacity: number
+  contactScale: number
+  direction: number
+  forward: number
+  inwardAngle: number
+  offset: number
+  originX: string
+  restOffset: number
+  restTilt: number
+  scale: number
+  stackOrder: number
 }
 
 function hashOf(s: string): number {
@@ -95,6 +110,64 @@ const sleeveFinishes = records.map((record) =>
   sleeveFinish(`${record.artist}, ${record.album} (${record.year})`),
 )
 
+function sleeveMotion(index: number, selectionPosition: number): SleeveMotion {
+  const offset = index - selectionPosition
+  const distance = Math.abs(offset)
+  const activeAmount = Math.max(0, 1 - distance)
+  const restingAmount = Math.min(distance, 1)
+  const inwardAngle = Math.min(68, 16 * Math.min(distance, 1) + distance * 13)
+  const contactScale = Math.max(0.38, Math.cos(inwardAngle * Math.PI / 180))
+  const finish = sleeveFinishes[index]
+
+  return {
+    contactOpacity: Math.max(0.16, 0.34 - distance * 0.035),
+    contactScale: Number((contactScale * (0.96 + activeAmount * 0.04)).toFixed(4)),
+    direction: Math.sign(offset),
+    forward: activeAmount * 4,
+    inwardAngle,
+    offset,
+    originX: `${50 - Math.max(-1, Math.min(1, offset)) * 50}%`,
+    restOffset: finish.restOffset * restingAmount,
+    restTilt: finish.restTilt * restingAmount,
+    scale: Math.max(0.92, 1 - distance * 0.012 + activeAmount * 0.04),
+    stackOrder: Math.max(
+      1,
+      Math.round((records.length - distance) * 100) +
+        (index === Math.round(selectionPosition) ? 1 : 0),
+    ),
+  }
+}
+
+function sleeveMotionStyle(motion: SleeveMotion): React.CSSProperties {
+  return {
+    '--vinyl-offset': motion.offset,
+    '--vinyl-direction': motion.direction,
+    '--vinyl-contact-opacity': motion.contactOpacity,
+    '--vinyl-contact-scale': motion.contactScale,
+    '--vinyl-forward': motion.forward,
+    '--vinyl-inward-angle': motion.inwardAngle,
+    '--vinyl-rest-offset': motion.restOffset,
+    '--vinyl-rest-tilt': motion.restTilt,
+    '--vinyl-scale': motion.scale,
+    '--vinyl-origin-x': motion.originX,
+  } as React.CSSProperties
+}
+
+function sleeveMotionCssText(motion: SleeveMotion) {
+  return [
+    `--vinyl-offset:${motion.offset}`,
+    `--vinyl-direction:${motion.direction}`,
+    `--vinyl-contact-opacity:${motion.contactOpacity}`,
+    `--vinyl-contact-scale:${motion.contactScale}`,
+    `--vinyl-forward:${motion.forward}`,
+    `--vinyl-inward-angle:${motion.inwardAngle}`,
+    `--vinyl-rest-offset:${motion.restOffset}`,
+    `--vinyl-rest-tilt:${motion.restTilt}`,
+    `--vinyl-scale:${motion.scale}`,
+    `--vinyl-origin-x:${motion.originX}`,
+  ].join(';')
+}
+
 // Favorite records as an overlapping horizontal stack of worn-paper
 // sleeves. Every interaction selects a sleeve; the separate annotation is
 // the only external destination.
@@ -107,6 +180,7 @@ export function VinylShelf() {
   const [pointerOwnerIndex, setPointerOwnerIndex] = useState<number | null>(null)
   const viewportRef = useRef<HTMLDivElement | null>(null)
   const shelfRef = useRef<HTMLUListElement | null>(null)
+  const sleeveRefs = useRef<Array<HTMLLIElement | null>>([])
   const triggerRefs = useRef<Array<HTMLButtonElement | null>>([])
   const hitCornerRefs = useRef<Array<Array<HTMLSpanElement | null>>>([])
   const selectionPositionRef = useRef(initialIndex)
@@ -125,7 +199,6 @@ export function VinylShelf() {
   const pointerFocusWasInsideRef = useRef(false)
 
   const activeRecord = records[activeIndex]
-  const visualFrontIndex = Math.round(selectionPosition)
 
   function clampPosition(position: number) {
     return Math.min(records.length - 1, Math.max(0, position))
@@ -143,13 +216,25 @@ export function VinylShelf() {
     setSelectionPosition(nextPosition)
   }
 
+  function applySelectionPosition(position: number) {
+    for (let index = 0; index < records.length; index++) {
+      const sleeve = sleeveRefs.current[index]
+      const trigger = triggerRefs.current[index]
+      if (!sleeve || !trigger) continue
+
+      const motion = sleeveMotion(index, position)
+      trigger.style.cssText = sleeveMotionCssText(motion)
+      sleeve.style.setProperty('--vinyl-stack-order', String(motion.stackOrder))
+    }
+  }
+
   function queueSelectionUpdate(position: number) {
     selectionPositionRef.current = clampPosition(position)
     if (selectionFrameRef.current !== null) return
 
     selectionFrameRef.current = window.requestAnimationFrame(() => {
       selectionFrameRef.current = null
-      setSelectionPosition(selectionPositionRef.current)
+      applySelectionPosition(selectionPositionRef.current)
     })
   }
 
@@ -229,6 +314,12 @@ export function VinylShelf() {
     const nextIndex = Math.min(records.length - 1, Math.max(0, index))
     const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
     const isAlreadySnapped = Math.abs(selectionPositionRef.current - nextIndex) < 0.001
+
+    if (interactionPhaseRef.current === 'panning') {
+      // Reconcile React with the last imperative frame before the snap. The
+      // following state update can then transition from that exact geometry.
+      flushSync(() => setSelectionPosition(selectionPositionRef.current))
+    }
 
     clearSettleTimer()
     clearInstantFrame()
@@ -535,49 +626,28 @@ export function VinylShelf() {
           className="vinyl-shelf"
           aria-label={localize(locale, '喜欢的唱片', 'Favorite records')}
           data-active-index={activeIndex}
-          style={{ '--vinyl-selection-position': selectionPosition } as React.CSSProperties}
         >
           {records.map((record, index) => {
-            const offset = index - selectionPosition
-            const distance = Math.abs(offset)
             const isActive = index === activeIndex
-            const isVisualFront = index === visualFrontIndex
-            const inwardAngle = Math.min(68, 16 * Math.min(distance, 1) + distance * 13)
             const accessibleName = `${record.artist}, ${record.album} (${record.year})`
             const finish = sleeveFinishes[index]
-            const activeAmount = Math.max(0, 1 - distance)
-            const restingAmount = Math.min(distance, 1)
-            const scale = Math.max(0.92, 1 - distance * 0.012 + activeAmount * 0.04)
-            const originX = 50 - Math.max(-1, Math.min(1, offset)) * 50
-            const contactScale = Math.max(0.38, Math.cos(inwardAngle * Math.PI / 180))
-            const projectedContactScale = Number(
-              (contactScale * (0.96 + activeAmount * 0.04)).toFixed(4),
-            )
+            const motion = sleeveMotion(index, selectionPosition)
             const spineTone = hashOf(accessibleName) % 5
 
             return (
               <li
                 key={`${record.artist}-${record.album}`}
+                ref={(element) => {
+                  sleeveRefs.current[index] = element
+                }}
                 className="vinyl"
                 data-active={isActive ? '' : undefined}
                 data-index={index}
                 style={
                   {
-                    '--vinyl-index': index,
-                    '--vinyl-offset': offset,
-                    '--vinyl-distance': distance,
-                    '--vinyl-direction': Math.sign(offset),
-                    '--vinyl-contact-opacity': Math.max(0.16, 0.34 - distance * 0.035),
-                    '--vinyl-contact-scale': projectedContactScale,
-                    '--vinyl-forward': activeAmount * 4,
-                    '--vinyl-inward-angle': inwardAngle,
                     '--vinyl-paper-size': `${finish.paperSize}px`,
                     '--vinyl-paper-x': `${finish.paperX}px`,
                     '--vinyl-paper-y': `${finish.paperY}px`,
-                    '--vinyl-rest-offset': finish.restOffset * restingAmount,
-                    '--vinyl-rest-tilt': finish.restTilt * restingAmount,
-                    '--vinyl-scale': scale,
-                    '--vinyl-origin-x': `${originX}%`,
                     '--vinyl-spine-tone': spineTone,
                     '--vinyl-spine-color':
                       record.spineColor ??
@@ -586,11 +656,7 @@ export function VinylShelf() {
                     '--vinyl-wear-opacity': finish.wearOpacity,
                     '--vinyl-wear-x': `${finish.wearX}%`,
                     '--vinyl-wear-y': `${finish.wearY}%`,
-                    '--vinyl-stack-order': Math.max(
-                      1,
-                      Math.round((records.length - distance) * 100) +
-                        (isVisualFront ? 1 : 0),
-                    ),
+                    '--vinyl-stack-order': motion.stackOrder,
                   } as React.CSSProperties
                 }
               >
@@ -598,6 +664,7 @@ export function VinylShelf() {
                   ref={(element) => {
                     triggerRefs.current[index] = element
                   }}
+                  style={sleeveMotionStyle(motion)}
                   type="button"
                   className="vinyl-trigger"
                   id={`vinyl-trigger-${index}`}

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -325,13 +325,13 @@ typewriter/ascii textures, measuring ticks, registration marks. Rules:
   `pointer-events: none; user-select: none` — a card is a printed label,
   never a control. Email's card is a little paper ENVELOPE (folded flap,
   perforated avatar stamp, mono address); the trigger opens mailto:.
-- **Room shelves** (`.room-shelf-plank`): records and books rest on an
-  actual wooden plank. The record shelf has a 6px top plane above its 12px
-  front face, low-contrast irregular longitudinal grain over an oak tone
-  (walnut in dark), and a layered wall shadow beneath. One upper-left light
-  source governs its top highlight, underside, sleeve edges, side faces, and
-  the per-item contact shadows where things meet the wood. The plank runs the
-  full framed width even when half empty — that's the point. A persistent
+- **Room shelves** (`.room-shelf-plank`): records and books rest on the same
+  material system: a 6px top plane above a 12px front face, low-contrast
+  irregular longitudinal grain over an oak tone (walnut in dark), and a
+  layered wall shadow beneath. One upper-left light source governs the top
+  highlight, underside, sleeve and cover edges, side faces, and the per-item
+  contact shadows where things meet the wood. The plank runs the full framed
+  width even when half empty — that's the point. A persistent
   muted plain-text annotation directly below it names the selected object and
   is the shelf's only external link. Covers always select; they never navigate.
   Record and book spines use static cover-derived color and contrasting ink
@@ -379,8 +379,10 @@ typewriter/ascii textures, measuring ticks, registration marks. Rules:
   aspect ratio at a fixed 210px book height; source dimensions drive the 3D
   projection, so square and narrow editions render whole without shifting the
   shelf. A closed book selects and opens into the accordion; activating the
-  open book leaves it selected. The annotation below the plank is the only link
-  to its official author or publisher page.
+  open book leaves it selected. Each projected book owns a shelf-plane contact
+  shadow that expands with its visible width but stays on the wood when the
+  jacket lifts on hover. The annotation below the plank is the only link to its
+  official author or publisher page.
 - Future candidates: ascii-on-hover for photos, dithered media
   placeholders, line-screen section dividers. One instrument per page —
   never stack rasters over each other.

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -364,9 +364,12 @@ typewriter/ascii textures, measuring ticks, registration marks. Rules:
   snaps to it. Pressed state, focus ownership, and the annotation stay with the
   committed selection during the continuous gesture, while paint order follows
   whichever sleeve is nearest the physical center. A long drag therefore cannot
-  leave the old selection covering the current centered album. The frame is tuned
-  for nine albums: one centered selection and four progressively turned sleeves
-  on either side. Sleeves without art retain the word-raster fallback.
+  leave the old selection covering the current centered album. Each sleeve's
+  bottom pivot also moves continuously from its outer edge through the center as
+  it crosses the physical midpoint, so the jacket never jumps beneath a held
+  pointer. The frame is tuned for nine albums: one centered selection and four
+  progressively turned sleeves on either side. Sleeves without art retain the
+  word-raster fallback.
 - **Bookshelf** (`components/bookshelf.tsx`): one book opens at a time while
   the other books remain as tightly packed spines with 1px seams. The books are
   ordered by relevance to Cali's work as a designer, developer, and founder,

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -367,9 +367,11 @@ typewriter/ascii textures, measuring ticks, registration marks. Rules:
   leave the old selection covering the current centered album. Each sleeve's
   bottom pivot also moves continuously from its outer edge through the center as
   it crosses the physical midpoint, so the jacket never jumps beneath a held
-  pointer. The frame is tuned for nine albums: one centered selection and four
-  progressively turned sleeves on either side. Sleeves without art retain the
-  word-raster fallback.
+  pointer. Pointer and wheel frames are coalesced through one animation frame
+  and update only the sleeves' motion styles; React commits at gesture
+  boundaries instead of on every movement. The frame is tuned for nine albums:
+  one centered selection and four progressively turned sleeves on either side.
+  Sleeves without art retain the word-raster fallback.
 - **Bookshelf** (`components/bookshelf.tsx`): one book opens at a time while
   the other books remain as tightly packed spines with 1px seams. The books are
   ordered by relevance to Cali's work as a designer, developer, and founder,

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -326,9 +326,11 @@ typewriter/ascii textures, measuring ticks, registration marks. Rules:
   never a control. Email's card is a little paper ENVELOPE (folded flap,
   perforated avatar stamp, mono address); the trigger opens mailto:.
 - **Room shelves** (`.room-shelf-plank`): records and books rest on an
-  actual wooden plank — edge grain drawn with layered CSS streaks over an
-  oak tone (walnut in dark), top highlight, wall shadow beneath, and
-  per-item contact shadows where things meet the wood. The plank runs the
+  actual wooden plank. The record shelf has a 6px top plane above its 12px
+  front face, low-contrast irregular longitudinal grain over an oak tone
+  (walnut in dark), and a layered wall shadow beneath. One upper-left light
+  source governs its top highlight, underside, sleeve edges, side faces, and
+  the per-item contact shadows where things meet the wood. The plank runs the
   full framed width even when half empty — that's the point. A persistent
   muted plain-text annotation directly below it names the selected object and
   is the shelf's only external link. Covers always select; they never navigate.
@@ -339,19 +341,28 @@ typewriter/ascii textures, measuring ticks, registration marks. Rules:
   sleeves form a horizontal cover stack with one active album enlarged in
   front. Sleeves on either side turn inward in 3D; rotation increases with
   distance so nearby albums retain more cover while distant albums read
-  increasingly as a spine. Each sleeve is a shallow 3D object with two rendered
-  side faces carrying its album and artist, not a shaded strip painted over the
-  cover. The middle item is selected by default so the first composition is
-  balanced on both sides. The records themselves are not rendered; the visual
-  system is entirely about paper sleeves, cover art, and their spines. One tap
+  increasingly as a spine. Each sleeve is a shallow 3D object with two thin
+  rendered side faces carrying its album and artist, not a shaded strip painted
+  over the cover. The face sits 3px forward, with the selected sleeve moving a
+  further 4px toward the viewer and scaling only to about 1.04. The middle item
+  is selected by default so the first composition is balanced on both sides.
+  The records themselves are not rendered; the visual system is entirely about
+  paper sleeves, cover art, and their spines. One tap
   brings a sleeve forward; tapping the active sleeve leaves it selected. The
-  sleeves carry a quiet layered drop shadow so their paper edges separate from
-  one another without floating away from the plank. Covers keep the default
-  cursor and only inactive sleeves lift slightly on a
+  sleeves carry a quiet directional drop shadow so their paper edges separate
+  from one another without floating away from the plank. Every sleeve also owns
+  a transformed shelf-plane contact shadow, which follows drag and selection
+  while staying on the wood when its jacket lifts on hover. Paper finish values
+  are derived deterministically from the record: texture position and scale,
+  corner wear, at most two short localized creases, and no more than 0.34° lean
+  or 1.1px settling variation. There is no runtime randomness. Covers keep the
+  default cursor and only inactive sleeves lift slightly on a
   fine-pointer hover. The shelf is clipped to a centered 37.5rem frame. Pointer
   drag and horizontal trackpad wheel input pan the stack continuously; vertical
   wheel input remains native page scrolling. Releasing the pointer or ending a
-  horizontal wheel gesture snaps to the nearest sleeve. The frame is tuned for
+  horizontal wheel gesture commits the new front sleeve and annotation, then
+  snaps to it. Selection ownership stays stable during the continuous gesture,
+  so covers do not swap paint order halfway through a drag. The frame is tuned for
   nine albums: one centered selection and four progressively turned sleeves on
   either side. Sleeves without art retain the word-raster fallback.
 - **Bookshelf** (`components/bookshelf.tsx`): one book opens at a time while

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -361,10 +361,12 @@ typewriter/ascii textures, measuring ticks, registration marks. Rules:
   drag and horizontal trackpad wheel input pan the stack continuously; vertical
   wheel input remains native page scrolling. Releasing the pointer or ending a
   horizontal wheel gesture commits the new front sleeve and annotation, then
-  snaps to it. Selection ownership stays stable during the continuous gesture,
-  so covers do not swap paint order halfway through a drag. The frame is tuned for
-  nine albums: one centered selection and four progressively turned sleeves on
-  either side. Sleeves without art retain the word-raster fallback.
+  snaps to it. Pressed state, focus ownership, and the annotation stay with the
+  committed selection during the continuous gesture, while paint order follows
+  whichever sleeve is nearest the physical center. A long drag therefore cannot
+  leave the old selection covering the current centered album. The frame is tuned
+  for nine albums: one centered selection and four progressively turned sleeves
+  on either side. Sleeves without art retain the word-raster fallback.
 - **Bookshelf** (`components/bookshelf.tsx`): one book opens at a time while
   the other books remain as tightly packed spines with 1px seams. The books are
   ordered by relevance to Cali's work as a designer, developer, and founder,


### PR DESCRIPTION
The record and book collections now share one physical shelf language: paper objects resting on a dimensional wooden plank under a consistent upper-left light source. Everything remains DOM and CSS based, with no WebGL, visible vinyl discs, or runtime randomness.

## Shelf and object treatment

- Gives both shelves a 6px top plane, irregular oak grain, layered wall shadow, and walnut dark-mode treatment.
- Gives every record sleeve deterministic grain placement, subtle corner wear, localized creases, small resting offsets, and thin 3D side faces.
- Adds one projected shelf-plane contact shadow per record and book, aligned to the visible object width.
- Keeps book shadows on the wood when a jacket lifts on hover and replaces the broad cover filter with directional edge shadows.
- Reduces the active record scale and forward depth so it separates without floating above the plank.

## Interaction behavior

- Keeps committed record selection, focus semantics, and the external annotation stable while paint order follows the sleeve nearest the physical center.
- Moves each sleeve's bottom pivot continuously through center instead of switching corners at the midpoint, preventing a held drag from jumping beneath the pointer.
- Coalesces continuous pointer and wheel motion into one animation frame and updates transient sleeve styles outside the React render loop.
- Reconciles React at gesture boundaries so release snapping, annotation state, and accessibility semantics still commit together.
- Preserves the book accordion, projected cover sizing, interrupted selection animation, keyboard focus, touch targets, and reduced-motion behavior.

## Performance profile

A production-build 180-frame record drag at the browser's 120 Hz cadence had no frames above 20ms and no long tasks. Compared with the previous implementation:

- Per-frame style mutations fell from about 66 to 18.
- Frame-time p95 improved from 10.0ms to 8.9ms.
- Traced JavaScript function time over the same 90-frame interaction fell from 285ms to 30ms.

The 650ms book accordion also remained smooth at 120 Hz, with 9.2ms frame-time p95, no frames above 20ms, and no long tasks after adding projected contact shadows.

## Verification

- `vitest run components/bookshelf.test.tsx components/vinyl-shelf.test.tsx`: 8 tests passed
- `vitest run app components db lib --exclude='**/*.live.test.ts'`: 107 files and 1,013 tests passed
- `tsc --noEmit`: passed
- `next build`: passed with schema-valid local dummy environment values
- `git diff --check`: passed
- Rendered both shelves in light and dark themes; verified book hover grounding, projected shadow width, accordion animation, reduced motion, keyboard selection, horizontal wheel input, record release snapping, and the held drag boundary in both directions

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the vinyl shelf and bookshelf into a more physically realistic rendering, using one shared wood material, an upper-left light source, per-sleeve contact shadows, and deterministic paper-finish values derived from each record's seed. The interaction model is also tightened: continuous panning now writes CSS custom properties directly to the DOM via `requestAnimationFrame` (bypassing React renders), `flushSync` reconciles the last imperative frame at the gesture boundary before the snap animation begins, and the sleeve pivot moves continuously through center instead of jumping at the midpoint.

- **Imperative panning loop**: `applySelectionPosition` sets all ten motion CSS variables on each trigger via `style.cssText` inside an rAF, while `sleeveMotionStyle` handles the same properties during React renders; `flushSync` at pointer-up bridges the two paths so the snap transition starts from the exact last-panned geometry.
- **Deterministic sleeve finish**: `sleeveFinish` replaces the old `creases()` function, computing paper size, grain offset, corner wear, up to two localised crease marks, and resting tilt entirely from a stable seed — no hydration drift, no runtime randomness.
- **Contact shadows**: each vinyl trigger and book frame now owns a shelf-plane contact shadow (`vinyl-contact-shadow` / `book3-contact-shadow`) that scales with the cover's projected width and follows the inward rotation, replacing the old shared pseudo-element shadow.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changed paths are UI-only with no data, auth, or API surface affected.

The imperative-during-gesture / React-at-boundary architecture is correctly implemented: transitions are disabled before any rAF fires, flushSync is properly guarded to the panning phase only, and the final snapped state is always fully React-owned. The deterministic finish, contact shadows, and continuous pivot are all exercised by the new tests.

No files require special attention. The only note is that sleeveMotionCssText and sleeveMotionStyle in vinyl-shelf.tsx are a parallel pair that must stay in sync when motion properties are added in the future.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| components/vinyl-shelf.tsx | Major refactor: separates continuous panning (imperative rAF DOM mutations via sleeveMotionCssText) from React renders (at gesture boundaries), adds deterministic sleeveFinish, contact shadow, and corrects the continuous pivot origin. |
| app/globals.css | Adds shelf wood material CSS variables, reworks .room-shelf-plank with a top-plane pseudo-element, introduces .vinyl-contact-shadow and .book3-contact-shadow with correct z-index and reduced-motion handling. |
| components/bookshelf.tsx | Caches coverWidth in module-level BOOK_COVER_WIDTHS, writes --book-contact-scale imperatively in applyPoses, renders .book3-contact-shadow per book frame with correct initial CSS variables. |
| components/vinyl-shelf.test.tsx | Adds five new tests covering deterministic finish, keyboard selection, drag z-order, pivot continuity, and React render-loop isolation during panning. |
| components/bookshelf.test.tsx | Adds structural test verifying contact shadow count, CSS variable presence, aria-hidden, and non-focusability for all book frames. |
| docs/design-language.md | Updated to reflect the new material system, depth values, contact shadow behaviour, deterministic finish details, and the React-at-boundaries panning model. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant RE as React Event
    participant rAF as requestAnimationFrame
    participant DOM as DOM (imperative)
    participant RS as React State

    U->>RE: pointerMove (panning)
    RE->>RS: setInteractionPhase('panning')
    RE->>rAF: queueSelectionUpdate(position)
    rAF->>DOM: applySelectionPosition() - trigger.style.cssText

    U->>RE: pointerUp
    RE->>RS: flushSync(setSelectionPosition(lastPos))
    Note over RS: Reconcile React with last imperative frame
    RE->>RS: setActiveIndex(snapIndex)
    RE->>RS: updateSelection - setSelectionPosition(snapIndex)
    RS->>DOM: React render sleeveMotionStyle on all triggers
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant RE as React Event
    participant rAF as requestAnimationFrame
    participant DOM as DOM (imperative)
    participant RS as React State

    U->>RE: pointerMove (panning)
    RE->>RS: setInteractionPhase('panning')
    RE->>rAF: queueSelectionUpdate(position)
    rAF->>DOM: applySelectionPosition() - trigger.style.cssText

    U->>RE: pointerUp
    RE->>RS: flushSync(setSelectionPosition(lastPos))
    Note over RS: Reconcile React with last imperative frame
    RE->>RS: setActiveIndex(snapIndex)
    RE->>RS: updateSelection - setSelectionPosition(snapIndex)
    RS->>DOM: React render sleeveMotionStyle on all triggers
```

</a>

<sub>Reviews (6): Last reviewed commit: ["style(site): ground bookshelf in wood"](https://github.com/calicastle/cali.so/commit/0e0f1ffb93385ebcd951a64442ae773b637d3138) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45315566)</sub>

<!-- /greptile_comment -->