### PR TITLE
Prove v3 readiness and refine interaction motion

### DIFF
--- a/app/_components/site-document.tsx
+++ b/app/_components/site-document.tsx
@@ -7,6 +7,7 @@ import { Suspense } from 'react'
 import { AmbientBackground } from '~/components/ambient-background'
 import { Dock, DockFallback } from '~/components/dock'
 import { LocaleRestorer } from '~/components/locale-restorer'
+import { PreviewCardTimingProvider } from '~/components/preview-card-timing'
 import {
   RouteMotionController,
   RouteViewTransition,
@@ -89,20 +90,22 @@ export async function SiteDocument({
       </head>
       <body className="antialiased">
         <ThemeProvider>
-          <RouteMotionController />
-          {restoreLocale && <LocaleRestorer />}
-          <AmbientBackground />
-          <div className="flex min-h-screen flex-col pb-20">
-            <main className="flex-1 pt-14">
-              {/* The non-none default isolates route content while keeping the
-                  CSS-named list → loading shell → article groups active. */}
-              <RouteViewTransition>{children}</RouteViewTransition>
-            </main>
-            <SiteFooter social={social} github={github} locale={locale} />
-          </div>
-          <Suspense fallback={<DockFallback locale={locale} />}>
-            <Dock />
-          </Suspense>
+          <PreviewCardTimingProvider>
+            <RouteMotionController />
+            {restoreLocale && <LocaleRestorer />}
+            <AmbientBackground />
+            <div className="flex min-h-screen flex-col pb-20">
+              <main className="flex-1 pt-14">
+                {/* The non-none default isolates route content while keeping the
+                    CSS-named list → loading shell → article groups active. */}
+                <RouteViewTransition>{children}</RouteViewTransition>
+              </main>
+              <SiteFooter social={social} github={github} locale={locale} />
+            </div>
+            <Suspense fallback={<DockFallback locale={locale} />}>
+              <Dock />
+            </Suspense>
+          </PreviewCardTimingProvider>
         </ThemeProvider>
         <Analytics />
       </body>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1867,20 +1867,6 @@ a:focus-visible .external-label .external-mark {
   user-select: none;
 }
 
-@keyframes link-card-in {
-  from {
-    opacity: 0;
-    transform: scale(0.95);
-  }
-}
-
-@keyframes link-card-out {
-  to {
-    opacity: 0;
-    transform: scale(0.97);
-  }
-}
-
 .link-card {
   /* informational only: never selectable, never a pointer target */
   pointer-events: none;
@@ -1897,6 +1883,11 @@ a:focus-visible .external-label .external-mark {
   transform-origin: var(--transform-origin);
   backface-visibility: hidden;
   z-index: var(--z-card);
+  opacity: 1;
+  transform: scale(1);
+  transition:
+    opacity 200ms var(--ease-swift),
+    transform 200ms var(--ease-swift);
 }
 
 /* Image-enabled preview cards: height comes from the content (the 16:9
@@ -1975,12 +1966,23 @@ a:focus-visible .external-label .external-mark {
   box-shadow: none;
 }
 
-.link-card[data-open] {
-  animation: link-card-in 200ms var(--ease-swift);
+.link-card[data-starting-style] {
+  opacity: 0;
+  transform: scale(0.95);
 }
 
 .link-card[data-ending-style] {
-  animation: link-card-out 130ms var(--ease-swift);
+  opacity: 0;
+  transform: scale(0.97);
+  transition-duration: 130ms;
+}
+
+.link-card.preview-card-instant,
+.link-card.preview-card-instant[data-starting-style],
+.link-card.preview-card-instant[data-ending-style] {
+  opacity: 1;
+  transform: none;
+  transition: none;
 }
 
 .link-card-site {
@@ -2014,14 +2016,6 @@ a:focus-visible .external-label .external-mark {
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .link-card[data-open],
-  .link-card[data-ending-style],
-  .service-card[data-open] {
-    animation: none;
-  }
 }
 
 /* ── Halftone portrait (components/halftone-portrait.tsx) ─────────── */
@@ -3059,23 +3053,18 @@ a:focus-visible .external-label .external-mark {
   gap: 0.5rem;
 }
 
-/* Service cards are UI chrome: quick and decisive, without overshoot. */
-.service-card[data-open] {
-  animation: service-pop 200ms var(--ease-swift);
+.service-card[data-starting-style] {
+  transform: scale(0.92) translateY(4px);
 }
 
-/* this rule sits after the reduced-motion block above, so it needs its
-   own guard — source order would otherwise resurrect the animation */
 @media (prefers-reduced-motion: reduce) {
-  .service-card[data-open] {
-    animation: none;
-  }
-}
-
-@keyframes service-pop {
-  from {
-    opacity: 0;
-    transform: scale(0.92) translateY(4px);
+  .link-card,
+  .link-card[data-starting-style],
+  .link-card[data-ending-style],
+  .service-card[data-starting-style] {
+    opacity: 1;
+    transform: none;
+    transition: none;
   }
 }
 
@@ -3197,6 +3186,10 @@ a:focus-visible .external-label .external-mark {
   background: color-mix(in oklab, var(--foreground) 7%, transparent);
   animation: contrib-cell-in 480ms var(--ease-swift) backwards;
   animation-delay: calc(var(--ci, 0) * 2ms);
+}
+
+.link-card.preview-card-instant .contrib-grid i {
+  animation: none;
 }
 
 .contrib-grid i[data-level='1'] {
@@ -3925,6 +3918,21 @@ html[data-locale='en'] [data-en-block] {
   .post-minimap-node > a::after {
     inset-block: -1.34375rem;
   }
+}
+
+.post-minimap-root[data-toggle-motion='instant'] .post-minimap-backdrop,
+.post-minimap-root[data-toggle-motion='instant'] .post-minimap,
+.post-minimap-root[data-toggle-motion='instant'] .post-minimap-toggle-panel,
+.post-minimap-root[data-toggle-motion='instant'] .post-minimap-toggle-chevron,
+.post-minimap-root[data-toggle-motion='instant'] .post-minimap-island-chevron,
+.post-minimap-root[data-toggle-motion='instant'] .post-minimap-node > a,
+.post-minimap-root[data-toggle-motion='instant'] .post-minimap-tick,
+.post-minimap-root[data-toggle-motion='instant'] .post-minimap-label {
+  transition: none;
+}
+
+.post-minimap-root[data-scroll-motion='instant'] .post-minimap-back-to-top {
+  transition: none;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/app/site-document.test.tsx
+++ b/app/site-document.test.tsx
@@ -24,6 +24,11 @@ vi.mock('~/components/dock', () => ({
 vi.mock('~/components/locale-restorer', () => ({
   LocaleRestorer: () => null,
 }))
+vi.mock('~/components/preview-card-timing', () => ({
+  PreviewCardTimingProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-public-preview-cards="">{children}</div>
+  ),
+}))
 vi.mock('~/components/site-footer', () => ({
   SiteFooter: () => <span data-public-footer="" />,
 }))
@@ -68,6 +73,7 @@ describe('SiteDocument analytics', () => {
       expect(html).toContain('data-public-dock')
       expect(html).toContain('data-public-footer')
       expect(html).toContain('data-public-route-transition')
+      expect(html).toContain('data-public-preview-cards')
     }
   })
 
@@ -85,6 +91,7 @@ describe('SiteDocument analytics', () => {
     expect(html).not.toContain('data-public-footer')
     expect(html).not.toContain('data-public-route-motion')
     expect(html).not.toContain('data-public-route-transition')
+    expect(html).not.toContain('data-public-preview-cards')
     expect(html).toContain('Owner admin')
     // The admin shares the warm working-paper palette (July 2026 decision)
     // while staying outside analytics and social reads.

--- a/components/external-link.tsx
+++ b/components/external-link.tsx
@@ -2,10 +2,9 @@
 
 import { useState } from 'react'
 
-import { PreviewCard } from '@base-ui/react/preview-card'
-
 import { ExternalLabel } from '~/components/external-mark'
 import { classifyFaviconTone } from '~/components/favicon-tone'
+import { SitePreviewCard } from '~/components/preview-card-timing'
 import { ogImageUrl, type LinkPreview } from '~/lib/link-previews'
 import { useLocale } from '~/lib/locale-client'
 
@@ -80,50 +79,44 @@ export function ExternalLink({
   }
 
   return (
-    <PreviewCard.Root>
-      {/* Base UI's trigger renders the <a> itself; delays live here, not on
-          the root (Base UI defaults are 600/300 — far too slow for prose) */}
-      <PreviewCard.Trigger
-        href={href}
-        target="_blank"
-        rel="noreferrer"
-        className="external-link"
-        delay={300}
-        closeDelay={100}
-      >
-        {icon}
-        <ExternalLabel>{children}</ExternalLabel>
-      </PreviewCard.Trigger>
-      <PreviewCard.Portal>
-        <PreviewCard.Positioner sideOffset={8} collisionPadding={16} className="pointer-events-none z-[var(--z-card)]">
-          <PreviewCard.Popup className={`link-card${image ? ' link-card-with-image' : ''}`}>
-            {image && (
-              <span className="link-card-image-frame" aria-hidden>
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  className="link-card-image"
-                  src={image}
-                  alt=""
-                  width={236}
-                  height={133}
-                  loading="eager"
-                  onError={() => setImageFailed(true)}
-                />
-              </span>
-            )}
-            <span className="link-card-site">
-              <Favicon src={favicon} size={16} />
-              {domain}
+    <SitePreviewCard
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      triggerClassName="external-link"
+      closeDelay={100}
+      popupClassName={`link-card${image ? ' link-card-with-image' : ''}`}
+      popup={
+        <>
+          {image && (
+            <span className="link-card-image-frame" aria-hidden>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                className="link-card-image"
+                src={image}
+                alt=""
+                width={236}
+                height={133}
+                loading="eager"
+                onError={() => setImageFailed(true)}
+              />
             </span>
-            <span className="link-card-title">{title}</span>
-            {/* the image already says what the page is — description text
-                only earns its rows on image-less cards */}
-            {!image && description && (
-              <span className="link-card-description">{description}</span>
-            )}
-          </PreviewCard.Popup>
-        </PreviewCard.Positioner>
-      </PreviewCard.Portal>
-    </PreviewCard.Root>
+          )}
+          <span className="link-card-site">
+            <Favicon src={favicon} size={16} />
+            {domain}
+          </span>
+          <span className="link-card-title">{title}</span>
+          {/* the image already says what the page is — description text
+              only earns its rows on image-less cards */}
+          {!image && description && (
+            <span className="link-card-description">{description}</span>
+          )}
+        </>
+      }
+    >
+      {icon}
+      <ExternalLabel>{children}</ExternalLabel>
+    </SitePreviewCard>
   )
 }

--- a/components/post-toc.test.tsx
+++ b/components/post-toc.test.tsx
@@ -568,6 +568,7 @@ describe('PostToc', () => {
     expect(root.getAttribute('data-toggle-motion')).toBeNull()
     expect(root.getAttribute('data-scroll-motion')).toBe('instant')
 
+    root.setAttribute('data-toggle-motion', 'instant')
     fireEvent.click(container.querySelector('a[href="#second"]')!, { detail: 1 })
     expect(toggle.getAttribute('aria-expanded')).toBe('true')
     expect(root.getAttribute('data-toggle-motion')).toBeNull()

--- a/components/post-toc.test.tsx
+++ b/components/post-toc.test.tsx
@@ -1,0 +1,615 @@
+/** @vitest-environment jsdom */
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { PostRailNode } from '~/lib/content'
+
+import { PostToc } from './post-toc'
+
+const motionMocks = vi.hoisted(() => {
+  let observer: ((target: Element | NodeListOf<Element>) => void) | null = null
+  const controls: Array<{
+    target: Element | NodeListOf<Element>
+    cancel: ReturnType<typeof vi.fn>
+    stop: ReturnType<typeof vi.fn>
+    finished: Promise<void>
+  }> = []
+  const animate = vi.fn(
+    (
+      target: Element | NodeListOf<Element>,
+      _keyframes?: unknown,
+      _options?: unknown,
+    ) => {
+      observer?.(target)
+      const control = {
+        target,
+        cancel: vi.fn(),
+        stop: vi.fn(),
+        finished: new Promise<void>(() => undefined),
+      }
+      controls.push(control)
+      return control
+    },
+  )
+  return {
+    animate,
+    clearObserver: () => {
+      observer = null
+    },
+    controls,
+    observe: (nextObserver: typeof observer) => {
+      observer = nextObserver
+    },
+    stagger: vi.fn((each: number, options: { from: string }) => ({
+      each,
+      ...options,
+    })),
+  }
+})
+
+vi.mock('motion', () => ({
+  animate: motionMocks.animate,
+  stagger: motionMocks.stagger,
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a {...props}>{children}</a>
+  ),
+}))
+
+vi.mock('~/lib/locale-client', () => ({
+  localize: (_locale: string, _zh: string, en: string) => en,
+  useLocale: () => 'en',
+}))
+
+vi.mock('~/lib/locale-route', () => ({
+  localePath: (_locale: string, path: string) => `/en${path}`,
+}))
+
+const nodes: PostRailNode[] = [
+  {
+    key: 'title',
+    kind: 'landmark',
+    id: 'article-start',
+    label: 'Article',
+    variant: 'title',
+  },
+  { key: 'gap-0', kind: 'tick' },
+  {
+    key: 'heading-1',
+    kind: 'landmark',
+    id: 'first',
+    label: 'First',
+    variant: 'heading',
+  },
+  { key: 'gap-1', kind: 'tick' },
+  {
+    key: 'heading-2',
+    kind: 'landmark',
+    id: 'second',
+    label: 'Second',
+    variant: 'heading',
+  },
+]
+
+let viewport: 'desktop' | 'phone' | 'tablet' = 'phone'
+let reducedMotion = false
+let scrollY = 200
+let frames: FrameRequestCallback[] = []
+const scrollToMock = vi.fn(
+  (options: ScrollToOptions | number, _y?: number) => {
+    if (typeof options === 'object') scrollY = Number(options.top ?? scrollY)
+  },
+)
+
+function matchesQuery(query: string) {
+  if (query === '(prefers-reduced-motion: reduce)') return reducedMotion
+  if (query === '(min-width: 64rem)') return viewport === 'desktop'
+  if (query === '(max-width: 39.99rem)') return viewport === 'phone'
+  return false
+}
+
+beforeEach(() => {
+  viewport = 'phone'
+  reducedMotion = false
+  scrollY = 200
+  frames = []
+  motionMocks.animate.mockClear()
+  motionMocks.stagger.mockClear()
+  motionMocks.controls.length = 0
+  motionMocks.clearObserver()
+  scrollToMock.mockClear()
+
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((query: string) => ({
+      matches: matchesQuery(query),
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })) as unknown as typeof window.matchMedia,
+  )
+  vi.stubGlobal(
+    'requestAnimationFrame',
+    vi.fn((callback: FrameRequestCallback) => {
+      frames.push(callback)
+      return frames.length
+    }),
+  )
+  vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  vi.stubGlobal(
+    'DOMMatrixReadOnly',
+    class {
+      m42 = 0
+    },
+  )
+  const getComputedStyle = window.getComputedStyle.bind(window)
+  vi.spyOn(window, 'getComputedStyle').mockImplementation((element) => {
+    const style = getComputedStyle(element)
+    return new Proxy(style, {
+      get(target, property) {
+        if (property === 'filter') return target.filter || 'none'
+        if (property === 'opacity') return target.opacity || '1'
+        if (property === 'transform') return target.transform || 'none'
+        const value = Reflect.get(target, property)
+        return typeof value === 'function' ? value.bind(target) : value
+      },
+    })
+  })
+  vi.stubGlobal('scrollTo', scrollToMock)
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 })
+  Object.defineProperty(window, 'scrollY', {
+    configurable: true,
+    get: () => scrollY,
+  })
+  Object.defineProperty(document.documentElement, 'scrollHeight', {
+    configurable: true,
+    value: 2400,
+  })
+
+  for (const [index, id] of ['article-start', 'first', 'second'].entries()) {
+    const target = document.createElement('h2')
+    target.id = id
+    target.getBoundingClientRect = () => {
+      const documentTop = index === 0 ? 60 : 760 + (index - 1) * 500
+      const top = documentTop - scrollY
+      return ({
+        bottom: top + 40,
+        height: 40,
+        left: 0,
+        right: 400,
+        top,
+        width: 400,
+        x: 0,
+        y: top,
+        toJSON: () => ({}),
+      }) as DOMRect
+    }
+    document.body.appendChild(target)
+  }
+})
+
+afterEach(() => {
+  cleanup()
+  document.body.replaceChildren()
+  history.replaceState(null, '', '/')
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('PostToc', () => {
+  it('settles an in-flight phone map instantly for keyboard toggle actions', () => {
+    const { container } = render(<PostToc nodes={nodes} nodesEn={nodes} />)
+    const root = container.querySelector<HTMLElement>('.post-minimap-root')!
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open article map' }), {
+      detail: 1,
+    })
+    const panelControl = motionMocks.controls.at(-2)!
+    const nodeControl = motionMocks.controls.at(-1)!
+    const panel = screen.getByRole('navigation', { name: 'Article map' })
+    const item = container.querySelector<HTMLElement>('.post-minimap-node')!
+    panel.style.opacity = '0.5'
+    panel.style.transform = 'translateY(-4px)'
+    panel.style.willChange = 'transform, opacity'
+    item.style.filter = 'blur(1px)'
+    item.style.opacity = '0.5'
+    item.style.transform = 'translateY(-4px)'
+    const controlCount = motionMocks.controls.length
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close article map' }), {
+      detail: 0,
+    })
+
+    expect(root.getAttribute('data-toggle-motion')).toBe('instant')
+    expect(screen.getByRole('button', { name: 'Open article map' }).getAttribute('aria-expanded')).toBe(
+      'false',
+    )
+    expect(panelControl.cancel).toHaveBeenCalledOnce()
+    expect(nodeControl.cancel).toHaveBeenCalledOnce()
+    expect(motionMocks.controls).toHaveLength(controlCount)
+    expect(panel.getAttribute('style')).toBe('')
+    expect(item.getAttribute('style')).toBe('')
+  })
+
+  it('preserves phone pointer timing, direction, blur, and reversal arguments', () => {
+    const { container } = render(<PostToc nodes={nodes} nodesEn={nodes} />)
+    const root = container.querySelector<HTMLElement>('.post-minimap-root')!
+    fireEvent.click(screen.getByRole('button', { name: 'Open article map' }), {
+      detail: 0,
+    })
+    motionMocks.animate.mockClear()
+    motionMocks.stagger.mockClear()
+    motionMocks.controls.length = 0
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close article map' }), {
+      detail: 1,
+    })
+
+    expect(root.getAttribute('data-toggle-motion')).toBeNull()
+    expect(motionMocks.animate).toHaveBeenCalledTimes(2)
+    expect(motionMocks.animate.mock.calls[0]?.[1]).toEqual({
+      opacity: 0,
+      transform: 'translateY(-12px) scale(0.96)',
+    })
+    expect(motionMocks.animate.mock.calls[0]?.[2]).toEqual({
+      duration: 0.26,
+      ease: [0.2, 0.8, 0.2, 1],
+    })
+    expect(motionMocks.animate.mock.calls[1]?.[1]).toEqual({
+      filter: 'blur(2px)',
+      opacity: 0,
+      transform: 'translateY(-8px) rotate(2deg)',
+    })
+    expect(motionMocks.animate.mock.calls[1]?.[2]).toMatchObject({
+      duration: 0.16,
+      ease: [0.2, 0.8, 0.2, 1],
+    })
+    expect(motionMocks.stagger).toHaveBeenLastCalledWith(0.05, { from: 'last' })
+  })
+
+  it('closes compact maps instantly on Escape and restores toggle focus', () => {
+    render(<PostToc nodes={nodes} nodesEn={nodes} />)
+    const toggle = screen.getByRole('button', { name: 'Open article map' })
+    fireEvent.click(toggle, { detail: 1 })
+    const controlCount = motionMocks.controls.length
+    const escape = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'Escape',
+    })
+
+    act(() => window.dispatchEvent(escape))
+
+    expect(escape.defaultPrevented).toBe(true)
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    expect(document.activeElement).toBe(toggle)
+    expect(motionMocks.controls).toHaveLength(controlCount)
+  })
+
+  it('settles the desktop entrance when keyboard focus enters the open map', () => {
+    viewport = 'desktop'
+    const matches = Element.prototype.matches
+    vi.spyOn(Element.prototype, 'matches').mockImplementation(function (this: Element, selector) {
+      if (selector === ':focus-visible') return true
+      return matches.call(this, selector)
+    })
+    const { container } = render(<PostToc nodes={nodes} nodesEn={nodes} />)
+    act(() => frames.shift()?.(0))
+    const entranceControl = motionMocks.controls.at(-1)!
+
+    screen.getByRole('link', { name: 'First' }).focus()
+
+    const root = container.querySelector<HTMLElement>('.post-minimap-root')!
+    expect(root.getAttribute('data-toggle-motion')).toBe('instant')
+    expect(screen.getByRole('button', { name: 'Close article map' }).getAttribute('aria-expanded')).toBe(
+      'true',
+    )
+    expect(entranceControl.cancel).toHaveBeenCalledOnce()
+  })
+
+  it('distinguishes pointer-created focus from later keyboard focus locally', async () => {
+    const matches = Element.prototype.matches
+    vi.spyOn(Element.prototype, 'matches').mockImplementation(function (this: Element, selector) {
+      if (selector === ':focus-visible') return true
+      return matches.call(this, selector)
+    })
+    const { container } = render(<PostToc nodes={nodes} nodesEn={nodes} />)
+    const root = container.querySelector<HTMLElement>('.post-minimap-root')!
+    const toggle = screen.getByRole('button', { name: 'Open article map' })
+    const island = container.querySelector('.post-minimap-island')
+    const islandControl = motionMocks.controls.find((control) => control.target === island)!
+
+    fireEvent.pointerDown(toggle)
+    toggle.focus()
+
+    expect(root.getAttribute('data-toggle-motion')).toBeNull()
+    expect(islandControl.cancel).not.toHaveBeenCalled()
+
+    toggle.blur()
+    fireEvent.pointerDown(toggle)
+    await act(async () => Promise.resolve())
+    toggle.focus()
+
+    expect(root.getAttribute('data-toggle-motion')).toBe('instant')
+    expect(islandControl.cancel).toHaveBeenCalledOnce()
+    expect((island as HTMLElement).style.opacity).toBe('1')
+    expect((island as HTMLElement).style.transform).toBe(
+      'translate(-50%, 0px) scale(1)',
+    )
+    expect((island as HTMLElement).style.willChange).toBe('')
+  })
+
+  it('closes before a keyboard landmark jump and settles visibility in the same frame', () => {
+    const { container } = render(<PostToc nodes={nodes} nodesEn={nodes} />)
+    const root = container.querySelector<HTMLElement>('.post-minimap-root')!
+    const toggle = screen.getByRole('button', { name: 'Open article map' })
+    fireEvent.click(toggle, { detail: 1 })
+    const controlCount = motionMocks.controls.length
+    const scrollStates: string[] = []
+    scrollToMock.mockImplementation((options) => {
+      scrollStates.push(toggle.getAttribute('aria-expanded') ?? '')
+      if (typeof options === 'object') scrollY = Number(options.top ?? scrollY)
+    })
+
+    fireEvent.click(container.querySelector('a[href="#first"]')!, { detail: 0 })
+
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    expect(root.getAttribute('data-toggle-motion')).toBe('instant')
+    expect(motionMocks.controls).toHaveLength(controlCount)
+    expect(frames).toHaveLength(1)
+
+    act(() => frames.shift()?.(0))
+
+    expect(scrollStates).toEqual(['false'])
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 660 })
+    expect(document.activeElement).toBe(document.getElementById('first'))
+    expect(document.getElementById('first')?.getAttribute('tabindex')).toBe('-1')
+    expect(location.hash).toBe('#first')
+    expect(container.querySelector('a[href="#first"]')?.getAttribute('aria-current')).toBe(
+      'location',
+    )
+    expect(
+      container.querySelector('.post-minimap-back-to-top')?.hasAttribute('data-visible'),
+    ).toBe(true)
+    expect(root.getAttribute('data-scroll-motion')).toBeNull()
+    expect(frames).toHaveLength(0)
+  })
+
+  it('settles an unchanged island target without suppressing the next reversal', () => {
+    scrollY = 800
+    const { container } = render(<PostToc nodes={nodes} nodesEn={nodes} />)
+    const island = container.querySelector<HTMLElement>('.post-minimap-island')!
+    const islandControl = motionMocks.controls.find(
+      (control) => control.target === island,
+    )!
+    const controlCount = motionMocks.controls.length
+
+    fireEvent.click(container.querySelector('a[href="#first"]')!, { detail: 0 })
+    act(() => frames.shift()?.(0))
+
+    expect(islandControl.cancel).toHaveBeenCalledOnce()
+    expect(motionMocks.controls).toHaveLength(controlCount)
+    expect(island.style.opacity).toBe('1')
+    expect(island.style.transform).toBe('translate(-50%, 0px) scale(1)')
+
+    motionMocks.animate.mockClear()
+    scrollY = 0
+    fireEvent.scroll(window)
+    act(() => frames.shift()?.(16))
+
+    expect(motionMocks.animate).toHaveBeenCalledOnce()
+    expect(motionMocks.animate.mock.calls[0]?.[0]).toBe(island)
+    expect(motionMocks.animate.mock.calls[0]?.[2]).toEqual({
+      duration: 0.26,
+      ease: [0.2, 0.8, 0.2, 1],
+    })
+  })
+
+  it('sets the active compact landmark before starting its pointer close', () => {
+    const { container } = render(<PostToc nodes={nodes} nodesEn={nodes} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Open article map' }), {
+      detail: 1,
+    })
+    motionMocks.animate.mockClear()
+    const observedStates: Array<{ active: string | null; expanded: string | null }> = []
+    motionMocks.observe(() => {
+      observedStates.push({
+        active: container
+          .querySelector('a[href="#second"]')
+          ?.getAttribute('aria-current') ?? null,
+        expanded: container
+          .querySelector('.post-minimap-toggle')
+          ?.getAttribute('aria-expanded') ?? null,
+      })
+    })
+
+    fireEvent.click(container.querySelector('a[href="#second"]')!, { detail: 1 })
+
+    expect(motionMocks.animate).toHaveBeenCalledTimes(2)
+    expect(observedStates[0]).toEqual({
+      active: 'location',
+      expanded: 'false',
+    })
+  })
+
+  it('settles phone Back to top before returning from a keyboard click', () => {
+    scrollY = 800
+    const { container } = render(<PostToc nodes={nodes} nodesEn={nodes} />)
+    const root = container.querySelector<HTMLElement>('.post-minimap-root')!
+    const island = container.querySelector<HTMLElement>('.post-minimap-island')!
+    const islandControl = motionMocks.controls.find((control) => control.target === island)!
+    const toggle = screen.getByRole('button', { name: 'Open article map' })
+    fireEvent.click(toggle, { detail: 1 })
+    const controlCount = motionMocks.controls.length
+    const backToTop = screen.getByRole('button', { name: 'Back to top' })
+    const stateAtScroll: string[] = []
+    scrollToMock.mockImplementation((options) => {
+      stateAtScroll.push(toggle.getAttribute('aria-expanded') ?? '')
+      if (typeof options === 'object') scrollY = Number(options.top ?? scrollY)
+    })
+
+    fireEvent.click(backToTop, { detail: 0 })
+
+    expect(stateAtScroll).toEqual(['false'])
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'auto' })
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    expect(islandControl.cancel).toHaveBeenCalledOnce()
+    expect(motionMocks.controls).toHaveLength(controlCount)
+    expect(island.style.opacity).toBe('0')
+    expect(island.style.transform).toBe('translate(-50%, -16px) scale(0.96)')
+    expect(island.style.willChange).toBe('')
+    expect(backToTop.hasAttribute('data-visible')).toBe(false)
+    expect(root.getAttribute('data-scroll-motion')).toBeNull()
+    expect(frames).toHaveLength(0)
+
+    scrollY = 800
+    fireEvent.scroll(window)
+    act(() => frames.shift()?.(16))
+    const ordinaryArrival = motionMocks.controls.at(-1)!
+    expect(ordinaryArrival.target).toBe(island)
+    expect(motionMocks.animate.mock.calls.at(-1)?.[2]).toEqual({
+      duration: 0.28,
+      ease: [0.2, 0.8, 0.2, 1],
+    })
+
+    scrollY = 0
+    fireEvent.scroll(window)
+    act(() => frames.shift()?.(32))
+    expect(ordinaryArrival.stop).toHaveBeenCalledOnce()
+    expect(motionMocks.animate.mock.calls.at(-1)?.[2]).toEqual({
+      duration: 0.26,
+      ease: [0.2, 0.8, 0.2, 1],
+    })
+  })
+
+  it('keeps compact pointer Back to top smooth and animated', () => {
+    scrollY = 800
+    const { container } = render(<PostToc nodes={nodes} nodesEn={nodes} />)
+    const root = container.querySelector<HTMLElement>('.post-minimap-root')!
+    fireEvent.click(screen.getByRole('button', { name: 'Open article map' }), {
+      detail: 1,
+    })
+    motionMocks.animate.mockClear()
+
+    fireEvent.click(container.querySelector('.post-minimap-back-to-top')!, {
+      detail: 1,
+    })
+
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' })
+    expect(screen.getByRole('button', { name: 'Open article map' }).getAttribute('aria-expanded')).toBe(
+      'false',
+    )
+    expect(motionMocks.animate).toHaveBeenCalledTimes(2)
+    expect(root.getAttribute('data-toggle-motion')).toBeNull()
+    expect(root.getAttribute('data-scroll-motion')).toBeNull()
+    expect(frames).toHaveLength(0)
+  })
+
+  it('settles reduced-motion pointer landmarks and Back to top without instant gates', () => {
+    reducedMotion = true
+    scrollY = 800
+    const { container } = render(<PostToc nodes={nodes} nodesEn={nodes} />)
+    const root = container.querySelector<HTMLElement>('.post-minimap-root')!
+    fireEvent.click(screen.getByRole('button', { name: 'Open article map' }), {
+      detail: 1,
+    })
+    const anchor = container.querySelector('a[href="#first"]')!
+
+    fireEvent.click(anchor, { detail: 1 })
+    expect(frames).toHaveLength(1)
+    act(() => frames.shift()?.(0))
+
+    expect(root.getAttribute('data-toggle-motion')).toBeNull()
+    expect(root.getAttribute('data-scroll-motion')).toBeNull()
+    expect(frames).toHaveLength(0)
+    expect(motionMocks.animate).not.toHaveBeenCalled()
+
+    fireEvent.click(container.querySelector('.post-minimap-back-to-top')!, {
+      detail: 1,
+    })
+
+    expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 0, behavior: 'auto' })
+    expect(root.getAttribute('data-toggle-motion')).toBeNull()
+    expect(root.getAttribute('data-scroll-motion')).toBeNull()
+    expect(motionMocks.animate).not.toHaveBeenCalled()
+    expect(frames).toHaveLength(0)
+  })
+
+  it('keeps desktop keyboard actions open and restores pointer transitions', () => {
+    viewport = 'desktop'
+    scrollY = 800
+    const { container } = render(<PostToc nodes={nodes} nodesEn={nodes} />)
+    act(() => frames.shift()?.(0))
+    const root = container.querySelector<HTMLElement>('.post-minimap-root')!
+    const toggle = screen.getByRole('button', { name: 'Close article map' })
+    const entranceControl = motionMocks.controls.at(-1)!
+
+    fireEvent.click(screen.getByRole('link', { name: 'First' }), { detail: 0 })
+
+    expect(toggle.getAttribute('aria-expanded')).toBe('true')
+    expect(root.getAttribute('data-toggle-motion')).toBe('instant')
+    expect(entranceControl.cancel).toHaveBeenCalledOnce()
+    act(() => frames.shift()?.(0))
+    expect(root.getAttribute('data-scroll-motion')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to top' }), {
+      detail: 0,
+    })
+
+    expect(toggle.getAttribute('aria-expanded')).toBe('true')
+    expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 0, behavior: 'auto' })
+    expect(root.getAttribute('data-toggle-motion')).toBe('instant')
+
+    root.setAttribute('data-scroll-motion', 'instant')
+    fireEvent.pointerMove(root)
+    expect(root.getAttribute('data-toggle-motion')).toBeNull()
+    expect(root.getAttribute('data-scroll-motion')).toBe('instant')
+
+    fireEvent.click(container.querySelector('a[href="#second"]')!, { detail: 1 })
+    expect(toggle.getAttribute('aria-expanded')).toBe('true')
+    expect(root.getAttribute('data-toggle-motion')).toBeNull()
+  })
+
+  it('keeps outside pointer dismissal on the animated compact path', () => {
+    render(<PostToc nodes={nodes} nodesEn={nodes} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Open article map' }), {
+      detail: 1,
+    })
+    motionMocks.animate.mockClear()
+
+    fireEvent.pointerDown(document.body)
+
+    expect(screen.getByRole('button', { name: 'Open article map' }).getAttribute('aria-expanded')).toBe(
+      'false',
+    )
+    expect(motionMocks.animate).toHaveBeenCalledTimes(2)
+  })
+
+  it('settles ordinary reduced-motion measurements and cancels queued work on cleanup', () => {
+    reducedMotion = true
+    scrollY = 0
+    const { container, unmount } = render(<PostToc nodes={nodes} nodesEn={nodes} />)
+    const root = container.querySelector<HTMLElement>('.post-minimap-root')!
+    const island = container.querySelector<HTMLElement>('.post-minimap-island')!
+    motionMocks.animate.mockClear()
+
+    scrollY = 800
+    fireEvent.scroll(window)
+    act(() => frames.shift()?.(0))
+
+    expect(root.hasAttribute('data-island-visible')).toBe(true)
+    expect(root.getAttribute('data-toggle-motion')).toBeNull()
+    expect(root.getAttribute('data-scroll-motion')).toBeNull()
+    expect(island.style.opacity).toBe('1')
+    expect(island.style.transform).toBe('translate(-50%, 0px) scale(1)')
+    expect(motionMocks.animate).not.toHaveBeenCalled()
+
+    fireEvent.resize(window)
+    expect(frames).toHaveLength(1)
+    unmount()
+    expect(cancelAnimationFrame).toHaveBeenCalled()
+  })
+})

