### PR TITLE
ci(deploy): add PR preview comments

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: preview-${{ github.ref_name }}
@@ -27,6 +28,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Deploy Preview
+        id: deployment
         uses: ./.github/actions/deploy-neon-vercel
         with:
           branch-name: preview/${{ github.ref_name }}
@@ -42,3 +44,11 @@ jobs:
           vercel-org-id: ${{ vars.VERCEL_ORG_ID }}
           vercel-project-id: ${{ vars.VERCEL_PROJECT_ID }}
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
+
+      - name: Comment Preview URL on pull request
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          DEPLOYMENT_URL: ${{ steps.deployment.outputs.deployment-url }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GIT_BRANCH: ${{ github.ref_name }}
+        run: node scripts/comment-preview-deployment.mjs

--- a/.github/workflows/refresh-preview.yml
+++ b/.github/workflows/refresh-preview.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: preview-${{ inputs.git_branch }}
@@ -46,6 +47,7 @@ jobs:
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Refresh Preview
+        id: deployment
         uses: ./.github/actions/deploy-neon-vercel
         with:
           branch-name: preview/${{ inputs.git_branch }}
@@ -62,3 +64,11 @@ jobs:
           vercel-org-id: ${{ vars.VERCEL_ORG_ID }}
           vercel-project-id: ${{ vars.VERCEL_PROJECT_ID }}
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
+
+      - name: Comment Preview URL on pull request
+        env:
+          COMMIT_SHA: ${{ steps.target.outputs.sha }}
+          DEPLOYMENT_URL: ${{ steps.deployment.outputs.deployment-url }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GIT_BRANCH: ${{ inputs.git_branch }}
+        run: node scripts/comment-preview-deployment.mjs

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:validate": "node --test scripts/ama-migrations.test.mjs",
-    "test:deployment": "node --test scripts/check-production-migrations.test.mjs scripts/delete-vercel-branch-deployments.test.mjs scripts/deployment-workflows.test.mjs",
+    "test:deployment": "node --test scripts/check-production-migrations.test.mjs scripts/comment-preview-deployment.test.mjs scripts/delete-vercel-branch-deployments.test.mjs scripts/deployment-workflows.test.mjs",
     "start": "next start",
     "test:ama": "vitest run lib/ama && pnpm db:validate",
     "test:security": "vitest run lib/security",

--- a/scripts/comment-preview-deployment.mjs
+++ b/scripts/comment-preview-deployment.mjs
@@ -1,0 +1,178 @@
+import { pathToFileURL } from 'node:url'
+
+const apiVersion = '2022-11-28'
+
+function required(name, value) {
+  if (!value) {
+    throw new Error(`${name} is required`)
+  }
+
+  return value
+}
+
+function repositoryParts(repository) {
+  const [owner, name, ...rest] = repository.split('/')
+
+  if (!owner || !name || rest.length > 0) {
+    throw new Error('GITHUB_REPOSITORY must use the owner/repository format')
+  }
+
+  return { name, owner }
+}
+
+function deploymentUrl(value) {
+  const url = new URL(value)
+
+  if (url.protocol !== 'https:' || !url.hostname.endsWith('.vercel.app')) {
+    throw new Error('DEPLOYMENT_URL must be an HTTPS vercel.app URL')
+  }
+
+  return url.toString()
+}
+
+function commitSha(value) {
+  if (!/^[0-9a-f]{40}$/i.test(value)) {
+    throw new Error('COMMIT_SHA must be a 40-character Git commit SHA')
+  }
+
+  return value.toLowerCase()
+}
+
+function inlineCode(value) {
+  return value.replaceAll('`', '\u02cb')
+}
+
+export function previewComment({
+  branch,
+  commit,
+  repository,
+  runId,
+  serverUrl,
+  url,
+}) {
+  const commitUrl = `${serverUrl}/${repository}/commit/${commit}`
+  const runUrl = `${serverUrl}/${repository}/actions/runs/${runId}`
+
+  return [
+    '<!-- cali-so-preview-deployment -->',
+    '## Preview deployment ready',
+    '',
+    '| Environment | Deployment | Commit |',
+    '| :-- | :-- | :-- |',
+    `| Preview | [Visit Preview](${url}) | [\`${commit.slice(0, 7)}\`](${commitUrl}) |`,
+    '',
+    `Branch: \`${inlineCode(branch)}\` · [View deployment logs](${runUrl})`,
+  ].join('\n')
+}
+
+async function githubRequest({ apiUrl, fetchImpl, path, token }, options = {}) {
+  const response = await fetchImpl(`${apiUrl}${path}`, {
+    ...options,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'cali-so-preview-deployment',
+      'X-GitHub-Api-Version': apiVersion,
+      ...options.headers,
+    },
+  })
+
+  if (!response.ok) {
+    const details = await response.text()
+    throw new Error(
+      `GitHub API ${response.status} for ${path}: ${details || response.statusText}`,
+    )
+  }
+
+  if (response.status === 204) {
+    return undefined
+  }
+
+  return response.json()
+}
+
+export async function commentOnPreviewPullRequests(
+  {
+    apiUrl = 'https://api.github.com',
+    branch,
+    commit,
+    deployment,
+    repository,
+    runId,
+    serverUrl = 'https://github.com',
+    token,
+  },
+  fetchImpl = fetch,
+) {
+  required('GITHUB_TOKEN', token)
+  required('GITHUB_RUN_ID', runId)
+  required('GIT_BRANCH', branch)
+
+  const { owner } = repositoryParts(
+    required('GITHUB_REPOSITORY', repository),
+  )
+  const normalizedCommit = commitSha(required('COMMIT_SHA', commit))
+  const normalizedDeployment = deploymentUrl(
+    required('DEPLOYMENT_URL', deployment),
+  )
+  const request = (path, options) =>
+    githubRequest({ apiUrl, fetchImpl, path, token }, options)
+  const query = new URLSearchParams({
+    head: `${owner}:${branch}`,
+    per_page: '100',
+    state: 'open',
+  })
+  const pullRequests = await request(
+    `/repos/${repository}/pulls?${query.toString()}`,
+  )
+
+  if (pullRequests.length === 0) {
+    console.log(`No open pull request found for ${branch}; skipping comment.`)
+    return []
+  }
+
+  const body = previewComment({
+    branch,
+    commit: normalizedCommit,
+    repository,
+    runId,
+    serverUrl,
+    url: normalizedDeployment,
+  })
+
+  for (const pullRequest of pullRequests) {
+    await request(`/repos/${repository}/issues/${pullRequest.number}/comments`, {
+      body: JSON.stringify({ body }),
+      method: 'POST',
+    })
+    console.log(
+      `Commented on pull request #${pullRequest.number}: ${normalizedDeployment}`,
+    )
+  }
+
+  return pullRequests.map((pullRequest) => pullRequest.number)
+}
+
+async function main() {
+  await commentOnPreviewPullRequests({
+    apiUrl: process.env.GITHUB_API_URL,
+    branch: process.env.GIT_BRANCH,
+    commit: process.env.COMMIT_SHA,
+    deployment: process.env.DEPLOYMENT_URL,
+    repository: process.env.GITHUB_REPOSITORY,
+    runId: process.env.GITHUB_RUN_ID,
+    serverUrl: process.env.GITHUB_SERVER_URL,
+    token: process.env.GITHUB_TOKEN,
+  })
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+}

--- a/scripts/comment-preview-deployment.mjs
+++ b/scripts/comment-preview-deployment.mjs
@@ -1,6 +1,7 @@
 import { pathToFileURL } from 'node:url'
 
 const apiVersion = '2022-11-28'
+const previewMarker = '<!-- cali-so-preview-deployment -->'
 
 function required(name, value) {
   if (!value) {
@@ -54,7 +55,7 @@ export function previewComment({
   const runUrl = `${serverUrl}/${repository}/actions/runs/${runId}`
 
   return [
-    '<!-- cali-so-preview-deployment -->',
+    previewMarker,
     '## Preview deployment ready',
     '',
     '| Environment | Deployment | Commit |',
@@ -90,6 +91,25 @@ async function githubRequest({ apiUrl, fetchImpl, path, token }, options = {}) {
   }
 
   return response.json()
+}
+
+async function findPreviewComment({ number, repository, request }) {
+  for (let page = 1; page <= 100; page += 1) {
+    const comments = await request(
+      `/repos/${repository}/issues/${number}/comments?per_page=100&page=${page}`,
+    )
+    const existing = comments.find(
+      (comment) =>
+        comment.user?.login === 'github-actions[bot]' &&
+        comment.body?.includes(previewMarker),
+    )
+
+    if (existing || comments.length < 100) {
+      return existing
+    }
+  }
+
+  throw new Error(`Pull request #${number} comments exceeded 100 pages`)
 }
 
 export async function commentOnPreviewPullRequests(
@@ -142,12 +162,21 @@ export async function commentOnPreviewPullRequests(
   })
 
   for (const pullRequest of pullRequests) {
-    await request(`/repos/${repository}/issues/${pullRequest.number}/comments`, {
+    const existing = await findPreviewComment({
+      number: pullRequest.number,
+      repository,
+      request,
+    })
+    const path = existing
+      ? `/repos/${repository}/issues/comments/${existing.id}`
+      : `/repos/${repository}/issues/${pullRequest.number}/comments`
+
+    await request(path, {
       body: JSON.stringify({ body }),
-      method: 'POST',
+      method: existing ? 'PATCH' : 'POST',
     })
     console.log(
-      `Commented on pull request #${pullRequest.number}: ${normalizedDeployment}`,
+      `${existing ? 'Updated' : 'Commented on'} pull request #${pullRequest.number}: ${normalizedDeployment}`,
     )
   }
 

--- a/scripts/comment-preview-deployment.test.mjs
+++ b/scripts/comment-preview-deployment.test.mjs
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  commentOnPreviewPullRequests,
+  previewComment,
+} from './comment-preview-deployment.mjs'
+
+const deployment = {
+  branch: 'cali/preview-comments',
+  commit: '0123456789abcdef0123456789abcdef01234567',
+  deployment: 'https://cali-so-example.vercel.app',
+  repository: 'CaliCastle/cali.so',
+  runId: '123456',
+  token: 'test-token',
+}
+
+function jsonResponse(value, status = 200) {
+  return new Response(JSON.stringify(value), {
+    headers: { 'Content-Type': 'application/json' },
+    status,
+  })
+}
+
+test('Preview comment links the deployment, commit, and workflow run', () => {
+  const body = previewComment({
+    branch: deployment.branch,
+    commit: deployment.commit,
+    repository: deployment.repository,
+    runId: deployment.runId,
+    serverUrl: 'https://github.com',
+    url: `${deployment.deployment}/`,
+  })
+
+  assert.match(body, /Preview deployment ready/)
+  assert.match(body, /\[Visit Preview\]\(https:\/\/cali-so-example\.vercel\.app\/\)/)
+  assert.match(
+    body,
+    /\[`0123456`\]\(https:\/\/github\.com\/CaliCastle\/cali\.so\/commit\//,
+  )
+  assert.match(
+    body,
+    /\[View deployment logs\]\(https:\/\/github\.com\/CaliCastle\/cali\.so\/actions\/runs\/123456\)/,
+  )
+})
+
+test('Successful Preview comments on every open pull request for the branch', async () => {
+  const requests = []
+  const fetchImpl = async (url, options) => {
+    requests.push({ options, url })
+
+    if (options.method === 'POST') {
+      return jsonResponse({ id: requests.length }, 201)
+    }
+
+    return jsonResponse([{ number: 174 }, { number: 175 }])
+  }
+
+  const numbers = await commentOnPreviewPullRequests(deployment, fetchImpl)
+
+  assert.deepEqual(numbers, [174, 175])
+  assert.equal(requests.length, 3)
+  assert.match(
+    requests[0].url,
+    /head=CaliCastle%3Acali%2Fpreview-comments/,
+  )
+  assert.equal(
+    requests[1].url,
+    'https://api.github.com/repos/CaliCastle/cali.so/issues/174/comments',
+  )
+  assert.equal(requests[1].options.method, 'POST')
+  assert.match(JSON.parse(requests[1].options.body).body, /Visit Preview/)
+  assert.equal(
+    requests[1].options.headers.Authorization,
+    'Bearer test-token',
+  )
+  assert.match(requests[2].url, /issues\/175\/comments$/)
+})
+
+test('Successful Preview without an open pull request does not post', async () => {
+  const requests = []
+  const fetchImpl = async (url, options) => {
+    requests.push({ options, url })
+    return jsonResponse([])
+  }
+
+  const numbers = await commentOnPreviewPullRequests(deployment, fetchImpl)
+
+  assert.deepEqual(numbers, [])
+  assert.equal(requests.length, 1)
+})
+
+test('Preview comment rejects a non-Vercel deployment URL', async () => {
+  await assert.rejects(
+    commentOnPreviewPullRequests(
+      { ...deployment, deployment: 'https://example.com' },
+      () => {
+        throw new Error('GitHub should not be called')
+      },
+    ),
+    /DEPLOYMENT_URL must be an HTTPS vercel\.app URL/,
+  )
+})
+
+test('GitHub API failures fail the comment step with context', async () => {
+  await assert.rejects(
+    commentOnPreviewPullRequests(deployment, () =>
+      Promise.resolve(new Response('permission denied', { status: 403 })),
+    ),
+    /GitHub API 403.*permission denied/,
+  )
+})

--- a/scripts/comment-preview-deployment.test.mjs
+++ b/scripts/comment-preview-deployment.test.mjs
@@ -44,37 +44,53 @@ test('Preview comment links the deployment, commit, and workflow run', () => {
   )
 })
 
-test('Successful Preview comments on every open pull request for the branch', async () => {
+test('Successful Preview updates or creates one comment per pull request', async () => {
   const requests = []
   const fetchImpl = async (url, options) => {
     requests.push({ options, url })
 
-    if (options.method === 'POST') {
+    if (options.method === 'PATCH' || options.method === 'POST') {
       return jsonResponse({ id: requests.length }, 201)
     }
 
-    return jsonResponse([{ number: 174 }, { number: 175 }])
+    if (url.includes('/pulls?')) {
+      return jsonResponse([{ number: 174 }, { number: 175 }])
+    }
+
+    if (url.includes('/issues/174/comments?')) {
+      return jsonResponse([
+        {
+          body: '<!-- cali-so-preview-deployment -->\nOld deployment',
+          id: 5011960335,
+          user: { login: 'github-actions[bot]' },
+        },
+      ])
+    }
+
+    return jsonResponse([])
   }
 
   const numbers = await commentOnPreviewPullRequests(deployment, fetchImpl)
 
   assert.deepEqual(numbers, [174, 175])
-  assert.equal(requests.length, 3)
+  assert.equal(requests.length, 5)
   assert.match(
     requests[0].url,
     /head=CaliCastle%3Acali%2Fpreview-comments/,
   )
   assert.equal(
-    requests[1].url,
-    'https://api.github.com/repos/CaliCastle/cali.so/issues/174/comments',
+    requests[2].url,
+    'https://api.github.com/repos/CaliCastle/cali.so/issues/comments/5011960335',
   )
-  assert.equal(requests[1].options.method, 'POST')
-  assert.match(JSON.parse(requests[1].options.body).body, /Visit Preview/)
+  assert.equal(requests[2].options.method, 'PATCH')
+  assert.match(JSON.parse(requests[2].options.body).body, /Visit Preview/)
   assert.equal(
-    requests[1].options.headers.Authorization,
+    requests[2].options.headers.Authorization,
     'Bearer test-token',
   )
-  assert.match(requests[2].url, /issues\/175\/comments$/)
+  assert.match(requests[3].url, /issues\/175\/comments\?/)
+  assert.match(requests[4].url, /issues\/175\/comments$/)
+  assert.equal(requests[4].options.method, 'POST')
 })
 
 test('Successful Preview without an open pull request does not post', async () => {

--- a/scripts/deployment-workflows.test.mjs
+++ b/scripts/deployment-workflows.test.mjs
@@ -49,10 +49,27 @@ test('feature pushes branch from Staging, migrate, then deploy Preview', async (
   assert.equal(config.concurrency.group, 'preview-${{ github.ref_name }}')
 
   const deploy = job.steps.find((step) => step.name === 'Deploy Preview')
+  assert.equal(config.permissions['pull-requests'], 'write')
+  assert.equal(deploy.id, 'deployment')
   assert.equal(deploy.uses, './.github/actions/deploy-neon-vercel')
   assert.equal(deploy.with['parent-branch'], 'staging')
   assert.match(deploy.with['branch-name'], /^preview\//)
   assert.equal(deploy.with.target, 'preview')
+  const comment = job.steps.find(
+    (step) => step.name === 'Comment Preview URL on pull request',
+  )
+  assert.equal(
+    comment.env.DEPLOYMENT_URL,
+    '${{ steps.deployment.outputs.deployment-url }}',
+  )
+  assert.equal(comment.env.GIT_BRANCH, '${{ github.ref_name }}')
+  assert.equal(comment.env.COMMIT_SHA, '${{ github.sha }}')
+  assert.match(comment.run, /comment-preview-deployment\.mjs/)
+  assertOrdered(
+    job.steps,
+    'Deploy Preview',
+    'Comment Preview URL on pull request',
+  )
 })
 
 test('dev continuously migrates and deploys the persistent Staging environment', async () => {
@@ -194,11 +211,28 @@ test('manual refresh resets a feature database from Staging before redeploying',
   const resolve = job.steps.find((step) => step.name === 'Resolve target commit')
   assert.equal(resolve['working-directory'], 'target')
   const reset = job.steps.find((step) => step.name === 'Refresh Preview')
+  assert.equal(config.permissions['pull-requests'], 'write')
+  assert.equal(reset.id, 'deployment')
   assert.equal(reset.uses, './.github/actions/deploy-neon-vercel')
   assert.equal(reset.with.reset, true)
   assert.equal(reset.with['working-directory'], 'target')
   assert.match(reset.with['branch-name'], /^preview\//)
   assert.equal(reset.with.target, 'preview')
+  const comment = job.steps.find(
+    (step) => step.name === 'Comment Preview URL on pull request',
+  )
+  assert.equal(
+    comment.env.DEPLOYMENT_URL,
+    '${{ steps.deployment.outputs.deployment-url }}',
+  )
+  assert.equal(comment.env.GIT_BRANCH, '${{ inputs.git_branch }}')
+  assert.equal(comment.env.COMMIT_SHA, '${{ steps.target.outputs.sha }}')
+  assert.match(comment.run, /comment-preview-deployment\.mjs/)
+  assertOrdered(
+    job.steps,
+    'Refresh Preview',
+    'Comment Preview URL on pull request',
+  )
 })
 
 test('shared non-production action keeps migration credentials out of Vercel', async () => {


### PR DESCRIPTION
Preview workflows now post a new PR comment only after Vercel returns a successful deployment URL.

## Deployment behavior

- Add a direct **Visit Preview** link with the deployed commit, source branch, and workflow logs.
- Cover both branch-push Preview deployments and manual Preview refreshes.
- Target open pull requests for the internal source branch and skip cleanly when no PR is open.

## Safety

- Grant only `pull-requests: write` in the two Preview workflows that need to comment.
- Validate the Vercel hostname and full commit SHA before publishing.
- Keep deployment failures from producing a success comment by ordering the comment step after deployment.

## Verification

- `node --test scripts/check-production-migrations.test.mjs scripts/comment-preview-deployment.test.mjs scripts/delete-vercel-branch-deployments.test.mjs scripts/deployment-workflows.test.mjs` (24 passed)
- `git diff --check origin/dev...HEAD`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds automated PR preview comments to two workflows (`deploy-preview` and `refresh-preview`). After a successful Vercel deployment, a new script posts or updates a single comment on any open PR for the source branch, linking the preview URL, commit SHA, and workflow run.

- **`scripts/comment-preview-deployment.mjs`**: Validates the deployment URL (must be `https://*.vercel.app`) and commit SHA, then upserts a comment using a typed HTML marker — PATCH if a prior comment exists, POST otherwise — so repeated pushes never accumulate stale comments.
- **Workflow changes**: Both workflows add `pull-requests: write`, give the deploy step an `id: deployment`, and append the comment step after deployment so a failed deploy never triggers a success comment.
- **`refresh-preview.yml`** correctly uses `steps.target.outputs.sha` for `COMMIT_SHA` rather than `github.sha`, matching the actual commit that was deployed from the checked-out target branch.

<h3>Confidence Score: 5/5</h3>

Safe to merge — adds an optional comment step that runs only after a successful deployment and fails cleanly when no open PR exists.

All changes are additive CI plumbing. The script validates inputs, upserts rather than accumulates comments, and is gated behind a successful deployment step. The refresh-preview workflow correctly sources the commit SHA from the resolved target rather than github.sha. Tests cover the main code paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/comment-preview-deployment.mjs | New script that finds open PRs for the deployed branch and upserts a single preview comment (PATCH existing, POST if none) using a typed HTML marker to avoid duplicates. |
| scripts/comment-preview-deployment.test.mjs | Covers the happy path (upsert across two PRs), no-PR skip, invalid URL rejection, and API error propagation; good breadth for the new script. |
| .github/workflows/deploy-preview.yml | Adds pull-requests: write, gives the deploy step an id, and appends the comment step after deployment — ordering and permission scope are correct. |
| .github/workflows/refresh-preview.yml | Same treatment as deploy-preview; correctly uses steps.target.outputs.sha for COMMIT_SHA since HEAD differs from github.sha in the refresh flow. |
| scripts/deployment-workflows.test.mjs | Extended to assert deployment step id, PR permissions, comment env vars, and ordering for both workflows. |
| package.json | Adds comment-preview-deployment.test.mjs to the test:deployment script. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GH as GitHub Push / workflow_dispatch
    participant WF as Workflow Runner
    participant VA as deploy-neon-vercel Action
    participant Vercel
    participant Script as comment-preview-deployment.mjs
    participant GHAPI as GitHub API

    GH->>WF: Trigger (push or workflow_dispatch)
    WF->>VA: Deploy Preview (id: deployment)
    VA->>Vercel: Deploy
    Vercel-->>VA: deployment-url
    VA-->>WF: outputs.deployment-url

    WF->>Script: node scripts/comment-preview-deployment.mjs
    Script->>Script: Validate DEPLOYMENT_URL (.vercel.app) + COMMIT_SHA (40-char hex)

    Script->>GHAPI: "GET /repos/{repo}/pulls?head={owner}:{branch}&state=open"
    GHAPI-->>Script: [ PR list ] or empty → skip

    loop For each open PR
        Script->>GHAPI: "GET /issues/{n}/comments?per_page=100&page=1..N"
        GHAPI-->>Script: comment list
        alt Existing marker comment found
            Script->>GHAPI: "PATCH /issues/comments/{id}"
        else No marker comment
            Script->>GHAPI: "POST /issues/{n}/comments"
        end
        GHAPI-->>Script: 200/201
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GH as GitHub Push / workflow_dispatch
    participant WF as Workflow Runner
    participant VA as deploy-neon-vercel Action
    participant Vercel
    participant Script as comment-preview-deployment.mjs
    participant GHAPI as GitHub API

    GH->>WF: Trigger (push or workflow_dispatch)
    WF->>VA: Deploy Preview (id: deployment)
    VA->>Vercel: Deploy
    Vercel-->>VA: deployment-url
    VA-->>WF: outputs.deployment-url

    WF->>Script: node scripts/comment-preview-deployment.mjs
    Script->>Script: Validate DEPLOYMENT_URL (.vercel.app) + COMMIT_SHA (40-char hex)

    Script->>GHAPI: "GET /repos/{repo}/pulls?head={owner}:{branch}&state=open"
    GHAPI-->>Script: [ PR list ] or empty → skip

    loop For each open PR
        Script->>GHAPI: "GET /issues/{n}/comments?per_page=100&page=1..N"
        GHAPI-->>Script: comment list
        alt Existing marker comment found
            Script->>GHAPI: "PATCH /issues/comments/{id}"
        else No marker comment
            Script->>GHAPI: "POST /issues/{n}/comments"
        end
        GHAPI-->>Script: 200/201
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(deploy): update existing preview com..."](https://github.com/calicastle/cali.so/commit/bc6ace95ca4872efb2ceb2dd287c6312aff1ea94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45337920)</sub>

<!-- /greptile_comment -->