### PR TITLE
Add hidden shader stages to Projects and Writing

### DIFF
--- a/app/_views/ama-page.test.tsx
+++ b/app/_views/ama-page.test.tsx
@@ -1,12 +1,26 @@
 // @vitest-environment jsdom
 
 import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AmaPageView } from './ama-page'
 import { AMA_TOPIC_LABELS, AMA_TOPICS } from '~/lib/ama/booking/topics'
 
-afterEach(cleanup)
+beforeEach(() => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
 
 describe('AmaPageView', () => {
   it('presents the AMA Session spec sheet in both languages', () => {
@@ -23,6 +37,13 @@ describe('AmaPageView', () => {
     expect(screen.getByText('60 分钟')).toBeTruthy()
     expect(container.textContent).toContain('24 hours')
     expect(container.textContent).toContain('Next 30 days')
+
+    const introductionStage = container.querySelector(
+      '[data-ama-introduction-stage]',
+    )
+    expect(introductionStage?.textContent).toContain('A focused hour with Cali')
+    expect(introductionStage?.textContent).toContain('US$99')
+    expect(introductionStage?.textContent).not.toContain('Who you are talking to')
   })
 
   it('lists all six topics in both languages', () => {

--- a/app/_views/ama-page.tsx
+++ b/app/_views/ama-page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import type { Metadata } from 'next'
 
+import { AmaIntroductionStage } from '~/components/ama/ama-introduction-stage'
 import { AMA_TOPIC_LABELS, AMA_TOPICS } from '~/lib/ama/booking/topics'
 import { T } from '~/lib/i18n'
 import { localeMetadata } from '~/lib/locale-metadata'
@@ -94,42 +95,44 @@ function SectionHeading({
 export function AmaPageView() {
   return (
     <div className="mx-auto w-full max-w-[37.5rem] px-6">
-      <header className="max-w-[34rem]">
-        <h1 className="enter text-sm font-medium text-muted-foreground">
-          <T zh="一对一" en="AMA" />
-        </h1>
-        <p
-          className="page-introduction enter mt-4 text-balance"
-          style={{ '--enter-delay': '70ms' } as React.CSSProperties}
-        >
-          <T
-            zh="与 Cali 的专注一小时。一场 60 分钟的一对一 AMA，你带着问题来，我们把它聊透。"
-            en="A focused hour with Cali. One 60 minute one-to-one AMA Session: you bring the questions, we work through them properly."
-          />
-        </p>
-      </header>
+      <AmaIntroductionStage>
+        <header className="max-w-[34rem]">
+          <h1 className="enter text-sm font-medium text-muted-foreground">
+            <T zh="一对一" en="AMA" />
+          </h1>
+          <p
+            className="page-introduction enter mt-4 text-balance"
+            style={{ '--enter-delay': '70ms' } as React.CSSProperties}
+          >
+            <T
+              zh="与 Cali 的专注一小时。一场 60 分钟的一对一 AMA，你带着问题来，我们把它聊透。"
+              en="A focused hour with Cali. One 60 minute one-to-one AMA Session: you bring the questions, we work through them properly."
+            />
+          </p>
+        </header>
 
-      <section
-        className="enter mt-10"
-        style={{ '--enter-delay': '120ms' } as React.CSSProperties}
-        aria-label="AMA Session"
-      >
-        <dl className="text-sm">
-          {SPEC_ROWS.map((row) => (
-            <div
-              key={row.enLabel}
-              className="hairline-top grid grid-cols-[7.5rem_minmax(0,1fr)] gap-4 py-2.5 first:border-t-0"
-            >
-              <dt className="text-muted-foreground">
-                <T zh={row.zhLabel} en={row.enLabel} />
-              </dt>
-              <dd className="tabular-nums">
-                <T zh={row.zhValue} en={row.enValue} />
-              </dd>
-            </div>
-          ))}
-        </dl>
-      </section>
+        <section
+          className="enter mt-10"
+          style={{ '--enter-delay': '120ms' } as React.CSSProperties}
+          aria-label="AMA Session"
+        >
+          <dl className="text-sm">
+            {SPEC_ROWS.map((row) => (
+              <div
+                key={row.enLabel}
+                className="hairline-top grid grid-cols-[7.5rem_minmax(0,1fr)] gap-4 py-2.5 first:border-t-0"
+              >
+                <dt className="text-muted-foreground">
+                  <T zh={row.zhLabel} en={row.enLabel} />
+                </dt>
+                <dd className="tabular-nums">
+                  <T zh={row.zhValue} en={row.enValue} />
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+      </AmaIntroductionStage>
 
       <section className="mt-12" aria-labelledby="ama-who-heading">
         <div id="ama-who-heading">

--- a/app/_views/blog-index-page.tsx
+++ b/app/_views/blog-index-page.tsx
@@ -1,3 +1,4 @@
+import { WritingInkStage } from '~/components/hidden-list-stage'
 import { PostRow } from '~/components/post-row'
 import { RevealScope } from '~/components/reveal-scope'
 import { getAllPosts } from '~/lib/content'
@@ -21,7 +22,7 @@ export function BlogIndexPageView({ locale }: { locale: Locale }) {
       <h1 className="enter text-sm font-medium text-muted-foreground">
         <T zh="写作" en="Writing" />
       </h1>
-      <div className="mt-6 flex flex-col gap-8">
+      <WritingInkStage className="mt-6" contentClassName="flex flex-col gap-8">
         {[...postsByYear].map(([year, yearPosts]) => {
           const center = (yearPosts.length - 1) / 2
 
@@ -49,6 +50,7 @@ export function BlogIndexPageView({ locale }: { locale: Locale }) {
                       headingLevel="h3"
                       dateStyle="month-day"
                       locale={locale}
+                      listStageId={post.slug}
                     />
                   </li>
                 ))}
@@ -56,7 +58,7 @@ export function BlogIndexPageView({ locale }: { locale: Locale }) {
             </section>
           )
         })}
-      </div>
+      </WritingInkStage>
     </div>
   )
 }

--- a/app/_views/projects-page.tsx
+++ b/app/_views/projects-page.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 
 import { ExternalLabel } from '~/components/external-mark'
+import { ProjectsBlueprintStage } from '~/components/hidden-list-stage'
 import { T } from '~/lib/i18n'
 import { publicPageMetadata } from '~/lib/public-page-metadata'
 import { projects } from '~/lib/projects'
@@ -25,45 +26,51 @@ export function ProjectsPageView() {
         </p>
       </header>
 
-      <ul className="focus-list mt-10 flex flex-col">
-        {projects.map((project, index) => (
-          <li
-            key={project.name}
-            className="enter-swing"
-            style={
-              { '--enter-delay': `${120 + Math.abs(index - center) * 50}ms` } as React.CSSProperties
-            }
-          >
-            <a
-              href={project.url}
-              target="_blank"
-              rel="noreferrer"
-              className="project-row hairline-top group"
+      <ProjectsBlueprintStage className="mt-10">
+        <ul className="focus-list flex flex-col">
+          {projects.map((project, index) => (
+            <li
+              key={project.name}
+              className="enter-swing"
+              style={
+                {
+                  '--enter-delay': `${120 + Math.abs(index - center) * 50}ms`,
+                } as React.CSSProperties
+              }
             >
-              <span className="project-icon-frame" aria-hidden="true">
-                <Image
-                  src={project.icon}
-                  alt=""
-                  width={36}
-                  height={36}
-                  className="project-icon"
-                />
-              </span>
-              <span className="project-identity">
-                <span className="project-name font-medium">
-                  <ExternalLabel>
-                    <T zh={project.name} en={project.nameEn} />
-                  </ExternalLabel>
+              <a
+                href={project.url}
+                target="_blank"
+                rel="noreferrer"
+                className="project-row hairline-top group"
+                data-list-stage-row
+                data-list-stage-id={project.name}
+              >
+                <span className="project-icon-frame" aria-hidden="true" data-list-stage-anchor>
+                  <Image
+                    src={project.icon}
+                    alt=""
+                    width={36}
+                    height={36}
+                    className="project-icon"
+                  />
                 </span>
-                <span className="project-domain text-muted-foreground">{project.domain}</span>
-              </span>
-              <span className="project-description text-muted-foreground">
-                <T zh={project.description} en={project.descriptionEn ?? project.description} />
-              </span>
-            </a>
-          </li>
-        ))}
-      </ul>
+                <span className="project-identity">
+                  <span className="project-name font-medium">
+                    <ExternalLabel>
+                      <T zh={project.name} en={project.nameEn} />
+                    </ExternalLabel>
+                  </span>
+                  <span className="project-domain text-muted-foreground">{project.domain}</span>
+                </span>
+                <span className="project-description text-muted-foreground">
+                  <T zh={project.description} en={project.descriptionEn ?? project.description} />
+                </span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </ProjectsBlueprintStage>
     </div>
   )
 }

--- a/app/api/ama/holds/[holdId]/route.test.ts
+++ b/app/api/ama/holds/[holdId]/route.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { GET, getLocalConfirmationFixture } from './route'
+import { getAmaBookingServices } from '~/lib/ama/booking/server'
+
+vi.mock('~/lib/ama/booking/server', () => ({
+  getAmaBookingServices: vi.fn(),
+}))
+
+const CONFIRMED_HOLD_ID = '00000000-0000-4000-8000-000000000001'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.mocked(getAmaBookingServices).mockReset()
+})
+
+describe('local AMA confirmation fixtures', () => {
+  it.each([
+    ['00000000-0000-4000-8000-000000000001', 'confirmed'],
+    ['00000000-0000-4000-8000-000000000002', 'finalizing'],
+    ['00000000-0000-4000-8000-000000000003', 'needs_reschedule'],
+  ])('returns %s as %s in development', async (holdId, bookingStatus) => {
+    vi.stubEnv('NODE_ENV', 'development')
+
+    const response = await GET(
+      new Request(`http://localhost/api/ama/holds/${holdId}`),
+      { params: Promise.resolve({ holdId }) },
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      hold: { state: 'paid', bookingStatus },
+    })
+    expect(getAmaBookingServices).not.toHaveBeenCalled()
+  })
+
+  it('never exposes fixture data outside development', () => {
+    expect(getLocalConfirmationFixture(CONFIRMED_HOLD_ID, 'production')).toBeNull()
+    expect(getLocalConfirmationFixture(CONFIRMED_HOLD_ID, 'test')).toBeNull()
+  })
+})

--- a/app/api/ama/holds/[holdId]/route.ts
+++ b/app/api/ama/holds/[holdId]/route.ts
@@ -1,11 +1,34 @@
 import { createHoldStateHandler } from '~/lib/ama/booking/http'
 import { getAmaBookingServices } from '~/lib/ama/booking/server'
 
+const LOCAL_CONFIRMATION_FIXTURES = {
+  '00000000-0000-4000-8000-000000000001': 'confirmed',
+  '00000000-0000-4000-8000-000000000002': 'finalizing',
+  '00000000-0000-4000-8000-000000000003': 'needs_reschedule',
+} as const
+
+export function getLocalConfirmationFixture(
+  holdId: string,
+  environment = process.env.NODE_ENV,
+) {
+  if (environment !== 'development') return null
+  return LOCAL_CONFIRMATION_FIXTURES[
+    holdId as keyof typeof LOCAL_CONFIRMATION_FIXTURES
+  ] ?? null
+}
+
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ holdId: string }> },
 ) {
   const { holdId } = await params
+  const fixture = getLocalConfirmationFixture(holdId)
+  if (fixture) {
+    return Response.json({
+      hold: { state: 'paid', bookingStatus: fixture },
+    })
+  }
+
   const { booking } = getAmaBookingServices()
   return createHoldStateHandler({ service: booking })(request, holdId)
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -4914,24 +4914,40 @@ html[data-locale='en'] [data-en-block] {
   text-align: left;
 }
 
-.ama-success-stage {
-  position: relative;
-  isolation: isolate;
-  display: grid;
-  min-height: 20rem;
-  overflow: hidden;
-  place-items: center;
-  border-radius: 0.75rem;
+body:has(.ama-success-stage) {
+  --background: #08070a;
+  --border: rgb(241 238 229 / 0.16);
+  --foreground: #f1eee5;
+  --muted-foreground: rgb(241 238 229 / 0.68);
+
   background: #08070a;
   color: #f1eee5;
-  box-shadow: 0 0 0 1px rgb(255 255 255 / 0.1);
+}
+
+body:has(.ama-success-stage) main {
+  isolation: isolate;
+}
+
+.ama-success-stage {
+  position: relative;
+  display: grid;
+  min-height: max(32rem, calc(100svh - 10.5rem));
+  place-items: center;
+  color: #f1eee5;
 }
 
 .ama-success-static-background,
 .ama-success-shader-layer,
-.ama-success-shader-shell,
-.ama-success-shader-canvas,
 .ama-success-confetti {
+  position: fixed;
+  inset: 0;
+  display: block;
+  pointer-events: none;
+  user-select: none;
+}
+
+.ama-success-shader-shell,
+.ama-success-shader-canvas {
   position: absolute;
   inset: 0;
   display: block;
@@ -4942,12 +4958,14 @@ html[data-locale='en'] [data-en-block] {
 }
 
 .ama-success-static-background {
+  z-index: -2;
   background:
     linear-gradient(164deg, transparent 18%, rgb(118 24 219 / 0.2) 42%, transparent 62%),
     linear-gradient(150deg, #030304 10%, #18181a 52%, #050407 90%);
 }
 
 .ama-success-shader-layer {
+  z-index: -1;
   opacity: 0;
   transition: opacity 350ms var(--ease-swift);
 }
@@ -4957,20 +4975,22 @@ html[data-locale='en'] [data-en-block] {
 }
 
 .ama-success-confetti {
+  z-index: 1;
   overflow: hidden;
 }
 
 .ama-success-confetti-piece {
   position: absolute;
-  top: -1.25rem;
-  left: var(--ama-confetti-left);
+  top: 0;
+  left: 0;
   width: 0.35rem;
   height: 0.7rem;
   border-radius: 1px;
   background: var(--ama-confetti-color);
   color: transparent;
   opacity: 0;
-  animation: ama-success-confetti-fall var(--ama-confetti-duration)
+  transform-origin: center;
+  animation: ama-success-confetti-burst var(--ama-confetti-duration)
     var(--ease-swift) var(--ama-confetti-delay) both;
 }
 
@@ -4985,8 +5005,9 @@ html[data-locale='en'] [data-en-block] {
 
 .ama-success-stage-content {
   position: relative;
+  z-index: 2;
   width: min(100%, 31rem);
-  padding: 3rem 2rem;
+  padding: 4rem 2rem calc(6rem + env(safe-area-inset-bottom));
   text-align: center;
 }
 
@@ -5013,24 +5034,39 @@ html[data-locale='en'] [data-en-block] {
   animation: ama-success-mark-arrive 350ms var(--ease-swift) both;
 }
 
-@keyframes ama-success-confetti-fall {
+@keyframes ama-success-confetti-burst {
   0% {
     opacity: 0;
-    transform: translate3d(0, -1rem, 0) rotate(0deg);
+    transform: translate3d(
+        var(--ama-confetti-origin-x),
+        var(--ama-confetti-origin-y),
+        0
+      )
+      scale(0.72) rotate(0deg);
   }
 
-  12% {
+  8% {
     opacity: 1;
   }
 
-  82% {
+  52% {
     opacity: 0.94;
+    transform: translate3d(
+        var(--ama-confetti-apex-x),
+        var(--ama-confetti-apex-y),
+        0
+      )
+      scale(1) rotate(var(--ama-confetti-mid-rotation));
   }
 
   100% {
     opacity: 0;
-    transform: translate3d(var(--ama-confetti-drift), 22rem, 0)
-      rotate(var(--ama-confetti-rotation));
+    transform: translate3d(
+        var(--ama-confetti-end-x),
+        var(--ama-confetti-end-y),
+        0
+      )
+      scale(0.86) rotate(var(--ama-confetti-rotation));
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -4914,6 +4914,157 @@ html[data-locale='en'] [data-en-block] {
   text-align: left;
 }
 
+.ama-success-stage {
+  position: relative;
+  isolation: isolate;
+  display: grid;
+  min-height: 20rem;
+  overflow: hidden;
+  place-items: center;
+  border-radius: 0.75rem;
+  background: #08070a;
+  color: #f1eee5;
+  box-shadow: 0 0 0 1px rgb(255 255 255 / 0.1);
+}
+
+.ama-success-static-background,
+.ama-success-shader-layer,
+.ama-success-shader-shell,
+.ama-success-shader-canvas,
+.ama-success-confetti {
+  position: absolute;
+  inset: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  user-select: none;
+}
+
+.ama-success-static-background {
+  background:
+    linear-gradient(164deg, transparent 18%, rgb(118 24 219 / 0.2) 42%, transparent 62%),
+    linear-gradient(150deg, #030304 10%, #18181a 52%, #050407 90%);
+}
+
+.ama-success-shader-layer {
+  opacity: 0;
+  transition: opacity 350ms var(--ease-swift);
+}
+
+.ama-success-stage[data-shader-ready='true'] .ama-success-shader-layer {
+  opacity: 1;
+}
+
+.ama-success-confetti {
+  overflow: hidden;
+}
+
+.ama-success-confetti-piece {
+  position: absolute;
+  top: -1.25rem;
+  left: var(--ama-confetti-left);
+  width: 0.35rem;
+  height: 0.7rem;
+  border-radius: 1px;
+  background: var(--ama-confetti-color);
+  color: transparent;
+  opacity: 0;
+  animation: ama-success-confetti-fall var(--ama-confetti-duration)
+    var(--ease-swift) var(--ama-confetti-delay) both;
+}
+
+.ama-success-confetti-piece:nth-child(3n) {
+  width: 0.5rem;
+  height: 0.18rem;
+}
+
+.ama-success-confetti-piece:nth-child(4n) {
+  border-radius: 50%;
+}
+
+.ama-success-stage-content {
+  position: relative;
+  width: min(100%, 31rem);
+  padding: 3rem 2rem;
+  text-align: center;
+}
+
+.ama-success-stage-content [role='status'] {
+  align-items: center;
+}
+
+.ama-success-stage .text-muted-foreground {
+  color: rgb(241 238 229 / 0.72);
+}
+
+.ama-success-mark {
+  display: grid;
+  width: 4rem;
+  height: 4rem;
+  margin: 0 auto 1.75rem;
+  place-items: center;
+  border-radius: 50%;
+  background: #f1eee5;
+  color: #131216;
+  box-shadow: 0 0 0 0.45rem rgb(217 239 98 / 0.46);
+  font-size: 1.5rem;
+  line-height: 1;
+  animation: ama-success-mark-arrive 350ms var(--ease-swift) both;
+}
+
+@keyframes ama-success-confetti-fall {
+  0% {
+    opacity: 0;
+    transform: translate3d(0, -1rem, 0) rotate(0deg);
+  }
+
+  12% {
+    opacity: 1;
+  }
+
+  82% {
+    opacity: 0.94;
+  }
+
+  100% {
+    opacity: 0;
+    transform: translate3d(var(--ama-confetti-drift), 22rem, 0)
+      rotate(var(--ama-confetti-rotation));
+  }
+}
+
+@keyframes ama-success-mark-arrive {
+  0% {
+    opacity: 0;
+    transform: scale(0.72) rotate(-10deg);
+  }
+
+  58% {
+    opacity: 1;
+    transform: scale(1.08) rotate(-2deg);
+  }
+
+  100% {
+    transform: scale(1) rotate(-4deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ama-success-shader-layer {
+    display: none;
+    transition: none;
+  }
+
+  .ama-success-confetti {
+    display: none;
+  }
+
+  .ama-success-mark {
+    animation: none;
+  }
+}
+
 @keyframes ama-waiting-dots {
   0% {
     content: '·';

--- a/app/globals.css
+++ b/app/globals.css
@@ -4906,6 +4906,83 @@ html[data-locale='en'] [data-en-block] {
 
 /* ── AMA booking: calm waiting dots (no spinner) ─────────────────── */
 
+.ama-introduction-stage {
+  position: relative;
+  isolation: isolate;
+  margin-inline: -1rem;
+  overflow: hidden;
+  padding: 1rem;
+}
+
+.ama-introduction-stage::before,
+.ama-conversation-static,
+.ama-conversation-shader-layer,
+.ama-conversation-shader-shell,
+.ama-conversation-shader-canvas {
+  position: absolute;
+  inset: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  user-select: none;
+}
+
+.ama-introduction-stage::before {
+  background: radial-gradient(
+    ellipse at center,
+    color-mix(in oklab, var(--surface-2) 62%, transparent) 0%,
+    color-mix(in oklab, var(--surface-1) 38%, transparent) 48%,
+    transparent 78%
+  );
+  content: '';
+}
+
+.ama-conversation-static,
+.ama-conversation-shader-layer {
+  mask-image: radial-gradient(ellipse at center, black 42%, transparent 78%);
+}
+
+.ama-conversation-static {
+  color: var(--foreground);
+  opacity: 0.055;
+  transition: opacity 350ms var(--ease-swift);
+}
+
+.ama-conversation-static svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 0.8;
+  vector-effect: non-scaling-stroke;
+}
+
+.ama-conversation-shader-layer {
+  opacity: 0;
+  transition: opacity 350ms var(--ease-swift);
+}
+
+.ama-introduction-stage[data-shader-ready='true'] .ama-conversation-static {
+  opacity: 0;
+}
+
+.ama-introduction-stage[data-shader-ready='true']
+  .ama-conversation-shader-layer {
+  opacity: 0.12;
+}
+
+.dark
+  .ama-introduction-stage[data-shader-ready='true']
+  .ama-conversation-shader-layer {
+  opacity: 0.15;
+}
+
+.ama-introduction-content {
+  position: relative;
+}
+
 .ama-waiting-dots::after {
   display: inline-block;
   min-width: 1.5em;
@@ -5087,6 +5164,15 @@ body:has(.ama-success-stage) main {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .ama-conversation-static,
+  .ama-conversation-shader-layer {
+    transition: none;
+  }
+
+  .ama-conversation-shader-layer {
+    display: none;
+  }
+
   .ama-success-shader-layer {
     display: none;
     transition: none;

--- a/app/globals.css
+++ b/app/globals.css
@@ -328,6 +328,200 @@
   border-top: var(--border-hairline) solid var(--border);
 }
 
+/* ── List stages: one dormant shader instrument per index ────────── */
+
+.hidden-list-stage {
+  position: relative;
+  isolation: isolate;
+}
+
+.hidden-list-stage-content {
+  position: relative;
+}
+
+.hidden-list-stage-field {
+  position: absolute;
+  inset: 0;
+  display: block;
+  overflow: hidden;
+  contain: layout paint;
+  color: var(--foreground);
+  pointer-events: none;
+  user-select: none;
+  opacity: 0;
+}
+
+.projects-hidden-stage .hidden-list-stage-field {
+  transform: scale(0.985);
+  transition:
+    opacity var(--list-stage-exit-ms) var(--ease-swift),
+    transform var(--list-stage-exit-ms) var(--ease-swift);
+}
+
+.writing-hidden-stage .hidden-list-stage-field {
+  transition: opacity var(--list-stage-exit-ms) var(--ease-swift);
+}
+
+.hidden-list-stage[data-active='true'] .hidden-list-stage-field {
+  opacity: 1;
+}
+
+.projects-hidden-stage[data-active='true'] .hidden-list-stage-field {
+  transform: scale(1);
+}
+
+@keyframes projects-blueprint-enter {
+  from {
+    opacity: 0;
+    transform: scale(0.985);
+  }
+}
+
+@keyframes writing-ink-enter {
+  from {
+    opacity: 0;
+  }
+}
+
+.projects-hidden-stage[data-active='true'][data-motion='true'] .hidden-list-stage-field {
+  animation: projects-blueprint-enter 260ms var(--ease-swift) backwards;
+}
+
+.writing-hidden-stage[data-active='true'][data-motion='true'] .hidden-list-stage-field {
+  animation: writing-ink-enter 180ms var(--ease-swift) backwards;
+}
+
+.hidden-list-stage[data-motion='false'] .hidden-list-stage-field,
+.hidden-list-stage[data-motion='false'] .hidden-list-shader-shell {
+  transition: none;
+}
+
+.hidden-list-stage-shader,
+.hidden-list-shader-shell,
+.hidden-list-shader-canvas {
+  position: absolute;
+  inset: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.hidden-list-shader-shell {
+  opacity: 0;
+}
+
+.hidden-list-shader-shell[data-ready='true'] {
+  opacity: 1;
+}
+
+.projects-blueprint-static {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(
+      color-mix(in oklab, currentColor 35%, transparent) var(--border-hairline),
+      transparent var(--border-hairline)
+    ),
+    linear-gradient(
+      90deg,
+      color-mix(in oklab, currentColor 35%, transparent) var(--border-hairline),
+      transparent var(--border-hairline)
+    );
+  background-size: 24px 24px;
+  opacity: 0.1;
+}
+
+.projects-hidden-stage .hidden-list-stage-shader {
+  opacity: 0.14;
+}
+
+.projects-registration-mark {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 58px;
+  height: 58px;
+  overflow: visible;
+  opacity: 0.26;
+  transform: translate3d(
+      var(--list-stage-target-x),
+      var(--list-stage-target-y),
+      0
+    )
+    translate(-50%, -50%);
+}
+
+.projects-registration-mark circle,
+.projects-registration-mark path {
+  vector-effect: non-scaling-stroke;
+  stroke: currentColor;
+  stroke-width: var(--border-hairline);
+}
+
+.writing-ink-current-target {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: block;
+  width: var(--list-stage-target-width);
+  height: var(--list-stage-target-height);
+  overflow: hidden;
+  transform: translate3d(
+    var(--list-stage-target-x),
+    var(--list-stage-target-y),
+    0
+  );
+}
+
+.writing-ink-static {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  fill: none;
+  opacity: 0.12;
+}
+
+.writing-ink-static path {
+  vector-effect: non-scaling-stroke;
+  stroke: currentColor;
+  stroke-width: 1.35;
+  stroke-linecap: round;
+}
+
+.writing-hidden-stage .hidden-list-stage-shader {
+  opacity: 0.2;
+}
+
+.dark .projects-blueprint-static {
+  opacity: 0.12;
+}
+
+.dark .projects-registration-mark {
+  opacity: 0.3;
+}
+
+.dark .projects-hidden-stage .hidden-list-stage-shader {
+  opacity: 0.12;
+}
+
+.dark .writing-ink-static {
+  opacity: 0.1;
+}
+
+.dark .writing-hidden-stage .hidden-list-stage-shader {
+  opacity: 0.17;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hidden-list-stage-field,
+  .hidden-list-shader-shell {
+    animation: none;
+    transition: none;
+  }
+}
+
 /* ── Project index: compact artifacts with drafting crop marks ───── */
 
 .project-row {

--- a/components/ama/ama-conversation-field.tsx
+++ b/components/ama/ama-conversation-field.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { Shader, SineWave } from 'shaders/react'
+
+import { useHiddenShaderField } from '~/components/use-hidden-shader-field'
+
+const UPPER_WAVE_POSITION = { x: 0.5, y: 0.46 }
+const LOWER_WAVE_POSITION = { x: 0.5, y: 0.54 }
+
+export function AmaConversationField({
+  onUnavailable,
+  onReady,
+}: {
+  onUnavailable: () => void
+  onReady: () => void
+}) {
+  const { handleReady, ink, ready } = useHiddenShaderField(
+    onUnavailable,
+    onReady,
+  )
+
+  return (
+    <span
+      className="ama-conversation-shader-shell"
+      data-ready={ready ? 'true' : 'false'}
+    >
+      <Shader
+        className="ama-conversation-shader-canvas"
+        colorSpace="srgb"
+        disableTelemetry
+        onReady={handleReady}
+      >
+        <SineWave
+          amplitude={0.13}
+          color={ink}
+          frequency={1.15}
+          position={UPPER_WAVE_POSITION}
+          softness={0.16}
+          speed={0.08}
+          thickness={0.035}
+        />
+        <SineWave
+          amplitude={0.11}
+          angle={180}
+          color={ink}
+          frequency={1.05}
+          opacity={0.72}
+          position={LOWER_WAVE_POSITION}
+          softness={0.16}
+          speed={-0.065}
+          thickness={0.03}
+        />
+      </Shader>
+    </span>
+  )
+}

--- a/components/ama/ama-introduction-stage.test.tsx
+++ b/components/ama/ama-introduction-stage.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { AmaIntroductionStage } from './ama-introduction-stage'
+
+vi.mock('next/dynamic', () => ({
+  default: () =>
+    function ConversationFieldBoundary({ onReady }: { onReady: () => void }) {
+      return (
+        <button type="button" data-conversation-shader-ready onClick={onReady}>
+          Mark conversation shader ready
+        </button>
+      )
+    },
+}))
+
+function setReducedMotion(initial = false) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({
+      matches: initial,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  )
+}
+
+function setWebGpu(adapter: unknown | null) {
+  const requestAdapter = vi.fn().mockResolvedValue(adapter)
+  Object.defineProperty(navigator, 'gpu', {
+    configurable: true,
+    value: { requestAdapter },
+  })
+  return requestAdapter
+}
+
+function setIntersectionObserver() {
+  let callback: IntersectionObserverCallback = () => undefined
+  const disconnect = vi.fn()
+  const observe = vi.fn()
+  class IntersectionObserverMock {
+    disconnect = disconnect
+    observe = observe
+    unobserve = vi.fn()
+
+    constructor(nextCallback: IntersectionObserverCallback) {
+      callback = nextCallback
+    }
+  }
+  vi.stubGlobal('IntersectionObserver', IntersectionObserverMock)
+  return {
+    disconnect,
+    observe,
+    set(isIntersecting: boolean) {
+      act(() => {
+        callback(
+          [{ isIntersecting } as IntersectionObserverEntry],
+          {} as IntersectionObserver,
+        )
+      })
+    },
+  }
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  Reflect.deleteProperty(navigator, 'gpu')
+})
+
+describe('AmaIntroductionStage', () => {
+  it('runs one shader only while the bounded field is visible', async () => {
+    setReducedMotion()
+    const requestAdapter = setWebGpu({})
+    const intersection = setIntersectionObserver()
+    const { container } = render(
+      <AmaIntroductionStage>
+        <p>AMA introduction</p>
+      </AmaIntroductionStage>,
+    )
+
+    await flush()
+
+    expect(requestAdapter).toHaveBeenCalledOnce()
+    expect(intersection.observe).toHaveBeenCalledOnce()
+    expect(container.querySelector('.ama-conversation-static')).not.toBeNull()
+    expect(
+      container.querySelectorAll('[data-conversation-shader-ready]').length,
+    ).toBe(1)
+
+    fireEvent.click(container.querySelector('[data-conversation-shader-ready]')!)
+    expect(
+      container.querySelector('[data-ama-introduction-stage]')?.getAttribute(
+        'data-shader-ready',
+      ),
+    ).toBe('true')
+
+    intersection.set(false)
+    expect(container.querySelector('[data-conversation-shader-ready]')).toBeNull()
+    expect(
+      container.querySelector('[data-ama-introduction-stage]')?.getAttribute(
+        'data-in-viewport',
+      ),
+    ).toBe('false')
+
+    intersection.set(true)
+    await flush()
+    expect(container.querySelector('[data-conversation-shader-ready]')).not.toBeNull()
+  })
+
+  it('keeps the static field and skips WebGPU under reduced motion', async () => {
+    setReducedMotion(true)
+    const requestAdapter = setWebGpu({})
+    setIntersectionObserver()
+    const { container } = render(
+      <AmaIntroductionStage>
+        <p>AMA introduction</p>
+      </AmaIntroductionStage>,
+    )
+
+    await flush()
+
+    expect(requestAdapter).not.toHaveBeenCalled()
+    expect(container.querySelector('.ama-conversation-static')).not.toBeNull()
+    expect(container.querySelector('[data-conversation-shader-ready]')).toBeNull()
+  })
+})

--- a/components/ama/ama-introduction-stage.tsx
+++ b/components/ama/ama-introduction-stage.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { useWebGpuCapability } from '~/components/use-webgpu-capability'
+
+const AmaConversationField = dynamic(
+  () =>
+    import('./ama-conversation-field').then(
+      (module) => module.AmaConversationField,
+    ),
+  { ssr: false },
+)
+
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)'
+
+export function AmaIntroductionStage({ children }: { children: React.ReactNode }) {
+  const rootRef = useRef<HTMLDivElement>(null)
+  const [inViewport, setInViewport] = useState(true)
+  const [shaderMounted, setShaderMounted] = useState(false)
+  const [shaderReady, setShaderReady] = useState(false)
+  const {
+    check: checkWebGpu,
+    markUnavailable: markWebGpuUnavailable,
+  } = useWebGpuCapability()
+
+  useEffect(() => {
+    const root = rootRef.current
+    if (!root || typeof IntersectionObserver === 'undefined') return
+
+    const observer = new IntersectionObserver(([entry]) =>
+      setInViewport(Boolean(entry?.isIntersecting)),
+    )
+    observer.observe(root)
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    const preference = window.matchMedia(REDUCED_MOTION_QUERY)
+    let active = true
+
+    const reconcileShaderMount = () => {
+      if (preference.matches || !inViewport) {
+        setShaderMounted(false)
+        setShaderReady(false)
+        return
+      }
+
+      void checkWebGpu().then((available) => {
+        if (active && !preference.matches && inViewport && available) {
+          setShaderMounted(true)
+        }
+      })
+    }
+
+    reconcileShaderMount()
+    preference.addEventListener('change', reconcileShaderMount)
+    return () => {
+      active = false
+      preference.removeEventListener('change', reconcileShaderMount)
+    }
+  }, [checkWebGpu, inViewport])
+
+  const markShaderUnavailable = useCallback(() => {
+    markWebGpuUnavailable()
+    setShaderMounted(false)
+    setShaderReady(false)
+  }, [markWebGpuUnavailable])
+
+  const markShaderReady = useCallback(() => setShaderReady(true), [])
+
+  return (
+    <div
+      ref={rootRef}
+      className="ama-introduction-stage"
+      data-ama-introduction-stage
+      data-in-viewport={inViewport ? 'true' : 'false'}
+      data-shader-ready={shaderReady ? 'true' : 'false'}
+    >
+      <span className="ama-conversation-static" aria-hidden>
+        <svg viewBox="0 0 600 240" preserveAspectRatio="none">
+          <path d="M0 102C100 24 200 180 300 102S500 180 600 102" />
+          <path d="M0 138C100 216 200 60 300 138S500 60 600 138" />
+        </svg>
+      </span>
+      {shaderMounted ? (
+        <span className="ama-conversation-shader-layer" aria-hidden>
+          <AmaConversationField
+            onUnavailable={markShaderUnavailable}
+            onReady={markShaderReady}
+          />
+        </span>
+      ) : null}
+      <div className="ama-introduction-content">{children}</div>
+    </div>
+  )
+}

--- a/components/ama/booking-confirmation.test.tsx
+++ b/components/ama/booking-confirmation.test.tsx
@@ -45,6 +45,14 @@ beforeEach(() => {
   search = `hold=${HOLD_ID}`
   vi.useFakeTimers()
   vi.stubGlobal('fetch', fetchMock)
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  )
 })
 
 afterEach(() => {
@@ -68,6 +76,8 @@ describe('BookingConfirmation', () => {
     expect(screen.getByText(/付款已确认/)).toBeTruthy()
     expect(screen.getByText(/Manage Link/)).toBeTruthy()
     expect(vi.mocked(trackFunnelEvent)).toHaveBeenCalledExactlyOnceWith('ama_booking_paid')
+    expect(document.querySelector('[data-ama-success-stage]')).not.toBeNull()
+    expect(document.querySelectorAll('[data-ama-confetti-piece]').length).toBeGreaterThan(0)
 
     const callsAfterSettle = fetchMock.mock.calls.length
     await act(async () => {
@@ -93,6 +103,7 @@ describe('BookingConfirmation', () => {
 
     expect(screen.getByText(/Payment confirmed/)).toBeTruthy()
     expect(screen.getByText(/being finalized/)).toBeTruthy()
+    expect(document.querySelector('[data-ama-success-stage]')).not.toBeNull()
   })
 
   it('tells the truth when payment landed but the time was taken', async () => {
@@ -105,6 +116,8 @@ describe('BookingConfirmation', () => {
 
     expect(screen.getByText(/that time was taken while you paid/)).toBeTruthy()
     expect(screen.getByText(/Manage Link/)).toBeTruthy()
+    expect(document.querySelector('[data-ama-success-stage]')).toBeNull()
+    expect(document.querySelector('[data-ama-confetti-piece]')).toBeNull()
   })
 
   it('offers a way back when the hold expired unpaid', async () => {

--- a/components/ama/booking-confirmation.tsx
+++ b/components/ama/booking-confirmation.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import { useEffect, useRef, useState } from 'react'
 
+import { BookingSuccessStage } from '~/components/ama/booking-success-stage'
 import { trackFunnelEvent } from '~/lib/analytics'
 import { T } from '~/lib/i18n'
 import { localize, useLocale } from '~/lib/locale-client'
@@ -219,25 +220,27 @@ export function BookingConfirmation() {
   }
 
   return (
-    <div role="status" className="flex flex-col gap-3">
-      <p className="text-sm font-medium">
-        <T zh="付款已确认。" en="Payment confirmed." />
-      </p>
-      {state.bookingStatus === 'finalizing' ? (
-        <p className="text-sm leading-6 text-muted-foreground">
-          <T
-            zh="会议细节正在生成，确认邮件很快就到。日历邀请、会议链接和管理链接都会发到你的邮箱。"
-            en="Your meeting details are being finalized; the confirmation email is on its way. The calendar invite, meeting link, and your Manage Link all arrive by email."
-          />
+    <BookingSuccessStage>
+      <div role="status" className="flex flex-col gap-3">
+        <p className="text-sm font-medium">
+          <T zh="付款已确认。" en="Payment confirmed." />
         </p>
-      ) : (
-        <p className="text-sm leading-6 text-muted-foreground">
-          <T
-            zh="确认邮件已经出发，里面有日历邀请、会议链接和专属管理链接。到时见。"
-            en="A confirmation email is on its way with the calendar invite, meeting link, and your private Manage Link. See you then."
-          />
-        </p>
-      )}
-    </div>
+        {state.bookingStatus === 'finalizing' ? (
+          <p className="text-sm leading-6 text-muted-foreground">
+            <T
+              zh="会议细节正在生成，确认邮件很快就到。日历邀请、会议链接和管理链接都会发到你的邮箱。"
+              en="Your meeting details are being finalized; the confirmation email is on its way. The calendar invite, meeting link, and your Manage Link all arrive by email."
+            />
+          </p>
+        ) : (
+          <p className="text-sm leading-6 text-muted-foreground">
+            <T
+              zh="确认邮件已经出发，里面有日历邀请、会议链接和专属管理链接。到时见。"
+              en="A confirmation email is on its way with the calendar invite, meeting link, and your private Manage Link. See you then."
+            />
+          </p>
+        )}
+      </div>
+    </BookingSuccessStage>
   )
 }

--- a/components/ama/booking-success-stage.test.tsx
+++ b/components/ama/booking-success-stage.test.tsx
@@ -111,7 +111,32 @@ describe('BookingSuccessStage', () => {
 
     expect(container.querySelector('[data-success-shader-ready]')).toBeNull()
     expect(container.querySelector('.ama-success-static-background')).not.toBeNull()
-    expect(container.querySelectorAll('[data-ama-confetti-piece]').length).toBe(17)
+    expect(container.querySelectorAll('[data-ama-confetti-piece]').length).toBe(24)
+    expect(
+      container.querySelectorAll('[data-ama-confetti-origin="left"]').length,
+    ).toBe(12)
+    expect(
+      container.querySelectorAll('[data-ama-confetti-origin="right"]').length,
+    ).toBe(12)
+
+    const leftBurst = container.querySelector<HTMLElement>(
+      '[data-ama-confetti-origin="left"]',
+    )
+    const rightBurst = container.querySelector<HTMLElement>(
+      '[data-ama-confetti-origin="right"]',
+    )
+    expect(
+      leftBurst?.style.getPropertyValue('--ama-confetti-origin-x'),
+    ).toContain('safe-area-inset-left')
+    expect(leftBurst?.style.getPropertyValue('--ama-confetti-apex-x')).toBe(
+      '30vw',
+    )
+    expect(
+      rightBurst?.style.getPropertyValue('--ama-confetti-origin-x'),
+    ).toContain('safe-area-inset-right')
+    expect(rightBurst?.style.getPropertyValue('--ama-confetti-apex-x')).toBe(
+      '70vw',
+    )
   })
 
   it('does not mount a pending shader after reduced motion is enabled', async () => {

--- a/components/ama/booking-success-stage.test.tsx
+++ b/components/ama/booking-success-stage.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { BookingSuccessStage } from './booking-success-stage'
+
+vi.mock('next/dynamic', () => ({
+  default: () =>
+    function ShaderFieldBoundary({
+      onReady,
+    }: {
+      onUnavailable: () => void
+      onReady: () => void
+    }) {
+      return (
+        <button type="button" data-success-shader-ready onClick={onReady}>
+          Mark shader ready
+        </button>
+      )
+    },
+}))
+
+function setReducedMotion(initial = false) {
+  let reduced = initial
+  const listeners = new Set<() => void>()
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({
+      get matches() {
+        return reduced
+      },
+      addEventListener: vi.fn((_type: string, listener: () => void) => {
+        listeners.add(listener)
+      }),
+      removeEventListener: vi.fn((_type: string, listener: () => void) => {
+        listeners.delete(listener)
+      }),
+    })),
+  )
+  return {
+    set(value: boolean) {
+      reduced = value
+      listeners.forEach((listener) => listener())
+    },
+  }
+}
+
+function setWebGpu(adapter: unknown | null) {
+  const requestAdapter = vi.fn().mockResolvedValue(adapter)
+  Object.defineProperty(navigator, 'gpu', {
+    configurable: true,
+    value: { requestAdapter },
+  })
+  return requestAdapter
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  Reflect.deleteProperty(navigator, 'gpu')
+})
+
+describe('BookingSuccessStage', () => {
+  it('mounts one shader after WebGPU preflight and removes it for reduced motion', async () => {
+    const motion = setReducedMotion()
+    const requestAdapter = setWebGpu({})
+    const { container } = render(
+      <BookingSuccessStage>
+        <p>Confirmed</p>
+      </BookingSuccessStage>,
+    )
+
+    await flush()
+
+    expect(requestAdapter).toHaveBeenCalledOnce()
+    expect(container.querySelectorAll('[data-success-shader-ready]').length).toBe(1)
+    fireEvent.click(container.querySelector('[data-success-shader-ready]')!)
+    expect(
+      container.querySelector('[data-ama-success-stage]')?.getAttribute(
+        'data-shader-ready',
+      ),
+    ).toBe('true')
+
+    act(() => motion.set(true))
+    expect(container.querySelector('[data-success-shader-ready]')).toBeNull()
+    expect(
+      container.querySelector('[data-ama-success-stage]')?.getAttribute(
+        'data-shader-ready',
+      ),
+    ).toBe('false')
+  })
+
+  it('keeps the static plate when WebGPU is unavailable', async () => {
+    setReducedMotion()
+    setWebGpu(null)
+    const { container } = render(
+      <BookingSuccessStage>
+        <p>Confirmed</p>
+      </BookingSuccessStage>,
+    )
+
+    await flush()
+
+    expect(container.querySelector('[data-success-shader-ready]')).toBeNull()
+    expect(container.querySelector('.ama-success-static-background')).not.toBeNull()
+    expect(container.querySelectorAll('[data-ama-confetti-piece]').length).toBe(17)
+  })
+
+  it('does not mount a pending shader after reduced motion is enabled', async () => {
+    const motion = setReducedMotion()
+    let resolveAdapter: (adapter: unknown) => void = () => undefined
+    const requestAdapter = vi.fn(
+      () =>
+        new Promise<unknown>((resolve) => {
+          resolveAdapter = resolve
+        }),
+    )
+    Object.defineProperty(navigator, 'gpu', {
+      configurable: true,
+      value: { requestAdapter },
+    })
+    const { container } = render(
+      <BookingSuccessStage>
+        <p>Confirmed</p>
+      </BookingSuccessStage>,
+    )
+
+    expect(requestAdapter).toHaveBeenCalledOnce()
+    act(() => motion.set(true))
+    await act(async () => resolveAdapter({}))
+    await flush()
+
+    expect(container.querySelector('[data-success-shader-ready]')).toBeNull()
+  })
+})

--- a/components/ama/booking-success-stage.tsx
+++ b/components/ama/booking-success-stage.tsx
@@ -1,0 +1,261 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import { type CSSProperties, useCallback, useEffect, useState } from 'react'
+
+import { useWebGpuCapability } from '~/components/use-webgpu-capability'
+
+const UndertonesEightField = dynamic(
+  () =>
+    import('./undertones-eight-field').then(
+      (module) => module.UndertonesEightField,
+    ),
+  { ssr: false },
+)
+
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)'
+
+type ConfettiStyle = CSSProperties & {
+  '--ama-confetti-color': string
+  '--ama-confetti-delay': string
+  '--ama-confetti-drift': string
+  '--ama-confetti-duration': string
+  '--ama-confetti-left': string
+  '--ama-confetti-rotation': string
+}
+
+type ConfettiPiece = {
+  left: string
+  drift: string
+  delay: string
+  duration: string
+  rotation: string
+  color: string
+}
+
+const CONFETTI = [
+  {
+    left: '4%',
+    drift: '-18px',
+    delay: '0ms',
+    duration: '2100ms',
+    rotation: '520deg',
+    color: '#d9ef62',
+  },
+  {
+    left: '9%',
+    drift: '26px',
+    delay: '90ms',
+    duration: '1950ms',
+    rotation: '-430deg',
+    color: '#ff6a82',
+  },
+  {
+    left: '14%',
+    drift: '-34px',
+    delay: '230ms',
+    duration: '2250ms',
+    rotation: '610deg',
+    color: '#68b7ff',
+  },
+  {
+    left: '19%',
+    drift: '42px',
+    delay: '40ms',
+    duration: '2050ms',
+    rotation: '-510deg',
+    color: '#a50ff2',
+  },
+  {
+    left: '25%',
+    drift: '-22px',
+    delay: '310ms',
+    duration: '1900ms',
+    rotation: '470deg',
+    color: '#f1eee5',
+  },
+  {
+    left: '31%',
+    drift: '48px',
+    delay: '160ms',
+    duration: '2200ms',
+    rotation: '-620deg',
+    color: '#d9ef62',
+  },
+  {
+    left: '37%',
+    drift: '-40px',
+    delay: '20ms',
+    duration: '2000ms',
+    rotation: '560deg',
+    color: '#ff6a82',
+  },
+  {
+    left: '43%',
+    drift: '20px',
+    delay: '260ms',
+    duration: '2300ms',
+    rotation: '-460deg',
+    color: '#68b7ff',
+  },
+  {
+    left: '49%',
+    drift: '-46px',
+    delay: '120ms',
+    duration: '2100ms',
+    rotation: '640deg',
+    color: '#a50ff2',
+  },
+  {
+    left: '55%',
+    drift: '32px',
+    delay: '350ms',
+    duration: '1950ms',
+    rotation: '-540deg',
+    color: '#f1eee5',
+  },
+  {
+    left: '61%',
+    drift: '-28px',
+    delay: '70ms',
+    duration: '2250ms',
+    rotation: '490deg',
+    color: '#d9ef62',
+  },
+  {
+    left: '67%',
+    drift: '44px',
+    delay: '210ms',
+    duration: '2050ms',
+    rotation: '-600deg',
+    color: '#ff6a82',
+  },
+  {
+    left: '73%',
+    drift: '-38px',
+    delay: '10ms',
+    duration: '2150ms',
+    rotation: '580deg',
+    color: '#68b7ff',
+  },
+  {
+    left: '79%',
+    drift: '24px',
+    delay: '290ms',
+    duration: '1900ms',
+    rotation: '-450deg',
+    color: '#a50ff2',
+  },
+  {
+    left: '85%',
+    drift: '-48px',
+    delay: '140ms',
+    duration: '2200ms',
+    rotation: '630deg',
+    color: '#f1eee5',
+  },
+  {
+    left: '91%',
+    drift: '30px',
+    delay: '330ms',
+    duration: '2000ms',
+    rotation: '-520deg',
+    color: '#d9ef62',
+  },
+  {
+    left: '96%',
+    drift: '-20px',
+    delay: '180ms',
+    duration: '2280ms',
+    rotation: '550deg',
+    color: '#ff6a82',
+  },
+] as const satisfies readonly ConfettiPiece[]
+
+export function BookingSuccessStage({ children }: { children: React.ReactNode }) {
+  const [shaderMounted, setShaderMounted] = useState(false)
+  const [shaderReady, setShaderReady] = useState(false)
+  const {
+    check: checkWebGpu,
+    markUnavailable: markWebGpuUnavailable,
+  } = useWebGpuCapability()
+
+  useEffect(() => {
+    const preference = window.matchMedia(REDUCED_MOTION_QUERY)
+    let active = true
+
+    const update = () => {
+      if (preference.matches) {
+        setShaderMounted(false)
+        setShaderReady(false)
+        return
+      }
+
+      void checkWebGpu().then((available) => {
+        if (active && !preference.matches && available) {
+          setShaderMounted(true)
+        }
+      })
+    }
+
+    update()
+    preference.addEventListener('change', update)
+    return () => {
+      active = false
+      preference.removeEventListener('change', update)
+    }
+  }, [checkWebGpu])
+
+  const markShaderUnavailable = useCallback(() => {
+    markWebGpuUnavailable()
+    setShaderMounted(false)
+    setShaderReady(false)
+  }, [markWebGpuUnavailable])
+
+  const markShaderReady = useCallback(() => setShaderReady(true), [])
+
+  return (
+    <section
+      className="ama-success-stage"
+      data-ama-success-stage
+      data-shader-ready={shaderReady ? 'true' : 'false'}
+    >
+      <span className="ama-success-static-background" aria-hidden />
+      {shaderMounted ? (
+        <span className="ama-success-shader-layer" aria-hidden>
+          <UndertonesEightField
+            onUnavailable={markShaderUnavailable}
+            onReady={markShaderReady}
+          />
+        </span>
+      ) : null}
+      <span className="ama-success-confetti" aria-hidden>
+        {CONFETTI.map(
+          ({ left, drift, delay, duration, rotation, color }) => (
+            <span
+              key={`${left}-${delay}`}
+              className="ama-success-confetti-piece"
+              data-ama-confetti-piece
+              style={
+                {
+                  '--ama-confetti-color': color,
+                  '--ama-confetti-delay': delay,
+                  '--ama-confetti-drift': drift,
+                  '--ama-confetti-duration': duration,
+                  '--ama-confetti-left': left,
+                  '--ama-confetti-rotation': rotation,
+                } as ConfettiStyle
+              }
+            />
+          ),
+        )}
+      </span>
+      <div className="ama-success-stage-content">
+        <span className="ama-success-mark" aria-hidden>
+          ✓
+        </span>
+        {children}
+      </div>
+    </section>
+  )
+}

--- a/components/ama/booking-success-stage.tsx
+++ b/components/ama/booking-success-stage.tsx
@@ -16,161 +16,89 @@ const UndertonesEightField = dynamic(
 const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)'
 
 type ConfettiStyle = CSSProperties & {
+  '--ama-confetti-apex-x': string
+  '--ama-confetti-apex-y': string
   '--ama-confetti-color': string
   '--ama-confetti-delay': string
-  '--ama-confetti-drift': string
   '--ama-confetti-duration': string
-  '--ama-confetti-left': string
+  '--ama-confetti-end-x': string
+  '--ama-confetti-end-y': string
+  '--ama-confetti-mid-rotation': string
+  '--ama-confetti-origin-x': string
+  '--ama-confetti-origin-y': string
   '--ama-confetti-rotation': string
 }
 
 type ConfettiPiece = {
-  left: string
-  drift: string
+  apexX: string
+  apexY: string
+  color: string
   delay: string
   duration: string
+  endX: string
+  endY: string
+  key: string
+  midRotation: string
+  origin: 'left' | 'right'
+  originX: string
+  originY: string
   rotation: string
-  color: string
 }
 
-const CONFETTI = [
-  {
-    left: '4%',
-    drift: '-18px',
-    delay: '0ms',
-    duration: '2100ms',
-    rotation: '520deg',
-    color: '#d9ef62',
+const CONFETTI_COLORS = [
+  '#d9ef62',
+  '#ff6a82',
+  '#68b7ff',
+  '#a50ff2',
+  '#f1eee5',
+] as const
+
+const BURST_PATHS = [
+  { apexX: 30, apexY: 64, endX: 38, endY: 43 },
+  { apexX: 36, apexY: 76, endX: 44, endY: 55 },
+  { apexX: 42, apexY: 58, endX: 51, endY: 35 },
+  { apexX: 46, apexY: 84, endX: 52, endY: 64 },
+  { apexX: 50, apexY: 68, endX: 58, endY: 44 },
+  { apexX: 54, apexY: 79, endX: 61, endY: 58 },
+  { apexX: 58, apexY: 60, endX: 65, endY: 37 },
+  { apexX: 62, apexY: 88, endX: 69, endY: 68 },
+  { apexX: 66, apexY: 72, endX: 73, endY: 50 },
+  { apexX: 70, apexY: 82, endX: 76, endY: 62 },
+  { apexX: 74, apexY: 64, endX: 81, endY: 42 },
+  { apexX: 78, apexY: 76, endX: 85, endY: 54 },
+] as const
+
+const CONFETTI = (['left', 'right'] as const).flatMap(
+  (origin, originIndex): ConfettiPiece[] => {
+    const direction = origin === 'left' ? 1 : -1
+    return BURST_PATHS.map((path, index) => {
+      const rotation = direction * (440 + ((index * 47) % 250))
+
+      return {
+        apexX: `${origin === 'left' ? path.apexX : 100 - path.apexX}vw`,
+        apexY: `${100 - path.apexY}dvh`,
+        color:
+          CONFETTI_COLORS[
+            (index + originIndex * 2) % CONFETTI_COLORS.length
+          ]!,
+        delay: `${(index * 53 + originIndex * 29) % 260}ms`,
+        duration: `${2200 + ((index * 73 + originIndex * 41) % 520)}ms`,
+        endX: `${origin === 'left' ? path.endX : 100 - path.endX}vw`,
+        endY: `${100 - path.endY}dvh`,
+        key: `${origin}-${index}`,
+        midRotation: `${Math.round(rotation * 0.58)}deg`,
+        origin,
+        originX:
+          origin === 'left'
+            ? 'calc(env(safe-area-inset-left) - 1rem)'
+            : 'calc(100vw - env(safe-area-inset-right) + 1rem)',
+        originY:
+          'calc(100dvh - env(safe-area-inset-bottom) + 1rem)',
+        rotation: `${rotation}deg`,
+      }
+    })
   },
-  {
-    left: '9%',
-    drift: '26px',
-    delay: '90ms',
-    duration: '1950ms',
-    rotation: '-430deg',
-    color: '#ff6a82',
-  },
-  {
-    left: '14%',
-    drift: '-34px',
-    delay: '230ms',
-    duration: '2250ms',
-    rotation: '610deg',
-    color: '#68b7ff',
-  },
-  {
-    left: '19%',
-    drift: '42px',
-    delay: '40ms',
-    duration: '2050ms',
-    rotation: '-510deg',
-    color: '#a50ff2',
-  },
-  {
-    left: '25%',
-    drift: '-22px',
-    delay: '310ms',
-    duration: '1900ms',
-    rotation: '470deg',
-    color: '#f1eee5',
-  },
-  {
-    left: '31%',
-    drift: '48px',
-    delay: '160ms',
-    duration: '2200ms',
-    rotation: '-620deg',
-    color: '#d9ef62',
-  },
-  {
-    left: '37%',
-    drift: '-40px',
-    delay: '20ms',
-    duration: '2000ms',
-    rotation: '560deg',
-    color: '#ff6a82',
-  },
-  {
-    left: '43%',
-    drift: '20px',
-    delay: '260ms',
-    duration: '2300ms',
-    rotation: '-460deg',
-    color: '#68b7ff',
-  },
-  {
-    left: '49%',
-    drift: '-46px',
-    delay: '120ms',
-    duration: '2100ms',
-    rotation: '640deg',
-    color: '#a50ff2',
-  },
-  {
-    left: '55%',
-    drift: '32px',
-    delay: '350ms',
-    duration: '1950ms',
-    rotation: '-540deg',
-    color: '#f1eee5',
-  },
-  {
-    left: '61%',
-    drift: '-28px',
-    delay: '70ms',
-    duration: '2250ms',
-    rotation: '490deg',
-    color: '#d9ef62',
-  },
-  {
-    left: '67%',
-    drift: '44px',
-    delay: '210ms',
-    duration: '2050ms',
-    rotation: '-600deg',
-    color: '#ff6a82',
-  },
-  {
-    left: '73%',
-    drift: '-38px',
-    delay: '10ms',
-    duration: '2150ms',
-    rotation: '580deg',
-    color: '#68b7ff',
-  },
-  {
-    left: '79%',
-    drift: '24px',
-    delay: '290ms',
-    duration: '1900ms',
-    rotation: '-450deg',
-    color: '#a50ff2',
-  },
-  {
-    left: '85%',
-    drift: '-48px',
-    delay: '140ms',
-    duration: '2200ms',
-    rotation: '630deg',
-    color: '#f1eee5',
-  },
-  {
-    left: '91%',
-    drift: '30px',
-    delay: '330ms',
-    duration: '2000ms',
-    rotation: '-520deg',
-    color: '#d9ef62',
-  },
-  {
-    left: '96%',
-    drift: '-20px',
-    delay: '180ms',
-    duration: '2280ms',
-    rotation: '550deg',
-    color: '#ff6a82',
-  },
-] as const satisfies readonly ConfettiPiece[]
+)
 
 export function BookingSuccessStage({ children }: { children: React.ReactNode }) {
   const [shaderMounted, setShaderMounted] = useState(false)
@@ -231,18 +159,38 @@ export function BookingSuccessStage({ children }: { children: React.ReactNode })
       ) : null}
       <span className="ama-success-confetti" aria-hidden>
         {CONFETTI.map(
-          ({ left, drift, delay, duration, rotation, color }) => (
+          ({
+            apexX,
+            apexY,
+            color,
+            delay,
+            duration,
+            endX,
+            endY,
+            key,
+            midRotation,
+            origin,
+            originX,
+            originY,
+            rotation,
+          }) => (
             <span
-              key={`${left}-${delay}`}
+              key={key}
               className="ama-success-confetti-piece"
               data-ama-confetti-piece
+              data-ama-confetti-origin={origin}
               style={
                 {
+                  '--ama-confetti-apex-x': apexX,
+                  '--ama-confetti-apex-y': apexY,
                   '--ama-confetti-color': color,
                   '--ama-confetti-delay': delay,
-                  '--ama-confetti-drift': drift,
                   '--ama-confetti-duration': duration,
-                  '--ama-confetti-left': left,
+                  '--ama-confetti-end-x': endX,
+                  '--ama-confetti-end-y': endY,
+                  '--ama-confetti-mid-rotation': midRotation,
+                  '--ama-confetti-origin-x': originX,
+                  '--ama-confetti-origin-y': originY,
                   '--ama-confetti-rotation': rotation,
                 } as ConfettiStyle
               }

--- a/components/ama/undertones-eight-field.tsx
+++ b/components/ama/undertones-eight-field.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import {
+  ChromaFlow,
+  FilmGrain,
+  FlutedGlass,
+  Shader,
+  Swirl,
+} from 'shaders/react'
+
+import { useHiddenShaderField } from '~/components/use-hidden-shader-field'
+
+export function UndertonesEightField({
+  onUnavailable,
+  onReady,
+}: {
+  onUnavailable: () => void
+  onReady: () => void
+}) {
+  const { handleReady, ready } = useHiddenShaderField(
+    onUnavailable,
+    onReady,
+  )
+
+  return (
+    <span
+      className="ama-success-shader-shell"
+      data-ready={ready ? 'true' : 'false'}
+    >
+      <Shader
+        className="ama-success-shader-canvas"
+        disableTelemetry
+        onReady={handleReady}
+      >
+        <Swirl colorA="#000000" colorB="#0a0a0a" detail={1.7} />
+        <ChromaFlow
+          baseColor="#18181a"
+          downColor="#0c096e"
+          leftColor="#7618db"
+          momentum={13}
+          rightColor="#301252"
+          upColor="#a50ff2"
+        />
+        <FlutedGlass
+          aberration={0.61}
+          angle={284}
+          frequency={8}
+          highlight={0.12}
+          highlightSoftness={0}
+          lightAngle={-90}
+          refraction={4}
+          shape="rounded"
+          softness={1}
+          speed={0.15}
+        />
+        <FilmGrain strength={0.05} />
+      </Shader>
+    </span>
+  )
+}

--- a/components/hidden-list-stage.test.tsx
+++ b/components/hidden-list-stage.test.tsx
@@ -1,0 +1,420 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ProjectsBlueprintStage, WritingInkStage } from './hidden-list-stage'
+
+vi.mock('next/dynamic', () => ({
+  default: () =>
+    function ShaderFieldBoundary({
+      onUnavailable,
+      onReady,
+    }: {
+      onUnavailable: () => void
+      onReady: () => void
+    }) {
+      return (
+        <span data-shader-boundary>
+          <button type="button" data-shader-ready onClick={onReady}>
+            Mark ready
+          </button>
+          <button type="button" data-shader-unavailable onClick={onUnavailable}>
+            Mark unavailable
+          </button>
+        </span>
+      )
+    },
+}))
+
+function setMediaPreferences({
+  finePointer = true,
+  reducedMotion = false,
+}: {
+  finePointer?: boolean
+  reducedMotion?: boolean
+} = {}) {
+  let reduce = reducedMotion
+  const reducedMotionListeners = new Set<() => void>()
+
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((query: string) => ({
+      get matches() {
+        if (query === '(prefers-reduced-motion: reduce)') return reduce
+        if (query === '(hover: hover) and (pointer: fine)') return finePointer
+        return false
+      },
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn((_type: string, listener: () => void) => {
+        if (query === '(prefers-reduced-motion: reduce)') {
+          reducedMotionListeners.add(listener)
+        }
+      }),
+      removeEventListener: vi.fn((_type: string, listener: () => void) => {
+        reducedMotionListeners.delete(listener)
+      }),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  )
+
+  return {
+    setReducedMotion(value: boolean) {
+      reduce = value
+      reducedMotionListeners.forEach((listener) => listener())
+    },
+  }
+}
+
+function enableWebGpu(adapter: unknown | null = {}) {
+  const requestAdapter = vi.fn().mockResolvedValue(adapter)
+  Object.defineProperty(navigator, 'gpu', {
+    configurable: true,
+    value: { requestAdapter },
+  })
+  return requestAdapter
+}
+
+function ProjectRows({ onFirstClick }: { onFirstClick?: () => void } = {}) {
+  return (
+    <div>
+      <a
+        href="/one"
+        data-list-stage-row
+        data-list-stage-id="one"
+        onClick={(event) => {
+          event.preventDefault()
+          onFirstClick?.()
+        }}
+      >
+        <span data-list-stage-anchor>One</span>
+      </a>
+      <a href="/two" data-list-stage-row data-list-stage-id="two">
+        <span data-list-stage-anchor>Two</span>
+      </a>
+    </div>
+  )
+}
+
+function WritingRows() {
+  return (
+    <div>
+      <a href="/post-one" data-list-stage-row data-list-stage-id="post-one">
+        Post one
+        <span data-list-stage-target>Leader one</span>
+      </a>
+      <a href="/post-two" data-list-stage-row data-list-stage-id="post-two">
+        Post two
+        <span data-list-stage-target>Leader two</span>
+      </a>
+    </div>
+  )
+}
+
+async function finishIntent() {
+  await act(async () => {
+    vi.advanceTimersByTime(120)
+    await Promise.resolve()
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  Reflect.deleteProperty(navigator, 'gpu')
+})
+
+describe('hidden list shader stages', () => {
+  it('waits for initial pointer intent and unmounts after the Projects exit', async () => {
+    vi.useFakeTimers()
+    setMediaPreferences()
+    enableWebGpu()
+
+    render(
+      <ProjectsBlueprintStage>
+        <ProjectRows />
+      </ProjectsBlueprintStage>,
+    )
+
+    const stage = document.querySelector<HTMLElement>(
+      '[data-list-stage="projects"]',
+    )!
+    const first = screen.getByRole('link', { name: 'One' })
+    fireEvent.pointerOver(first, { pointerType: 'mouse' })
+
+    act(() => vi.advanceTimersByTime(119))
+    expect(stage.dataset.active).toBe('false')
+    expect(document.querySelector('[data-list-shader-stage]')).toBeNull()
+
+    await finishIntent()
+    expect(stage.dataset.activeId).toBe('one')
+    expect(stage.dataset.motion).toBe('true')
+    expect(document.querySelector('[data-list-shader-stage]')).not.toBeNull()
+    fireEvent.click(document.querySelector('[data-shader-ready]')!)
+    expect(document.querySelector('.projects-blueprint-static')).toBeNull()
+
+    fireEvent.pointerLeave(stage, { pointerType: 'mouse' })
+    fireEvent.blur(first)
+    expect(stage.dataset.active).toBe('false')
+    expect(document.querySelector('[data-list-shader-stage]')).not.toBeNull()
+
+    act(() => vi.advanceTimersByTime(179))
+    expect(document.querySelector('[data-list-shader-stage]')).not.toBeNull()
+    act(() => vi.advanceTimersByTime(1))
+    expect(document.querySelector('[data-list-shader-stage]')).toBeNull()
+  })
+
+  it('retargets immediately without remounting the shared runtime', async () => {
+    vi.useFakeTimers()
+    setMediaPreferences()
+    const requestAdapter = enableWebGpu()
+
+    render(
+      <ProjectsBlueprintStage>
+        <ProjectRows />
+      </ProjectsBlueprintStage>,
+    )
+
+    const stage = document.querySelector<HTMLElement>(
+      '[data-list-stage="projects"]',
+    )!
+    const first = screen.getByRole('link', { name: 'One' })
+    const second = screen.getByRole('link', { name: 'Two' })
+    fireEvent.pointerOver(first, { pointerType: 'mouse' })
+    await finishIntent()
+
+    const runtime = document.querySelector('[data-shader-boundary]')
+    fireEvent.pointerOver(second, {
+      pointerType: 'mouse',
+      relatedTarget: first,
+    })
+
+    expect(stage.dataset.activeId).toBe('two')
+    expect(document.querySelector('[data-shader-boundary]')).toBe(runtime)
+    expect(requestAdapter).toHaveBeenCalledOnce()
+  })
+
+  it('keeps one Writing runtime across rows and uses its faster exit', async () => {
+    vi.useFakeTimers()
+    setMediaPreferences()
+    enableWebGpu()
+
+    render(
+      <WritingInkStage>
+        <WritingRows />
+      </WritingInkStage>,
+    )
+
+    const stage = document.querySelector<HTMLElement>(
+      '[data-list-stage="writing"]',
+    )!
+    const first = screen.getByRole('link', { name: /Post one/ })
+    const second = screen.getByRole('link', { name: /Post two/ })
+    fireEvent.pointerOver(first, { pointerType: 'mouse' })
+    await finishIntent()
+
+    const runtime = document.querySelector('[data-shader-boundary]')
+    fireEvent.click(document.querySelector('[data-shader-ready]')!)
+    expect(document.querySelector('.writing-ink-static')).toBeNull()
+    fireEvent.pointerOver(second, {
+      pointerType: 'mouse',
+      relatedTarget: first,
+    })
+
+    expect(stage.dataset.activeId).toBe('post-two')
+    expect(document.querySelector('[data-shader-boundary]')).toBe(runtime)
+
+    fireEvent.pointerLeave(stage, { pointerType: 'mouse' })
+    act(() => vi.advanceTimersByTime(119))
+    expect(document.querySelector('[data-list-shader-stage]')).not.toBeNull()
+    act(() => vi.advanceTimersByTime(1))
+    expect(document.querySelector('[data-list-shader-stage]')).toBeNull()
+  })
+
+  it('uses an immediate static treatment for keyboard focus', () => {
+    setMediaPreferences()
+    const requestAdapter = enableWebGpu()
+
+    render(
+      <ProjectsBlueprintStage>
+        <ProjectRows />
+      </ProjectsBlueprintStage>,
+    )
+
+    const stage = document.querySelector<HTMLElement>(
+      '[data-list-stage="projects"]',
+    )!
+    fireEvent.focus(screen.getByRole('link', { name: 'One' }))
+
+    expect(stage.dataset.activeId).toBe('one')
+    expect(stage.dataset.motion).toBe('false')
+    expect(document.querySelector('.projects-blueprint-static')).not.toBeNull()
+    expect(document.querySelector('[data-list-shader-stage]')).toBeNull()
+    expect(requestAdapter).not.toHaveBeenCalled()
+  })
+
+  it('does not intercept a touch link or reveal a preview', () => {
+    setMediaPreferences({ finePointer: false })
+    const requestAdapter = enableWebGpu()
+    const onFirstClick = vi.fn()
+
+    render(
+      <ProjectsBlueprintStage>
+        <ProjectRows onFirstClick={onFirstClick} />
+      </ProjectsBlueprintStage>,
+    )
+
+    const stage = document.querySelector<HTMLElement>(
+      '[data-list-stage="projects"]',
+    )!
+    const first = screen.getByRole('link', { name: 'One' })
+    fireEvent.pointerDown(first, { pointerType: 'touch' })
+    fireEvent.focus(first)
+    fireEvent.pointerOver(first, { pointerType: 'touch' })
+    fireEvent.click(first)
+
+    expect(onFirstClick).toHaveBeenCalledOnce()
+    expect(stage.dataset.active).toBe('false')
+    expect(document.querySelector('.hidden-list-stage-field')).toBeNull()
+    expect(requestAdapter).not.toHaveBeenCalled()
+  })
+
+  it('keeps reduced-motion pointer attention static', async () => {
+    vi.useFakeTimers()
+    setMediaPreferences({ reducedMotion: true })
+    const requestAdapter = enableWebGpu()
+
+    render(
+      <ProjectsBlueprintStage>
+        <ProjectRows />
+      </ProjectsBlueprintStage>,
+    )
+
+    const stage = document.querySelector<HTMLElement>(
+      '[data-list-stage="projects"]',
+    )!
+    fireEvent.pointerOver(screen.getByRole('link', { name: 'One' }), {
+      pointerType: 'mouse',
+    })
+    await finishIntent()
+
+    expect(stage.dataset.activeId).toBe('one')
+    expect(stage.dataset.motion).toBe('false')
+    expect(document.querySelector('[data-list-shader-stage]')).toBeNull()
+    expect(requestAdapter).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the static plate when WebGPU has no adapter', async () => {
+    vi.useFakeTimers()
+    setMediaPreferences()
+    const requestAdapter = enableWebGpu(null)
+
+    render(
+      <ProjectsBlueprintStage>
+        <ProjectRows />
+      </ProjectsBlueprintStage>,
+    )
+
+    const stage = document.querySelector<HTMLElement>(
+      '[data-list-stage="projects"]',
+    )!
+    fireEvent.pointerOver(screen.getByRole('link', { name: 'One' }), {
+      pointerType: 'mouse',
+    })
+    await finishIntent()
+
+    expect(stage.dataset.activeId).toBe('one')
+    expect(stage.dataset.motion).toBe('false')
+    expect(document.querySelector('.projects-blueprint-static')).not.toBeNull()
+    expect(document.querySelector('[data-list-shader-stage]')).toBeNull()
+    expect(requestAdapter).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the active row static after shader initialization fails', async () => {
+    vi.useFakeTimers()
+    setMediaPreferences()
+    enableWebGpu()
+
+    render(
+      <ProjectsBlueprintStage>
+        <ProjectRows />
+      </ProjectsBlueprintStage>,
+    )
+
+    const stage = document.querySelector<HTMLElement>(
+      '[data-list-stage="projects"]',
+    )!
+    fireEvent.pointerOver(screen.getByRole('link', { name: 'One' }), {
+      pointerType: 'mouse',
+    })
+    await finishIntent()
+    fireEvent.click(document.querySelector('[data-shader-unavailable]')!)
+
+    expect(stage.dataset.activeId).toBe('one')
+    expect(stage.dataset.motion).toBe('false')
+    expect(document.querySelector('.projects-blueprint-static')).not.toBeNull()
+    expect(document.querySelector('[data-list-shader-stage]')).toBeNull()
+  })
+
+  it('positions the Writing treatment on the active dotted-leader lane', () => {
+    setMediaPreferences()
+    enableWebGpu()
+
+    render(
+      <WritingInkStage>
+        <a href="/post" data-list-stage-row data-list-stage-id="post">
+          Post
+          <span data-list-stage-target>Leader</span>
+        </a>
+      </WritingInkStage>,
+    )
+
+    const stage = document.querySelector<HTMLElement>(
+      '[data-list-stage="writing"]',
+    )!
+    const target = document.querySelector<HTMLElement>(
+      '[data-list-stage-target]',
+    )!
+    vi.spyOn(stage, 'getBoundingClientRect').mockReturnValue({
+      x: 10,
+      y: 20,
+      left: 10,
+      top: 20,
+      right: 410,
+      bottom: 220,
+      width: 400,
+      height: 200,
+      toJSON: () => ({}),
+    })
+    vi.spyOn(target, 'getBoundingClientRect').mockReturnValue({
+      x: 110,
+      y: 70,
+      left: 110,
+      top: 70,
+      right: 290,
+      bottom: 71,
+      width: 180,
+      height: 1,
+      toJSON: () => ({}),
+    })
+
+    fireEvent.focus(screen.getByRole('link', { name: /Post/ }))
+
+    expect(stage.dataset.activeId).toBe('post')
+    expect(stage.dataset.motion).toBe('false')
+    expect(stage.style.getPropertyValue('--list-stage-target-x')).toBe('100px')
+    expect(stage.style.getPropertyValue('--list-stage-target-y')).toBe('44.5px')
+    expect(stage.style.getPropertyValue('--list-stage-target-width')).toBe(
+      '180px',
+    )
+    expect(stage.style.getPropertyValue('--list-stage-target-height')).toBe(
+      '12px',
+    )
+    expect(document.querySelector('.writing-ink-static')).not.toBeNull()
+    expect(document.querySelector('[data-list-shader-stage]')).toBeNull()
+  })
+})

--- a/components/hidden-list-stage.test.tsx
+++ b/components/hidden-list-stage.test.tsx
@@ -129,6 +129,28 @@ afterEach(() => {
 })
 
 describe('hidden list shader stages', () => {
+  it('reuses the fine-pointer media query across pointer events', () => {
+    setMediaPreferences()
+
+    render(
+      <ProjectsBlueprintStage>
+        <ProjectRows />
+      </ProjectsBlueprintStage>,
+    )
+
+    const matchMedia = vi.mocked(window.matchMedia)
+    const stage = document.querySelector<HTMLElement>(
+      '[data-list-stage="projects"]',
+    )!
+    const first = screen.getByRole('link', { name: 'One' })
+
+    expect(matchMedia).toHaveBeenCalledTimes(2)
+    fireEvent.pointerOver(first, { pointerType: 'mouse' })
+    fireEvent.pointerOut(first, { pointerType: 'mouse' })
+    fireEvent.pointerLeave(stage, { pointerType: 'mouse' })
+    expect(matchMedia).toHaveBeenCalledTimes(2)
+  })
+
   it('waits for initial pointer intent and unmounts after the Projects exit', async () => {
     vi.useFakeTimers()
     setMediaPreferences()

--- a/components/hidden-list-stage.tsx
+++ b/components/hidden-list-stage.tsx
@@ -1,0 +1,505 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import {
+  type CSSProperties,
+  type FocusEvent,
+  type PointerEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
+
+import { useWebGpuCapability } from '~/components/use-webgpu-capability'
+
+const ProjectsBlueprintField = dynamic(
+  () =>
+    import('./projects-blueprint-field').then(
+      (module) => module.ProjectsBlueprintField,
+    ),
+  { ssr: false },
+)
+
+const WritingInkField = dynamic(
+  () => import('./writing-ink-field').then((module) => module.WritingInkField),
+  { ssr: false },
+)
+
+const ROW_SELECTOR = '[data-list-stage-row]'
+const FINE_POINTER_QUERY = '(hover: hover) and (pointer: fine)'
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)'
+const INITIAL_INTENT_MS = 120
+const WRITING_LANE_HEIGHT = 12
+
+type StageVariant = 'projects' | 'writing'
+
+const STAGE_CONFIG = {
+  projects: {
+    exitMs: 180,
+    initialHeight: 0,
+    targetSelector: '[data-list-stage-anchor]',
+  },
+  writing: {
+    exitMs: 120,
+    initialHeight: WRITING_LANE_HEIGHT,
+    targetSelector: '[data-list-stage-target]',
+  },
+} as const satisfies Record<
+  StageVariant,
+  { exitMs: number; initialHeight: number; targetSelector: string }
+>
+
+type StageGeometry = {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+type StageStyle = CSSProperties & {
+  '--list-stage-target-x': string
+  '--list-stage-target-y': string
+  '--list-stage-target-width': string
+  '--list-stage-target-height': string
+  '--list-stage-exit-ms': string
+}
+
+function rowFromTarget(root: HTMLElement | null, target: EventTarget | null) {
+  if (!root || !(target instanceof Element)) return null
+  const row = target.closest<HTMLElement>(ROW_SELECTOR)
+  return row && root.contains(row) ? row : null
+}
+
+function rowId(row: HTMLElement | null) {
+  return row?.dataset.listStageId ?? null
+}
+
+function stageClassName(variant: StageVariant, className?: string) {
+  return [`hidden-list-stage`, `${variant}-hidden-stage`, className]
+    .filter(Boolean)
+    .join(' ')
+}
+
+function HiddenListStage({
+  children,
+  className,
+  contentClassName,
+  variant,
+}: Readonly<{
+  children: React.ReactNode
+  className?: string
+  contentClassName?: string
+  variant: StageVariant
+}>) {
+  const config = STAGE_CONFIG[variant]
+  const rootRef = useRef<HTMLDivElement>(null)
+  const activeRow = useRef<HTMLElement | null>(null)
+  const hoveredRow = useRef<HTMLElement | null>(null)
+  const keyboardRow = useRef<HTMLElement | null>(null)
+  const pointerIntentReady = useRef(false)
+  const pointerFocusSuppressed = useRef(false)
+  const reducedMotion = useRef(false)
+  const motionActive = useRef(false)
+  const mounted = useRef(true)
+  const intentTimer = useRef<number | undefined>(undefined)
+  const exitTimer = useRef<number | undefined>(undefined)
+  const {
+    check: checkWebGpu,
+    markUnavailable: markWebGpuUnavailable,
+    supported: webGpuSupported,
+  } = useWebGpuCapability()
+
+  const [activeId, setActiveId] = useState<string | null>(null)
+  const [motionEnabled, setMotionEnabled] = useState(false)
+  const [shaderMounted, setShaderMounted] = useState(false)
+  const [shaderReady, setShaderReady] = useState(false)
+  const [geometry, setGeometry] = useState<StageGeometry>({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: config.initialHeight,
+  })
+
+  const clearIntentTimer = useCallback(() => {
+    if (intentTimer.current !== undefined)
+      window.clearTimeout(intentTimer.current)
+    intentTimer.current = undefined
+  }, [])
+
+  const clearExitTimer = useCallback(() => {
+    if (exitTimer.current !== undefined) window.clearTimeout(exitTimer.current)
+    exitTimer.current = undefined
+  }, [])
+
+  const measureRow = useCallback(
+    (row: HTMLElement) => {
+      const root = rootRef.current
+      const target = row.querySelector<HTMLElement>(config.targetSelector)
+      if (!root || !target) return
+
+      const rootRect = root.getBoundingClientRect()
+      const targetRect = target.getBoundingClientRect()
+
+      if (variant === 'projects') {
+        setGeometry({
+          x: targetRect.left - rootRect.left + targetRect.width / 2,
+          y: targetRect.top - rootRect.top + targetRect.height / 2,
+          width: targetRect.width,
+          height: targetRect.height,
+        })
+        return
+      }
+
+      setGeometry({
+        x: targetRect.left - rootRect.left,
+        y:
+          targetRect.top -
+          rootRect.top +
+          targetRect.height / 2 -
+          WRITING_LANE_HEIGHT / 2,
+        width: targetRect.width,
+        height: WRITING_LANE_HEIGHT,
+      })
+    },
+    [config, variant],
+  )
+
+  const setStageRow = useCallback(
+    (row: HTMLElement | null) => {
+      activeRow.current = row
+      setActiveId(rowId(row))
+      if (row) measureRow(row)
+    },
+    [measureRow],
+  )
+
+  const syncStage = useCallback(() => {
+    const pointerRow = pointerIntentReady.current ? hoveredRow.current : null
+    const nextRow = pointerRow ?? keyboardRow.current
+
+    if (!nextRow) {
+      if (exitTimer.current !== undefined && !reducedMotion.current) return
+
+      const shouldFade = motionActive.current && !reducedMotion.current
+      motionActive.current = false
+      setStageRow(null)
+      clearExitTimer()
+
+      if (!shouldFade) {
+        setShaderMounted(false)
+        setShaderReady(false)
+        setMotionEnabled(false)
+        return
+      }
+
+      setMotionEnabled(true)
+      exitTimer.current = window.setTimeout(
+        () => {
+          setShaderMounted(false)
+          setShaderReady(false)
+          setMotionEnabled(false)
+        },
+        config.exitMs,
+      )
+      return
+    }
+
+    clearExitTimer()
+    setStageRow(nextRow)
+
+    const wantsMotion =
+      pointerRow !== null &&
+      !reducedMotion.current &&
+      webGpuSupported.current !== false
+
+    if (!wantsMotion) {
+      motionActive.current = false
+      setShaderMounted(false)
+      setShaderReady(false)
+      setMotionEnabled(false)
+      return
+    }
+
+    if (webGpuSupported.current === null) {
+      motionActive.current = false
+      setShaderMounted(false)
+      setShaderReady(false)
+      setMotionEnabled(false)
+      void checkWebGpu().then(() => {
+        if (mounted.current) syncStage()
+      })
+      return
+    }
+
+    motionActive.current = true
+    setMotionEnabled(true)
+    setShaderMounted(true)
+  }, [checkWebGpu, clearExitTimer, config, setStageRow])
+
+  const markShaderUnavailable = useCallback(() => {
+    markWebGpuUnavailable()
+    motionActive.current = false
+    setShaderMounted(false)
+    setShaderReady(false)
+    setMotionEnabled(false)
+  }, [markWebGpuUnavailable])
+
+  const markShaderReady = useCallback(() => setShaderReady(true), [])
+
+  useEffect(() => {
+    const preference = window.matchMedia(REDUCED_MOTION_QUERY)
+    const updatePreference = () => {
+      reducedMotion.current = preference.matches
+      syncStage()
+    }
+
+    updatePreference()
+    preference.addEventListener('change', updatePreference)
+    return () => preference.removeEventListener('change', updatePreference)
+  }, [syncStage])
+
+  useEffect(() => {
+    const row = activeRow.current
+    const root = rootRef.current
+    if (!activeId || !row || !root) return
+
+    const target = row.querySelector<HTMLElement>(config.targetSelector)
+    const update = () => measureRow(row)
+    update()
+    window.addEventListener('resize', update)
+
+    if (typeof ResizeObserver === 'undefined') {
+      return () => window.removeEventListener('resize', update)
+    }
+
+    const observer = new ResizeObserver(update)
+    observer.observe(root)
+    observer.observe(row)
+    if (target) observer.observe(target)
+
+    return () => {
+      observer.disconnect()
+      window.removeEventListener('resize', update)
+    }
+  }, [activeId, config, measureRow])
+
+  useEffect(() => {
+    mounted.current = true
+    return () => {
+      mounted.current = false
+      clearIntentTimer()
+      clearExitTimer()
+    }
+  }, [clearExitTimer, clearIntentTimer])
+
+  const isFinePointer = (event: PointerEvent<HTMLElement>) =>
+    event.pointerType !== 'touch' &&
+    window.matchMedia(FINE_POINTER_QUERY).matches
+
+  const handlePointerOver = (event: PointerEvent<HTMLDivElement>) => {
+    if (!isFinePointer(event)) return
+    const root = rootRef.current
+    const row = rowFromTarget(root, event.target)
+    if (!row) return
+    if (
+      event.relatedTarget instanceof Node &&
+      row.contains(event.relatedTarget)
+    )
+      return
+
+    hoveredRow.current = row
+    measureRow(row)
+    clearExitTimer()
+
+    if (pointerIntentReady.current) {
+      syncStage()
+      return
+    }
+
+    clearIntentTimer()
+    intentTimer.current = window.setTimeout(() => {
+      pointerIntentReady.current = true
+      syncStage()
+    }, INITIAL_INTENT_MS)
+  }
+
+  const handlePointerOut = (event: PointerEvent<HTMLDivElement>) => {
+    if (!isFinePointer(event) || pointerIntentReady.current) return
+    const root = rootRef.current
+    const row = rowFromTarget(root, event.target)
+    if (
+      !row ||
+      (event.relatedTarget instanceof Node && row.contains(event.relatedTarget))
+    )
+      return
+    if (rowFromTarget(root, event.relatedTarget)) return
+
+    hoveredRow.current = null
+    clearIntentTimer()
+  }
+
+  const handleFocus = (event: FocusEvent<HTMLDivElement>) => {
+    if (pointerFocusSuppressed.current) return
+    const row = rowFromTarget(rootRef.current, event.target)
+    if (!row) return
+    keyboardRow.current = row
+    syncStage()
+  }
+
+  const handleBlur = (event: FocusEvent<HTMLDivElement>) => {
+    const nextRow = rowFromTarget(rootRef.current, event.relatedTarget)
+    keyboardRow.current = pointerFocusSuppressed.current ? null : nextRow
+    syncStage()
+  }
+
+  const geometryStyle: StageStyle = {
+    '--list-stage-target-x': `${geometry.x}px`,
+    '--list-stage-target-y': `${geometry.y}px`,
+    '--list-stage-target-width': `${geometry.width}px`,
+    '--list-stage-target-height': `${geometry.height}px`,
+    '--list-stage-exit-ms': `${config.exitMs}ms`,
+  }
+  const renderVisual = activeId !== null || shaderMounted
+
+  return (
+    <div
+      ref={rootRef}
+      className={stageClassName(variant, className)}
+      data-active={activeId === null ? 'false' : 'true'}
+      data-active-id={activeId ?? undefined}
+      data-motion={motionEnabled ? 'true' : 'false'}
+      data-list-stage={variant}
+      style={geometryStyle}
+      onPointerOver={handlePointerOver}
+      onPointerOut={handlePointerOut}
+      onPointerLeave={(event) => {
+        if (!isFinePointer(event)) return
+        hoveredRow.current = null
+        pointerIntentReady.current = false
+        clearIntentTimer()
+        syncStage()
+      }}
+      onPointerDownCapture={() => {
+        pointerFocusSuppressed.current = true
+      }}
+      onPointerCancelCapture={() => {
+        pointerFocusSuppressed.current = false
+      }}
+      onClickCapture={() => {
+        pointerFocusSuppressed.current = false
+      }}
+      onKeyDownCapture={() => {
+        pointerFocusSuppressed.current = false
+        const row = rowFromTarget(rootRef.current, document.activeElement)
+        if (row) {
+          keyboardRow.current = row
+          syncStage()
+        }
+      }}
+      onFocusCapture={handleFocus}
+      onBlurCapture={handleBlur}
+    >
+      {renderVisual && (
+        <span className="hidden-list-stage-field" aria-hidden>
+          {variant === 'projects' ? (
+            <>
+              {!shaderReady && <span className="projects-blueprint-static" />}
+              {shaderMounted && (
+                <span
+                  className="hidden-list-stage-shader"
+                  data-list-shader-stage
+                >
+                  <ProjectsBlueprintField
+                    onUnavailable={markShaderUnavailable}
+                    onReady={markShaderReady}
+                  />
+                </span>
+              )}
+              <svg
+                className="projects-registration-mark"
+                viewBox="0 0 20 20"
+                fill="none"
+              >
+                <circle cx="10" cy="10" r="7.4" />
+                <path d="M10 0v5M10 15v5M0 10h5M15 10h5" />
+              </svg>
+            </>
+          ) : (
+            <span className="writing-ink-current-target">
+              {!shaderReady && (
+                <svg
+                  className="writing-ink-static"
+                  viewBox="0 0 100 12"
+                  preserveAspectRatio="none"
+                >
+                  <path d="M0 4.1C18 3.3 31 5.1 49 4.2s34-1.2 51-.2" />
+                  <path d="M0 6C19 6.8 34 5.1 52 6s30 1.1 48 0" />
+                  <path d="M0 7.9C17 8.5 35 7 51 7.8s33 .7 49 .1" />
+                </svg>
+              )}
+              {shaderMounted && (
+                <span
+                  className="hidden-list-stage-shader"
+                  data-list-shader-stage
+                >
+                  <WritingInkField
+                    onUnavailable={markShaderUnavailable}
+                    onReady={markShaderReady}
+                  />
+                </span>
+              )}
+            </span>
+          )}
+        </span>
+      )}
+      <div
+        className={['hidden-list-stage-content', contentClassName]
+          .filter(Boolean)
+          .join(' ')}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export function ProjectsBlueprintStage({
+  children,
+  className,
+  contentClassName,
+}: Readonly<{
+  children: React.ReactNode
+  className?: string
+  contentClassName?: string
+}>) {
+  return (
+    <HiddenListStage
+      variant="projects"
+      className={className}
+      contentClassName={contentClassName}
+    >
+      {children}
+    </HiddenListStage>
+  )
+}
+
+export function WritingInkStage({
+  children,
+  className,
+  contentClassName,
+}: Readonly<{
+  children: React.ReactNode
+  className?: string
+  contentClassName?: string
+}>) {
+  return (
+    <HiddenListStage
+      variant="writing"
+      className={className}
+      contentClassName={contentClassName}
+    >
+      {children}
+    </HiddenListStage>
+  )
+}

--- a/components/hidden-list-stage.tsx
+++ b/components/hidden-list-stage.tsx
@@ -99,6 +99,7 @@ function HiddenListStage({
   const keyboardRow = useRef<HTMLElement | null>(null)
   const pointerIntentReady = useRef(false)
   const pointerFocusSuppressed = useRef(false)
+  const finePointer = useRef<MediaQueryList | null>(null)
   const reducedMotion = useRef(false)
   const motionActive = useRef(false)
   const mounted = useRef(true)
@@ -249,6 +250,7 @@ function HiddenListStage({
 
   useEffect(() => {
     const preference = window.matchMedia(REDUCED_MOTION_QUERY)
+    finePointer.current = window.matchMedia(FINE_POINTER_QUERY)
     const updatePreference = () => {
       reducedMotion.current = preference.matches
       syncStage()
@@ -256,7 +258,10 @@ function HiddenListStage({
 
     updatePreference()
     preference.addEventListener('change', updatePreference)
-    return () => preference.removeEventListener('change', updatePreference)
+    return () => {
+      finePointer.current = null
+      preference.removeEventListener('change', updatePreference)
+    }
   }, [syncStage])
 
   useEffect(() => {
@@ -294,8 +299,7 @@ function HiddenListStage({
   }, [clearExitTimer, clearIntentTimer])
 
   const isFinePointer = (event: PointerEvent<HTMLElement>) =>
-    event.pointerType !== 'touch' &&
-    window.matchMedia(FINE_POINTER_QUERY).matches
+    event.pointerType !== 'touch' && finePointer.current?.matches === true
 
   const handlePointerOver = (event: PointerEvent<HTMLDivElement>) => {
     if (!isFinePointer(event)) return

--- a/components/portrait-hidden-stage.tsx
+++ b/components/portrait-hidden-stage.tsx
@@ -3,6 +3,8 @@
 import dynamic from 'next/dynamic'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+import { useWebGpuCapability } from '~/components/use-webgpu-capability'
+
 const PortraitShaderField = dynamic(
   () => import('./portrait-shader-field').then((module) => module.PortraitShaderField),
   { ssr: false },
@@ -10,12 +12,6 @@ const PortraitShaderField = dynamic(
 
 const EXIT_MS = 320
 const TOUCH_REVEAL_MS = 2600
-
-type WebGpuNavigator = Navigator & {
-  gpu?: {
-    requestAdapter: () => Promise<unknown | null>
-  }
-}
 
 export function PortraitHiddenStage({
   children,
@@ -37,8 +33,11 @@ export function PortraitHiddenStage({
   const animatedRef = useRef(false)
   const mounted = useRef(true)
   const reducedMotion = useRef(false)
-  const webGpuSupported = useRef<boolean | null>(null)
-  const webGpuRequest = useRef<Promise<boolean> | null>(null)
+  const {
+    check: checkWebGpu,
+    markUnavailable: markWebGpuUnavailable,
+    supported: webGpuSupported,
+  } = useWebGpuCapability()
 
   const clearExitTimer = useCallback(() => {
     if (exitTimer.current !== undefined) window.clearTimeout(exitTimer.current)
@@ -48,29 +47,6 @@ export function PortraitHiddenStage({
   const clearTouchTimer = useCallback(() => {
     if (touchTimer.current !== undefined) window.clearTimeout(touchTimer.current)
     touchTimer.current = undefined
-  }, [])
-
-  const checkWebGpu = useCallback(() => {
-    if (webGpuSupported.current !== null) {
-      return Promise.resolve(webGpuSupported.current)
-    }
-
-    if (webGpuRequest.current === null) {
-      const gpu = (navigator as WebGpuNavigator).gpu
-      webGpuRequest.current = (async () => {
-        if (!gpu?.requestAdapter) return false
-        try {
-          return Boolean(await gpu.requestAdapter())
-        } catch {
-          return false
-        }
-      })().then((supported) => {
-        webGpuSupported.current = supported
-        return supported
-      })
-    }
-
-    return webGpuRequest.current
   }, [])
 
   const syncStage = useCallback(() => {
@@ -155,11 +131,11 @@ export function PortraitHiddenStage({
   }, [clearTouchTimer, syncStage])
 
   const markShaderUnavailable = useCallback(() => {
-    webGpuSupported.current = false
+    markWebGpuUnavailable()
     animatedRef.current = false
     setShaderMounted(false)
     setMotionEnabled(false)
-  }, [])
+  }, [markWebGpuUnavailable])
 
   useEffect(() => {
     const preference = window.matchMedia('(prefers-reduced-motion: reduce)')

--- a/components/portrait-shader-field.tsx
+++ b/components/portrait-shader-field.tsx
@@ -1,31 +1,11 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
 import { ContourLines, PerlinNoise, Shader } from 'shaders/react'
 
-const SHADER_READY_TIMEOUT_MS = 2000
-
-function readForegroundInk() {
-  return getComputedStyle(document.body).color
-}
+import { useHiddenShaderField } from '~/components/use-hidden-shader-field'
 
 export function PortraitShaderField({ onUnavailable }: { onUnavailable: () => void }) {
-  const [ink, setInk] = useState(readForegroundInk)
-  const [ready, setReady] = useState(false)
-  const handleReady = useCallback(() => setReady(true), [])
-
-  useEffect(() => {
-    const root = document.documentElement
-    const observer = new MutationObserver(() => setInk(readForegroundInk()))
-    observer.observe(root, { attributes: true, attributeFilter: ['class'] })
-    return () => observer.disconnect()
-  }, [])
-
-  useEffect(() => {
-    if (ready) return
-    const timer = window.setTimeout(onUnavailable, SHADER_READY_TIMEOUT_MS)
-    return () => window.clearTimeout(timer)
-  }, [onUnavailable, ready])
+  const { handleReady, ink, ready } = useHiddenShaderField(onUnavailable)
 
   return (
     <span className="portrait-hidden-stage-shader-shell" data-ready={ready ? 'true' : 'false'}>

--- a/components/post-row.tsx
+++ b/components/post-row.tsx
@@ -15,11 +15,13 @@ export function PostRow({
   headingLevel = 'h2',
   dateStyle = 'full',
   locale = 'zh',
+  listStageId,
 }: {
   post: Post
   headingLevel?: 'h2' | 'h3'
   dateStyle?: 'full' | 'month-day' | 'short'
   locale?: Locale
+  listStageId?: string
 }) {
   const Heading = headingLevel
   const safeSlug = encodeURIComponent(post.slug)
@@ -31,6 +33,7 @@ export function PostRow({
       coverTransitionName={coverTransitionName}
       titleTransitionName={titleTransitionName}
       className="group blog-row hairline-top"
+      listStageId={listStageId}
     >
       <span className="print-pile" aria-hidden>
         <span className="print-pile-sheet" />
@@ -53,7 +56,11 @@ export function PostRow({
       >
         <T zh={post.title} en={post.titleEn} />
       </Heading>
-      <span className="blog-row-leader" aria-hidden />
+      <span
+        className="blog-row-leader"
+        aria-hidden
+        data-list-stage-target={listStageId ? '' : undefined}
+      />
       <time
         dateTime={post.publishedAt.toISOString()}
         className="shrink-0 text-muted-foreground tabular-nums"

--- a/components/post-transition-link.tsx
+++ b/components/post-transition-link.tsx
@@ -9,12 +9,14 @@ export function PostTransitionLink({
   titleTransitionName,
   className,
   children,
+  listStageId,
 }: {
   href: string
   coverTransitionName: string
   titleTransitionName: string
   className?: string
   children: ReactNode
+  listStageId?: string
 }) {
   function preparePointerMorph(event: MouseEvent<HTMLAnchorElement>) {
     if (
@@ -46,6 +48,8 @@ export function PostTransitionLink({
       href={href}
       className={className}
       data-post-transition-link
+      data-list-stage-row={listStageId ? '' : undefined}
+      data-list-stage-id={listStageId}
       onClick={preparePointerMorph}
     >
       {children}

--- a/components/projects-blueprint-field.tsx
+++ b/components/projects-blueprint-field.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { FlowField, Grid, Shader } from 'shaders/react'
+
+import { useHiddenShaderField } from '~/components/use-hidden-shader-field'
+
+export function ProjectsBlueprintField({
+  onUnavailable,
+  onReady,
+}: {
+  onUnavailable: () => void
+  onReady: () => void
+}) {
+  const { handleReady, ink, ready } = useHiddenShaderField(
+    onUnavailable,
+    onReady,
+  )
+
+  return (
+    <span
+      className="hidden-list-shader-shell"
+      data-ready={ready ? 'true' : 'false'}
+    >
+      <Shader
+        className="hidden-list-shader-canvas"
+        colorSpace="srgb"
+        disableTelemetry
+        onReady={handleReady}
+      >
+        <FlowField
+          strength={0.035}
+          detail={1.6}
+          speed={0.1}
+          evolutionSpeed={0.06}
+          seed={31}
+          edges="wrap"
+        >
+          <Grid
+            color={ink}
+            cellColor="transparent"
+            cells={22}
+            thickness={0.6}
+            softness={0.08}
+            variation={0}
+            rotation={0}
+            colorSpace="oklab"
+          />
+        </FlowField>
+      </Shader>
+    </span>
+  )
+}

--- a/components/use-hidden-shader-field.ts
+++ b/components/use-hidden-shader-field.ts
@@ -1,0 +1,36 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+const SHADER_READY_TIMEOUT_MS = 2000
+
+function readForegroundInk() {
+  return getComputedStyle(document.body).color
+}
+
+export function useHiddenShaderField(
+  onUnavailable: () => void,
+  onReady?: () => void,
+) {
+  const [ink, setInk] = useState(readForegroundInk)
+  const [ready, setReady] = useState(false)
+  const handleReady = useCallback(() => {
+    setReady(true)
+    onReady?.()
+  }, [onReady])
+
+  useEffect(() => {
+    const root = document.documentElement
+    const observer = new MutationObserver(() => setInk(readForegroundInk()))
+    observer.observe(root, { attributes: true, attributeFilter: ['class'] })
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    if (ready) return
+    const timer = window.setTimeout(onUnavailable, SHADER_READY_TIMEOUT_MS)
+    return () => window.clearTimeout(timer)
+  }, [onUnavailable, ready])
+
+  return { handleReady, ink, ready }
+}

--- a/components/use-webgpu-capability.ts
+++ b/components/use-webgpu-capability.ts
@@ -1,0 +1,41 @@
+'use client'
+
+import { useCallback, useRef } from 'react'
+
+type WebGpuNavigator = Navigator & {
+  gpu?: {
+    requestAdapter: () => Promise<unknown | null>
+  }
+}
+
+export function useWebGpuCapability() {
+  const supported = useRef<boolean | null>(null)
+  const request = useRef<Promise<boolean> | null>(null)
+
+  const check = useCallback(() => {
+    if (supported.current !== null) return Promise.resolve(supported.current)
+
+    if (request.current === null) {
+      const gpu = (navigator as WebGpuNavigator).gpu
+      request.current = (async () => {
+        if (!gpu?.requestAdapter) return false
+        try {
+          return Boolean(await gpu.requestAdapter())
+        } catch {
+          return false
+        }
+      })().then((available) => {
+        supported.current = available
+        return available
+      })
+    }
+
+    return request.current
+  }, [])
+
+  const markUnavailable = useCallback(() => {
+    supported.current = false
+  }, [])
+
+  return { check, markUnavailable, supported }
+}

--- a/components/writing-ink-field.tsx
+++ b/components/writing-ink-field.tsx
@@ -5,6 +5,9 @@ import { Shader, Strands } from 'shaders/react'
 
 import { useHiddenShaderField } from '~/components/use-hidden-shader-field'
 
+const STRANDS_START = { x: 0, y: 0.5 }
+const STRANDS_END = { x: 1, y: 0.5 }
+
 export function WritingInkField({
   onUnavailable,
   onReady,
@@ -50,8 +53,8 @@ export function WritingInkField({
           colorScale={1}
           colorVariance={0}
           colorSpeed={0}
-          start={{ x: 0, y: 0.5 }}
-          end={{ x: 1, y: 0.5 }}
+          start={STRANDS_START}
+          end={STRANDS_END}
         />
       </Shader>
     </span>

--- a/components/writing-ink-field.tsx
+++ b/components/writing-ink-field.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useMemo } from 'react'
+import { Shader, Strands } from 'shaders/react'
+
+import { useHiddenShaderField } from '~/components/use-hidden-shader-field'
+
+export function WritingInkField({
+  onUnavailable,
+  onReady,
+}: {
+  onUnavailable: () => void
+  onReady: () => void
+}) {
+  const { handleReady, ink, ready } = useHiddenShaderField(
+    onUnavailable,
+    onReady,
+  )
+  const stops = useMemo(
+    () => [
+      { color: ink, position: 0 },
+      { color: ink, position: 0.5 },
+      { color: ink, position: 1 },
+    ],
+    [ink],
+  )
+
+  return (
+    <span
+      className="hidden-list-shader-shell"
+      data-ready={ready ? 'true' : 'false'}
+    >
+      <Shader
+        className="hidden-list-shader-canvas"
+        colorSpace="srgb"
+        disableTelemetry
+        onReady={handleReady}
+      >
+        <Strands
+          speed={0.72}
+          amplitude={0.7}
+          frequency={1.4}
+          lineCount={4}
+          lineWidth={0.05}
+          softness={0.04}
+          spread={0.2}
+          pinEdges
+          stops={stops}
+          colorSpace="oklab"
+          colorScale={1}
+          colorVariance={0}
+          colorSpeed={0}
+          start={{ x: 0, y: 0.5 }}
+          end={{ x: 1, y: 0.5 }}
+        />
+      </Shader>
+    </span>
+  )
+}

--- a/docs/ama-booking-operations.md
+++ b/docs/ama-booking-operations.md
@@ -67,6 +67,19 @@ unconfigured returns 503 before touching provider code.
 durable operations under leases; an interrupted worker's lease expires and the
 next run reclaims the work, so no step depends on a healthy previous run.
 
+## Local confirmation previews
+
+In `next dev`, these URLs exercise the real public confirmation page and API
+contract without a database record. They add no preview-only page chrome:
+
+- Confirmed: `/en/ama/book/confirmation?hold=00000000-0000-4000-8000-000000000001`
+- Finalizing: `/en/ama/book/confirmation?hold=00000000-0000-4000-8000-000000000002`
+- Needs reschedule: `/en/ama/book/confirmation?hold=00000000-0000-4000-8000-000000000003`
+
+The same hold ids work on the unprefixed Chinese confirmation route. Outside
+the development server, they are ordinary unknown ids and never return fixture
+data.
+
 ## Recovery
 
 - A paid Booking whose provider work keeps failing stays `finalizing`

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -328,6 +328,14 @@ typewriter/ascii textures, measuring ticks, registration marks. Rules:
   static decoration; they never join the morph or change the row geometry.
   Desktop titles remain one line; below 40rem they may use two balanced lines
   before truncating. Rows swing in center-out.
+- **Writing ink current**: the index owns one dormant `Strands` field, never
+  one canvas per post. After 120ms of fine-pointer intent, three or four fine
+  monochrome strands occupy only the active row's dotted-leader lane and
+  retarget immediately as the pointer crosses rows. Keyboard focus reveals a
+  static ink plate with no animation. Touch remains an ordinary first-tap
+  link, and reduced motion, unavailable WebGPU, or initialization failure use
+  the same static treatment. The field fades out and unmounts only after the
+  pointer leaves the complete writing list.
 - **Hover cards are informational only**: `.link-card` carries
   `pointer-events: none; user-select: none` — a card is a printed label,
   never a control. Email's card is a little paper ENVELOPE (folded flap,
@@ -499,6 +507,16 @@ the shared selective-focus treatment softens the other rows. The row never
 expands or moves. Touch is a plain whole-row link, keyboard focus uses the
 neutral focus ring without motion, and reduced motion keeps every artifact
 still.
+
+The list also owns one dormant **blueprint field** behind all project rows:
+a monochrome `Grid` passing through one very low-strength `FlowField`. After
+120ms of initial fine-pointer intent, it develops across the bounded list and
+a separate registration mark retargets immediately to the active project's
+icon; the same runtime remains mounted while rows are traversed. It never
+tracks the cursor or emits ripples. Keyboard focus uses a static blueprint
+plate, touch preserves direct first-tap navigation, and reduced motion,
+unavailable WebGPU, or initialization failure stay static. The field fades
+away and unmounts only after the pointer leaves the full list.
 
 ## Photo index
 

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -522,18 +522,21 @@ away and unmounts only after the pointer leaves the full list.
 
 The public confirmation route reserves its full celebration for a server-proven
 paid AMA Session whose Booking is `finalizing` or `confirmed`. Those two states
-become one bounded dark stage using the Shaders **Undertones 8** preset
+become one full-viewport dark stage using the Shaders **Undertones 8** preset
 (`bb1fda80-5ce2-4072-b528-9837f6e7aff7`) as its background: `Swirl` and
 `ChromaFlow`, refracted once through `FlutedGlass`, with the preset's restrained
 `FilmGrain` finish. The four layers remain one canvas, use the exported preset
 values, disable vendor telemetry, and mount only after WebGPU preflight. A
 matching static plate remains underneath during initialization and on browsers
-without WebGPU.
+without WebGPU. The field covers the full visual viewport behind the site
+chrome and confirmation copy; it is not framed as a card inside the content
+column.
 
-Seventeen small registration-color confetti pieces cross the stage once when
-the success state mounts, using only transform and opacity, while a centered
-check mark settles over the field. Confetti never loops. Reduced motion keeps
-the static dark plate and check mark but omits both the shader and confetti.
+Two twelve-piece registration-color confetti bursts launch once from the lower
+left and lower right corners, arc inward across the viewport, and settle toward
+the center while a centered check mark arrives over the field. The pieces use
+only transform and opacity and never loop. Reduced motion keeps the static dark
+plate and check mark but omits both the shader and confetti.
 `needs_reschedule` is deliberately not celebratory: payment landed, but the
 chosen time did not, so it retains the calm explanatory state with no success
 stage.

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -518,6 +518,22 @@ plate, touch preserves direct first-tap navigation, and reduced motion,
 unavailable WebGPU, or initialization failure stay static. The field fades
 away and unmounts only after the pointer leaves the full list.
 
+## AMA introduction
+
+The public AMA route opens with one bounded **conversation field** behind its
+introduction and session specification. Two monochrome sine traces move slowly
+toward and through one another, reading as a conversation without becoming an
+illustration or previewing the paid confirmation treatment. The field is
+visible immediately at very low contrast and has no pointer interaction.
+
+The content keeps its normal editorial alignment and contrast while the field
+fades softly at its edges instead of becoming a card. A matching static pair
+of traces is present in the server-rendered page and fades out once the live
+canvas is ready, so the pair is replaced rather than doubled. The live canvas
+mounts only after WebGPU preflight, unmounts when the bounded field leaves the
+viewport, and returns when it re-enters. Reduced motion, unavailable WebGPU,
+or shader initialization failure retain only the static traces.
+
 ## AMA confirmation
 
 The public confirmation route reserves its full celebration for a server-proven

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -518,6 +518,26 @@ plate, touch preserves direct first-tap navigation, and reduced motion,
 unavailable WebGPU, or initialization failure stay static. The field fades
 away and unmounts only after the pointer leaves the full list.
 
+## AMA confirmation
+
+The public confirmation route reserves its full celebration for a server-proven
+paid AMA Session whose Booking is `finalizing` or `confirmed`. Those two states
+become one bounded dark stage using the Shaders **Undertones 8** preset
+(`bb1fda80-5ce2-4072-b528-9837f6e7aff7`) as its background: `Swirl` and
+`ChromaFlow`, refracted once through `FlutedGlass`, with the preset's restrained
+`FilmGrain` finish. The four layers remain one canvas, use the exported preset
+values, disable vendor telemetry, and mount only after WebGPU preflight. A
+matching static plate remains underneath during initialization and on browsers
+without WebGPU.
+
+Seventeen small registration-color confetti pieces cross the stage once when
+the success state mounts, using only transform and opacity, while a centered
+check mark settles over the field. Confetti never loops. Reduced motion keeps
+the static dark plate and check mark but omits both the shader and confetti.
+`needs_reschedule` is deliberately not celebratory: payment landed, but the
+chosen time did not, so it retains the calm explanatory state with no success
+stage.
+
 ## Photo index
 
 The photo route keeps its title in the prefetched static shell and streams the


### PR DESCRIPTION
Projects and Writing now each use one shared, lazy shader stage that follows the visitor's active row without changing the site's editorial structure.

## Projects

- Places a low-strength blueprint grid and flow field behind the full project list.
- Retargets a registration mark to the active project icon instead of mounting a shader per row.
- Keeps ordinary links and touch navigation unchanged.

## Writing

- Runs one four-line ink-strand field across the list.
- Retargets the field to the active dotted-leader lane with continuous row tracking.
- Preserves the static leader treatment until the shader is confirmed ready.

## Interaction and resilience

- Shares a 120ms hover-intent threshold across both stages.
- Supports keyboard focus with a static treatment and respects reduced motion.
- Preflights WebGPU support, times out failed initialization, and cleanly fades and unmounts inactive stages.
- Uses theme-aware ink and disables shader telemetry.
- Reuses the shared readiness and capability hooks in the homepage portrait stage.
- Documents the list-stage contract in the design language.

## Verification

- Typecheck passed.
- Full unit suite passed: 109 files, 1,023 tests.
- Production build passed with inert build-only environment placeholders.
- Live WebGPU QA passed for Projects and Writing in light and dark mode, desktop, and 390px mobile.
- Confirmed one canvas per stage, no horizontal overflow, keyboard-static behavior, Writing lane alignment, no duplicate static layers after readiness, and zero clean-session JavaScript errors.
- Repository-standards and feature-spec reviews passed after all findings were resolved.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces lazy, per-page shader stages for the Projects and Writing index pages, and adds new shader treatments to the AMA booking flow. A shared `HiddenListStage` component manages one WebGPU canvas per index page, targeting the hovered or focused row via CSS custom properties, with a 120ms hover-intent guard, keyboard/touch/reduced-motion handling, and graceful static fallbacks.

- **Shared infrastructure:** `useWebGpuCapability` (deduped preflight, per-stage isolation) and `useHiddenShaderField` (theme-aware ink, 2s init timeout) are extracted from `portrait-hidden-stage` and reused across all new stages.
- **List stages:** `ProjectsBlueprintStage` wraps a flow-field blueprint grid with a retargetable registration mark; `WritingInkStage` overlays a 4-strand ink field on the active leader lane — both sharing a single canvas that follows the active row without remounting.
- **AMA stages:** `AmaIntroductionStage` adds an intersection-observer-gated sine-wave field; `BookingSuccessStage` adds a full-viewport confetti + WebGPU shader success screen.

<h3>Confidence Score: 5/5</h3>

Safe to merge. All shader stages degrade gracefully to static SVG fallbacks and no existing page behavior is altered.

The shared shader canvas pattern is well-implemented: hover-intent gating, pointer/keyboard/touch isolation, WebGPU deduplication, and 2s initialization timeout are all handled correctly with refs to avoid stale closures. The fine-pointer MediaQueryList is correctly initialized once in a useEffect and cached in a ref rather than called per event. The WritingInkField strand endpoint constants are correctly hoisted to module scope. Tests cover all nine interaction scenarios including edge cases. Existing portrait-stage behaviour is preserved through a clean extraction of shared hooks.

No files require special attention. The new components are self-contained, lazily loaded, and do not alter any existing server-rendered markup or routing.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| components/hidden-list-stage.tsx | Core new component: manages one shared shader canvas per index page with hover-intent gating (120ms), pointer/keyboard/touch/reduced-motion handling, WebGPU preflight, and CSS-variable-driven retargeting. Well-structured with stable memoized callbacks and correct ref usage throughout. |
| components/use-webgpu-capability.ts | New hook wrapping the WebGPU adapter preflight with in-flight deduplication (single promise ref) and per-instance isolation via useRef. Correctly extracted from portrait-hidden-stage and shared across all three stage types. |
| components/use-hidden-shader-field.ts | Extracts theme-aware ink reading (MutationObserver on html class), shader readiness state, and a 2s initialization timeout into a reusable hook. Replaces identical logic duplicated in portrait-shader-field. |
| components/writing-ink-field.tsx | 4-strand ink field; STRANDS_START/END are correctly hoisted to module-level constants. Stop colors are memoized on ink changes. |
| components/ama/ama-introduction-stage.tsx | Intersection-observer-gated shader stage for the AMA page header. Initial inViewport=true means a brief shader mount attempt can happen before the observer fires if the element is initially off-screen, though in practice the AMA header is always in viewport on load. |
| components/ama/booking-success-stage.tsx | Full-viewport success screen with fixed-position WebGPU shader + deterministic confetti burst. CONFETTI array is computed once at module level with correct 24-piece count (2 origins × 12 paths) verified by tests. |
| components/hidden-list-stage.test.tsx | Comprehensive 9-scenario test suite covering intent timing, single-runtime retargeting, touch/keyboard/reduced-motion isolation, WebGPU fallback, and Writing lane geometry. |
| app/globals.css | Adds ~280 lines of CSS for list stages, AMA introduction, and booking success. Well-organized with dark-mode overrides, reduced-motion suppression, and CSS custom properties driving shader positioning via translate3d. |
| components/portrait-hidden-stage.tsx | Refactored to use the extracted useWebGpuCapability hook, removing ~25 lines of duplicate WebGPU-check logic. Behavior unchanged. |
| components/portrait-shader-field.tsx | Refactored to use the extracted useHiddenShaderField hook. Removes ~20 lines of duplicate ink/timeout/ready logic. Behavior unchanged. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PO[pointerover on row] --> FP{fine pointer?}
    FP -- no --> IGNORE[ignore]
    FP -- yes --> HR[hoveredRow = row\nmeasureRow immediately]
    HR --> IR{intent ready?}
    IR -- yes --> SS1[syncStage]
    IR -- no --> TM[start 120ms timer]
    TM --> |timer fires| IRSE[pointerIntentReady = true\nsyncStage]

    IRSE --> WM{wantsMotion?}
    SS1 --> WM
    WM -- no --> STATIC[show static fallback\nno shader mount]
    WM -- webGpuSupported=null --> CHK[checkWebGpu async\nthen syncStage again]
    WM -- webGpuSupported=true --> MOUNT[setShaderMounted = true]

    MOUNT --> FIELD[shader field mounts\nuseHiddenShaderField]
    FIELD --> |onReady| READY[setShaderReady = true\nstatic SVG hidden]
    FIELD --> |2s timeout| UNAV[markShaderUnavailable\nstatic fallback shown]

    PL[pointerLeave stage] --> CLR[hoveredRow = null\nintentReady = false]
    CLR --> SS2[syncStage]
    SS2 --> |motionActive| FADE[setMotionEnabled = true\nexitMs timer]
    FADE --> |timer fires| UNM[shaderMounted = false\nshaderReady = false]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    PO[pointerover on row] --> FP{fine pointer?}
    FP -- no --> IGNORE[ignore]
    FP -- yes --> HR[hoveredRow = row\nmeasureRow immediately]
    HR --> IR{intent ready?}
    IR -- yes --> SS1[syncStage]
    IR -- no --> TM[start 120ms timer]
    TM --> |timer fires| IRSE[pointerIntentReady = true\nsyncStage]

    IRSE --> WM{wantsMotion?}
    SS1 --> WM
    WM -- no --> STATIC[show static fallback\nno shader mount]
    WM -- webGpuSupported=null --> CHK[checkWebGpu async\nthen syncStage again]
    WM -- webGpuSupported=true --> MOUNT[setShaderMounted = true]

    MOUNT --> FIELD[shader field mounts\nuseHiddenShaderField]
    FIELD --> |onReady| READY[setShaderReady = true\nstatic SVG hidden]
    FIELD --> |2s timeout| UNAV[markShaderUnavailable\nstatic fallback shown]

    PL[pointerLeave stage] --> CLR[hoveredRow = null\nintentReady = false]
    CLR --> SS2[syncStage]
    SS2 --> |motionActive| FADE[setMotionEnabled = true\nexitMs timer]
    FADE --> |timer fires| UNM[shaderMounted = false\nshaderReady = false]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `components/hidden-list-stage.tsx`, line 1204-1213 ([link](https://github.com/calicastle/cali.so/blob/619ec586fad561cecc7c3b6cc002724a049273fa/components/hidden-list-stage.tsx#L1204-L1213)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Static fallback strand count mismatches the animated shader.** The `writing-ink-static` SVG has 3 `<path>` elements, but `WritingInkField` uses `lineCount={4}`. When the shader becomes ready and the static SVG swaps out, the visual count changes from 3 to 4 strands. The design-language doc says "three or four fine monochrome strands," so either aligning both to 4 paths in the static SVG, or changing `lineCount` to 3, would make the transition seamless.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: components/hidden-list-stage.tsx
   Line: 1204-1213

   Comment:
   **Static fallback strand count mismatches the animated shader.** The `writing-ink-static` SVG has 3 `<path>` elements, but `WritingInkField` uses `lineCount={4}`. When the shader becomes ready and the static SVG swaps out, the visual count changes from 3 to 4 strands. The design-language doc says "three or four fine monochrome strands," so either aligning both to 4 paths in the static SVG, or changing `lineCount` to 3, would make the transition seamless.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20components%2Fhidden-list-stage.tsx%0ALine%3A%201204-1213%0A%0AComment%3A%0A**Static%20fallback%20strand%20count%20mismatches%20the%20animated%20shader.**%20The%20%60writing-ink-static%60%20SVG%20has%203%20%60%3Cpath%3E%60%20elements%2C%20but%20%60WritingInkField%60%20uses%20%60lineCount%3D%7B4%7D%60.%20When%20the%20shader%20becomes%20ready%20and%20the%20static%20SVG%20swaps%20out%2C%20the%20visual%20count%20changes%20from%203%20to%204%20strands.%20The%20design-language%20doc%20says%20%22three%20or%20four%20fine%20monochrome%20strands%2C%22%20so%20either%20aligning%20both%20to%204%20paths%20in%20the%20static%20SVG%2C%20or%20changing%20%60lineCount%60%20to%203%2C%20would%20make%20the%20transition%20seamless.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=calicastle%2Fcali.so&pr=187&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22calicastle%2Fcali.so%22%20on%20the%20existing%20branch%20%22cali%2Fproject-writing-shaders%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cali%2Fproject-writing-shaders%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20components%2Fhidden-list-stage.tsx%0ALine%3A%201204-1213%0A%0AComment%3A%0A**Static%20fallback%20strand%20count%20mismatches%20the%20animated%20shader.**%20The%20%60writing-ink-static%60%20SVG%20has%203%20%60%3Cpath%3E%60%20elements%2C%20but%20%60WritingInkField%60%20uses%20%60lineCount%3D%7B4%7D%60.%20When%20the%20shader%20becomes%20ready%20and%20the%20static%20SVG%20swaps%20out%2C%20the%20visual%20count%20changes%20from%203%20to%204%20strands.%20The%20design-language%20doc%20says%20%22three%20or%20four%20fine%20monochrome%20strands%2C%22%20so%20either%20aligning%20both%20to%204%20paths%20in%20the%20static%20SVG%2C%20or%20changing%20%60lineCount%60%20to%203%2C%20would%20make%20the%20transition%20seamless.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=calicastle%2Fcali.so&pr=187&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["chore: merge dev into shader branch"](https://github.com/calicastle/cali.so/commit/3ed0bfc0a0911685bc5fe4f18124cb45742c2a90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45333920)</sub>

<!-- /greptile_comment -->