--- a/components/post-toc.tsx
+++ b/components/post-toc.tsx
@@ -2,7 +2,7 @@
 
 import { animate, stagger } from 'motion'
 import Link from 'next/link'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { flushSync } from 'react-dom'
 
 import type { PostRailNode } from '~/lib/content'
@@ -102,6 +102,9 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
   const [backToTopVisible, setBackToTopVisible] = useState(false)
   const [active, setActive] = useState(landmarks[0]?.id)
   const activeRef = useRef(active)
+  const openRef = useRef(open)
+  const desktopRef = useRef(desktop)
+  const phoneRef = useRef(phone)
   const islandRef = useRef<HTMLDivElement>(null)
   const panelRef = useRef<HTMLElement>(null)
   const progressCircleRef = useRef<SVGCircleElement>(null)
@@ -119,6 +122,10 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
   const phoneIslandVisibleRef = useRef(false)
   const instantIslandTargetRef = useRef<boolean | null>(null)
 
+  openRef.current = open
+  desktopRef.current = desktop
+  phoneRef.current = phone
+
   useEffect(() => {
     activeRef.current = active
   }, [active])
@@ -129,121 +136,127 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
     setActive(first)
   }, [landmarks])
 
-  function animateOpenState(nextOpen: boolean, motion: OpenMotion = 'animated') {
-    if (motion === 'instant') {
-      rootRef.current?.setAttribute('data-toggle-motion', 'instant')
-    } else {
-      rootRef.current?.removeAttribute('data-toggle-motion')
-    }
+  const animateOpenState = useCallback(
+    (nextOpen: boolean, motion: OpenMotion = 'animated') => {
+      const currentOpen = openRef.current
+      const isDesktop = desktopRef.current
+      const isPhone = phoneRef.current
 
-    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-    if (motion === 'animated' && !reducedMotion && nextOpen === open) return
-
-    const items = rootRef.current?.querySelectorAll<HTMLElement>('.post-minimap-node')
-    const panel = panelRef.current
-
-    if (motion === 'instant' || reducedMotion) {
-      nodeAnimationRef.current?.cancel()
-      nodeAnimationRef.current = null
-      panelAnimationRef.current?.cancel()
-      panelAnimationRef.current = null
-      for (const item of items ?? []) {
-        item.style.removeProperty('filter')
-        item.style.removeProperty('opacity')
-        item.style.removeProperty('transform')
+      if (motion === 'instant') {
+        rootRef.current?.setAttribute('data-toggle-motion', 'instant')
+      } else {
+        rootRef.current?.removeAttribute('data-toggle-motion')
       }
-      panel?.style.removeProperty('opacity')
-      panel?.style.removeProperty('transform')
-      panel?.style.removeProperty('will-change')
-      if (nextOpen !== open) flushSync(() => setOpen(nextOpen))
-      return
-    }
 
-    nodeAnimationRef.current?.stop()
-    panelAnimationRef.current?.stop()
-    if (!items?.length) {
-      nodeAnimationRef.current = null
-      panelAnimationRef.current = null
-      setOpen(nextOpen)
-      return
-    }
+      const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      if (motion === 'animated' && !reducedMotion && nextOpen === currentOpen) return
 
-    const closingDesktop = desktop && !nextOpen
-    const furthestCenterIndex = Math.ceil((items.length - 1) / 2)
-    const desktopExitStagger =
-      furthestCenterIndex > 0
-        ? Math.min(0.01, DESKTOP_EXIT_STAGGER_WINDOW / furthestCenterIndex)
-        : 0
-    const phoneStaggerWindow = nextOpen
-      ? PHONE_ENTER_STAGGER_WINDOW
-      : PHONE_EXIT_STAGGER_WINDOW
-    const phoneFurthestIndex = items.length - 1
-    const phoneStagger =
-      phoneFurthestIndex > 0 ? phoneStaggerWindow / phoneFurthestIndex : 0
+      const items = rootRef.current?.querySelectorAll<HTMLElement>('.post-minimap-node')
+      const panel = panelRef.current
 
-    // Motion otherwise resolves the first open against the incoming React
-    // state, so phone items jump directly to their final styles. Pinning the
-    // rendered frame also keeps rapid direction changes interruptible.
-    for (const item of items) {
-      const style = window.getComputedStyle(item)
-      if (phone) item.style.filter = style.filter
-      item.style.opacity = style.opacity
-      item.style.transform = style.transform
-    }
-    if (phone && panel) {
-      const style = window.getComputedStyle(panel)
-      panel.style.opacity = style.opacity
-      panel.style.transform = style.transform
-      panel.style.willChange = 'transform, opacity'
-    }
-
-    flushSync(() => setOpen(nextOpen))
-
-    if (phone && panel) {
-      const panelAnimation = animate(
-        panel,
-        {
-          opacity: nextOpen ? 1 : 0,
-          transform: nextOpen ? PHONE_PANEL_VISIBLE_TRANSFORM : PHONE_PANEL_HIDDEN_TRANSFORM,
-        },
-        {
-          duration: nextOpen ? PHONE_PANEL_ENTER_DURATION : PHONE_PANEL_EXIT_DURATION,
-          ease: EASE_SWIFT,
-        },
-      )
-      panelAnimationRef.current = panelAnimation
-      void panelAnimation.finished
-        .then(() => {
-          if (panelAnimationRef.current !== panelAnimation) return
-          panelAnimation.cancel()
-          panelAnimationRef.current = null
-          panel.style.removeProperty('opacity')
-          panel.style.removeProperty('transform')
-          panel.style.removeProperty('will-change')
-        })
-        .catch(() => undefined)
-    }
-
-    const itemTransform = nextOpen
-      ? 'translateY(0) rotate(0deg)'
-      : 'translateY(-8px) rotate(2deg)'
-    const itemKeyframes = phone
-      ? {
-          filter: nextOpen ? 'blur(0px)' : PHONE_NODE_HIDDEN_FILTER,
-          opacity: nextOpen ? 1 : 0,
-          transform: itemTransform,
+      if (motion === 'instant' || reducedMotion) {
+        nodeAnimationRef.current?.cancel()
+        nodeAnimationRef.current = null
+        panelAnimationRef.current?.cancel()
+        panelAnimationRef.current = null
+        for (const item of items ?? []) {
+          item.style.removeProperty('filter')
+          item.style.removeProperty('opacity')
+          item.style.removeProperty('transform')
         }
-      : {
-          opacity: nextOpen ? 1 : 0,
-          transform: itemTransform,
-        }
-    const animation = animate(
-      items,
-      itemKeyframes,
-      {
+        panel?.style.removeProperty('opacity')
+        panel?.style.removeProperty('transform')
+        panel?.style.removeProperty('will-change')
+        if (nextOpen !== currentOpen) flushSync(() => setOpen(nextOpen))
+        return
+      }
+
+      nodeAnimationRef.current?.stop()
+      panelAnimationRef.current?.stop()
+      if (!items?.length) {
+        nodeAnimationRef.current = null
+        panelAnimationRef.current = null
+        setOpen(nextOpen)
+        return
+      }
+
+      const closingDesktop = isDesktop && !nextOpen
+      const furthestCenterIndex = Math.ceil((items.length - 1) / 2)
+      const desktopExitStagger =
+        furthestCenterIndex > 0
+          ? Math.min(0.01, DESKTOP_EXIT_STAGGER_WINDOW / furthestCenterIndex)
+          : 0
+      const phoneStaggerWindow = nextOpen
+        ? PHONE_ENTER_STAGGER_WINDOW
+        : PHONE_EXIT_STAGGER_WINDOW
+      const phoneFurthestIndex = items.length - 1
+      const phoneStagger =
+        phoneFurthestIndex > 0 ? phoneStaggerWindow / phoneFurthestIndex : 0
+
+      // Motion otherwise resolves the first open against the incoming React
+      // state, so phone items jump directly to their final styles. Pinning the
+      // rendered frame also keeps rapid direction changes interruptible.
+      for (const item of items) {
+        const style = window.getComputedStyle(item)
+        if (isPhone) item.style.filter = style.filter
+        item.style.opacity = style.opacity
+        item.style.transform = style.transform
+      }
+      if (isPhone && panel) {
+        const style = window.getComputedStyle(panel)
+        panel.style.opacity = style.opacity
+        panel.style.transform = style.transform
+        panel.style.willChange = 'transform, opacity'
+      }
+
+      flushSync(() => setOpen(nextOpen))
+
+      if (isPhone && panel) {
+        const panelAnimation = animate(
+          panel,
+          {
+            opacity: nextOpen ? 1 : 0,
+            transform: nextOpen
+              ? PHONE_PANEL_VISIBLE_TRANSFORM
+              : PHONE_PANEL_HIDDEN_TRANSFORM,
+          },
+          {
+            duration: nextOpen
+              ? PHONE_PANEL_ENTER_DURATION
+              : PHONE_PANEL_EXIT_DURATION,
+            ease: EASE_SWIFT,
+          },
+        )
+        panelAnimationRef.current = panelAnimation
+        void panelAnimation.finished
+          .then(() => {
+            if (panelAnimationRef.current !== panelAnimation) return
+            panelAnimation.cancel()
+            panelAnimationRef.current = null
+            panel.style.removeProperty('opacity')
+            panel.style.removeProperty('transform')
+            panel.style.removeProperty('will-change')
+          })
+          .catch(() => undefined)
+      }
+
+      const itemTransform = nextOpen
+        ? 'translateY(0) rotate(0deg)'
+        : 'translateY(-8px) rotate(2deg)'
+      const itemKeyframes = isPhone
+        ? {
+            filter: nextOpen ? 'blur(0px)' : PHONE_NODE_HIDDEN_FILTER,
+            opacity: nextOpen ? 1 : 0,
+            transform: itemTransform,
+          }
+        : {
+            opacity: nextOpen ? 1 : 0,
+            transform: itemTransform,
+          }
+      const animation = animate(items, itemKeyframes, {
         duration: closingDesktop
           ? DESKTOP_EXIT_DURATION
-          : phone
+          : isPhone
             ? nextOpen
               ? PHONE_NODE_ENTER_DURATION
               : PHONE_NODE_EXIT_DURATION
@@ -251,27 +264,34 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
               ? 0.26
               : 0.2,
         delay: stagger(
-          closingDesktop ? desktopExitStagger : phone ? phoneStagger : nextOpen ? 0.012 : 0.01,
-          { from: phone ? (nextOpen ? 'first' : 'last') : 'center' },
+          closingDesktop
+            ? desktopExitStagger
+            : isPhone
+              ? phoneStagger
+              : nextOpen
+                ? 0.012
+                : 0.01,
+          { from: isPhone ? (nextOpen ? 'first' : 'last') : 'center' },
         ),
         ease: EASE_SWIFT,
-      },
-    )
-    nodeAnimationRef.current = animation
-
-    void animation.finished
-      .then(() => {
-        if (nodeAnimationRef.current !== animation) return
-        animation.cancel()
-        nodeAnimationRef.current = null
-        for (const item of items) {
-          item.style.removeProperty('filter')
-          item.style.removeProperty('opacity')
-          item.style.removeProperty('transform')
-        }
       })
-      .catch(() => undefined)
-  }
+      nodeAnimationRef.current = animation
+
+      void animation.finished
+        .then(() => {
+          if (nodeAnimationRef.current !== animation) return
+          animation.cancel()
+          nodeAnimationRef.current = null
+          for (const item of items) {
+            item.style.removeProperty('filter')
+            item.style.removeProperty('opacity')
+            item.style.removeProperty('transform')
+          }
+        })
+        .catch(() => undefined)
+    },
+    [],
+  )
 
   function settlePhoneIsland(visible: boolean) {
     islandAnimationRef.current?.cancel()
@@ -325,7 +345,7 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
       query.removeEventListener('change', sync)
       if (frame) window.cancelAnimationFrame(frame)
     }
-  }, [])
+  }, [animateOpenState])
 
   useEffect(() => {
     const query = window.matchMedia(PHONE_QUERY)
@@ -431,12 +451,12 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
       window.removeEventListener('keydown', onKeyDown)
       window.removeEventListener('pointerdown', onPointerDown)
     }
-  }, [desktop, open])
+  }, [animateOpenState, desktop, open])
 
   useEffect(() => {
     if (!phone || phoneIslandVisible || !open) return
     animateOpenState(false)
-  }, [open, phone, phoneIslandVisible])
+  }, [animateOpenState, open, phone, phoneIslandVisible])
 
   useEffect(() => {
     const targets = landmarks
@@ -532,6 +552,8 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
       animateOpenState(desktop ? open : false, 'instant')
       setActive(id)
     } else {
+      // A same-state animated call clears the persistent keyboard CSS gate.
+      // Under reduced motion it also settles controls without changing open.
       animateOpenState(open, 'animated')
       setActive(id)
       if (!desktop) animateOpenState(false, 'animated')

--- a/components/post-toc.tsx
+++ b/components/post-toc.tsx
@@ -29,6 +29,7 @@ const PHONE_PANEL_VISIBLE_TRANSFORM = 'translateY(0px) scale(1)'
 const PHONE_QUERY = '(max-width: 39.99rem)'
 const TARGET_OFFSET = 100
 const RAIL_ID = 'post-document-minimap'
+type OpenMotion = 'animated' | 'instant'
 
 function getReadingTop(target: HTMLElement) {
   const rectTop = target.getBoundingClientRect().top
@@ -111,6 +112,12 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
   const panelAnimationRef = useRef<ReturnType<typeof animate> | null>(null)
   const desktopEntrancePlayedRef = useRef(false)
   const phoneIslandInitializedRef = useRef(false)
+  const pointerFocusPendingRef = useRef(false)
+  const measureNowRef = useRef<(() => void) | null>(null)
+  const pendingInstantMeasurementRef = useRef(false)
+  const phoneQueryRef = useRef(false)
+  const phoneIslandVisibleRef = useRef(false)
+  const instantIslandTargetRef = useRef<boolean | null>(null)
 
   useEffect(() => {
     activeRef.current = active
@@ -122,14 +129,20 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
     setActive(first)
   }, [landmarks])
 
-  function animateOpenState(nextOpen: boolean) {
-    if (nextOpen === open) return
+  function animateOpenState(nextOpen: boolean, motion: OpenMotion = 'animated') {
+    if (motion === 'instant') {
+      rootRef.current?.setAttribute('data-toggle-motion', 'instant')
+    } else {
+      rootRef.current?.removeAttribute('data-toggle-motion')
+    }
+
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (motion === 'animated' && !reducedMotion && nextOpen === open) return
 
     const items = rootRef.current?.querySelectorAll<HTMLElement>('.post-minimap-node')
     const panel = panelRef.current
-    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
 
-    if (reducedMotion) {
+    if (motion === 'instant' || reducedMotion) {
       nodeAnimationRef.current?.cancel()
       nodeAnimationRef.current = null
       panelAnimationRef.current?.cancel()
@@ -142,7 +155,7 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
       panel?.style.removeProperty('opacity')
       panel?.style.removeProperty('transform')
       panel?.style.removeProperty('will-change')
-      setOpen(nextOpen)
+      if (nextOpen !== open) flushSync(() => setOpen(nextOpen))
       return
     }
 
@@ -260,6 +273,19 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
       .catch(() => undefined)
   }
 
+  function settlePhoneIsland(visible: boolean) {
+    islandAnimationRef.current?.cancel()
+    islandAnimationRef.current = null
+    const island = islandRef.current
+    if (!island) return
+    island.style.opacity = visible ? '1' : '0'
+    island.style.transform = visible
+      ? PHONE_ISLAND_VISIBLE_TRANSFORM
+      : PHONE_ISLAND_HIDDEN_TRANSFORM
+    island.style.removeProperty('will-change')
+    phoneIslandInitializedRef.current = true
+  }
+
   useEffect(
     () => () => {
       islandAnimationRef.current?.stop()
@@ -304,6 +330,7 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
   useEffect(() => {
     const query = window.matchMedia(PHONE_QUERY)
     const sync = () => {
+      phoneQueryRef.current = query.matches
       setPhone(query.matches)
       setPhoneQueryReady(true)
     }
@@ -316,7 +343,14 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
     const island = islandRef.current
     if (!phoneQueryReady || !island) return
 
+    if (instantIslandTargetRef.current === phoneIslandVisible) {
+      instantIslandTargetRef.current = null
+      settlePhoneIsland(phoneIslandVisible)
+      return
+    }
+
     if (!phone) {
+      instantIslandTargetRef.current = null
       islandAnimationRef.current?.stop()
       islandAnimationRef.current = null
       phoneIslandInitializedRef.current = false
@@ -351,10 +385,7 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
     }
 
     if (reducedMotion) {
-      islandAnimationRef.current = null
-      island.style.opacity = targetOpacity
-      island.style.transform = targetTransform
-      island.style.removeProperty('will-change')
+      settlePhoneIsland(visible)
       return
     }
 
@@ -386,7 +417,8 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
     if (!open || desktop) return
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return
-      animateOpenState(false)
+      event.preventDefault()
+      animateOpenState(false, 'instant')
       toggleRef.current?.focus()
     }
     const onPointerDown = (event: PointerEvent) => {
@@ -418,11 +450,43 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
       const scrollable = document.documentElement.scrollHeight - window.innerHeight
       const progress = scrollable > 0 ? Math.min(1, Math.max(0, window.scrollY / scrollable)) : 0
       progressCircleRef.current?.setAttribute('stroke-dasharray', `${progress} 1`)
-      setBackToTopVisible(window.scrollY >= window.innerHeight * 0.75)
+      const nextBackToTopVisible = window.scrollY >= window.innerHeight * 0.75
       const titleCard = document.querySelector('.post-title-card')
-      setPhoneIslandVisible(
-        titleCard ? titleCard.getBoundingClientRect().bottom <= TARGET_OFFSET : window.scrollY > 1,
-      )
+      const nextPhoneIslandVisible = titleCard
+        ? titleCard.getBoundingClientRect().bottom <= TARGET_OFFSET
+        : window.scrollY > 1
+      const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      const settleVisibility = pendingInstantMeasurementRef.current || reducedMotion
+
+      if (settleVisibility) {
+        islandAnimationRef.current?.cancel()
+        islandAnimationRef.current = null
+        const island = islandRef.current
+        island?.style.removeProperty('opacity')
+        island?.style.removeProperty('transform')
+        island?.style.removeProperty('will-change')
+
+        const islandVisibilityChanged =
+          nextPhoneIslandVisible !== phoneIslandVisibleRef.current
+        instantIslandTargetRef.current =
+          phoneQueryRef.current && islandVisibilityChanged
+            ? nextPhoneIslandVisible
+            : null
+        phoneIslandVisibleRef.current = nextPhoneIslandVisible
+        const updateVisibility = () => {
+          setBackToTopVisible(nextBackToTopVisible)
+          setPhoneIslandVisible(nextPhoneIslandVisible)
+        }
+        flushSync(updateVisibility)
+        if (phoneQueryRef.current) settlePhoneIsland(nextPhoneIslandVisible)
+        void rootRef.current?.offsetHeight
+        rootRef.current?.removeAttribute('data-scroll-motion')
+        pendingInstantMeasurementRef.current = false
+      } else {
+        phoneIslandVisibleRef.current = nextPhoneIslandVisible
+        setBackToTopVisible(nextBackToTopVisible)
+        setPhoneIslandVisible(nextPhoneIslandVisible)
+      }
 
       let current = targets[0].id
       for (const target of targets) {
@@ -438,14 +502,22 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
     const requestMeasure = () => {
       if (!frame) frame = window.requestAnimationFrame(measure)
     }
+    const measureNow = () => {
+      if (frame) window.cancelAnimationFrame(frame)
+      frame = 0
+      measure()
+    }
 
-    measure()
+    measureNowRef.current = measureNow
+    measureNow()
     window.addEventListener('scroll', requestMeasure, { passive: true })
     window.addEventListener('resize', requestMeasure)
     return () => {
       window.removeEventListener('scroll', requestMeasure)
       window.removeEventListener('resize', requestMeasure)
       if (frame) window.cancelAnimationFrame(frame)
+      measureNowRef.current = null
+      pendingInstantMeasurementRef.current = false
     }
   }, [landmarks])
 
@@ -453,22 +525,63 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
     event.preventDefault()
     const target = document.getElementById(id)
     if (!target) return
+    const keyboard = event.detail === 0
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
 
-    setActive(id)
-    if (!desktop) animateOpenState(false)
+    if (keyboard) {
+      animateOpenState(desktop ? open : false, 'instant')
+      setActive(id)
+    } else {
+      animateOpenState(open, 'animated')
+      setActive(id)
+      if (!desktop) animateOpenState(false, 'animated')
+    }
 
     window.requestAnimationFrame(() => {
       if (!target.hasAttribute('tabindex')) target.setAttribute('tabindex', '-1')
       target.focus({ preventScroll: true })
+      if (keyboard) {
+        rootRef.current?.setAttribute('data-scroll-motion', 'instant')
+        pendingInstantMeasurementRef.current = true
+      }
       window.scrollTo({ top: window.scrollY + getReadingTop(target) - TARGET_OFFSET })
+      if (keyboard || reducedMotion) measureNowRef.current?.()
       history.replaceState(null, '', `#${id}`)
     })
   }
 
-  function returnToTop() {
+  function returnToTop(event: React.MouseEvent<HTMLButtonElement>) {
+    const keyboard = event.detail === 0
     const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-    if (!desktop) animateOpenState(false)
-    window.scrollTo({ top: 0, behavior: reducedMotion ? 'auto' : 'smooth' })
+    animateOpenState(desktop ? open : false, keyboard ? 'instant' : 'animated')
+    if (keyboard) {
+      rootRef.current?.setAttribute('data-scroll-motion', 'instant')
+      pendingInstantMeasurementRef.current = true
+    }
+    window.scrollTo({
+      top: 0,
+      behavior: keyboard || reducedMotion ? 'auto' : 'smooth',
+    })
+    if (keyboard || reducedMotion) measureNowRef.current?.()
+  }
+
+  function markPointerFocusPending() {
+    pointerFocusPendingRef.current = true
+    queueMicrotask(() => {
+      pointerFocusPendingRef.current = false
+    })
+  }
+
+  function settleKeyboardFocus(event: React.FocusEvent<HTMLDivElement>) {
+    const pointerCreated = pointerFocusPendingRef.current
+    pointerFocusPendingRef.current = false
+    if (pointerCreated) return
+    if (!(event.target as HTMLElement).matches(':focus-visible')) return
+
+    animateOpenState(open, 'instant')
+    if (phoneQueryRef.current) {
+      settlePhoneIsland(phoneIslandVisibleRef.current)
+    }
   }
 
   if (landmarks.length < 2) return null
@@ -482,6 +595,9 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
       className="post-minimap-root"
       data-island-visible={phoneIslandVisible || undefined}
       data-open={open || undefined}
+      onPointerDownCapture={markPointerFocusPending}
+      onFocusCapture={settleKeyboardFocus}
+      onPointerMove={() => rootRef.current?.removeAttribute('data-toggle-motion')}
     >
       <div className="post-minimap-backdrop backdrop-blur-[8px]" aria-hidden />
       <div
@@ -501,7 +617,9 @@ export function PostToc({ nodes, nodesEn }: { nodes: PostRailNode[]; nodesEn: Po
           }
           aria-expanded={open}
           aria-controls={RAIL_ID}
-          onClick={() => animateOpenState(!open)}
+          onClick={(event) =>
+            animateOpenState(!open, event.detail === 0 ? 'instant' : 'animated')
+          }
         >
           <svg
             className="post-minimap-progress"

--- a/components/preview-card-timing.test.tsx
+++ b/components/preview-card-timing.test.tsx
@@ -1,0 +1,329 @@
+/** @vitest-environment jsdom */
+
+import { readFileSync } from 'node:fs'
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@base-ui/react/preview-card', async () => {
+  const React = await import('react')
+
+  type PopupState = {
+    instant: 'dismiss' | 'focus' | undefined
+    open: boolean
+    transitionStatus: 'ending' | 'starting'
+  }
+  type Payload = { id: string; popup: React.ReactNode }
+  type Controller = {
+    close: (instant?: PopupState['instant']) => void
+    open: (payload: Payload | undefined, instant?: PopupState['instant']) => void
+  }
+  type Handle = { controller?: Controller }
+
+  const RootContext = React.createContext<Handle | null>(null)
+  const PopupContext = React.createContext<PopupState>({
+    instant: undefined,
+    open: false,
+    transitionStatus: 'starting',
+  })
+
+  function Root({
+    children,
+    handle,
+    onOpenChange,
+  }: {
+    children:
+      | React.ReactNode
+      | ((value: { payload: Payload | undefined }) => React.ReactNode)
+    handle?: Handle
+    onOpenChange?: (open: boolean) => void
+  }) {
+    const localHandle = React.useRef<Handle>({}).current
+    const activeHandle = handle ?? localHandle
+    const [payload, setPayload] = React.useState<Payload>()
+    const [popupState, setPopupState] = React.useState<PopupState>({
+      instant: undefined,
+      open: false,
+      transitionStatus: 'starting',
+    })
+
+    React.useLayoutEffect(() => {
+      activeHandle.controller = {
+        close(instant) {
+          setPopupState((current) => ({
+            ...current,
+            instant,
+            open: false,
+            transitionStatus: 'ending',
+          }))
+          onOpenChange?.(false)
+        },
+        open(nextPayload, instant) {
+          setPayload(nextPayload)
+          setPopupState((current) => ({
+            instant,
+            open: true,
+            transitionStatus:
+              current.transitionStatus === 'ending' ? 'ending' : 'starting',
+          }))
+          onOpenChange?.(true)
+        },
+      }
+      return () => {
+        activeHandle.controller = undefined
+      }
+    }, [activeHandle, onOpenChange])
+
+    return (
+      <RootContext.Provider value={activeHandle}>
+        <PopupContext.Provider value={popupState}>
+          <div data-preview-root="">
+            {typeof children === 'function' ? children({ payload }) : children}
+          </div>
+        </PopupContext.Provider>
+      </RootContext.Provider>
+    )
+  }
+
+  function Trigger({
+    children,
+    closeDelay,
+    delay,
+    handle,
+    payload,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    closeDelay?: number
+    delay?: number
+    handle?: Handle
+    payload?: Payload
+  }) {
+    const localHandle = React.useContext(RootContext)
+    const activeHandle = handle ?? localHandle
+    return (
+      <a
+        {...props}
+        data-close-delay={closeDelay}
+        data-delay={delay}
+        onBlur={() => activeHandle?.controller?.close('dismiss')}
+        onFocus={() => activeHandle?.controller?.open(payload, 'focus')}
+        onKeyDown={(event) => {
+          if (event.key === 'Escape') activeHandle?.controller?.close('dismiss')
+        }}
+        onMouseEnter={() => activeHandle?.controller?.open(payload)}
+        onMouseLeave={() => activeHandle?.controller?.close()}
+      >
+        {children}
+      </a>
+    )
+  }
+
+  function Popup({
+    children,
+    className,
+  }: {
+    children: React.ReactNode
+    className: string | ((state: PopupState) => string)
+  }) {
+    const state = React.useContext(PopupContext)
+    return (
+      <div
+        className={typeof className === 'function' ? className(state) : className}
+        data-popup=""
+        data-transition-status={state.transitionStatus}
+      >
+        {children}
+      </div>
+    )
+  }
+
+  return {
+    PreviewCard: {
+      createHandle: () => ({}),
+      Root,
+      Trigger,
+      Portal: ({ children }: { children: React.ReactNode }) => children,
+      Positioner: ({
+        children,
+        side,
+      }: {
+        children: React.ReactNode
+        side?: string
+      }) => <div data-positioner-side={side}>{children}</div>,
+      Popup,
+    },
+  }
+})
+
+import {
+  PreviewCardTimingProvider,
+  SitePreviewCard,
+} from './preview-card-timing'
+
+function PreviewPair() {
+  return (
+    <PreviewCardTimingProvider>
+      <SitePreviewCard
+        href="https://example.com/a"
+        triggerClassName="trigger"
+        closeDelay={100}
+        popupClassName="link-card"
+        popup={
+          <span data-payload="a" style={{ display: 'block', height: 24 }}>
+            Alpha card
+          </span>
+        }
+        side="top"
+      >
+        Alpha
+      </SitePreviewCard>
+      <SitePreviewCard
+        href="https://example.com/b"
+        triggerClassName="trigger"
+        closeDelay={120}
+        popupClassName="link-card service-card"
+        popup={
+          <span data-payload="b" style={{ display: 'block', height: 72 }}>
+            Beta card
+            <span className="contrib-grid">
+              <i />
+            </span>
+          </span>
+        }
+        side="bottom"
+      >
+        Beta
+      </SitePreviewCard>
+    </PreviewCardTimingProvider>
+  )
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.runOnlyPendingTimers()
+  vi.useRealTimers()
+})
+
+describe('preview card timing', () => {
+  it('uses one cold shared root before any trigger provides a payload', () => {
+    const { container } = render(<PreviewPair />)
+
+    expect(container.querySelectorAll('[data-preview-root]')).toHaveLength(1)
+    expect(container.querySelector('[data-popup]')).toBeNull()
+    for (const trigger of screen.getAllByRole('link')) {
+      expect(trigger.getAttribute('data-delay')).toBe('300')
+    }
+  })
+
+  it('stays warm while open and for exactly 300ms after close', () => {
+    render(<PreviewPair />)
+    const [alpha, beta] = screen.getAllByRole('link')
+
+    fireEvent.mouseEnter(alpha)
+    expect(screen.getByText('Alpha card')).not.toBeNull()
+    expect(beta.getAttribute('data-delay')).toBe('0')
+
+    fireEvent.mouseLeave(alpha)
+    act(() => vi.advanceTimersByTime(299))
+    expect(beta.getAttribute('data-delay')).toBe('0')
+    act(() => vi.advanceTimersByTime(1))
+    expect(beta.getAttribute('data-delay')).toBe('300')
+  })
+
+  it('cancels cooldown and preserves one Popup while switching payloads mid-exit', () => {
+    const { container } = render(<PreviewPair />)
+    const [alpha, beta] = screen.getAllByRole('link')
+    fireEvent.mouseEnter(alpha)
+    const popup = container.querySelector('[data-popup]')
+
+    fireEvent.mouseLeave(alpha)
+    act(() => vi.advanceTimersByTime(200))
+    expect(popup?.getAttribute('data-transition-status')).toBe('ending')
+    fireEvent.mouseEnter(beta)
+
+    expect(container.querySelector('[data-popup]')).toBe(popup)
+    expect(container.querySelector('[data-payload="a"]')).toBeNull()
+    expect(container.querySelector('[data-payload="b"]')?.textContent).toContain(
+      'Beta card',
+    )
+    expect(
+      (container.querySelector('[data-payload="b"]') as HTMLElement).style.height,
+    ).toBe('72px')
+    expect(
+      container
+        .querySelector('[data-positioner-side]')
+        ?.getAttribute('data-positioner-side'),
+    ).toBe('bottom')
+    act(() => vi.advanceTimersByTime(200))
+    expect(beta.getAttribute('data-delay')).toBe('0')
+  })
+
+  it('marks focus and dismiss states instant, including contribution cells', () => {
+    const { container } = render(<PreviewPair />)
+    const beta = screen.getByRole('link', { name: 'Beta' })
+
+    fireEvent.focus(beta)
+    expect(container.querySelector('[data-popup]')?.className).toContain(
+      'preview-card-instant',
+    )
+    expect(container.querySelector('.contrib-grid i')).not.toBeNull()
+
+    fireEvent.keyDown(beta, { key: 'Escape' })
+    expect(container.querySelector('[data-popup]')?.className).toContain(
+      'preview-card-instant',
+    )
+  })
+
+  it('clears its cooldown timer when the provider unmounts', () => {
+    const { unmount } = render(<PreviewPair />)
+    const alpha = screen.getByRole('link', { name: 'Alpha' })
+    fireEvent.mouseEnter(alpha)
+    fireEvent.mouseLeave(alpha)
+    expect(vi.getTimerCount()).toBe(1)
+
+    unmount()
+
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('keeps a standalone local root with the cold delay', () => {
+    const { container } = render(
+      <SitePreviewCard
+        href="https://example.com/local"
+        triggerClassName="trigger"
+        closeDelay={100}
+        popupClassName="link-card"
+        popup={<span>Local card</span>}
+      >
+        Local
+      </SitePreviewCard>,
+    )
+
+    const trigger = screen.getByRole('link', { name: 'Local' })
+    expect(container.querySelectorAll('[data-preview-root]')).toHaveLength(1)
+    expect(trigger.getAttribute('data-delay')).toBe('300')
+    fireEvent.focus(trigger)
+    expect(screen.getByText('Local card')).not.toBeNull()
+  })
+
+  it('keeps the pointer cascade but disables it for instant popup states', () => {
+    const stylesheet = readFileSync('app/globals.css', 'utf8')
+
+    expect(stylesheet).toMatch(
+      /\.contrib-grid i \{[\s\S]*animation: contrib-cell-in 480ms/,
+    )
+    expect(stylesheet).toMatch(
+      /\.link-card\.preview-card-instant \.contrib-grid i \{\s*animation: none;/,
+    )
+    expect(stylesheet).toMatch(
+      /transition:\s*opacity 200ms var\(--ease-swift\),\s*transform 200ms var\(--ease-swift\);/,
+    )
+    expect(stylesheet).not.toMatch(
+      /\.link-card \{[^}]*transition:[^}]*(?:width|height)/,
+    )
+  })
+})

--- a/components/preview-card-timing.tsx
+++ b/components/preview-card-timing.tsx
@@ -1,0 +1,190 @@
+'use client'
+
+import { PreviewCard } from '@base-ui/react/preview-card'
+import {
+  createContext,
+  Fragment,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+
+const PREVIEW_OPEN_DELAY_MS = 300
+const PREVIEW_WARM_WINDOW_MS = 300
+
+type PreviewCardSide = 'top' | 'bottom' | 'left' | 'right'
+
+type PreviewCardPayload = {
+  id: string
+  popup: React.ReactNode
+  popupClassName: string
+  side?: PreviewCardSide
+}
+
+type SharedPreviewCard = {
+  delay: number
+  handle: PreviewCard.Handle<PreviewCardPayload>
+}
+
+type SitePreviewCardProps = {
+  children: React.ReactNode
+  href: string
+  target?: string
+  rel?: string
+  triggerClassName: string
+  popup: React.ReactNode
+  popupClassName: string
+  side?: PreviewCardSide
+  closeDelay: number
+}
+
+const PreviewCardTimingContext = createContext<SharedPreviewCard | null>(null)
+
+function PreviewSurface({ payload }: { payload: PreviewCardPayload }) {
+  return (
+    <PreviewCard.Portal>
+      <PreviewCard.Positioner
+        side={payload.side}
+        sideOffset={8}
+        collisionPadding={16}
+        className="pointer-events-none z-[var(--z-card)]"
+      >
+        <PreviewCard.Popup
+          className={(state) =>
+            `${payload.popupClassName}${state.instant ? ' preview-card-instant' : ''}`
+          }
+        >
+          <Fragment key={payload.id}>{payload.popup}</Fragment>
+        </PreviewCard.Popup>
+      </PreviewCard.Positioner>
+    </PreviewCard.Portal>
+  )
+}
+
+function PreviewTrigger({
+  children,
+  closeDelay,
+  delay,
+  handle,
+  href,
+  payload,
+  rel,
+  target,
+  triggerClassName,
+}: SitePreviewCardProps & {
+  delay: number
+  handle: PreviewCard.Handle<PreviewCardPayload>
+  payload: PreviewCardPayload
+}) {
+  return (
+    <PreviewCard.Trigger
+      handle={handle}
+      payload={payload}
+      href={href}
+      target={target}
+      rel={rel}
+      className={triggerClassName}
+      delay={delay}
+      closeDelay={closeDelay}
+    >
+      {children}
+    </PreviewCard.Trigger>
+  )
+}
+
+export function PreviewCardTimingProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const [handle] = useState(() => PreviewCard.createHandle<PreviewCardPayload>())
+  const [delay, setDelay] = useState(PREVIEW_OPEN_DELAY_MS)
+  const cooldownRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearCooldown = useCallback(() => {
+    if (cooldownRef.current === null) return
+    clearTimeout(cooldownRef.current)
+    cooldownRef.current = null
+  }, [])
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      clearCooldown()
+      setDelay(0)
+      if (open) return
+
+      cooldownRef.current = setTimeout(() => {
+        cooldownRef.current = null
+        setDelay(PREVIEW_OPEN_DELAY_MS)
+      }, PREVIEW_WARM_WINDOW_MS)
+    },
+    [clearCooldown],
+  )
+
+  useEffect(() => clearCooldown, [clearCooldown])
+
+  const shared = useMemo(() => ({ delay, handle }), [delay, handle])
+
+  return (
+    <PreviewCardTimingContext.Provider value={shared}>
+      {children}
+      <PreviewCard.Root handle={handle} onOpenChange={handleOpenChange}>
+        {({ payload }) =>
+          payload ? <PreviewSurface payload={payload} /> : null
+        }
+      </PreviewCard.Root>
+    </PreviewCardTimingContext.Provider>
+  )
+}
+
+function StandalonePreviewCard({
+  payload,
+  ...props
+}: SitePreviewCardProps & { payload: PreviewCardPayload }) {
+  const [handle] = useState(() => PreviewCard.createHandle<PreviewCardPayload>())
+
+  return (
+    <>
+      <PreviewTrigger
+        {...props}
+        payload={payload}
+        handle={handle}
+        delay={PREVIEW_OPEN_DELAY_MS}
+      />
+      <PreviewCard.Root handle={handle}>
+        {({ payload: activePayload }) =>
+          activePayload ? <PreviewSurface payload={activePayload} /> : null
+        }
+      </PreviewCard.Root>
+    </>
+  )
+}
+
+export function SitePreviewCard(props: SitePreviewCardProps) {
+  const shared = useContext(PreviewCardTimingContext)
+  const id = useId()
+  const payload = useMemo<PreviewCardPayload>(
+    () => ({
+      id,
+      popup: props.popup,
+      popupClassName: props.popupClassName,
+      side: props.side,
+    }),
+    [id, props.popup, props.popupClassName, props.side],
+  )
+
+  if (!shared) return <StandalonePreviewCard {...props} payload={payload} />
+
+  return (
+    <PreviewTrigger
+      {...props}
+      payload={payload}
+      handle={shared.handle}
+      delay={shared.delay}
+    />
+  )
+}

--- a/components/social-cards.tsx
+++ b/components/social-cards.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { PreviewCard } from '@base-ui/react/preview-card'
 import Image from 'next/image'
 
 import { ExternalLabel } from '~/components/external-mark'
+import { SitePreviewCard } from '~/components/preview-card-timing'
 import { T } from '~/lib/i18n'
 
 export interface SocialSnapshot {
@@ -75,25 +75,18 @@ function Card({
   triggerClassName?: string
 }) {
   return (
-    <PreviewCard.Root>
-      {/* Base UI's trigger renders the <a> itself; delays live on the
-          trigger (defaults 600/300 are too sleepy for chrome links) */}
-      <PreviewCard.Trigger
-        href={href}
-        target="_blank"
-        rel="noreferrer"
-        className={triggerClassName}
-        delay={300}
-        closeDelay={120}
-      >
-        <ExternalLabel>{trigger}</ExternalLabel>
-      </PreviewCard.Trigger>
-      <PreviewCard.Portal>
-        <PreviewCard.Positioner side="top" sideOffset={8} collisionPadding={16} className="pointer-events-none z-[var(--z-card)]">
-          <PreviewCard.Popup className={className}>{children}</PreviewCard.Popup>
-        </PreviewCard.Positioner>
-      </PreviewCard.Portal>
-    </PreviewCard.Root>
+    <SitePreviewCard
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      triggerClassName={triggerClassName}
+      closeDelay={120}
+      popupClassName={className}
+      popup={children}
+      side="top"
+    >
+      <ExternalLabel>{trigger}</ExternalLabel>
+    </SitePreviewCard>
   )
 }
 
@@ -345,45 +338,40 @@ export function EmailCard({
   triggerClassName?: string
 }) {
   return (
-    <PreviewCard.Root>
-      <PreviewCard.Trigger
-        href={`mailto:${address}`}
-        className={triggerClassName}
-        delay={300}
-        closeDelay={120}
-      >
-        {trigger}
-      </PreviewCard.Trigger>
-      <PreviewCard.Portal>
-        <PreviewCard.Positioner side="top" sideOffset={8} collisionPadding={16} className="pointer-events-none z-[var(--z-card)]">
-          <PreviewCard.Popup className="link-card email-envelope-card">
-            <span className="email-envelope" aria-hidden>
-              <span className="email-envelope-flap" />
-              <span className="email-envelope-return">
-                <span>FROM</span>
-                CALI CASTLE
-                <br />
-                TAIPEI
-              </span>
-              <span className="email-envelope-stamps">
-                <span className="email-envelope-stamp email-envelope-stamp-portrait">
-                  <Image src="/images/avatar.png" alt="" width={32} height={32} />
-                  <span>CALI · 20</span>
-                </span>
-                <span className="email-envelope-stamp email-envelope-stamp-mark">
-                  <span className="email-envelope-stamp-star">✦</span>
-                  <span>POST · 26</span>
-                </span>
-              </span>
-              <span className="email-envelope-postmark" />
-              <span className="email-envelope-address">
-                <span><T zh="收" en="TO" /></span>
-                {address}
-              </span>
+    <SitePreviewCard
+      href={`mailto:${address}`}
+      triggerClassName={triggerClassName}
+      closeDelay={120}
+      popupClassName="link-card email-envelope-card"
+      side="top"
+      popup={
+        <span className="email-envelope" aria-hidden>
+          <span className="email-envelope-flap" />
+          <span className="email-envelope-return">
+            <span>FROM</span>
+            CALI CASTLE
+            <br />
+            TAIPEI
+          </span>
+          <span className="email-envelope-stamps">
+            <span className="email-envelope-stamp email-envelope-stamp-portrait">
+              <Image src="/images/avatar.png" alt="" width={32} height={32} />
+              <span>CALI · 20</span>
             </span>
-          </PreviewCard.Popup>
-        </PreviewCard.Positioner>
-      </PreviewCard.Portal>
-    </PreviewCard.Root>
+            <span className="email-envelope-stamp email-envelope-stamp-mark">
+              <span className="email-envelope-stamp-star">✦</span>
+              <span>POST · 26</span>
+            </span>
+          </span>
+          <span className="email-envelope-postmark" />
+          <span className="email-envelope-address">
+            <span><T zh="收" en="TO" /></span>
+            {address}
+          </span>
+        </span>
+      }
+    >
+      {trigger}
+    </SitePreviewCard>
   )
 }

--- a/components/zoom-image.test.tsx
+++ b/components/zoom-image.test.tsx
@@ -1,0 +1,193 @@
+/** @vitest-environment jsdom */
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ZoomImage } from './zoom-image'
+
+vi.mock('next/image', () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img {...props} />
+  ),
+}))
+
+vi.mock('~/lib/locale-client', () => ({
+  localize: (_locale: string, _zh: string, en: string) => en,
+  useLocale: () => 'en',
+}))
+
+let reducedMotion = false
+
+beforeEach(() => {
+  reducedMotion = false
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({ matches: reducedMotion }) as MediaQueryList),
+  )
+  vi.stubGlobal('requestAnimationFrame', vi.fn(() => 1))
+  vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1200 })
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 900 })
+  vi.spyOn(HTMLImageElement.prototype, 'getBoundingClientRect').mockReturnValue({
+    bottom: 300,
+    height: 200,
+    left: 100,
+    right: 400,
+    top: 100,
+    width: 300,
+    x: 100,
+    y: 100,
+    toJSON: () => ({}),
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('ZoomImage', () => {
+  it('opens keyboard activation in its settled state without scheduling motion', () => {
+    render(<ZoomImage src="/photo.jpg" alt="Taipei" width={800} height={600} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Zoom image: Taipei' }), {
+      detail: 0,
+    })
+
+    expect(
+      screen.getByRole('dialog', { name: 'Taipei' }).getAttribute('data-state'),
+    ).toBe('open')
+    expect(requestAnimationFrame).not.toHaveBeenCalled()
+  })
+
+  it('closes on Escape immediately and restores trigger focus', () => {
+    render(<ZoomImage src="/photo.jpg" alt="Taipei" width={800} height={600} />)
+    const trigger = screen.getByRole('button', { name: 'Zoom image: Taipei' })
+    trigger.focus()
+    fireEvent.click(trigger, { detail: 0 })
+
+    const escape = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'Escape',
+    })
+    act(() => {
+      window.dispatchEvent(escape)
+    })
+
+    expect(escape.defaultPrevented).toBe(true)
+    expect(screen.queryByRole('dialog', { name: 'Taipei' })).toBeNull()
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('preserves the two-frame pointer opening transition', () => {
+    const frames: FrameRequestCallback[] = []
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        frames.push(callback)
+        return frames.length
+      }),
+    )
+    render(<ZoomImage src="/photo.jpg" alt="Taipei" width={800} height={600} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Zoom image: Taipei' }), {
+      detail: 1,
+    })
+
+    const dialog = screen.getByRole('dialog', { name: 'Taipei' })
+    expect(dialog.getAttribute('data-state')).toBe('opening')
+    expect(frames).toHaveLength(1)
+
+    act(() => frames.shift()?.(0))
+    expect(dialog.getAttribute('data-state')).toBe('opening')
+    expect(frames).toHaveLength(1)
+
+    act(() => frames.shift()?.(16))
+    expect(dialog.getAttribute('data-state')).toBe('open')
+  })
+
+  it('keeps pointer overlay closing animated until the image settles', () => {
+    const frames: FrameRequestCallback[] = []
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        frames.push(callback)
+        return frames.length
+      }),
+    )
+    render(<ZoomImage src="/photo.jpg" alt="Taipei" width={800} height={600} />)
+    const trigger = screen.getByRole('button', { name: 'Zoom image: Taipei' })
+    trigger.focus()
+    fireEvent.click(trigger, { detail: 1 })
+    act(() => frames.shift()?.(0))
+    act(() => frames.shift()?.(16))
+
+    const dialog = screen.getByRole('dialog', { name: 'Taipei' })
+    fireEvent.click(dialog, { detail: 1 })
+
+    expect(dialog.getAttribute('data-state')).toBe('closing')
+    fireEvent.transitionEnd(dialog.querySelector('img')!)
+    expect(screen.queryByRole('dialog', { name: 'Taipei' })).toBeNull()
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('bypasses pointer closing motion when Escape is pressed', () => {
+    const frames: FrameRequestCallback[] = []
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        frames.push(callback)
+        return frames.length
+      }),
+    )
+    render(<ZoomImage src="/photo.jpg" alt="Taipei" width={800} height={600} />)
+    const trigger = screen.getByRole('button', { name: 'Zoom image: Taipei' })
+    fireEvent.click(trigger, { detail: 1 })
+    act(() => frames.shift()?.(0))
+    act(() => frames.shift()?.(16))
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    expect(screen.queryByRole('dialog', { name: 'Taipei' })).toBeNull()
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('settles reduced-motion pointer activation and dismissal immediately', () => {
+    reducedMotion = true
+    render(<ZoomImage src="/photo.jpg" alt="Taipei" width={800} height={600} />)
+    const trigger = screen.getByRole('button', { name: 'Zoom image: Taipei' })
+    trigger.focus()
+
+    fireEvent.click(trigger, { detail: 1 })
+
+    const dialog = screen.getByRole('dialog', { name: 'Taipei' })
+    expect(dialog.getAttribute('data-state')).toBe('open')
+    expect(requestAnimationFrame).not.toHaveBeenCalled()
+
+    fireEvent.click(dialog, { detail: 1 })
+    expect(screen.queryByRole('dialog', { name: 'Taipei' })).toBeNull()
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('removes every viewport and keyboard listener when unmounted', () => {
+    const removeListener = vi.spyOn(window, 'removeEventListener')
+    const { unmount } = render(
+      <ZoomImage src="/photo.jpg" alt="Taipei" width={800} height={600} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Zoom image: Taipei' }), {
+      detail: 0,
+    })
+
+    unmount()
+
+    for (const type of ['keydown', 'wheel', 'touchmove', 'resize']) {
+      expect(removeListener.mock.calls.some(([removedType]) => removedType === type)).toBe(
+        true,
+      )
+    }
+  })
+})

--- a/components/zoom-image.tsx
+++ b/components/zoom-image.tsx
@@ -1,12 +1,17 @@
 'use client'
 
 import Image from 'next/image'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState, type MouseEvent } from 'react'
 import { createPortal } from 'react-dom'
 
 import { localize, useLocale } from '~/lib/locale-client'
 
 const VIEWPORT_PAD = 32
+type CloseReason = 'escape' | 'overlay' | 'viewport'
+
+function prefersReducedMotion() {
+  return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
+}
 
 interface ZoomImageProps {
   src: string
@@ -50,7 +55,7 @@ export function ZoomImage({
     stateRef.current = state
   }, [state])
 
-  const open = useCallback(() => {
+  const open = useCallback((event: MouseEvent<HTMLButtonElement>) => {
     const img = triggerRef.current?.querySelector('img')
     if (!img) return
     const rect = img.getBoundingClientRect()
@@ -85,7 +90,8 @@ export function ZoomImage({
       target,
       from: `translate(${tx}px, ${ty}px) scale(${s})`,
     })
-    setState('opening')
+    const reduced = prefersReducedMotion()
+    setState(event.detail === 0 || reduced ? 'open' : 'opening')
   }, [src, width, height, expandedContent])
 
   const unmount = useCallback(() => {
@@ -94,11 +100,11 @@ export function ZoomImage({
     triggerRef.current?.focus({ preventScroll: true })
   }, [])
 
-  const close = useCallback(() => {
+  const close = useCallback((reason: CloseReason) => {
     // Nothing to reverse if the enter transition never started, and
     // reduced motion never fires transitionend — unmount directly.
-    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-    if (reduced || stateRef.current === 'opening') unmount()
+    const reduced = prefersReducedMotion()
+    if (reason === 'escape' || reduced || stateRef.current === 'opening') unmount()
     else if (stateRef.current === 'open') setState('closing')
   }, [unmount])
 
@@ -121,20 +127,23 @@ export function ZoomImage({
   useEffect(() => {
     if (!zoom) return
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') close()
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        close('escape')
+      }
       // image-only dialog: the overlay is the sole focusable — keep Tab inside
       if (e.key === 'Tab') e.preventDefault()
     }
-    const onScroll = () => close()
+    const onViewportChange = () => close('viewport')
     window.addEventListener('keydown', onKey)
-    window.addEventListener('wheel', onScroll, { passive: true })
-    window.addEventListener('touchmove', onScroll, { passive: true })
-    window.addEventListener('resize', onScroll)
+    window.addEventListener('wheel', onViewportChange, { passive: true })
+    window.addEventListener('touchmove', onViewportChange, { passive: true })
+    window.addEventListener('resize', onViewportChange)
     return () => {
       window.removeEventListener('keydown', onKey)
-      window.removeEventListener('wheel', onScroll)
-      window.removeEventListener('touchmove', onScroll)
-      window.removeEventListener('resize', onScroll)
+      window.removeEventListener('wheel', onViewportChange)
+      window.removeEventListener('touchmove', onViewportChange)
+      window.removeEventListener('resize', onViewportChange)
     }
   }, [zoom, close])
 
@@ -194,7 +203,7 @@ export function ZoomImage({
             role="dialog"
             aria-modal="true"
             aria-label={alt || localize(locale, '图片', 'Image')}
-            onClick={close}
+            onClick={() => close('overlay')}
           >
             <div className="zoom-overlay-backdrop" />
             {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/db/migrations/0000_shallow_iron_fist.sql
+++ b/db/migrations/0000_shallow_iron_fist.sql
@@ -1,0 +1,39 @@
+CREATE TABLE IF NOT EXISTS "comments" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" varchar(200) NOT NULL,
+	"user_info" json,
+	"post_id" varchar(100) NOT NULL,
+	"parent_id" integer,
+	"body" json,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "guestbook" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" varchar(200) NOT NULL,
+	"user_info" json,
+	"message" text NOT NULL,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "newsletters" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"subject" varchar(200),
+	"body" text,
+	"sent_at" timestamp,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "subscribers" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"email" varchar(120),
+	"token" varchar(50),
+	"subscribed_at" timestamp,
+	"unsubscribed_at" timestamp,
+	"updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "post_idx" ON "comments" ("post_id");

--- a/docs/adr/0003-retire-comments-reactions-guestbook.md
+++ b/docs/adr/0003-retire-comments-reactions-guestbook.md
@@ -1,5 +1,10 @@
 # Retire comments, reactions, and guestbook; archive then drop their data
 
+## Status
+
+Accepted. The public-AMA launch-disable sentence below is superseded by
+ADR-0011; the retired-content decisions remain in force.
+
 v3 keeps the public blog, projects, photos, feeds, and published newsletter editions, but deliberately retires comments, reactions, and the guestbook. Newsletter editions become static read-only archives; newsletter signup, sending, and administration do not ship. Public AMA transactions remain disabled for the production launch. Owner admin availability is governed separately by ADR-0008. These absences are scope decisions, not oversights.
 
 Legacy comments, reactions, and guestbook records are exported to a private JSON archive (kept out of this public repo, alongside the Sanity `_id → slug` map so the archive stays interpretable) before their production tables are retired.

--- a/docs/adr/0008-owner-admin-is-always-available.md
+++ b/docs/adr/0008-owner-admin-is-always-available.md
@@ -3,7 +3,8 @@
 ## Status
 
 Accepted. This supersedes the admin launch-disable portions of ADR-0003 and
-ADR-0004.
+ADR-0004. ADR-0011 supersedes this ADR's independent capability-switch
+requirement.
 
 The owner must be able to curate photos and manage AMA operations in every
 deployed environment, so `/admin` and its authentication endpoints have no

--- a/docs/adr/0009-clerk-owner-metadata.md
+++ b/docs/adr/0009-clerk-owner-metadata.md
@@ -3,7 +3,9 @@
 ## Status
 
 Accepted. This supersedes ADR-0004 and the immutable-user-ID allowlist direction
-previously recorded in issue #93.
+previously recorded in issue #93. ADR-0011 supersedes the provider capability
+switch requirement, and ADR-0012 supersedes the step-up verification
+requirement below.
 
 Clerk is the sole runtime authentication system for owner admin. Signed-out
 requests for `/admin` redirect directly to Clerk sign-in. After sign-in, every

--- a/docs/adr/0011-credential-driven-ama-capabilities.md
+++ b/docs/adr/0011-credential-driven-ama-capabilities.md
@@ -1,0 +1,39 @@
+# Drive AMA capabilities from complete provider credentials
+
+## Status
+
+Accepted. This supersedes the public-AMA launch-disable sentence in ADR-0003,
+the independent capability-switch requirement in ADR-0008 and ADR-0009, and
+the corresponding kill-switch requirement in the security baseline.
+
+## Decision
+
+Public AMA mutations are available by default. A provider-backed capability is
+available only when its complete credential pair is configured in that
+environment:
+
+- Stripe secret and webhook keys enable payment operations;
+- Resend key and sender enable booking finalization email;
+- Google client ID and secret enable Calendar operations; and
+- Tencent Meeting URL and token enable meeting operations.
+
+An absent pair leaves that capability unavailable and its routes fail closed
+with HTTP 503. A half-configured pair fails server-environment validation and
+prevents deployment. There are no separate `AMA_*_ENABLED` runtime switches.
+Removing an environment-scoped credential pair and redeploying is the emergency
+provider shutdown path.
+
+The credential gate does not replace request validation, same-origin mutation
+checks, rate limits, owner authorization, provider signature verification, or
+privacy-safe audit events.
+
+## Consequences
+
+- Environment inventories must evaluate complete credential pairs, not feature
+  flags.
+- Preview and Staging use only non-production provider credentials. Production
+  credentials never enter those environments.
+- Public database-only mutations remain available when provider credentials
+  are absent, subject to their validation and rate-limit boundaries.
+- Introducing an independent runtime switch again requires a new threat or
+  operations case and a superseding decision.

--- a/docs/adr/0012-owner-admin-without-step-up.md
+++ b/docs/adr/0012-owner-admin-without-step-up.md
@@ -1,0 +1,31 @@
+# Keep owner admin behind one authoritative Clerk boundary
+
+## Status
+
+Accepted. This supersedes the step-up verification requirement in ADR-0009.
+
+## Decision
+
+Every owner-admin page, read, and mutation requires an authenticated Clerk user
+whose authoritative server-loaded `publicMetadata.siteOwner` value is exactly
+the string `"yes"`. High-impact actions do not add a second, time-bounded Clerk
+first-factor check or trigger client-side `verifyWithPasskey()`.
+
+The single-owner personal-site workflow did not justify repeated verification
+prompts after an already authenticated owner session. The remaining controls
+stay mandatory: same-origin mutation guards, per-actor rate limits,
+privileged-action audit events, the admin CSP, and least-privileged provider and
+database credentials. Media Asset Purge also requires the literal `PURGE`
+confirmation validated by the server.
+
+Passkeys remain the recommended Clerk sign-in method and the owner should keep
+two independently recoverable passkeys. Session revocation, owner-metadata
+removal, and Clerk credential rotation remain the incident-response controls.
+
+## Consequences
+
+- Reviews must not claim that the server proves a recent factor or a passkey.
+- Recovery and rotation procedures continue to verify the authoritative owner
+  marker and active sessions.
+- Reintroducing step-up verification requires a new threat model and an
+  explicit decision covering factor semantics, recovery, and user experience.

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -179,11 +179,15 @@ open rich hover cards. The contract:
   - Social card: avatar, name + verified mark, bio, follower and following stats in
     `tabular-nums`.
   - Music card: current/last track with artwork.
-- **Behavior.** ~256px fixed-width card, 300ms open intent delay (0ms when
-  moving between adjacent triggers), enter 200ms `--ease-swift` from
-  `scale(0.95)` + `opacity: 0`, `transform-origin` at the trigger,
-  `backface-visibility: hidden`. Exit faster than enter. Built on the fluid
-  hover-card primitive so pointer exit mid-animation reverses smoothly.
+- **Behavior.** ~256px fixed-width card, 300ms open intent delay. One public
+  preview surface stays warm while open and for 300ms after closing, so the
+  next eligible trigger opens at 0ms; cold intent always returns to 300ms.
+  Generic cards enter over 200ms `--ease-swift` from `scale(0.95)` +
+  `opacity: 0`; service cards preserve their tighter
+  `scale(0.92) translateY(4px)` start. Both use `transform-origin` at the
+  trigger and `backface-visibility: hidden`, with a faster exit. The shared
+  fluid hover-card surface retargets from its current frame when pointer
+  direction reverses or the active payload changes.
 - **Fixed dimensions per service card type** — service-card content loads
   into a fixed-size card (skeleton first). External-link preview cards are
   instead fixed-width with content-driven height, settled at render. Either
@@ -437,13 +441,17 @@ clearance, and the map scrolls internally when its fixed rhythm exceeds the
 available height. Larger layouts remain transparent and borderless.
 
 Every toggle exposes `aria-expanded`/`aria-controls` and morphs its chevron
-between directions. Map items remain mounted inside the clipped shell and
-animate through Motion's DOM animator with a tiny center-out stagger, vertical
-develop, and two-degree swing. Avoid native view-transition snapshots here:
-they live above the island's clipping boundary. A closed map is inert and hidden
-from assistive technology. Escape closes a compact map and restores toggle
-focus. Reduced motion removes island, rail, content, tick, icon, and staggered
-item transitions.
+between directions. Map items remain mounted inside the clipped shell and use
+Motion's DOM animator for opacity, vertical develop, and a two-degree swing.
+Tablet and desktop nodes sequence from the center out. On phones, the island
+and panel enter over 280ms and exit over 260ms; nodes enter over 180ms from the
+first item and exit over 160ms from the last, spanning a 100ms stagger window.
+Phone nodes use a restrained 2px develop blur. Avoid native view-transition
+snapshots here: they live above the island's clipping boundary. A closed map is
+inert and hidden from assistive technology. Escape closes a compact map and
+restores toggle focus. Keyboard actions and reduced motion cancel and settle
+the island, panel, nodes, tick, and icon before paint. Touch keeps the same
+directional timing, and no map motion changes width, height, or layout geometry.
 
 ## Bilingual content
 

--- a/docs/security/baseline.md
+++ b/docs/security/baseline.md
@@ -25,9 +25,10 @@ an attacker can read the implementation.
 - Give each integration a distinct credential and the narrowest scopes it
   supports. Rotate on suspected exposure and remove old credentials after a
   verified cutover.
-- Keep public mutations, payments, booking finalization, Google, and Tencent
-  behind independent server-side kill switches that fail closed. Client-only
-  flags are not controls.
+- AMA capabilities follow ADR-0011: public mutations are available by default,
+  while each provider-backed capability requires its complete
+  environment-scoped credential pair. Missing pairs fail closed and half pairs
+  fail deployment validation. Client-only flags are not controls.
 - Owner admin is always reachable and has no environment switch. Every admin
   page, data read, and mutation must enforce Clerk authentication and require
   the authoritative user record to contain the exact public metadata marker
@@ -98,17 +99,17 @@ recording their sensitive payloads.
   rotate the credential first, then remove it from current code and, where
   appropriate, rewrite history through a separately approved process.
 
-The public production CSP keeps `script-src 'unsafe-inline'` because Next.js
+The public Production CSP keeps `script-src 'unsafe-inline'` because Next.js
 static, ISR, and partial-prerendered output includes inline hydration payloads.
 A per-request nonce would disable those rendering modes. Next.js SRI is enabled
 for supported build assets, `unsafe-eval` is development-only, script
 attributes are blocked, and all other directives remain restricted. The
-dynamic `/admin` surface receives a fresh nonce CSP through `proxy.ts` and does
-not inherit the public production script exception. Its owned pre-paint
-bootstrap is limited by a tested hash, while framework scripts receive the
-request nonce. Inline styles remain allowed because shared React UI emits style
-attributes. Revisit the public script and shared style exceptions when Next.js
-and the UI can remove them without giving up static shells or functionality.
+partially prerendered `/admin` surface uses the same static script policy so its
+Instant Navigation shells remain cacheable; it has no client-side Clerk
+provider or provider-origin allowance. Inline styles remain allowed because
+shared React UI emits style attributes. Revisit the script and shared style
+exceptions when Next.js and the UI can remove them without giving up static
+shells or functionality.
 
 Configuration committed to this repository does not prove that a hosted
 setting is enabled. Track hosted verification separately in

--- a/docs/security/clerk-admin-operations.md
+++ b/docs/security/clerk-admin-operations.md
@@ -6,7 +6,8 @@ credentials or user identifiers. Perform each hosted change in one Clerk
 environment at a time and verify the matching Vercel environment before moving
 on.
 
-The application authorization contract is ADR-0009: every admin page and API
+The application authorization contract is ADR-0009 as superseded by ADR-0012:
+every admin page and API
 loads the authoritative Clerk user on the server and requires
 `publicMetadata.siteOwner` to equal the exact string `"yes"`. Email addresses,
 browser state, unsafe metadata, and the durable `ADMIN_EMAIL` data namespace

--- a/docs/v3-cutover-ops-runbook.md
+++ b/docs/v3-cutover-ops-runbook.md
@@ -19,19 +19,17 @@ npx vercel project inspect cali-so $SCOPE
 If the repo is not yet linked, run `npx vercel link` once and pick the team
 and the `cali-so` project.
 
-## 1. Activate the controlled deployment topology
+## 1. Preserve the controlled deployment topology
 
-These hosted changes are shared state. Obtain an action-time confirmation
-before the Git branch rename, and two fresh confirmations before inspecting or
-changing either Neon project.
+The topology below was activated on 2026-07-18. Treat future changes as shared
+state, and obtain two fresh confirmations before inspecting or changing either
+Neon project.
 
-1. Rename the Git integration branch from `v2` to `dev` through GitHub's branch
-   rename operation. Do not create a second unrelated branch or delete `v2`
-   manually. Verify open pull requests, local tracking branches, and the
-   existing ruleset now target `dev`.
-2. In the non-production Neon project, rename the persistent `preview` branch
-   to `staging`. Preserve its data, migration history, migration role, and
-   SQL-created CRUD-only runtime role. Configure the migration role's default
+1. Keep `dev` as the Git integration branch. Verify open pull requests, local
+   tracking branches, and ruleset `18920686` continue to target `dev`.
+2. Keep `staging` as the persistent non-production Neon branch. Preserve its
+   data, migration history, migration role, and SQL-created CRUD-only runtime
+   role. Configure the migration role's default
    privileges so new tables and sequences grant only the required CRUD and
    sequence access to the runtime role; grant the same access explicitly on
    existing objects. The runtime role must not own objects or inherit DDL.
@@ -39,8 +37,8 @@ changing either Neon project.
    those roles and grants are copied into every Preview.
 3. Keep Production in a separate Neon project. Its API key and migration URL
    must never be stored in the Preview or Staging GitHub environments.
-4. Create a Vercel custom environment named `staging`. Set `SITE_URL` to its
-   stable custom alias (currently `https://beta.cali.so`) so browser mutation
+4. Keep the Vercel custom environment named `staging`. Set `SITE_URL` to its
+   stable custom alias (`https://beta.cali.so`) so browser mutation
    checks match the URL maintainers use. Copy only approved non-production
    application settings into it; database URLs are supplied per deployment by
    GitHub Actions.
@@ -55,15 +53,13 @@ changing either Neon project.
 
 The committed `vercel.json` disables Vercel Git deployments. Do not re-enable
 them in the dashboard: GitHub must create or select the Neon branch, migrate it,
-and only then call Vercel. Configure the hosted environments and rename the
-branch before merging this automation change into `dev`. That merge is the
-first Staging workflow run and applies all pending migrations, including
-`0010` and `0011`, before deploying. Use GitHub's job rerun for a failed
-activation; the manual Staging dispatch becomes available after the workflow
-reaches the default branch.
+and only then call Vercel. Run `29644176180` successfully applied the Staging
+migrations and deployed `dev@8802607`; use GitHub's job rerun for a later failed
+deployment.
 
-Verify the unified `/admin/media` workflow on Staging after the workflow is
-green, including that `/admin/photos` redirects to `/admin/media#publish`.
+Verify both owner surfaces on Staging after the workflow is green:
+`/admin/media` is the upload-to-archive library, while `/admin/photos` is the
+separate Photo Selection curation room. Neither redirects to the other.
 Feature pushes should create `preview/<git-branch>` once, preserve it across
 subsequent pushes, and delete both Neon and Vercel Preview resources when the
 Git branch is deleted. `Refresh Preview` is the explicit destructive reset path.
@@ -73,10 +69,9 @@ from the isolated `target/` working directory.
 
 ## 2. Require Quality and CodeQL on both branches
 
-The historical `v2` ruleset (`18920686`) already requires `Quality` and
-`CodeQL` alongside its deletion, non-fast-forward, and pull-request rules.
-After the branch rename, inspect the ruleset and verify its ref condition now
-targets `dev`; do not append a duplicate required-check rule.
+The `dev` ruleset (`18920686`) already requires `Quality` and `CodeQL`
+alongside its deletion, non-fast-forward, and pull-request rules. Do not append
+a duplicate required-check rule.
 
 Protect `main` as well (PUT replaces the whole protection object; force pushes
 and deletions stay disabled by default):
@@ -116,13 +111,16 @@ JSON
   variables are already absent, do not count mutation checks as passed
   until this migration and grant verification succeeds.
 
-- Add a Preview-only `CLERK_SECRET_KEY` from the non-production Clerk
-  environment. Never copy the Production Clerk secret into Preview.
+- Keep the non-production Clerk keys isolated to Preview and Staging. Never
+  copy the Production Clerk secret into either environment.
 
-- Remove the dead capability switch left behind by ADR-0008:
+- Verify the dead capability switch removed under ADR-0008 stays absent:
 
   ```bash
-  npx vercel env rm AMA_ADMIN_ENABLED preview $SCOPE
+  if npx vercel env ls preview $SCOPE | rg -q '^AMA_ADMIN_ENABLED\b'; then
+    echo 'ERROR: remove AMA_ADMIN_ENABLED from Preview' >&2
+    exit 1
+  fi
   ```
 
 ## 4. Provision the Production environment
@@ -215,8 +213,10 @@ to `main` then starts `Deploy Production`. The no-secret
 after it succeeds can the separately protected `production` environment expose
 the migration credential and record the second approval.
 
-The workflow hash-locks reviewed migrations `0001` through `0011` and rejects
-any modification or deletion. Future migrations fail closed unless every SQL
+The workflow hash-locks the immutable legacy baseline `0000` and reviewed v3
+migrations `0001` through `0011`, rejecting any modification or deletion.
+Migration `0000` stays outside the v3 Drizzle journal and is not rerun. Future
+migrations fail closed unless every SQL
 statement is an explicitly allowed expand operation: create a new table, type,
 sequence, view, function, or non-unique index; add a nullable column; add a
 non-null column with a statically proven non-null default; validate a named

--- a/docs/v3-cutover-readiness.md
+++ b/docs/v3-cutover-readiness.md
@@ -1,25 +1,24 @@
 # v3 cutover readiness
 
-Last checked: 2026-07-16 (hosted-control inventory refreshed the same day).
+Last checked: 2026-07-18.
 
-The accepted deployment architecture now renames the integration branch from
-`v2` to `dev` and the persistent non-production database branch from Preview to
-Staging. The hosted rename and environment setup are still pending. Exact `v2`
-names below remain historical evidence from the dated audit baseline until the
-next hosted verification refresh.
+The controlled deployment architecture is active: `dev` is the integration
+branch, `staging` is the persistent non-production database branch, and the
+GitHub environments are configured for Preview, Staging, migration review, and
+Production. `main` remains the Production branch and has not been merged or
+deployed as part of this ticket.
 
 ## Verdict
 
-**NOT READY.** The merged `v2` integration branch is green under the complete
-local release suite, the Standards vocabulary breach is resolved, and the
-hosted-control inventory now has current evidence. The decisive blocker is
-that the Production environment is not yet provisioned for v3: its runtime
-database credential predates the rewrite and the v3 server-environment
-contract — including every media provider value — is unmet. Required GitHub
-checks on `main`, the Preview database gate, and the production database and
-media verifications also remain open. Vercel Web Analytics has been restored
-and verified on PR #156's Preview, which is `v2` plus documentation-only
-changes; only dashboard-ingestion proof remains for that gate.
+**NOT READY.** `dev` is green under the complete local release suite and the
+current Staging deployment at `https://beta.cali.so` passed its migration,
+public-site, security-boundary, link, URL-contract, and browser checks. The
+decisive blocker is still Production provisioning: the last authorized audit
+found that its runtime contract, including the database and media provider
+configuration, was not ready for v3. Required checks on `main`, Staging runtime
+grant and signed-in owner verification, Production database and provider proof,
+Vercel dashboard checks, Analytics ingestion proof, and rollback proof remain
+open.
 
 Unknown hosted state is not counted as passed. This report does not authorize
 merging to `main`, changing production settings, accessing production data, or
@@ -30,7 +29,8 @@ running production migrations.
 | Item | Value |
 | --- | --- |
 | Production branch | `main` at `8c258834af538dd501486a5fd319b3e96a2ff5bc` |
-| Integration branch | `v2` at `f647fdb` (post `#153`, including the Web Analytics restoration) |
+| Integration branch | `dev` at `880260769d1d74815e63acf8928fd95565ff75b6` |
+| Staging deployment | `https://beta.cali.so`, deployed from the audited `dev` SHA by successful run [#29644176180](https://github.com/CaliCastle/cali.so/actions/runs/29644176180) |
 | Vercel project | `cali-so` (`prj_oIl5…`) on team `team_r1Mln…`; full IDs live in the local `.vercel/project.json` link state |
 | Production deployment | `dpl_A29CV…`, created 2026-07-11, status Ready at inventory time |
 | Release issue | [#98](https://github.com/CaliCastle/cali.so/issues/98) |
@@ -40,7 +40,7 @@ running production migrations.
 | Production site observed | `https://cali.so`, HTTP 200 from Vercel, still serving `main` |
 
 Prerequisite issues #99 through #106 are closed and their changes are merged
-into `v2`. The complete issue #96 Media Library stack is also merged: the
+into `dev`. The complete issue #96 Media Library stack is also merged: the
 owner admin manages the catalog and curation workflow, and the public homepage
 and `/photos` now consume the active Published Photo Selection from Bunny
 Renditions. The retired static photo fallback has been removed.
@@ -51,21 +51,22 @@ Renditions. The retired static photo fallback has been removed.
 | --- | --- | --- |
 | Frozen install | PASS | `pnpm install --frozen-lockfile` completed from the audited commit. |
 | Repository validation | PASS | Every command and count in the automated evidence section passed. |
-| Public browser behavior | PASS | Desktop, mobile, both locales, light and dark appearance, reduced motion, metadata, overflow, accessibility tree, and dock targets were reviewed locally. |
-| Owner admin boundary | PASS (Preview sign-in) / AWAITING MUTATION AND PRODUCTION PROOF | PR #156's Preview redirects `/admin` to the isolated non-production Clerk sign-in UI in a normal browser. Local and CI checks prove exact `publicMetadata.siteOwner = "yes"` authorization, same-origin mutations, rate limits, audit events, and strict admin CSP. Preview mutation proof depends on the database gate below; confirm the Production Clerk keys and owner metadata at cutover. |
+| Public browser behavior | PASS | Local and Staging review covered desktop and mobile, both locales, light and dark appearance, reduced motion, keyboard navigation, metadata, overflow, feeds, generated social images, and Instant Navigation. |
+| Owner admin boundary | PASS (Staging signed-out path) / AWAITING OWNER AND PRODUCTION PROOF | A clean browser navigation to Staging `/admin` completes Clerk's development-instance handshake and reaches the isolated sign-in UI. The complete remote security-boundary verifier passes. Signed-in owner reads and mutations still require authorized operator access and the database gate below; confirm the Production Clerk keys and owner metadata at cutover. |
 | Complete diff Standards review | PASS | Portal layering and admin typography findings were fixed. The Media `lifecycle` vocabulary breach was resolved by PR #138 (issue #134 closed): Catalog State is the glossary term, and additive migration `0009` renames the column. |
 | Complete diff Spec review | PASS | No scope creep, incorrect PASS treatment, or missing local evidence was found; the unresolved hosted and production requirements below correctly keep the verdict at NOT READY. |
-| Production-like PR Preview | PARTIAL | Targeted verification passed on PR #156's `https://cali-so-git-cali-complete-v3-readiness-cali.vercel.app`, which contains `v2` at `f647fdb` plus documentation-only commit `25e7026`: Chinese and English public routes render without browser errors, and `/admin` reaches Clerk sign-in. Repeat the complete release matrix after Production provisioning. |
-| Vercel Web Analytics | AWAITING DASHBOARD CONFIRMATION | On PR #156's `v2`-based Preview, Chinese and English public routes each loaded the injected `@vercel/analytics/next` 2.0.1 first-party script and received HTTP 200 from the first-party pageview endpoint. Owner-admin navigation loaded no Analytics script or request. Confirm the fresh Preview pageviews are visible in the existing `cali-so` Analytics dashboard. |
+| Production-like Staging | PASS (public and signed-out boundaries) | `https://beta.cali.so` serves `dev@8802607`. The complete public route, link, discovery, legacy-URL, security-boundary, and browser matrix passed. Signed-in owner operations and provider-backed workflows remain separate gates. |
+| Vercel Web Analytics | AWAITING DASHBOARD CONFIRMATION | Chinese and English Staging routes load the first-party Insights client; owner-admin navigation does not load it before the Clerk redirect. Confirm fresh Staging pageviews are visible in the existing `cali-so` Analytics dashboard. |
 | GitHub security settings | PASS | Secret scanning, push protection, Dependabot security updates, read-only Actions defaults, and full-SHA action policy are enabled. |
-| Required GitHub checks | PARTIAL | The `v2` ruleset now requires `Quality` and `CodeQL`; `main` branch protection still requires neither. The maintainer-operated command is in `docs/v3-cutover-ops-runbook.md`. |
+| Required GitHub checks | PARTIAL | The `dev` ruleset requires `Quality` and `CodeQL`; `main` branch protection still requires neither. The maintainer-operated command is in `docs/v3-cutover-ops-runbook.md`. |
+| Deployment environments | PASS | GitHub has Preview, Staging, `production-migration-review`, and Production environments with the intended branch policies; the last two require maintainer review. |
 | Current Vercel project settings | PASS | Project inspection succeeds with the explicit team scope. The earlier `Not authorized` was a CLI quirk: the team slug `cali` resolves to the personal account, so commands must pass the team ID as `--scope` (see the runbook). |
 | Production capability posture | PASS (superseded July 2026) | The former `AMA_*_ENABLED` switches are removed by maintainer decision: AMA capabilities are enabled by default, and each provider capability follows its credential pair, failing closed with 503 while the pair is absent. Owner admin has no capability switch. |
-| Preview and Production secret isolation | FAIL-CLOSED / AWAITING DATABASE CONFIRMATION | Preview now has its own working non-production Clerk instance. `RESEND_API_KEY`, `AMA_ADMIN_ENABLED`, and every `KV_*`, `REDIS_URL`, and `UPSTASH_*` variable are absent. The runtime unconditionally selects the database limiter in Preview and has no Redis fallback. Migration `0010` and the runtime role's CRUD grants have not been inspected; if either is missing, rate-limited admin mutations return 503 while public reads remain available. Two fresh confirmations are required before remote database inspection. |
-| Production runtime environment | FAIL | Production `DATABASE_URL` predates the rewrite by over three years, and the v3 server-environment contract is otherwise unmet: the environment-specific Clerk keys, `AMA_ENCRYPTION_KEY`, `RATE_LIMIT_HASH_KEY`, `SITE_URL`, admin rate-limit values, `CRON_SECRET`, and required `BUNNY_*`/`MEDIA_*` variables are not fully provisioned. The first v3 production build would fail environment validation. |
+| Staging and Production secret isolation | PARTIAL / AWAITING DATABASE CONFIRMATION | Staging uses its isolated Clerk instance and has no Redis fallback. The successful Staging workflow reported that all migrations were applied, but table state and the runtime role's CRUD-only grants were not inspected. If migration `0010` or its grants are missing, rate-limited admin mutations fail closed with 503 while public reads remain available. Two fresh confirmations are required before remote database inspection. |
+| Production runtime environment | FAIL (last authorized audit) | The 2026-07-16 audit found that Production's `DATABASE_URL` predates the rewrite and the v3 server-environment contract was otherwise unmet, including required Clerk, cryptographic, rate-limit, Bunny, and media values. Production cloud configuration was not reopened during this refresh because the required confirmations were not given. |
 | Production runtime database grants | AWAITING CONFIRMATION | Requires two fresh confirmations before inspecting the production role or sensitive cloud state. |
 | Production migration credential | PASS (name level) | `MIGRATION_DATABASE_URL` is absent from every Vercel environment. Its availability to the controlled migration operation is confirmed at cutover time. |
-| Production migrations | AWAITING CONFIRMATION | Eleven additive migrations validate locally. Media migrations `0005` through `0009` are required for the v3 photo surface, `0010` adds durable rate-limit windows, and `0011` adds AMA booking storage; execution and schema state require a separately authorized cutover step. |
+| Production migrations | AWAITING CONFIRMATION | The immutable legacy baseline `0000` and eleven additive v3 migrations validate locally. Staging reported successful application through `0011`; Production execution and schema state require the separately authorized cutover step. |
 | Media provider and publication | FAIL | Production has no Bunny or media configuration at all, so the provider boundary, live storage contract, and the two-photo Published Photo Selection cannot exist yet. Provisioning precedes verification. |
 | Other external providers | PASS (name level) | No Google, Tencent, payment, or booking-finalization credentials exist in Production. Legacy-era variables (Clerk, Sanity, Edge Config, a three-year-old Upstash pair) remain for the current `main` site and need pruning or rotation at cutover. |
 | Logs and drains | UNKNOWN | Not exposed through the CLI; verify access, retention, drains, and the privacy allowlist in the Vercel dashboard. |
@@ -77,9 +78,10 @@ Renditions. The retired static photo fallback has been removed.
 The following passed from the frozen installation:
 
 - TypeScript typecheck.
-- 396 Vitest unit and integration tests across application, component, and
-  library code, excluding only explicitly live provider suites.
-- 112 AMA tests and 5 migration checks.
+- 1,014 Vitest unit and integration tests across 108 application, component,
+  database, and library test files, excluding only explicitly live suites.
+- 611 AMA tests across 33 files and 7 migration checks.
+- 20 deployment workflow and migration-policy checks.
 - 5 security tests.
 - 148 localization checks.
 - 19 Media Library catalog tests.
@@ -87,34 +89,37 @@ The following passed from the frozen installation:
 - 9 Media Library processing tests.
 - 41 Media Library storage tests.
 - 7 Media Library geocoding tests.
-- 18 Media Library Alt Text tests.
-- 27 Media Library admin tests.
-- 12 Media Asset review tests.
-- 27 Photo Selection publication tests.
+- 17 Media Library Alt Text tests.
+- 43 Media Library admin tests.
+- 13 Media Asset review tests.
+- 29 Photo Selection publication tests.
 - 8 Media Asset Purge tests.
 - 11 Media reconciliation tests.
 - 4 port-post tests.
-- Production build with 83 generated pages using the CI placeholder
-  environment and every optional AMA capability disabled.
-- 9 Instant Navigation, keyboard, motion, and typography browser tests.
+- Production build with 72 generated pages using the isolated CI environment.
 - 53 legacy URL probes against the production server.
-- 354 internal links and 147 live external links across all 28 sitemap pages.
-- Public discovery and failure-handling verification.
-- Disabled production security-boundary verification.
-- OSV audit of 626 production packages with no findings.
+- 400 internal links and 147 external targets across all 30 sitemap pages; one
+  aggregate fetch was transiently inconclusive and returned 200 on direct
+  retry.
+- 30 public discovery pages and failure-handling verification.
+- Production security-boundary verification.
+- OSV audit of 653 production package versions with no findings.
 - Full-SHA GitHub Action reference check.
 - Redacted Gitleaks 8.30.1 scan of the reachable history with no findings.
 - `git diff --check origin/main`.
 
-The content check exposed five trailing spaces in two historical MDX files.
-They were removed without changing rendered content.
+The focused migration-policy regression also proves that the legacy `0000`
+migration remains byte-for-byte immutable and absent from the v3 Drizzle
+journal.
 
 ## Browser review
 
 Local production-build review covered the homepage and a representative blog
-post in Chinese and English at desktop and mobile widths. It also covered light
-and dark appearance, reduced motion, page metadata, horizontal overflow, the
-accessibility tree, and the dock's 44-pixel pointer targets.
+post in Chinese and English at desktop and mobile widths. Staging repeated the
+matrix on `dev@8802607`: Chinese and English Home, Projects, Photos, Writing,
+and AMA routes rendered at 1440 pixels and an emulated 390-pixel iPhone; light
+and dark appearance had no horizontal overflow or browser errors; and reduced
+motion reported zero running animations.
 
 The review found that the custom `scroll-fade*` class names collided with
 generated Tailwind scroll utilities. The collision introduced scroll-driven
@@ -142,8 +147,13 @@ feeds; localized Chinese and English Open Graph images; and zero running
 animations under reduced motion. A final design-contract pass also confirmed
 stable selection weights and contrast, instant indicator geometry, 14-pixel
 Tweet copy, the shared chrome tracking value, and the 300ms swift image reveal.
-The PR Preview must repeat the release matrix against Vercel rather than
-assuming the local result proves hosted behavior.
+The Staging keyboard path opened Preferences with Enter, dismissed it with
+Escape, and restored trigger focus. A keyboard activation from English Home to
+Projects stayed within one browser navigation entry, confirming client-side
+Instant Navigation; the reduced-motion path remained animation-free. Clean
+Staging `/admin` navigation completed Clerk's development handshake and reached
+the non-production sign-in UI. Remote link, URL-contract, discovery, and
+security-boundary checks also passed against the same origin.
 
 Final review artifacts after the accessibility corrections:
 
@@ -199,6 +209,8 @@ Final review artifacts after the accessibility corrections:
 
 ## Migration and provider boundary
 
+Migration `0000` is the immutable legacy Production baseline restored from
+`main`; it remains outside the v3 Drizzle journal and must never be rerun.
 Migrations `0001` through `0004` are additive AMA foundations. Migrations
 `0005` through `0009` define the Media catalog, Photo Selection publication,
 publication revisions, durable Purge progress, and the Catalog State rename.
@@ -245,32 +257,30 @@ operator before cutover.
 The maintainer-operated commands for actions 1 through 4 are collected in
 `docs/v3-cutover-ops-runbook.md`.
 
-1. Rename Git `v2` to `dev`, rename the persistent non-production Neon branch
-   to `staging`, configure the four GitHub deployment environments, and create
-   the Vercel custom Staging environment.
-2. Run the GitHub-controlled Staging deployment. With two fresh confirmations,
-   verify migrations `0010` and `0011`, Media and AMA tables, and the runtime
-   role's CRUD-only grants. Until these pass, treat Staging admin reads and
-   mutations as unavailable rather than validated.
-3. Provision the Production environment for the v3 contract: replace the
+1. With two fresh confirmations, verify Staging migrations `0010` and `0011`,
+   Media and AMA tables, and the runtime role's CRUD-only grants. Then sign in
+   as the marked owner and prove one non-destructive read plus the required
+   mutation boundaries. Until then, treat signed-in Staging admin operations as
+   unvalidated.
+2. Provision the Production environment for the v3 contract: replace the
    legacy `DATABASE_URL` with the CRUD-only Neon runtime role and add the
    missing secrets, rate limits, intended AMA provider credential pairs, and
    complete Bunny and media configuration.
-4. Verify `Quality` and `CodeQL` are required on protected `dev` and `main`.
-5. In the Vercel dashboard, verify logs, drains, retention, firewall rules,
+3. Add required `Quality` and `CodeQL` checks to protected `main`; `dev` already
+   requires both.
+4. In the Vercel dashboard, verify logs, drains, retention, firewall rules,
    the production-branch mapping, and the certificate.
-6. With two fresh confirmations, verify Production runtime grants and the
+5. With two fresh confirmations, verify Production runtime grants and the
    reviewed initial migration baseline. Configure and approve the no-secret
    `production-migration-review` environment first, then approve the protected
    `production` environment only after confirming the workflow will migrate
    before deploy.
-7. Verify the production Bunny and Neon Media boundary, run the protected live
+6. Verify the production Bunny and Neon Media boundary, run the protected live
    storage contract, and publish the intended two-photo Published Photo
    Selection through the owner admin.
-8. Review the recorded production-like Vercel Preview across the remaining
-   browser matrix and confirm the fresh Chinese and English Preview pageviews
-   are visible in the existing `cali-so` Analytics dashboard.
-9. Confirm the rollback procedure against the recorded known-good deployment.
-10. Only after every blocker above is passed, merge `dev` to `main`, approve
+7. Confirm the fresh Chinese and English Staging pageviews are visible in the
+   existing `cali-so` Analytics dashboard.
+8. Confirm the rollback procedure against the recorded known-good deployment.
+9. Only after every blocker above is passed, merge `dev` to `main`, approve
     both Production deployment gates in order, and complete the cutover smoke
     tests.

--- a/docs/v3-cutover-readiness.md
+++ b/docs/v3-cutover-readiness.md
@@ -18,7 +18,10 @@ found that its runtime contract, including the database and media provider
 configuration, was not ready for v3. Required checks on `main`, Staging runtime
 grant and signed-in owner verification, Production database and provider proof,
 Vercel dashboard checks, Analytics ingestion proof, and rollback proof remain
-open.
+open. The final complete-diff reviews also found unresolved motion and layer
+standards plus two literal issue-acceptance gaps: the repository has no
+automated browser-test command, and the reviewed custom Staging environment has
+not been explicitly accepted as the issue's requested feature Preview.
 
 Unknown hosted state is not counted as passed. This report does not authorize
 merging to `main`, changing production settings, accessing production data, or
@@ -50,13 +53,14 @@ Renditions. The retired static photo fallback has been removed.
 | Gate | Status | Evidence or blocker |
 | --- | --- | --- |
 | Frozen install | PASS | `pnpm install --frozen-lockfile` completed from the audited commit. |
-| Repository validation | PASS | Every command and count in the automated evidence section passed. |
+| Repository validation | PARTIAL | Every existing command and count in the automated evidence section passed, but the repository no longer has an automated browser-test command. Issue #107 explicitly requires browser tests in addition to its manual browser matrix. |
 | Public browser behavior | PASS | Local and Staging review covered desktop and mobile, both locales, light and dark appearance, reduced motion, keyboard navigation, metadata, overflow, feeds, generated social images, and Instant Navigation. |
 | Owner admin boundary | PASS (Staging signed-out path) / AWAITING OWNER AND PRODUCTION PROOF | A clean browser navigation to Staging `/admin` completes Clerk's development-instance handshake and reaches the isolated sign-in UI. The complete remote security-boundary verifier passes. Signed-in owner reads and mutations still require authorized operator access and the database gate below; confirm the Production Clerk keys and owner metadata at cutover. |
-| Complete diff Standards review | PASS | Portal layering and admin typography findings were fixed. The Media `lifecycle` vocabulary breach was resolved by PR #138 (issue #134 closed): Catalog State is the glossary term, and additive migration `0009` renames the column. |
-| Complete diff Spec review | PASS | No scope creep, incorrect PASS treatment, or missing local evidence was found; the unresolved hosted and production requirements below correctly keep the verdict at NOT READY. |
-| Production-like Staging | PASS (public and signed-out boundaries) | `https://beta.cali.so` serves `dev@8802607`. The complete public route, link, discovery, legacy-URL, security-boundary, and browser matrix passed. Signed-in owner operations and provider-backed workflows remain separate gates. |
-| Vercel Web Analytics | AWAITING DASHBOARD CONFIRMATION | Chinese and English Staging routes load the first-party Insights client; owner-admin navigation does not load it before the Clerk redirect. Confirm fresh Staging pageviews are visible in the existing `cali-so` Analytics dashboard. |
+| Complete diff Standards review | FAIL | The final review found outdated AMA capability and owner step-up decisions, keyboard animation in Preview cards, undocumented global/local layer values, and a judgement-level divergent-change smell in `app/globals.css`. ADR-0011, ADR-0012, and the security baseline now resolve the first two conflicts. Preview-card keyboard motion remains tracked by [#184](https://github.com/CaliCastle/cali.so/issues/184); the layer-scale finding still needs a fix, a dedicated issue, or explicit maintainer rejection. |
+| Complete diff Spec review | PARTIAL | No scope creep was found. Automated browser tests are absent, the issue literally requests feature Preview evidence while the current matrix used Staging, Analytics dashboard proof remains absent, and Domain evidence was overstated. The Clerk redirect-shape verifier intentionally stops at the first 307, but the separate clean-browser matrix completed the development handshake and rendered Clerk sign-in. |
+| Production-like Staging | PASS (public and signed-out boundaries) | `https://beta.cali.so` serves `dev@8802607`. The complete public route, link, discovery, legacy-URL, security-boundary, and manual browser matrix passed. Signed-in owner operations and provider-backed workflows remain separate gates. |
+| Issue #107 feature Preview evidence | PARTIAL | The accepted deployment architecture promotes `dev` continuously to a stable custom Staging environment, which is a stronger repeatable target than an ephemeral feature Preview. The issue text still says Preview; obtain an explicit maintainer acceptance of Staging as the substitute or repeat the complete matrix on a recorded feature Preview URL and SHA. |
+| Vercel Web Analytics | AWAITING DASHBOARD CONFIRMATION | Chinese and English Staging routes load the first-party Insights client; owner-admin navigation does not load it before the Clerk redirect. Confirm fresh pageviews from the accepted production-like target in the existing `cali-so` Analytics dashboard: Staging if the maintainer accepts it as the Preview substitute, otherwise the recorded feature Preview. |
 | GitHub security settings | PASS | Secret scanning, push protection, Dependabot security updates, read-only Actions defaults, and full-SHA action policy are enabled. |
 | Required GitHub checks | PARTIAL | The `dev` ruleset requires `Quality` and `CodeQL`; `main` branch protection still requires neither. The maintainer-operated command is in `docs/v3-cutover-ops-runbook.md`. |
 | Deployment environments | PASS | GitHub has Preview, Staging, `production-migration-review`, and Production environments with the intended branch policies; the last two require maintainer review. |
@@ -70,7 +74,7 @@ Renditions. The retired static photo fallback has been removed.
 | Media provider and publication | FAIL | Production has no Bunny or media configuration at all, so the provider boundary, live storage contract, and the two-photo Published Photo Selection cannot exist yet. Provisioning precedes verification. |
 | Other external providers | PASS (name level) | No Google, Tencent, payment, or booking-finalization credentials exist in Production. Legacy-era variables (Clerk, Sanity, Edge Config, a three-year-old Upstash pair) remain for the current `main` site and need pruning or rotation at cutover. |
 | Logs and drains | UNKNOWN | Not exposed through the CLI; verify access, retention, drains, and the privacy allowlist in the Vercel dashboard. |
-| Domain cutover | PASS (partial) | `cali.so` is assigned to the correct team with third-party DNS pointing at Vercel and the production alias intact. The production-branch mapping and certificate still need a dashboard check before merge. |
+| Domain cutover | PARTIAL / AWAITING DASHBOARD CONFIRMATION | `cali.so` was assigned to the correct team with third-party DNS pointing at Vercel and the production alias intact at the last authorized audit. The Production-branch mapping and certificate still need a dashboard check before merge. |
 | Rollback | AWAITING CONFIRMATION | The last known-good production deployment is recorded in the audit baseline. An operator must still confirm promotion or merge-revert works without reversing additive migrations. |
 
 ## Automated evidence
@@ -169,16 +173,16 @@ Final review artifacts after the accessibility corrections:
   internal targets, and live-check external targets. A repeated 404 or 410 is
   a failure; transient provider or TLS failures remain visible as inconclusive
   rather than making repository release status depend on another service's
-  uptime. The final run had no inconclusive targets.
-- The keyboard-coverage gap is closed by replacing the Preferences menu with
-  the correct popover semantics. Shared
-  controls now follow the 44-pixel target, 14-pixel chrome, reduced-motion,
-  and motion-token contracts.
-- The remaining design-contract findings are closed. Shared product controls
-  now change selection and focus without decorative
-  motion, keep selected and unselected labels at one weight, and preserve
-  selected-label contrast. Scroll reveals and public chrome typography use the
-  documented timing and type tokens.
+  uptime. The final aggregate run had one inconclusive X/Twitter fetch; a direct
+  retry returned HTTP 200.
+- The Preferences keyboard path and reduced-motion behavior pass, but the final
+  review found that Preview-card keyboard focus still runs its card and cell
+  animations. Issue #184 owns that defect. The same keyboard hard rule is
+  already tracked for lightbox and article-map actions in issues #185 and #186.
+- Earlier design-contract findings around selection weight, contrast, scroll
+  reveals, and chrome typography are closed. The final review newly found that
+  the implementation uses local and page-level numeric stacking values beyond
+  the design language's closed layer scale; that finding remains open.
 - The Media Library is now part of the v3 launch surface. Owner routes cover
   ingestion, review, recovery, and Photo Selection curation; public routes read
   an immutable Published Photo Selection from Bunny Renditions. The six static
@@ -192,12 +196,14 @@ Final review artifacts after the accessibility corrections:
   State and aligning the schema, repositories, admin surfaces, tests, and
   glossary. State transitions and publication behavior are unchanged, and the
   Standards breach is closed.
-- The complete-diff Standards review also found arbitrary `z-50` portal layers
-  and widened letter spacing in admin chrome. Those findings are fixed with
-  the existing `--z-card` layer and the shared `-0.011em` chrome tracking.
-- The complete-diff Spec review found no scope creep or incorrect PASS
-  treatment. Its incomplete requirements are the same hosted and production
-  blockers recorded in the gate table and remaining actions.
+- The final complete-diff Standards review found two stale decision conflicts.
+  ADR-0011 now records credential-driven AMA capabilities, ADR-0012 records the
+  removal of owner step-up prompts, and the superseded ADR and security-baseline
+  text is explicit. The motion and layer findings above still fail this gate.
+- The final complete-diff Spec review found no scope creep. It did find missing
+  automated browser tests, Staging substituted for the issue's literal Preview
+  requirement, and the overstated Domain row corrected above. Production and
+  dashboard blockers remain unchanged.
 - Remaining type below 14 pixels is limited to the design language's explicit
   13-pixel code exception and text printed onto physical craft objects such as
   polaroids, record sleeves, book covers, and the illustrated envelope. It is
@@ -254,33 +260,45 @@ operator before cutover.
 
 ## Remaining manual actions
 
-The maintainer-operated commands for actions 1 through 4 are collected in
+Maintainer-operated commands for the hosted actions below are collected in
 `docs/v3-cutover-ops-runbook.md`.
 
-1. With two fresh confirmations, verify Staging migrations `0010` and `0011`,
+1. Resolve or explicitly reject the remaining Standards blockers with recorded
+   reasoning: complete keyboard-instant issues #184 through #186 and reconcile
+   the implementation with the documented closed layer scale. The
+   judgement-level `app/globals.css` divergent-change finding may remain a
+   follow-up only if the maintainer records that disposition.
+2. Restore an automated browser-test command and CI gate, or explicitly revise
+   issue #107's browser-test acceptance criterion with maintainer reasoning.
+3. Either record maintainer acceptance that the stable custom Staging
+   environment supersedes the issue's ephemeral Preview wording, or repeat the
+   full matrix on a recorded feature Preview URL and SHA.
+4. With two fresh confirmations, verify Staging migrations `0010` and `0011`,
    Media and AMA tables, and the runtime role's CRUD-only grants. Then sign in
    as the marked owner and prove one non-destructive read plus the required
    mutation boundaries. Until then, treat signed-in Staging admin operations as
    unvalidated.
-2. Provision the Production environment for the v3 contract: replace the
+5. Provision the Production environment for the v3 contract: replace the
    legacy `DATABASE_URL` with the CRUD-only Neon runtime role and add the
    missing secrets, rate limits, intended AMA provider credential pairs, and
    complete Bunny and media configuration.
-3. Add required `Quality` and `CodeQL` checks to protected `main`; `dev` already
+6. Add required `Quality` and `CodeQL` checks to protected `main`; `dev` already
    requires both.
-4. In the Vercel dashboard, verify logs, drains, retention, firewall rules,
+7. In the Vercel dashboard, verify logs, drains, retention, firewall rules,
    the production-branch mapping, and the certificate.
-5. With two fresh confirmations, verify Production runtime grants and the
+8. With two fresh confirmations, verify Production runtime grants and the
    reviewed initial migration baseline. Configure and approve the no-secret
    `production-migration-review` environment first, then approve the protected
    `production` environment only after confirming the workflow will migrate
    before deploy.
-6. Verify the production Bunny and Neon Media boundary, run the protected live
+9. Verify the production Bunny and Neon Media boundary, run the protected live
    storage contract, and publish the intended two-photo Published Photo
    Selection through the owner admin.
-7. Confirm the fresh Chinese and English Staging pageviews are visible in the
-   existing `cali-so` Analytics dashboard.
-8. Confirm the rollback procedure against the recorded known-good deployment.
-9. Only after every blocker above is passed, merge `dev` to `main`, approve
+10. Confirm fresh Chinese and English pageviews from the accepted
+    production-like target are visible in the existing `cali-so` Analytics
+    dashboard: Staging if action 3 accepts it as the substitute, otherwise the
+    recorded feature Preview.
+11. Confirm the rollback procedure against the recorded known-good deployment.
+12. Only after every blocker above is passed, merge `dev` to `main`, approve
     both Production deployment gates in order, and complete the cutover smoke
     tests.

--- a/scripts/check-production-migrations.mjs
+++ b/scripts/check-production-migrations.mjs
@@ -5,6 +5,10 @@ import { pathToFileURL } from 'node:url'
 
 const reviewedMigrationDigests = new Map([
   [
+    'db/migrations/0000_shallow_iron_fist.sql',
+    '932eb3131df58e17e75e89bf5b0754e5d6766bdd933d3fe3ef8e66223e6cd34a',
+  ],
+  [
     'db/migrations/0001_ama_owner_auth.sql',
     '839932b28e9c4bf079a03b911f93a17ee52ca9360989d57f5b9bb19dfe07885b',
   ],

--- a/scripts/check-production-migrations.test.mjs
+++ b/scripts/check-production-migrations.test.mjs
@@ -191,6 +191,18 @@ test('admits the exact reviewed migration baseline without weakening future chec
   )
 })
 
+test('preserves the applied legacy migration byte-for-byte', async () => {
+  const path = 'db/migrations/0000_shallow_iron_fist.sql'
+  const sql = await readFile(path, 'utf8')
+
+  assert.deepEqual(productionMigrationFindings(path, sql), [])
+  assert.throws(
+    () =>
+      productionMigrationFindings(path, `${sql}\n-- changed after review\n`),
+    /immutable/,
+  )
+})
+
 test('checks every migration still present, not only files in the latest push', () => {
   assert.deepEqual(
     migrationPathsInRepository([

--- a/scripts/verify-production-security-boundary.mjs
+++ b/scripts/verify-production-security-boundary.mjs
@@ -48,6 +48,16 @@ function visibleText(body) {
   return document.body?.textContent ?? ''
 }
 
+function expectedMutationOrigin(baseUrl) {
+  if (process.env.SECURITY_BOUNDARY_EXPECTED_ORIGIN) {
+    return new URL(process.env.SECURITY_BOUNDARY_EXPECTED_ORIGIN).origin
+  }
+  if (process.env.SECURITY_BOUNDARY_BASE_URL) {
+    return new URL(baseUrl).origin
+  }
+  return new URL(process.env.SITE_URL ?? 'https://cali.so').origin
+}
+
 async function fetchBoundary(baseUrl, path, init, options = {}) {
   const response = await fetch(new URL(path, baseUrl), {
     redirect: 'manual',
@@ -93,11 +103,21 @@ async function verifyAdminPages(baseUrl) {
     '/admin/login',
     '/admin/photos?view=draft',
   ]) {
-    const { response } = await fetchBoundary(baseUrl, path)
+    // Clerk redirects document navigations to sign-in, but deliberately
+    // rewrites non-page requests to 404. Model the browser boundary here.
+    const { response } = await fetchBoundary(baseUrl, path, {
+      headers: {
+        accept: 'text/html',
+        'sec-fetch-dest': 'document',
+      },
+    })
     assert.equal(response.status, 307, `${path} Clerk redirect status`)
     const location = new URL(response.headers.get('location'))
     assert.equal(location.protocol, 'https:')
-    assert.match(location.pathname, /\/sign-in(?:\/|$)/)
+    assert.match(
+      location.pathname,
+      /(?:\/sign-in(?:\/|$)|\/v1\/client\/handshake$)/,
+    )
     const returnUrl = new URL(location.searchParams.get('redirect_url'))
     const requestedUrl = new URL(path, baseUrl)
     assert.equal(returnUrl.origin, requestedUrl.origin, `${path} Clerk return origin`)
@@ -111,7 +131,7 @@ async function verifyAdminPages(baseUrl) {
 
 async function verifyAdminApiSecurity(baseUrl) {
   const sameOriginHeaders = {
-    origin: 'https://cali.so',
+    origin: expectedMutationOrigin(baseUrl),
     'sec-fetch-site': 'same-origin',
   }
 
@@ -174,7 +194,7 @@ async function verifyAdminApiSecurity(baseUrl) {
 
 async function verifyProviderApiAuthentication(baseUrl) {
   const sameOriginHeaders = {
-    origin: 'https://cali.so',
+    origin: expectedMutationOrigin(baseUrl),
     'sec-fetch-site': 'same-origin',
   }
   // Google is configured in this environment, so the owner provider routes
@@ -210,7 +230,7 @@ async function verifyProviderApiAuthentication(baseUrl) {
 
 async function verifyPublicAmaApiBoundary(baseUrl) {
   const sameOriginHeaders = {
-    origin: 'https://cali.so',
+    origin: expectedMutationOrigin(baseUrl),
     'sec-fetch-site': 'same-origin',
     'content-type': 'application/json',
   }

--- a/scripts/verify-public-links.mjs
+++ b/scripts/verify-public-links.mjs
@@ -5,7 +5,8 @@ import { JSDOM } from 'jsdom'
 
 import { openProductionServer } from './production-server.mjs'
 
-const productionOrigin = 'https://cali.so'
+const productionOrigin =
+  process.env.PUBLIC_LINKS_EXPECTED_ORIGIN ?? 'https://cali.so'
 const externalTimeoutMs = 12_000
 const externalConcurrency = 8
 const verifyExternal = process.env.VERIFY_EXTERNAL_LINKS === '1'


### PR DESCRIPTION
Closes [#184](https://github.com/CaliCastle/cali.so/issues/184)
Closes [#185](https://github.com/CaliCastle/cali.so/issues/185)
Closes [#186](https://github.com/CaliCastle/cali.so/issues/186)

Advances [#107](https://github.com/CaliCastle/cali.so/issues/107) without closing it; protected hosted proof remains a separate release gate.

## Summary

- Restore the immutable Production migration baseline, align Staging/security verifiers, and record the current cutover evidence without treating unknown hosted state as passed.
- Record the maintainer-approved credential-driven AMA and owner-auth decisions in superseding ADRs.
- Share one interruptible public preview-card surface with a tested 300ms warm window and instant keyboard states.
- Make lightbox and article-map keyboard actions synchronous while preserving pointer/touch FLIP geometry, phone sequencing, and reduced-motion settlement.

## Verification

- `pnpm test:unit` (1,042 tests)
- `pnpm typecheck`
- `pnpm build` with the CI placeholder environment
- Focused interaction suite (35 tests)
- `git diff --check` and issue-specific static checks
- Standards and Spec re-reviews: no remaining findings

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR advances v3 readiness by hardening the Production migration baseline with SHA-256 immutability checks, recording maintainer-approved ADRs for owner-admin and credential-driven AMA decisions, and refining interaction motion across three components.

- **Shared preview-card surface** (`preview-card-timing.tsx`): a single `PreviewCard.Root` now lives in `SiteDocument` and is shared by all `ExternalLink` and social-card triggers; a 300 ms warm-window cooldown keeps subsequent hovers instant, and focus/dismiss states are marked for synchronous CSS treatment.
- **ZoomImage keyboard fix**: keyboard activation (`event.detail === 0`) and Escape now bypass the two-frame rAF entirely and settle synchronously, while pointer-driven FLIP geometry and the 450 ms fallback unmount are preserved.
- **Migration safety gate**: `check-production-migrations.mjs` adds a SHA-256 immutability guard for all reviewed migrations and an expand-only SQL parser (handles dollar-quoting, nested block comments, `ADD COLUMN IF NOT EXISTS`) for new ones; the baseline migration for `0000` is restored and locked.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changed interaction paths are covered by focused unit tests and the migration immutability gate is independently verified.

The three runtime changes (shared preview-card provider, ZoomImage keyboard path, post-toc instant landmark navigation) each have dedicated test suites that verify the exact edge cases modified. The migration verifier adds a hard SHA-256 guard against baseline drift rather than relying on convention. No changed code path lacks a corresponding test, and the security boundary script remains additive-only.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| components/preview-card-timing.tsx | New shared preview-card provider that lifts a single PreviewCard.Root above all site triggers, enabling the 300 ms warm-window delay reset via a cooldown timer; cleanup on unmount is correct. |
| components/zoom-image.tsx | FLIP lightbox with keyboard-synchronous open/close: keyboard activation (detail === 0) and reduced-motion both skip the two-frame rAF entirely; Escape always unmounts immediately; viewport changes re-measure the landing spot before the return flight. |
| components/post-toc.tsx | Keyboard actions in visitLandmark now use 'instant' motion; landmark navigation triggers synchronous open-state settlement on keyboard while preserving animated FLIP on pointer; phone sequencing and island animation unchanged. |
| scripts/check-production-migrations.mjs | Adds SHA-256 immutability guard for reviewed migrations and an expand-only SQL parser for new ones; the parser handles quoted strings, dollar-delimited bodies, nested parens, and rejecting unsafe DDL (DROP, RENAME, TYPE change, SET NOT NULL, etc.). |
| scripts/verify-production-security-boundary.mjs | Integration script asserting CSP/X-Frame/nosniff headers, private-marker absence, Clerk redirect shape, cross-site 403, retired auth 404, and AMA API boundaries across public/admin/provider routes. |
| app/_components/site-document.tsx | Public layout now wraps content in PreviewCardTimingProvider, providing the shared warm-window root for all external-link and social-card triggers site-wide; admin path is correctly excluded. |
| components/external-link.tsx | ExternalLink now uses SitePreviewCard instead of a standalone root; falls back gracefully to StandalonePreviewCard when rendered outside PreviewCardTimingProvider. |
| components/social-cards.tsx | All social card triggers (X, GitHub, Telegram, YouTube, Xiaohongshu, Email) now use SitePreviewCard through the shared provider, enabling cross-card warm-window switching in the footer. |
| db/migrations/0000_shallow_iron_fist.sql | Baseline Production migration (comments, guestbook, newsletters, subscribers tables + index); restored as immutable baseline with its SHA-256 recorded in the migration verifier. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant T as SitePreviewCard (Trigger)
    participant P as PreviewCardTimingProvider
    participant R as PreviewCard.Root (shared)

    Note over P: delay = 300 ms (cold)

    U->>T: mouseEnter (first trigger)
    T->>R: open(payload)
    R->>P: onOpenChange(true)
    P->>P: clearCooldown(), setDelay(0)
    Note over P: warm window active

    U->>T: mouseLeave
    R->>P: onOpenChange(false)
    P->>P: setDelay(0), start 300 ms cooldown

    U->>T: mouseEnter (second trigger, within 300 ms)
    T->>R: "open(payload B) — delay = 0, instant"
    R->>P: onOpenChange(true)
    P->>P: clearCooldown() — reset timer cancelled

    Note over P,R: after 300 ms: delay resets to 300 (cold)

    U->>T: focus (keyboard)
    T->>R: open(payload, instant: focus)
    Note over R: popup className += ' preview-card-instant'
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant T as SitePreviewCard (Trigger)
    participant P as PreviewCardTimingProvider
    participant R as PreviewCard.Root (shared)

    Note over P: delay = 300 ms (cold)

    U->>T: mouseEnter (first trigger)
    T->>R: open(payload)
    R->>P: onOpenChange(true)
    P->>P: clearCooldown(), setDelay(0)
    Note over P: warm window active

    U->>T: mouseLeave
    R->>P: onOpenChange(false)
    P->>P: setDelay(0), start 300 ms cooldown

    U->>T: mouseEnter (second trigger, within 300 ms)
    T->>R: "open(payload B) — delay = 0, instant"
    R->>P: onOpenChange(true)
    P->>P: clearCooldown() — reset timer cancelled

    Note over P,R: after 300 ms: delay resets to 300 (cold)

    U->>T: focus (keyboard)
    T->>R: open(payload, instant: focus)
    Note over R: popup className += ' preview-card-instant'
```

</a>

<sub>Reviews (3): Last reviewed commit: ["chore: merge latest dev"](https://github.com/calicastle/cali.so/commit/da2faf1877cdbb2dc5c2392a11660f1bea904ef6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45343701)</sub>

<!-- /greptile_comment -->