### PR TITLE
fix(media): improve photo lightbox quality

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4907,7 +4907,7 @@ html[data-locale='en'] [data-en-block] {
 .zoom-overlay-details::before {
   position: absolute;
   z-index: -1;
-  inset: -6rem 0 calc(-1 * var(--zoom-details-bottom));
+  inset: -10rem 0 calc(-1 * var(--zoom-details-bottom));
   content: '';
   background: var(--background);
   opacity: 0;
@@ -4915,18 +4915,20 @@ html[data-locale='en'] [data-en-block] {
   -webkit-mask-image: linear-gradient(
     to bottom,
     transparent 0,
-    rgb(0 0 0 / 0.08) 1rem,
-    rgb(0 0 0 / 0.28) 2.25rem,
-    rgb(0 0 0 / 0.64) 4rem,
-    black 6rem
+    rgb(0 0 0 / 0.18) 1rem,
+    rgb(0 0 0 / 0.46) 2.5rem,
+    rgb(0 0 0 / 0.72) 4rem,
+    rgb(0 0 0 / 0.92) 5.5rem,
+    black 7rem
   );
   mask-image: linear-gradient(
     to bottom,
     transparent 0,
-    rgb(0 0 0 / 0.08) 1rem,
-    rgb(0 0 0 / 0.28) 2.25rem,
-    rgb(0 0 0 / 0.64) 4rem,
-    black 6rem
+    rgb(0 0 0 / 0.18) 1rem,
+    rgb(0 0 0 / 0.46) 2.5rem,
+    rgb(0 0 0 / 0.72) 4rem,
+    rgb(0 0 0 / 0.92) 5.5rem,
+    black 7rem
   );
   transition: opacity 150ms ease;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -4894,15 +4894,51 @@ html[data-locale='en'] [data-en-block] {
 }
 
 .zoom-overlay-details {
+  --zoom-details-bottom: calc(1.5rem + env(safe-area-inset-bottom, 0px));
   position: fixed;
   inset-inline: 0;
-  bottom: calc(1.5rem + env(safe-area-inset-bottom, 0px));
+  bottom: var(--zoom-details-bottom);
+  isolation: isolate;
   pointer-events: none;
+}
+
+/* A masked paper runway gives the overlapping plate deterministic contrast
+   without changing the photograph's colors or blending the type. */
+.zoom-overlay-details::before {
+  position: absolute;
+  z-index: -1;
+  inset: -6rem 0 calc(-1 * var(--zoom-details-bottom));
+  content: '';
+  background: var(--background);
+  opacity: 0;
+  pointer-events: none;
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    transparent 0,
+    rgb(0 0 0 / 0.08) 1rem,
+    rgb(0 0 0 / 0.28) 2.25rem,
+    rgb(0 0 0 / 0.64) 4rem,
+    black 6rem
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    transparent 0,
+    rgb(0 0 0 / 0.08) 1rem,
+    rgb(0 0 0 / 0.28) 2.25rem,
+    rgb(0 0 0 / 0.64) 4rem,
+    black 6rem
+  );
+  transition: opacity 150ms ease;
+}
+
+.zoom-overlay[data-state='open'] .zoom-overlay-details::before {
+  opacity: 1;
+  transition: opacity 200ms ease 120ms;
 }
 
 @media (max-width: 39.999rem) {
   .zoom-overlay-details {
-    bottom: calc(5.5rem + env(safe-area-inset-bottom, 0px));
+    --zoom-details-bottom: calc(5.5rem + env(safe-area-inset-bottom, 0px));
   }
 }
 
@@ -4938,7 +4974,8 @@ html[data-locale='en'] [data-en-block] {
 
 @media (prefers-reduced-motion: reduce) {
   .zoom-detail-item,
-  .zoom-detail-frame {
+  .zoom-detail-frame,
+  .zoom-overlay-details::before {
     transform: none;
     transition: none;
   }

--- a/app/globals.css
+++ b/app/globals.css
@@ -4907,7 +4907,7 @@ html[data-locale='en'] [data-en-block] {
 .zoom-overlay-details::before {
   position: absolute;
   z-index: -1;
-  inset: -10rem 0 calc(-1 * var(--zoom-details-bottom));
+  inset: -4rem 0 calc(-1 * var(--zoom-details-bottom));
   content: '';
   background: var(--background);
   opacity: 0;
@@ -4915,20 +4915,18 @@ html[data-locale='en'] [data-en-block] {
   -webkit-mask-image: linear-gradient(
     to bottom,
     transparent 0,
-    rgb(0 0 0 / 0.18) 1rem,
-    rgb(0 0 0 / 0.46) 2.5rem,
-    rgb(0 0 0 / 0.72) 4rem,
-    rgb(0 0 0 / 0.92) 5.5rem,
-    black 7rem
+    rgb(0 0 0 / 0.12) 1rem,
+    rgb(0 0 0 / 0.38) 2rem,
+    rgb(0 0 0 / 0.75) 3rem,
+    black 4rem
   );
   mask-image: linear-gradient(
     to bottom,
     transparent 0,
-    rgb(0 0 0 / 0.18) 1rem,
-    rgb(0 0 0 / 0.46) 2.5rem,
-    rgb(0 0 0 / 0.72) 4rem,
-    rgb(0 0 0 / 0.92) 5.5rem,
-    black 7rem
+    rgb(0 0 0 / 0.12) 1rem,
+    rgb(0 0 0 / 0.38) 2rem,
+    rgb(0 0 0 / 0.75) 3rem,
+    black 4rem
   );
   transition: opacity 150ms ease;
 }
@@ -4936,6 +4934,20 @@ html[data-locale='en'] [data-en-block] {
 .zoom-overlay[data-state='open'] .zoom-overlay-details::before {
   opacity: 1;
   transition: opacity 200ms ease 120ms;
+}
+
+.zoom-overlay-details .spec-plate {
+  gap: 0.375rem 1.25rem;
+  padding-block: 0.5rem;
+}
+
+.zoom-overlay-details .spec-plate dt {
+  font-size: 0.625rem;
+}
+
+.zoom-overlay-details .spec-plate dd {
+  margin-top: 0.125rem;
+  font-size: 0.75rem;
 }
 
 @media (max-width: 39.999rem) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -4894,50 +4894,15 @@ html[data-locale='en'] [data-en-block] {
 }
 
 .zoom-overlay-details {
-  --zoom-details-bottom: calc(1.5rem + env(safe-area-inset-bottom, 0px));
+  --zoom-details-bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
   position: fixed;
   inset-inline: 0;
   bottom: var(--zoom-details-bottom);
-  isolation: isolate;
   pointer-events: none;
-}
-
-/* A masked paper runway gives the overlapping plate deterministic contrast
-   without changing the photograph's colors or blending the type. */
-.zoom-overlay-details::before {
-  position: absolute;
-  z-index: -1;
-  inset: -4rem 0 calc(-1 * var(--zoom-details-bottom));
-  content: '';
-  background: var(--background);
-  opacity: 0;
-  pointer-events: none;
-  -webkit-mask-image: linear-gradient(
-    to bottom,
-    transparent 0,
-    rgb(0 0 0 / 0.12) 1rem,
-    rgb(0 0 0 / 0.38) 2rem,
-    rgb(0 0 0 / 0.75) 3rem,
-    black 4rem
-  );
-  mask-image: linear-gradient(
-    to bottom,
-    transparent 0,
-    rgb(0 0 0 / 0.12) 1rem,
-    rgb(0 0 0 / 0.38) 2rem,
-    rgb(0 0 0 / 0.75) 3rem,
-    black 4rem
-  );
-  transition: opacity 150ms ease;
-}
-
-.zoom-overlay[data-state='open'] .zoom-overlay-details::before {
-  opacity: 1;
-  transition: opacity 200ms ease 120ms;
 }
 
 .zoom-overlay-details .spec-plate {
-  gap: 0.375rem 1.25rem;
+  gap: 0.375rem 0.875rem;
   padding-block: 0.5rem;
 }
 
@@ -4948,12 +4913,6 @@ html[data-locale='en'] [data-en-block] {
 .zoom-overlay-details .spec-plate dd {
   margin-top: 0.125rem;
   font-size: 0.75rem;
-}
-
-@media (max-width: 39.999rem) {
-  .zoom-overlay-details {
-    --zoom-details-bottom: calc(5.5rem + env(safe-area-inset-bottom, 0px));
-  }
 }
 
 /* The caption sheet follows the print: items spring in one by one once the
@@ -4988,8 +4947,7 @@ html[data-locale='en'] [data-en-block] {
 
 @media (prefers-reduced-motion: reduce) {
   .zoom-detail-item,
-  .zoom-detail-frame,
-  .zoom-overlay-details::before {
+  .zoom-detail-frame {
     transform: none;
     transition: none;
   }

--- a/components/published-photo-wall.tsx
+++ b/components/published-photo-wall.tsx
@@ -72,14 +72,14 @@ function PhotoDetails({ photo }: { photo: PublishedPhoto }) {
     <div className="mx-auto w-full max-w-xl px-5 text-foreground">
       {(location || captured) && (
         <p
-          className="zoom-detail-item text-sm font-medium tabular-nums"
+          className="zoom-detail-item text-xs font-medium tabular-nums"
           style={{ '--detail-index': 0 } as React.CSSProperties}
         >
           {[location, captured].filter(Boolean).join(' · ')}
         </p>
       )}
       {fields.length > 0 && (
-        <dl className="spec-plate spec-plate-flow zoom-detail-frame mt-3">
+        <dl className="spec-plate spec-plate-flow zoom-detail-frame mt-2">
           {fields.map((field, index) => (
             <div
               key={field.en}

--- a/components/published-photo-wall.tsx
+++ b/components/published-photo-wall.tsx
@@ -110,9 +110,6 @@ function PublishedPhotoItem({
   const locale = useLocale()
   const alt = localize(locale, photo.altText.zhHans, photo.altText.en)
   const rendition = photo.renditions.at(-1)!
-  const srcSet = photo.renditions
-    .map(({ src, profileWidth }) => `${src} ${profileWidth}w`)
-    .join(', ')
 
   // Tiles stay quiet: location and capture data live in the lightbox details.
   return (
@@ -127,9 +124,8 @@ function PublishedPhotoItem({
     >
       <div className="photo-frame relative overflow-hidden">
         <ZoomImage
-          native
           src={rendition.src}
-          srcSet={srcSet}
+          renditions={photo.renditions}
           alt={alt}
           width={photo.width}
           height={photo.height}

--- a/components/published-photo-wall.tsx
+++ b/components/published-photo-wall.tsx
@@ -18,15 +18,6 @@ const LOADING_ASPECT_RATIOS = [
   '1 / 1',
 ]
 
-function captureDate(date: Date, locale: 'zh' | 'en') {
-  return new Intl.DateTimeFormat(locale === 'zh' ? 'zh-CN' : 'en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    timeZone: 'UTC',
-  }).format(new Date(date))
-}
-
 // The capture data as spec-plate fields — EXIF was always plate content
 function cameraFields(photo: PublishedPhoto) {
   if (!photo.camera) return []
@@ -62,38 +53,32 @@ function cameraFields(photo: PublishedPhoto) {
 function PhotoDetails({ photo }: { photo: PublishedPhoto }) {
   const locale = useLocale()
   const location = photo.locationLabel?.[locale === 'zh' ? 'zhHans' : 'en']
-  const captured = photo.capturedAt ? captureDate(photo.capturedAt, locale) : null
-  const fields = cameraFields(photo)
-  if (!location && !captured && fields.length === 0) return null
+  const fields = [
+    ...(location
+      ? [{ zh: '地点', en: 'Location', value: location }]
+      : []),
+    ...cameraFields(photo),
+  ]
+  if (fields.length === 0) return null
 
   // The caption sheet staggers in behind the print: each item carries its
   // order so the overlay's open state can spring them in one by one.
   return (
     <div className="mx-auto w-full max-w-xl px-5 text-foreground">
-      {(location || captured) && (
-        <p
-          className="zoom-detail-item text-xs font-medium tabular-nums"
-          style={{ '--detail-index': 0 } as React.CSSProperties}
-        >
-          {[location, captured].filter(Boolean).join(' · ')}
-        </p>
-      )}
-      {fields.length > 0 && (
-        <dl className="spec-plate spec-plate-flow zoom-detail-frame mt-2">
-          {fields.map((field, index) => (
-            <div
-              key={field.en}
-              className="zoom-detail-item"
-              style={{ '--detail-index': index + 1 } as React.CSSProperties}
-            >
-              <dt>
-                <T zh={field.zh} en={field.en} />
-              </dt>
-              <dd>{field.value}</dd>
-            </div>
-          ))}
-        </dl>
-      )}
+      <dl className="spec-plate spec-plate-flow zoom-detail-frame">
+        {fields.map((field, index) => (
+          <div
+            key={field.en}
+            className="zoom-detail-item"
+            style={{ '--detail-index': index } as React.CSSProperties}
+          >
+            <dt>
+              <T zh={field.zh} en={field.en} />
+            </dt>
+            <dd>{field.value}</dd>
+          </div>
+        ))}
+      </dl>
     </div>
   )
 }

--- a/components/zoom-image.test.tsx
+++ b/components/zoom-image.test.tsx
@@ -5,8 +5,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ZoomImage } from './zoom-image'
 
+type MockImageProps = React.ImgHTMLAttributes<HTMLImageElement> & {
+  loader?: unknown
+  unoptimized?: boolean
+}
+
 vi.mock('next/image', () => ({
-  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+  default: ({
+    loader: _loader,
+    unoptimized: _unoptimized,
+    ...props
+  }: MockImageProps) => (
     // eslint-disable-next-line @next/next/no-img-element
     <img {...props} />
   ),
@@ -30,6 +39,7 @@ beforeEach(() => {
 
   Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1200 })
   Object.defineProperty(window, 'innerHeight', { configurable: true, value: 900 })
+  document.documentElement.style.fontSize = ''
   vi.spyOn(HTMLImageElement.prototype, 'getBoundingClientRect').mockReturnValue({
     bottom: 300,
     height: 200,
@@ -47,9 +57,59 @@ afterEach(() => {
   cleanup()
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
+  document.documentElement.style.fontSize = ''
 })
 
 describe('ZoomImage', () => {
+  it('preloads the largest rendition only once across hover and focus', () => {
+    render(
+      <ZoomImage
+        src="/photo-640.jpg"
+        alt="Taipei"
+        width={800}
+        height={600}
+        renditions={[
+          { src: '/photo-640.jpg', width: 640 },
+          { src: '/photo-2560.jpg', width: 2560 },
+        ]}
+      />,
+    )
+    const createElement = vi.spyOn(document, 'createElement')
+    const trigger = screen.getByRole('button', { name: 'Zoom image: Taipei' })
+
+    fireEvent.pointerEnter(trigger)
+    fireEvent.pointerEnter(trigger)
+    fireEvent.focus(trigger)
+
+    expect(
+      createElement.mock.calls.filter(([tagName]) => tagName === 'img'),
+    ).toHaveLength(1)
+  })
+
+  it('scales the detail reservation and mobile breakpoint with rem', () => {
+    document.documentElement.style.fontSize = '20px'
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 700 })
+    render(
+      <ZoomImage
+        src="/photo.jpg"
+        alt="Taipei"
+        width={800}
+        height={1600}
+        expandedContent={<p>Details</p>}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Zoom image: Taipei' }), {
+      detail: 0,
+    })
+
+    const expandedImage = screen
+      .getByRole('dialog', { name: 'Taipei' })
+      .querySelector('img')!
+    expect(expandedImage.style.height).toBe('696px')
+    expect(expandedImage.style.top).toBe('32px')
+  })
+
   it('opens keyboard activation in its settled state without scheduling motion', () => {
     render(<ZoomImage src="/photo.jpg" alt="Taipei" width={800} height={600} />)
 

--- a/components/zoom-image.tsx
+++ b/components/zoom-image.tsx
@@ -99,7 +99,7 @@ export function ZoomImage({
     // Fit within the viewport but never beyond the intrinsic size —
     // zoom means "actual size", not "stretch".
     const maxW = Math.min(window.innerWidth - VIEWPORT_PAD * 2, width)
-    const detailSpace = expandedContent ? 152 : 0
+    const detailSpace = expandedContent ? 128 : 0
     const maxH = Math.max(
       1,
       Math.min(

--- a/components/zoom-image.tsx
+++ b/components/zoom-image.tsx
@@ -7,15 +7,23 @@ import { createPortal } from 'react-dom'
 import { localize, useLocale } from '~/lib/locale-client'
 
 const VIEWPORT_PAD = 32
-const DETAIL_SPACE = 72
-const MOBILE_DETAIL_SPACE = 112
-const MOBILE_BREAKPOINT = 640
+const DEFAULT_ROOT_FONT_SIZE = 16
+const DETAIL_SPACE_REM = 4.5
+const MOBILE_DETAIL_SPACE_REM = 7
+const MOBILE_BREAKPOINT_REM = 40
 
 type ZoomImageRendition = { src: string; width: number }
 type CloseReason = 'escape' | 'overlay' | 'viewport'
 
 function prefersReducedMotion() {
   return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
+}
+
+function rootFontSizePixels() {
+  const rootFontSize = Number.parseFloat(
+    window.getComputedStyle(document.documentElement).fontSize,
+  )
+  return Number.isFinite(rootFontSize) ? rootFontSize : DEFAULT_ROOT_FONT_SIZE
 }
 
 interface ZoomImageProps {
@@ -71,6 +79,7 @@ export function ZoomImage({
   const locale = useLocale()
   const triggerRef = useRef<HTMLButtonElement>(null)
   const overlayRef = useRef<HTMLDivElement>(null)
+  const preloadedSrcRef = useRef<string | null>(null)
   const [zoom, setZoom] = useState<{
     expandedSrc: string
     target: { left: number; top: number; width: number; height: number }
@@ -93,10 +102,11 @@ export function ZoomImage({
   )
 
   const preloadExpanded = useCallback(() => {
-    if (expandedSrc === src) return
+    if (expandedSrc === src || preloadedSrcRef.current === expandedSrc) return
     const preload = document.createElement('img')
     preload.decoding = 'async'
     preload.src = expandedSrc
+    preloadedSrcRef.current = expandedSrc
   }, [expandedSrc, src])
 
   const open = useCallback((event: MouseEvent<HTMLButtonElement>) => {
@@ -107,10 +117,11 @@ export function ZoomImage({
     // Fit within the viewport but never beyond the intrinsic size —
     // zoom means "actual size", not "stretch".
     const maxW = Math.min(window.innerWidth - VIEWPORT_PAD * 2, width)
+    const rootFontSize = rootFontSizePixels()
     const detailSpace = expandedContent
-      ? window.innerWidth < MOBILE_BREAKPOINT
-        ? MOBILE_DETAIL_SPACE
-        : DETAIL_SPACE
+      ? (window.innerWidth < MOBILE_BREAKPOINT_REM * rootFontSize
+          ? MOBILE_DETAIL_SPACE_REM
+          : DETAIL_SPACE_REM) * rootFontSize
       : 0
     const maxH = Math.max(
       1,

--- a/components/zoom-image.tsx
+++ b/components/zoom-image.tsx
@@ -1,12 +1,14 @@
 'use client'
 
-import Image from 'next/image'
+import Image, { type ImageLoader } from 'next/image'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 
 import { localize, useLocale } from '~/lib/locale-client'
 
 const VIEWPORT_PAD = 32
+
+type ZoomImageRendition = { src: string; width: number }
 
 interface ZoomImageProps {
   src: string
@@ -16,9 +18,32 @@ interface ZoomImageProps {
   sizes?: string
   className?: string
   style?: React.CSSProperties
-  native?: boolean
-  srcSet?: string
+  renditions?: ReadonlyArray<ZoomImageRendition>
   expandedContent?: React.ReactNode
+}
+
+function largestRendition(
+  renditions: ZoomImageProps['renditions'],
+) {
+  return renditions?.reduce<ZoomImageRendition | undefined>(
+    (largest, rendition) =>
+      !largest || rendition.width > largest.width ? rendition : largest,
+    undefined,
+  )
+}
+
+function renditionForWidth(
+  renditions: ZoomImageProps['renditions'],
+  requestedWidth: number,
+) {
+  return renditions?.reduce<ZoomImageRendition | undefined>(
+    (best, rendition) =>
+      rendition.width >= requestedWidth &&
+      (!best || rendition.width < best.width)
+        ? rendition
+        : best,
+    undefined,
+  )
 }
 
 // Click-to-zoom for post images: the photo is picked up off the page and
@@ -32,15 +57,14 @@ export function ZoomImage({
   sizes,
   className,
   style,
-  native = false,
-  srcSet,
+  renditions,
   expandedContent,
 }: ZoomImageProps) {
   const locale = useLocale()
   const triggerRef = useRef<HTMLButtonElement>(null)
   const overlayRef = useRef<HTMLDivElement>(null)
   const [zoom, setZoom] = useState<{
-    currentSrc: string
+    expandedSrc: string
     target: { left: number; top: number; width: number; height: number }
     from: string
   } | null>(null)
@@ -49,6 +73,23 @@ export function ZoomImage({
   useEffect(() => {
     stateRef.current = state
   }, [state])
+
+  const expandedSrc = largestRendition(renditions)?.src ?? src
+  // Next Image owns responsive selection and layout, while Bunny remains the
+  // encoder/cache layer. Selecting an immutable Rendition here avoids a second
+  // quality pass through Next's optimizer.
+  const renditionLoader = useCallback<ImageLoader>(
+    ({ width: requestedWidth }) =>
+      renditionForWidth(renditions, requestedWidth)?.src ?? expandedSrc,
+    [expandedSrc, renditions],
+  )
+
+  const preloadExpanded = useCallback(() => {
+    if (expandedSrc === src) return
+    const preload = document.createElement('img')
+    preload.decoding = 'async'
+    preload.src = expandedSrc
+  }, [expandedSrc, src])
 
   const open = useCallback(() => {
     const img = triggerRef.current?.querySelector('img')
@@ -81,12 +122,12 @@ export function ZoomImage({
     const tx = rect.left + rect.width / 2 - (target.left + w / 2)
     const ty = rect.top + rect.height / 2 - (target.top + h / 2)
     setZoom({
-      currentSrc: img.currentSrc || src,
+      expandedSrc,
       target,
       from: `translate(${tx}px, ${ty}px) scale(${s})`,
     })
     setState('opening')
-  }, [src, width, height, expandedContent])
+  }, [expandedSrc, width, height, expandedContent])
 
   const unmount = useCallback(() => {
     setZoom(null)
@@ -185,32 +226,19 @@ export function ZoomImage({
             : localize(locale, '放大图片', 'Zoom image')
         }
         data-zoomed={zoom ? '' : undefined}
+        onPointerEnter={preloadExpanded}
+        onFocus={preloadExpanded}
         onClick={open}
       >
-        {native ? (
-          // Bunny is the public binary cache layer for Published Photo Selections.
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={src}
-            srcSet={srcSet}
-            alt={alt}
-            width={width}
-            height={height}
-            sizes={sizes}
-            className={className}
-            loading="lazy"
-            decoding="async"
-          />
-        ) : (
-          <Image
-            src={src}
-            alt={alt}
-            width={width}
-            height={height}
-            sizes={sizes}
-            className={className}
-          />
-        )}
+        <Image
+          loader={renditions ? renditionLoader : undefined}
+          src={src}
+          alt={alt}
+          width={width}
+          height={height}
+          sizes={sizes}
+          className={className}
+        />
       </button>
       {zoom &&
         createPortal(
@@ -225,10 +253,14 @@ export function ZoomImage({
             onClick={close}
           >
             <div className="zoom-overlay-backdrop" />
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={zoom.currentSrc}
+            <Image
+              unoptimized
+              src={zoom.expandedSrc}
               alt={alt}
+              width={width}
+              height={height}
+              loading="eager"
+              fetchPriority="high"
               style={{
                 left: zoom.target.left,
                 top: zoom.target.top,

--- a/components/zoom-image.tsx
+++ b/components/zoom-image.tsx
@@ -7,6 +7,9 @@ import { createPortal } from 'react-dom'
 import { localize, useLocale } from '~/lib/locale-client'
 
 const VIEWPORT_PAD = 32
+const DETAIL_SPACE = 72
+const MOBILE_DETAIL_SPACE = 112
+const MOBILE_BREAKPOINT = 640
 
 type ZoomImageRendition = { src: string; width: number }
 
@@ -99,7 +102,11 @@ export function ZoomImage({
     // Fit within the viewport but never beyond the intrinsic size —
     // zoom means "actual size", not "stretch".
     const maxW = Math.min(window.innerWidth - VIEWPORT_PAD * 2, width)
-    const detailSpace = expandedContent ? 128 : 0
+    const detailSpace = expandedContent
+      ? window.innerWidth < MOBILE_BREAKPOINT
+        ? MOBILE_DETAIL_SPACE
+        : DETAIL_SPACE
+      : 0
     const maxH = Math.max(
       1,
       Math.min(
@@ -112,7 +119,7 @@ export function ZoomImage({
     const h = Math.round(height * scale)
     const target = {
       left: Math.round((window.innerWidth - w) / 2),
-      top: Math.round((window.innerHeight - h) / 2),
+      top: Math.round((window.innerHeight - detailSpace - h) / 2),
       width: w,
       height: h,
     }

--- a/db/migrations/0012_high_fidelity_photo_renditions.sql
+++ b/db/migrations/0012_high_fidelity_photo_renditions.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "media_published_photo_selection_renditions" ADD CONSTRAINT "media_published_photo_selection_renditions_profile_check_v2" CHECK ("media_published_photo_selection_renditions"."profile_width" IN (640, 1024, 1600, 2560)) NOT VALID;--> statement-breakpoint
+ALTER TABLE "media_published_photo_selection_renditions" VALIDATE CONSTRAINT "media_published_photo_selection_renditions_profile_check_v2";--> statement-breakpoint
+ALTER TABLE "media_published_photo_selection_renditions" DROP CONSTRAINT "media_published_photo_selection_renditions_profile_check";--> statement-breakpoint
+ALTER TABLE "media_published_photo_selection_renditions" RENAME CONSTRAINT "media_published_photo_selection_renditions_profile_check_v2" TO "media_published_photo_selection_renditions_profile_check";--> statement-breakpoint
+ALTER TABLE "media_renditions" ADD CONSTRAINT "media_renditions_profile_check_v2" CHECK ("media_renditions"."profile_width" IN (640, 1024, 1600, 2560)) NOT VALID;--> statement-breakpoint
+ALTER TABLE "media_renditions" VALIDATE CONSTRAINT "media_renditions_profile_check_v2";--> statement-breakpoint
+ALTER TABLE "media_renditions" DROP CONSTRAINT "media_renditions_profile_check";--> statement-breakpoint
+ALTER TABLE "media_renditions" RENAME CONSTRAINT "media_renditions_profile_check_v2" TO "media_renditions_profile_check";

--- a/db/migrations/meta/0012_snapshot.json
+++ b/db/migrations/meta/0012_snapshot.json
@@ -1,0 +1,3377 @@
+{
+  "id": "4242c828-f65d-43c5-a3e4-378fc721ead8",
+  "prevId": "dfdc2fad-e943-404b-9fdc-145fd5a6df91",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ama_admin_sessions": {
+      "name": "ama_admin_sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_admin_sessions_expires_at_idx": {
+          "name": "ama_admin_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ama_alternate_time_requests": {
+      "name": "ama_alternate_time_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "guest_name": {
+          "name": "guest_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guest_email": {
+          "name": "guest_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guest_time_zone": {
+          "name": "guest_time_zone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_windows": {
+          "name": "preferred_windows",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ama_alternate_time_requests_status_idx": {
+          "name": "ama_alternate_time_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_alternate_time_requests_guest_check": {
+          "name": "ama_alternate_time_requests_guest_check",
+          "value": "length(btrim(\"ama_alternate_time_requests\".\"guest_name\")) > 0 AND length(btrim(\"ama_alternate_time_requests\".\"guest_email\")) > 0"
+        },
+        "ama_alternate_time_requests_locale_check": {
+          "name": "ama_alternate_time_requests_locale_check",
+          "value": "\"ama_alternate_time_requests\".\"locale\" IN ('zh', 'en')"
+        },
+        "ama_alternate_time_requests_windows_check": {
+          "name": "ama_alternate_time_requests_windows_check",
+          "value": "length(btrim(\"ama_alternate_time_requests\".\"preferred_windows\")) > 0 AND char_length(\"ama_alternate_time_requests\".\"preferred_windows\") <= 1000"
+        },
+        "ama_alternate_time_requests_note_check": {
+          "name": "ama_alternate_time_requests_note_check",
+          "value": "\"ama_alternate_time_requests\".\"note\" IS NULL OR char_length(\"ama_alternate_time_requests\".\"note\") <= 1000"
+        },
+        "ama_alternate_time_requests_status_check": {
+          "name": "ama_alternate_time_requests_status_check",
+          "value": "\"ama_alternate_time_requests\".\"status\" IN ('new', 'resolved', 'dismissed')"
+        },
+        "ama_alternate_time_requests_resolution_check": {
+          "name": "ama_alternate_time_requests_resolution_check",
+          "value": "(\"ama_alternate_time_requests\".\"status\" = 'new') = (\"ama_alternate_time_requests\".\"resolved_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_auth_tokens": {
+      "name": "ama_auth_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_auth_tokens_expires_at_idx": {
+          "name": "ama_auth_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ama_availability_windows": {
+      "name": "ama_availability_windows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "iso_weekday": {
+          "name": "iso_weekday",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_minute": {
+          "name": "start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_minute": {
+          "name": "end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_availability_windows_order_idx": {
+          "name": "ama_availability_windows_order_idx",
+          "columns": [
+            {
+              "expression": "iso_weekday",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_minute",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_minute",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_availability_windows_iso_weekday_check": {
+          "name": "ama_availability_windows_iso_weekday_check",
+          "value": "\"ama_availability_windows\".\"iso_weekday\" BETWEEN 1 AND 7"
+        },
+        "ama_availability_windows_start_minute_check": {
+          "name": "ama_availability_windows_start_minute_check",
+          "value": "\"ama_availability_windows\".\"start_minute\" BETWEEN 0 AND 1439"
+        },
+        "ama_availability_windows_end_minute_check": {
+          "name": "ama_availability_windows_end_minute_check",
+          "value": "\"ama_availability_windows\".\"end_minute\" BETWEEN 1 AND 1440"
+        },
+        "ama_availability_windows_same_day_check": {
+          "name": "ama_availability_windows_same_day_check",
+          "value": "\"ama_availability_windows\".\"start_minute\" < \"ama_availability_windows\".\"end_minute\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_booking_events": {
+      "name": "ama_booking_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(48)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "ama_booking_events_booking_idx": {
+          "name": "ama_booking_events_booking_idx",
+          "columns": [
+            {
+              "expression": "booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ama_booking_events_booking_id_ama_bookings_id_fk": {
+          "name": "ama_booking_events_booking_id_ama_bookings_id_fk",
+          "tableFrom": "ama_booking_events",
+          "tableTo": "ama_bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_booking_events_event_check": {
+          "name": "ama_booking_events_event_check",
+          "value": "length(btrim(\"ama_booking_events\".\"event\")) > 0"
+        },
+        "ama_booking_events_actor_check": {
+          "name": "ama_booking_events_actor_check",
+          "value": "\"ama_booking_events\".\"actor\" IN ('guest', 'owner', 'system', 'provider')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_booking_intents": {
+      "name": "ama_booking_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "hold_claim_id": {
+          "name": "hold_claim_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guest_name": {
+          "name": "guest_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guest_email": {
+          "name": "guest_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guest_time_zone": {
+          "name": "guest_time_zone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief_text": {
+          "name": "brief_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief_urls": {
+          "name": "brief_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "meeting_provider": {
+          "name": "meeting_provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_booking_intents_hold_claim_uidx": {
+          "name": "ama_booking_intents_hold_claim_uidx",
+          "columns": [
+            {
+              "expression": "hold_claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ama_booking_intents_checkout_session_uidx": {
+          "name": "ama_booking_intents_checkout_session_uidx",
+          "columns": [
+            {
+              "expression": "stripe_checkout_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ama_booking_intents_hold_claim_id_ama_slot_claims_id_fk": {
+          "name": "ama_booking_intents_hold_claim_id_ama_slot_claims_id_fk",
+          "tableFrom": "ama_booking_intents",
+          "tableTo": "ama_slot_claims",
+          "columnsFrom": [
+            "hold_claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_booking_intents_guest_check": {
+          "name": "ama_booking_intents_guest_check",
+          "value": "length(btrim(\"ama_booking_intents\".\"guest_name\")) > 0 AND length(btrim(\"ama_booking_intents\".\"guest_email\")) > 0"
+        },
+        "ama_booking_intents_locale_check": {
+          "name": "ama_booking_intents_locale_check",
+          "value": "\"ama_booking_intents\".\"locale\" IN ('zh', 'en')"
+        },
+        "ama_booking_intents_time_zone_check": {
+          "name": "ama_booking_intents_time_zone_check",
+          "value": "length(btrim(\"ama_booking_intents\".\"guest_time_zone\")) > 0"
+        },
+        "ama_booking_intents_topics_check": {
+          "name": "ama_booking_intents_topics_check",
+          "value": "jsonb_typeof(\"ama_booking_intents\".\"topics\") = 'array' AND jsonb_array_length(\"ama_booking_intents\".\"topics\") BETWEEN 1 AND 8"
+        },
+        "ama_booking_intents_brief_check": {
+          "name": "ama_booking_intents_brief_check",
+          "value": "length(btrim(\"ama_booking_intents\".\"brief_text\")) > 0 AND char_length(\"ama_booking_intents\".\"brief_text\") <= 2000"
+        },
+        "ama_booking_intents_brief_urls_check": {
+          "name": "ama_booking_intents_brief_urls_check",
+          "value": "jsonb_typeof(\"ama_booking_intents\".\"brief_urls\") = 'array' AND jsonb_array_length(\"ama_booking_intents\".\"brief_urls\") <= 5"
+        },
+        "ama_booking_intents_provider_check": {
+          "name": "ama_booking_intents_provider_check",
+          "value": "\"ama_booking_intents\".\"meeting_provider\" IN ('google-meet', 'tencent-meeting')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_bookings": {
+      "name": "ama_bookings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finalizing'"
+        },
+        "guest_name": {
+          "name": "guest_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guest_email": {
+          "name": "guest_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guest_time_zone": {
+          "name": "guest_time_zone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief_text": {
+          "name": "brief_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brief_urls": {
+          "name": "brief_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brief_purged_at": {
+          "name": "brief_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_provider": {
+          "name": "meeting_provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_total": {
+          "name": "amount_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refund_status": {
+          "name": "refund_status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "stripe_refund_id": {
+          "name": "stripe_refund_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refund_reason": {
+          "name": "refund_reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by": {
+          "name": "cancelled_by",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_url": {
+          "name": "meeting_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_calendar_event_id": {
+          "name": "google_calendar_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tencent_meeting_id": {
+          "name": "tencent_meeting_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_created_at": {
+          "name": "meeting_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manage_token_hash": {
+          "name": "manage_token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manage_token_issued_at": {
+          "name": "manage_token_issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manage_token_revoked_at": {
+          "name": "manage_token_revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_bookings_intent_uidx": {
+          "name": "ama_bookings_intent_uidx",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ama_bookings_checkout_session_uidx": {
+          "name": "ama_bookings_checkout_session_uidx",
+          "columns": [
+            {
+              "expression": "stripe_checkout_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ama_bookings_manage_token_uidx": {
+          "name": "ama_bookings_manage_token_uidx",
+          "columns": [
+            {
+              "expression": "manage_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ama_bookings_schedule_idx": {
+          "name": "ama_bookings_schedule_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ama_bookings_claim_idx": {
+          "name": "ama_bookings_claim_idx",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ama_bookings_intent_id_ama_booking_intents_id_fk": {
+          "name": "ama_bookings_intent_id_ama_booking_intents_id_fk",
+          "tableFrom": "ama_bookings",
+          "tableTo": "ama_booking_intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "ama_bookings_claim_id_ama_slot_claims_id_fk": {
+          "name": "ama_bookings_claim_id_ama_slot_claims_id_fk",
+          "tableFrom": "ama_bookings",
+          "tableTo": "ama_slot_claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_bookings_status_check": {
+          "name": "ama_bookings_status_check",
+          "value": "\"ama_bookings\".\"status\" IN ('finalizing', 'confirmed', 'needs_reschedule', 'cancelled')"
+        },
+        "ama_bookings_locale_check": {
+          "name": "ama_bookings_locale_check",
+          "value": "\"ama_bookings\".\"locale\" IN ('zh', 'en')"
+        },
+        "ama_bookings_provider_check": {
+          "name": "ama_bookings_provider_check",
+          "value": "\"ama_bookings\".\"meeting_provider\" IN ('google-meet', 'tencent-meeting')"
+        },
+        "ama_bookings_interval_check": {
+          "name": "ama_bookings_interval_check",
+          "value": "\"ama_bookings\".\"starts_at\" < \"ama_bookings\".\"ends_at\""
+        },
+        "ama_bookings_claim_presence_check": {
+          "name": "ama_bookings_claim_presence_check",
+          "value": "\"ama_bookings\".\"status\" IN ('needs_reschedule', 'cancelled') OR \"ama_bookings\".\"claim_id\" IS NOT NULL"
+        },
+        "ama_bookings_refund_status_check": {
+          "name": "ama_bookings_refund_status_check",
+          "value": "\"ama_bookings\".\"refund_status\" IN ('none', 'pending', 'refunded', 'failed')"
+        },
+        "ama_bookings_refund_reason_check": {
+          "name": "ama_bookings_refund_reason_check",
+          "value": "\"ama_bookings\".\"refund_reason\" IS NULL OR \"ama_bookings\".\"refund_reason\" IN ('guest_cancellation', 'owner_cancellation', 'owner_exception')"
+        },
+        "ama_bookings_cancellation_check": {
+          "name": "ama_bookings_cancellation_check",
+          "value": "(\"ama_bookings\".\"status\" = 'cancelled') = (\"ama_bookings\".\"cancelled_at\" IS NOT NULL AND \"ama_bookings\".\"cancelled_by\" IS NOT NULL)"
+        },
+        "ama_bookings_cancelled_by_check": {
+          "name": "ama_bookings_cancelled_by_check",
+          "value": "\"ama_bookings\".\"cancelled_by\" IS NULL OR \"ama_bookings\".\"cancelled_by\" IN ('guest', 'owner')"
+        },
+        "ama_bookings_brief_purge_check": {
+          "name": "ama_bookings_brief_purge_check",
+          "value": "(\"ama_bookings\".\"brief_purged_at\" IS NULL AND \"ama_bookings\".\"brief_text\" IS NOT NULL AND \"ama_bookings\".\"brief_urls\" IS NOT NULL) OR (\"ama_bookings\".\"brief_purged_at\" IS NOT NULL AND \"ama_bookings\".\"brief_text\" IS NULL AND \"ama_bookings\".\"brief_urls\" IS NULL)"
+        },
+        "ama_bookings_manage_token_check": {
+          "name": "ama_bookings_manage_token_check",
+          "value": "(\"ama_bookings\".\"manage_token_hash\" IS NULL) = (\"ama_bookings\".\"manage_token_issued_at\" IS NULL)"
+        },
+        "ama_bookings_amount_check": {
+          "name": "ama_bookings_amount_check",
+          "value": "\"ama_bookings\".\"amount_total\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_durable_operations": {
+      "name": "ama_durable_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(48)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_durable_operations_dedupe_uidx": {
+          "name": "ama_durable_operations_dedupe_uidx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ama_durable_operations_due_idx": {
+          "name": "ama_durable_operations_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ama_durable_operations_booking_idx": {
+          "name": "ama_durable_operations_booking_idx",
+          "columns": [
+            {
+              "expression": "booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ama_durable_operations_booking_id_ama_bookings_id_fk": {
+          "name": "ama_durable_operations_booking_id_ama_bookings_id_fk",
+          "tableFrom": "ama_durable_operations",
+          "tableTo": "ama_bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_durable_operations_kind_check": {
+          "name": "ama_durable_operations_kind_check",
+          "value": "length(btrim(\"ama_durable_operations\".\"kind\")) > 0"
+        },
+        "ama_durable_operations_status_check": {
+          "name": "ama_durable_operations_status_check",
+          "value": "\"ama_durable_operations\".\"status\" IN ('pending', 'running', 'succeeded', 'failed', 'cancelled', 'resolved')"
+        },
+        "ama_durable_operations_attempts_check": {
+          "name": "ama_durable_operations_attempts_check",
+          "value": "\"ama_durable_operations\".\"attempt_count\" >= 0 AND \"ama_durable_operations\".\"max_attempts\" > 0"
+        },
+        "ama_durable_operations_lease_check": {
+          "name": "ama_durable_operations_lease_check",
+          "value": "num_nonnulls(\"ama_durable_operations\".\"lease_token\", \"ama_durable_operations\".\"lease_expires_at\") IN (0, 2)"
+        },
+        "ama_durable_operations_completion_check": {
+          "name": "ama_durable_operations_completion_check",
+          "value": "(\"ama_durable_operations\".\"status\" IN ('succeeded', 'failed', 'cancelled', 'resolved')) = (\"ama_durable_operations\".\"completed_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_google_calendar_connections": {
+      "name": "ama_google_calendar_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_email": {
+          "name": "calendar_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_summary": {
+          "name": "calendar_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_scopes": {
+          "name": "granted_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "refresh_token_envelope": {
+          "name": "refresh_token_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_google_calendar_connections_singleton_check": {
+          "name": "ama_google_calendar_connections_singleton_check",
+          "value": "\"ama_google_calendar_connections\".\"id\" = 1"
+        },
+        "ama_google_calendar_connections_status_check": {
+          "name": "ama_google_calendar_connections_status_check",
+          "value": "\"ama_google_calendar_connections\".\"status\" IN ('disconnected', 'connected', 'expired', 'revoked', 'denied_scope', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_google_oauth_attempts": {
+      "name": "ama_google_oauth_attempts",
+      "schema": "",
+      "columns": {
+        "state_hash": {
+          "name": "state_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pkce_verifier_envelope": {
+          "name": "pkce_verifier_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_google_oauth_attempts_expires_at_idx": {
+          "name": "ama_google_oauth_attempts_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ama_provider_events": {
+      "name": "ama_provider_events",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ama_provider_events_provider_event_id_pk": {
+          "name": "ama_provider_events_provider_event_id_pk",
+          "columns": [
+            "provider",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_provider_events_provider_check": {
+          "name": "ama_provider_events_provider_check",
+          "value": "\"ama_provider_events\".\"provider\" = 'stripe'"
+        },
+        "ama_provider_events_identity_check": {
+          "name": "ama_provider_events_identity_check",
+          "value": "length(btrim(\"ama_provider_events\".\"event_id\")) > 0 AND length(btrim(\"ama_provider_events\".\"event_type\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_slot_claims": {
+      "name": "ama_slot_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_during": {
+          "name": "blocked_during",
+          "type": "tstzrange",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_reason": {
+          "name": "release_reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_slot_claims_active_idx": {
+          "name": "ama_slot_claims_active_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ama_slot_claims_expiry_idx": {
+          "name": "ama_slot_claims_expiry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_slot_claims_kind_check": {
+          "name": "ama_slot_claims_kind_check",
+          "value": "\"ama_slot_claims\".\"kind\" IN ('hold', 'booking')"
+        },
+        "ama_slot_claims_status_check": {
+          "name": "ama_slot_claims_status_check",
+          "value": "\"ama_slot_claims\".\"status\" IN ('active', 'released')"
+        },
+        "ama_slot_claims_interval_check": {
+          "name": "ama_slot_claims_interval_check",
+          "value": "\"ama_slot_claims\".\"starts_at\" < \"ama_slot_claims\".\"ends_at\""
+        },
+        "ama_slot_claims_blocked_during_check": {
+          "name": "ama_slot_claims_blocked_during_check",
+          "value": "\"ama_slot_claims\".\"blocked_during\" = tstzrange(\"ama_slot_claims\".\"starts_at\" - interval '15 minutes', \"ama_slot_claims\".\"ends_at\" + interval '15 minutes', '[)')"
+        },
+        "ama_slot_claims_hold_expiry_check": {
+          "name": "ama_slot_claims_hold_expiry_check",
+          "value": "(\"ama_slot_claims\".\"kind\" = 'hold') = (\"ama_slot_claims\".\"expires_at\" IS NOT NULL)"
+        },
+        "ama_slot_claims_release_check": {
+          "name": "ama_slot_claims_release_check",
+          "value": "(\"ama_slot_claims\".\"status\" = 'active' AND \"ama_slot_claims\".\"released_at\" IS NULL AND \"ama_slot_claims\".\"release_reason\" IS NULL) OR (\"ama_slot_claims\".\"status\" = 'released' AND \"ama_slot_claims\".\"released_at\" IS NOT NULL AND \"ama_slot_claims\".\"release_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_active_photo_publication": {
+      "name": "media_active_photo_publication",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "published_selection_id": {
+          "name": "published_selection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_active_photo_publication_selection_uidx": {
+          "name": "media_active_photo_publication_selection_uidx",
+          "columns": [
+            {
+              "expression": "published_selection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_active_photo_publication_published_selection_id_media_published_photo_selections_id_fk": {
+          "name": "media_active_photo_publication_published_selection_id_media_published_photo_selections_id_fk",
+          "tableFrom": "media_active_photo_publication",
+          "tableTo": "media_published_photo_selections",
+          "columnsFrom": [
+            "published_selection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_active_photo_publication_singleton_check": {
+          "name": "media_active_photo_publication_singleton_check",
+          "value": "\"media_active_photo_publication\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_asset_purge_jobs": {
+      "name": "media_asset_purge_jobs",
+      "schema": "",
+      "columns": {
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_deleted_at": {
+          "name": "original_deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "media_asset_purge_jobs_owner_idx": {
+          "name": "media_asset_purge_jobs_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_asset_purge_jobs_owner_check": {
+          "name": "media_asset_purge_jobs_owner_check",
+          "value": "length(btrim(\"media_asset_purge_jobs\".\"owner_user_id\")) > 0"
+        },
+        "media_asset_purge_jobs_claim_check": {
+          "name": "media_asset_purge_jobs_claim_check",
+          "value": "num_nonnulls(\"media_asset_purge_jobs\".\"claim_token\", \"media_asset_purge_jobs\".\"claim_expires_at\") IN (0, 2)"
+        },
+        "media_asset_purge_jobs_error_check": {
+          "name": "media_asset_purge_jobs_error_check",
+          "value": "\"media_asset_purge_jobs\".\"last_error_code\" IS NULL OR length(btrim(\"media_asset_purge_jobs\".\"last_error_code\")) > 0"
+        },
+        "media_asset_purge_jobs_completion_check": {
+          "name": "media_asset_purge_jobs_completion_check",
+          "value": "(\"media_asset_purge_jobs\".\"completed_at\" IS NULL AND \"media_asset_purge_jobs\".\"original_key\" IS NOT NULL) OR (\"media_asset_purge_jobs\".\"completed_at\" IS NOT NULL AND \"media_asset_purge_jobs\".\"original_key\" IS NULL AND \"media_asset_purge_jobs\".\"original_deleted_at\" IS NOT NULL AND \"media_asset_purge_jobs\".\"claim_token\" IS NULL AND \"media_asset_purge_jobs\".\"claim_expires_at\" IS NULL AND \"media_asset_purge_jobs\".\"last_error_code\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_asset_purge_renditions": {
+      "name": "media_asset_purge_renditions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_deleted_at": {
+          "name": "object_deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cdn_purged_at": {
+          "name": "cdn_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "media_asset_purge_renditions_object_uidx": {
+          "name": "media_asset_purge_renditions_object_uidx",
+          "columns": [
+            {
+              "expression": "media_asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_asset_purge_renditions_media_asset_id_media_asset_purge_jobs_media_asset_id_fk": {
+          "name": "media_asset_purge_renditions_media_asset_id_media_asset_purge_jobs_media_asset_id_fk",
+          "tableFrom": "media_asset_purge_renditions",
+          "tableTo": "media_asset_purge_jobs",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "media_asset_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_asset_purge_renditions_object_key_check": {
+          "name": "media_asset_purge_renditions_object_key_check",
+          "value": "length(btrim(\"media_asset_purge_renditions\".\"object_key\")) > 0"
+        },
+        "media_asset_purge_renditions_progress_check": {
+          "name": "media_asset_purge_renditions_progress_check",
+          "value": "\"media_asset_purge_renditions\".\"cdn_purged_at\" IS NULL OR \"media_asset_purge_renditions\".\"object_deleted_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_assets": {
+      "name": "media_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "upload_intent_id": {
+          "name": "upload_intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'image'"
+        },
+        "catalog_state": {
+          "name": "catalog_state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "processing_state": {
+          "name": "processing_state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upload_initiated'"
+        },
+        "processing_error_code": {
+          "name": "processing_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_content_type": {
+          "name": "original_content_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_byte_size": {
+          "name": "original_byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_checksum_sha256": {
+          "name": "original_checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera_make": {
+          "name": "camera_make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera_model": {
+          "name": "camera_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lens": {
+          "name": "lens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_length_millimeters": {
+          "name": "focal_length_millimeters",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aperture": {
+          "name": "aperture",
+          "type": "numeric(6, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutter_speed_seconds": {
+          "name": "shutter_speed_seconds",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iso": {
+          "name": "iso",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_point_x": {
+          "name": "focal_point_x",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_point_y": {
+          "name": "focal_point_y",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_location_envelope": {
+          "name": "capture_location_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_label_zh_hans": {
+          "name": "location_label_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_label_en": {
+          "name": "location_label_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_suggestion_zh_hans": {
+          "name": "alt_text_suggestion_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_suggestion_en": {
+          "name": "alt_text_suggestion_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_suggestion_model": {
+          "name": "alt_text_suggestion_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_suggested_at": {
+          "name": "alt_text_suggested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_zh_hans": {
+          "name": "alt_text_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_en": {
+          "name": "alt_text_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_approved_at": {
+          "name": "alt_text_approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purge_started_at": {
+          "name": "purge_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_assets_upload_intent_uidx": {
+          "name": "media_assets_upload_intent_uidx",
+          "columns": [
+            {
+              "expression": "upload_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_assets_original_key_uidx": {
+          "name": "media_assets_original_key_uidx",
+          "columns": [
+            {
+              "expression": "original_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_assets_library_idx": {
+          "name": "media_assets_library_idx",
+          "columns": [
+            {
+              "expression": "catalog_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processing_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_assets_upload_intent_id_media_upload_intents_id_fk": {
+          "name": "media_assets_upload_intent_id_media_upload_intents_id_fk",
+          "tableFrom": "media_assets",
+          "tableTo": "media_upload_intents",
+          "columnsFrom": [
+            "upload_intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_assets_kind_check": {
+          "name": "media_assets_kind_check",
+          "value": "\"media_assets\".\"kind\" = 'image'"
+        },
+        "media_assets_catalog_state_check": {
+          "name": "media_assets_catalog_state_check",
+          "value": "\"media_assets\".\"catalog_state\" IN ('active', 'archived', 'purging')"
+        },
+        "media_assets_processing_state_check": {
+          "name": "media_assets_processing_state_check",
+          "value": "\"media_assets\".\"processing_state\" IN ('upload_initiated', 'original_verified', 'processing', 'ready', 'retryable_failure', 'repair_required')"
+        },
+        "media_assets_processing_error_check": {
+          "name": "media_assets_processing_error_check",
+          "value": "(\"media_assets\".\"processing_state\" IN ('retryable_failure', 'repair_required')) = (\"media_assets\".\"processing_error_code\" IS NOT NULL AND length(btrim(\"media_assets\".\"processing_error_code\")) > 0)"
+        },
+        "media_assets_original_key_check": {
+          "name": "media_assets_original_key_check",
+          "value": "length(btrim(\"media_assets\".\"original_key\")) > 0"
+        },
+        "media_assets_original_content_type_check": {
+          "name": "media_assets_original_content_type_check",
+          "value": "\"media_assets\".\"original_content_type\" IN ('image/jpeg', 'image/png', 'image/heic', 'image/heif')"
+        },
+        "media_assets_original_byte_size_check": {
+          "name": "media_assets_original_byte_size_check",
+          "value": "\"media_assets\".\"original_byte_size\" BETWEEN 1 AND 52428800"
+        },
+        "media_assets_original_checksum_check": {
+          "name": "media_assets_original_checksum_check",
+          "value": "\"media_assets\".\"original_checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "media_assets_dimensions_check": {
+          "name": "media_assets_dimensions_check",
+          "value": "num_nonnulls(\"media_assets\".\"width\", \"media_assets\".\"height\") IN (0, 2) AND (\"media_assets\".\"width\" IS NULL OR (\"media_assets\".\"width\" > 0 AND \"media_assets\".\"height\" > 0 AND (\"media_assets\".\"width\"::bigint * \"media_assets\".\"height\"::bigint) <= 100000000))"
+        },
+        "media_assets_focal_point_check": {
+          "name": "media_assets_focal_point_check",
+          "value": "num_nonnulls(\"media_assets\".\"focal_point_x\", \"media_assets\".\"focal_point_y\") IN (0, 2) AND (\"media_assets\".\"focal_point_x\" IS NULL OR (\"media_assets\".\"focal_point_x\" BETWEEN 0 AND 1 AND \"media_assets\".\"focal_point_y\" BETWEEN 0 AND 1))"
+        },
+        "media_assets_camera_values_check": {
+          "name": "media_assets_camera_values_check",
+          "value": "(\"media_assets\".\"focal_length_millimeters\" IS NULL OR \"media_assets\".\"focal_length_millimeters\" > 0) AND (\"media_assets\".\"aperture\" IS NULL OR \"media_assets\".\"aperture\" > 0) AND (\"media_assets\".\"shutter_speed_seconds\" IS NULL OR \"media_assets\".\"shutter_speed_seconds\" > 0) AND (\"media_assets\".\"iso\" IS NULL OR \"media_assets\".\"iso\" > 0)"
+        },
+        "media_assets_alt_suggestion_check": {
+          "name": "media_assets_alt_suggestion_check",
+          "value": "num_nonnulls(\"media_assets\".\"alt_text_suggestion_zh_hans\", \"media_assets\".\"alt_text_suggestion_en\", \"media_assets\".\"alt_text_suggestion_model\", \"media_assets\".\"alt_text_suggested_at\") IN (0, 4) AND (\"media_assets\".\"alt_text_suggestion_zh_hans\" IS NULL OR (length(btrim(\"media_assets\".\"alt_text_suggestion_zh_hans\")) > 0 AND length(btrim(\"media_assets\".\"alt_text_suggestion_en\")) > 0 AND length(btrim(\"media_assets\".\"alt_text_suggestion_model\")) > 0))"
+        },
+        "media_assets_alt_text_check": {
+          "name": "media_assets_alt_text_check",
+          "value": "num_nonnulls(\"media_assets\".\"alt_text_zh_hans\", \"media_assets\".\"alt_text_en\", \"media_assets\".\"alt_text_approved_at\") IN (0, 3) AND (\"media_assets\".\"alt_text_zh_hans\" IS NULL OR (length(btrim(\"media_assets\".\"alt_text_zh_hans\")) > 0 AND length(btrim(\"media_assets\".\"alt_text_en\")) > 0))"
+        },
+        "media_assets_archive_check": {
+          "name": "media_assets_archive_check",
+          "value": "(\"media_assets\".\"catalog_state\" = 'active' AND \"media_assets\".\"archived_at\" IS NULL AND \"media_assets\".\"purge_started_at\" IS NULL) OR (\"media_assets\".\"catalog_state\" = 'archived' AND \"media_assets\".\"archived_at\" IS NOT NULL AND \"media_assets\".\"purge_started_at\" IS NULL) OR (\"media_assets\".\"catalog_state\" = 'purging' AND \"media_assets\".\"archived_at\" IS NOT NULL AND \"media_assets\".\"purge_started_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_photo_selection_draft_entries": {
+      "name": "media_photo_selection_draft_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_photo_selection_draft_entries_asset_uidx": {
+          "name": "media_photo_selection_draft_entries_asset_uidx",
+          "columns": [
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_photo_selection_draft_entries_position_uidx": {
+          "name": "media_photo_selection_draft_entries_position_uidx",
+          "columns": [
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_photo_selection_draft_entries_draft_id_media_photo_selection_drafts_id_fk": {
+          "name": "media_photo_selection_draft_entries_draft_id_media_photo_selection_drafts_id_fk",
+          "tableFrom": "media_photo_selection_draft_entries",
+          "tableTo": "media_photo_selection_drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_photo_selection_draft_entries_media_asset_id_media_assets_id_fk": {
+          "name": "media_photo_selection_draft_entries_media_asset_id_media_assets_id_fk",
+          "tableFrom": "media_photo_selection_draft_entries",
+          "tableTo": "media_assets",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_photo_selection_draft_entries_position_check": {
+          "name": "media_photo_selection_draft_entries_position_check",
+          "value": "\"media_photo_selection_draft_entries\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_photo_selection_drafts": {
+      "name": "media_photo_selection_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_photo_selection_drafts_owner_uidx": {
+          "name": "media_photo_selection_drafts_owner_uidx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_photo_selection_drafts_owner_check": {
+          "name": "media_photo_selection_drafts_owner_check",
+          "value": "length(btrim(\"media_photo_selection_drafts\".\"owner_user_id\")) > 0"
+        },
+        "media_photo_selection_drafts_revision_check": {
+          "name": "media_photo_selection_drafts_revision_check",
+          "value": "\"media_photo_selection_drafts\".\"revision\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_published_photo_selection_entries": {
+      "name": "media_published_photo_selection_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "published_selection_id": {
+          "name": "published_selection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_media_asset_id": {
+          "name": "source_media_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "focal_point_x": {
+          "name": "focal_point_x",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_point_y": {
+          "name": "focal_point_y",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_zh_hans": {
+          "name": "alt_text_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt_text_en": {
+          "name": "alt_text_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_label_zh_hans": {
+          "name": "location_label_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_label_en": {
+          "name": "location_label_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera_make": {
+          "name": "camera_make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera_model": {
+          "name": "camera_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lens": {
+          "name": "lens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_length_millimeters": {
+          "name": "focal_length_millimeters",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aperture": {
+          "name": "aperture",
+          "type": "numeric(6, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutter_speed_seconds": {
+          "name": "shutter_speed_seconds",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iso": {
+          "name": "iso",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_published_photo_selection_entries_asset_uidx": {
+          "name": "media_published_photo_selection_entries_asset_uidx",
+          "columns": [
+            {
+              "expression": "published_selection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_media_asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_published_photo_selection_entries_position_uidx": {
+          "name": "media_published_photo_selection_entries_position_uidx",
+          "columns": [
+            {
+              "expression": "published_selection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_published_photo_selection_entries_published_selection_id_media_published_photo_selections_id_fk": {
+          "name": "media_published_photo_selection_entries_published_selection_id_media_published_photo_selections_id_fk",
+          "tableFrom": "media_published_photo_selection_entries",
+          "tableTo": "media_published_photo_selections",
+          "columnsFrom": [
+            "published_selection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_published_photo_selection_entries_position_check": {
+          "name": "media_published_photo_selection_entries_position_check",
+          "value": "\"media_published_photo_selection_entries\".\"position\" >= 0"
+        },
+        "media_published_photo_selection_entries_dimensions_check": {
+          "name": "media_published_photo_selection_entries_dimensions_check",
+          "value": "\"media_published_photo_selection_entries\".\"width\" > 0 AND \"media_published_photo_selection_entries\".\"height\" > 0 AND (\"media_published_photo_selection_entries\".\"width\"::bigint * \"media_published_photo_selection_entries\".\"height\"::bigint) <= 100000000"
+        },
+        "media_published_photo_selection_entries_focal_point_check": {
+          "name": "media_published_photo_selection_entries_focal_point_check",
+          "value": "num_nonnulls(\"media_published_photo_selection_entries\".\"focal_point_x\", \"media_published_photo_selection_entries\".\"focal_point_y\") IN (0, 2) AND (\"media_published_photo_selection_entries\".\"focal_point_x\" IS NULL OR (\"media_published_photo_selection_entries\".\"focal_point_x\" BETWEEN 0 AND 1 AND \"media_published_photo_selection_entries\".\"focal_point_y\" BETWEEN 0 AND 1))"
+        },
+        "media_published_photo_selection_entries_alt_text_check": {
+          "name": "media_published_photo_selection_entries_alt_text_check",
+          "value": "length(btrim(\"media_published_photo_selection_entries\".\"alt_text_zh_hans\")) > 0 AND length(btrim(\"media_published_photo_selection_entries\".\"alt_text_en\")) > 0"
+        },
+        "media_published_photo_selection_entries_camera_values_check": {
+          "name": "media_published_photo_selection_entries_camera_values_check",
+          "value": "(\"media_published_photo_selection_entries\".\"focal_length_millimeters\" IS NULL OR \"media_published_photo_selection_entries\".\"focal_length_millimeters\" > 0) AND (\"media_published_photo_selection_entries\".\"aperture\" IS NULL OR \"media_published_photo_selection_entries\".\"aperture\" > 0) AND (\"media_published_photo_selection_entries\".\"shutter_speed_seconds\" IS NULL OR \"media_published_photo_selection_entries\".\"shutter_speed_seconds\" > 0) AND (\"media_published_photo_selection_entries\".\"iso\" IS NULL OR \"media_published_photo_selection_entries\".\"iso\" > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_published_photo_selection_renditions": {
+      "name": "media_published_photo_selection_renditions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "published_entry_id": {
+          "name": "published_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_width": {
+          "name": "profile_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_published_photo_selection_renditions_profile_uidx": {
+          "name": "media_published_photo_selection_renditions_profile_uidx",
+          "columns": [
+            {
+              "expression": "published_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_width",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_published_photo_selection_renditions_published_entry_id_media_published_photo_selection_entries_id_fk": {
+          "name": "media_published_photo_selection_renditions_published_entry_id_media_published_photo_selection_entries_id_fk",
+          "tableFrom": "media_published_photo_selection_renditions",
+          "tableTo": "media_published_photo_selection_entries",
+          "columnsFrom": [
+            "published_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_published_photo_selection_renditions_profile_check": {
+          "name": "media_published_photo_selection_renditions_profile_check",
+          "value": "\"media_published_photo_selection_renditions\".\"profile_width\" IN (640, 1024, 1600, 2560)"
+        },
+        "media_published_photo_selection_renditions_object_key_check": {
+          "name": "media_published_photo_selection_renditions_object_key_check",
+          "value": "length(btrim(\"media_published_photo_selection_renditions\".\"object_key\")) > 0"
+        },
+        "media_published_photo_selection_renditions_dimensions_check": {
+          "name": "media_published_photo_selection_renditions_dimensions_check",
+          "value": "\"media_published_photo_selection_renditions\".\"width\" BETWEEN 1 AND \"media_published_photo_selection_renditions\".\"profile_width\" AND \"media_published_photo_selection_renditions\".\"height\" > 0 AND (\"media_published_photo_selection_renditions\".\"width\"::bigint * \"media_published_photo_selection_renditions\".\"height\"::bigint) <= 100000000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_published_photo_selections": {
+      "name": "media_published_photo_selections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_revision": {
+          "name": "draft_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_count": {
+          "name": "item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "media_published_photo_selections_idempotency_uidx": {
+          "name": "media_published_photo_selections_idempotency_uidx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_published_photo_selections_draft_revision_uidx": {
+          "name": "media_published_photo_selections_draft_revision_uidx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "draft_revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_published_photo_selections_identity_check": {
+          "name": "media_published_photo_selections_identity_check",
+          "value": "length(btrim(\"media_published_photo_selections\".\"owner_user_id\")) > 0 AND length(btrim(\"media_published_photo_selections\".\"idempotency_key\")) > 0"
+        },
+        "media_published_photo_selections_revision_check": {
+          "name": "media_published_photo_selections_revision_check",
+          "value": "\"media_published_photo_selections\".\"draft_revision\" >= 0"
+        },
+        "media_published_photo_selections_item_count_check": {
+          "name": "media_published_photo_selections_item_count_check",
+          "value": "\"media_published_photo_selections\".\"item_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_renditions": {
+      "name": "media_renditions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_width": {
+          "name": "profile_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum_sha256": {
+          "name": "checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'image/jpeg'"
+        },
+        "color_space": {
+          "name": "color_space",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'srgb'"
+        },
+        "progressive": {
+          "name": "progressive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata_stripped": {
+          "name": "metadata_stripped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_renditions_asset_profile_uidx": {
+          "name": "media_renditions_asset_profile_uidx",
+          "columns": [
+            {
+              "expression": "media_asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_width",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_renditions_object_key_uidx": {
+          "name": "media_renditions_object_key_uidx",
+          "columns": [
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_renditions_media_asset_id_media_assets_id_fk": {
+          "name": "media_renditions_media_asset_id_media_assets_id_fk",
+          "tableFrom": "media_renditions",
+          "tableTo": "media_assets",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_renditions_object_key_check": {
+          "name": "media_renditions_object_key_check",
+          "value": "length(btrim(\"media_renditions\".\"object_key\")) > 0"
+        },
+        "media_renditions_profile_check": {
+          "name": "media_renditions_profile_check",
+          "value": "\"media_renditions\".\"profile_width\" IN (640, 1024, 1600, 2560)"
+        },
+        "media_renditions_checksum_check": {
+          "name": "media_renditions_checksum_check",
+          "value": "\"media_renditions\".\"checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "media_renditions_dimensions_check": {
+          "name": "media_renditions_dimensions_check",
+          "value": "\"media_renditions\".\"width\" BETWEEN 1 AND \"media_renditions\".\"profile_width\" AND \"media_renditions\".\"height\" > 0 AND (\"media_renditions\".\"width\"::bigint * \"media_renditions\".\"height\"::bigint) <= 100000000"
+        },
+        "media_renditions_byte_size_check": {
+          "name": "media_renditions_byte_size_check",
+          "value": "\"media_renditions\".\"byte_size\" > 0"
+        },
+        "media_renditions_content_type_check": {
+          "name": "media_renditions_content_type_check",
+          "value": "\"media_renditions\".\"content_type\" = 'image/jpeg'"
+        },
+        "media_renditions_color_space_check": {
+          "name": "media_renditions_color_space_check",
+          "value": "\"media_renditions\".\"color_space\" = 'srgb'"
+        },
+        "media_renditions_progressive_check": {
+          "name": "media_renditions_progressive_check",
+          "value": "\"media_renditions\".\"progressive\" = true"
+        },
+        "media_renditions_metadata_stripped_check": {
+          "name": "media_renditions_metadata_stripped_check",
+          "value": "\"media_renditions\".\"metadata_stripped\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_upload_intents": {
+      "name": "media_upload_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum_sha256": {
+          "name": "checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_upload_intents_owner_idempotency_uidx": {
+          "name": "media_upload_intents_owner_idempotency_uidx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_upload_intents_original_key_uidx": {
+          "name": "media_upload_intents_original_key_uidx",
+          "columns": [
+            {
+              "expression": "original_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_upload_intents_expiry_idx": {
+          "name": "media_upload_intents_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_upload_intents_identity_check": {
+          "name": "media_upload_intents_identity_check",
+          "value": "length(btrim(\"media_upload_intents\".\"owner_user_id\")) > 0 AND length(btrim(\"media_upload_intents\".\"idempotency_key\")) > 0"
+        },
+        "media_upload_intents_original_key_check": {
+          "name": "media_upload_intents_original_key_check",
+          "value": "length(btrim(\"media_upload_intents\".\"original_key\")) > 0"
+        },
+        "media_upload_intents_content_type_check": {
+          "name": "media_upload_intents_content_type_check",
+          "value": "\"media_upload_intents\".\"content_type\" IN ('image/jpeg', 'image/png', 'image/heic', 'image/heif')"
+        },
+        "media_upload_intents_byte_size_check": {
+          "name": "media_upload_intents_byte_size_check",
+          "value": "\"media_upload_intents\".\"byte_size\" BETWEEN 1 AND 52428800"
+        },
+        "media_upload_intents_checksum_check": {
+          "name": "media_upload_intents_checksum_check",
+          "value": "\"media_upload_intents\".\"checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "media_upload_intents_expiry_check": {
+          "name": "media_upload_intents_expiry_check",
+          "value": "\"media_upload_intents\".\"expires_at\" > \"media_upload_intents\".\"created_at\""
+        },
+        "media_upload_intents_completion_check": {
+          "name": "media_upload_intents_completion_check",
+          "value": "\"media_upload_intents\".\"completed_at\" IS NULL OR \"media_upload_intents\".\"completed_at\" >= \"media_upload_intents\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.newsletters": {
+      "name": "newsletters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_windows": {
+      "name": "rate_limit_windows",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_times": {
+          "name": "request_times",
+          "type": "timestamp with time zone[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_expires_at": {
+          "name": "window_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_windows_expiry_idx": {
+          "name": "rate_limit_windows_expiry_idx",
+          "columns": [
+            {
+              "expression": "window_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_windows_scope_key_hash_pk": {
+          "name": "rate_limit_windows_scope_key_hash_pk",
+          "columns": [
+            "scope",
+            "key_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "rate_limit_windows_request_times_check": {
+          "name": "rate_limit_windows_request_times_check",
+          "value": "cardinality(\"rate_limit_windows\".\"request_times\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subscribers": {
+      "name": "subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1784261629002,
       "tag": "0011_ama_booking_system",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1784425491213,
+      "tag": "0012_high_fidelity_photo_renditions",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -362,7 +362,7 @@ export const mediaRenditions = pgTable(
     ),
     check(
       'media_renditions_profile_check',
-      sql`${table.profileWidth} IN (640, 1024, 1600)`,
+      sql`${table.profileWidth} IN (640, 1024, 1600, 2560)`,
     ),
     check(
       'media_renditions_checksum_check',
@@ -628,7 +628,7 @@ export const mediaPublishedPhotoSelectionRenditions = pgTable(
     ),
     check(
       'media_published_photo_selection_renditions_profile_check',
-      sql`${table.profileWidth} IN (640, 1024, 1600)`,
+      sql`${table.profileWidth} IN (640, 1024, 1600, 2560)`,
     ),
     check(
       'media_published_photo_selection_renditions_object_key_check',

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -305,6 +305,14 @@ fades without transform. On close they slip away on the swift curve —
 300ms return. Items carry their order as `--detail-index`; reduced motion
 renders the sheet instantly with no transform.
 
+Photo details intentionally overlap the lower edge of the print. A solid
+`--background` runway sits above the photo and uses an eased `mask-image` to
+develop from transparent to fully opaque before the first line of type. The
+text never blends with the photograph, and the mask itself is inert. Published
+photo tiles use `next/image` with the immutable Bunny Renditions as a custom
+responsive source set; the lightbox preloads and displays the largest available
+Rendition instead of enlarging the tile's selected source.
+
 ## Portrait & avatar
 
 The site carries its author: the bottom dock uses the portrait as its Home

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -305,12 +305,12 @@ fades without transform. On close they slip away on the swift curve —
 300ms return. Items carry their order as `--detail-index`; reduced motion
 renders the sheet instantly with no transform.
 
-Photo details intentionally overlap the lower edge of the print. A compact 4rem
-`--background` runway sits beneath the plate and uses an eased `mask-image` to
-develop from transparent to fully opaque at the first line of type. The
-lightbox caption is 12px; capture labels are 10px and values are 12px so the
-plate preserves more room for the photograph. The text never blends with the
-photograph, and the mask itself is inert. Published photo tiles use
+Photo details sit below the print with reserved viewport space; they never
+overlap the photograph and use no fade, scrim, or blend mode. Public capture
+dates are intentionally omitted. An available Location Label joins the plate
+as a labeled cell. Capture labels are 10px and values are 12px so the plate
+preserves room for the photograph. The plate stays 0.75rem plus the device safe
+area from the screen's bottom edge on every viewport. Published photo tiles use
 `next/image` with the immutable Bunny Renditions as a custom responsive source
 set; the lightbox preloads and displays the largest available Rendition instead
 of enlarging the tile's selected source.

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -305,13 +305,14 @@ fades without transform. On close they slip away on the swift curve —
 300ms return. Items carry their order as `--detail-index`; reduced motion
 renders the sheet instantly with no transform.
 
-Photo details intentionally overlap the lower edge of the print. A solid
+Photo details intentionally overlap the lower edge of the print. A broad 10rem
 `--background` runway sits above the photo and uses an eased `mask-image` to
-develop from transparent to fully opaque before the first line of type. The
-text never blends with the photograph, and the mask itself is inert. Published
-photo tiles use `next/image` with the immutable Bunny Renditions as a custom
-responsive source set; the lightbox preloads and displays the largest available
-Rendition instead of enlarging the tile's selected source.
+develop decisively from transparent to fully opaque 3rem before the first line
+of type. The text never blends with the photograph, and the mask itself is
+inert. Published photo tiles use `next/image` with the immutable Bunny
+Renditions as a custom responsive source set; the lightbox preloads and
+displays the largest available Rendition instead of enlarging the tile's
+selected source.
 
 ## Portrait & avatar
 

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -305,14 +305,15 @@ fades without transform. On close they slip away on the swift curve —
 300ms return. Items carry their order as `--detail-index`; reduced motion
 renders the sheet instantly with no transform.
 
-Photo details intentionally overlap the lower edge of the print. A broad 10rem
-`--background` runway sits above the photo and uses an eased `mask-image` to
-develop decisively from transparent to fully opaque 3rem before the first line
-of type. The text never blends with the photograph, and the mask itself is
-inert. Published photo tiles use `next/image` with the immutable Bunny
-Renditions as a custom responsive source set; the lightbox preloads and
-displays the largest available Rendition instead of enlarging the tile's
-selected source.
+Photo details intentionally overlap the lower edge of the print. A compact 4rem
+`--background` runway sits beneath the plate and uses an eased `mask-image` to
+develop from transparent to fully opaque at the first line of type. The
+lightbox caption is 12px; capture labels are 10px and values are 12px so the
+plate preserves more room for the photograph. The text never blends with the
+photograph, and the mask itself is inert. Published photo tiles use
+`next/image` with the immutable Bunny Renditions as a custom responsive source
+set; the lightbox preloads and displays the largest available Rendition instead
+of enlarging the tile's selected source.
 
 ## Portrait & avatar
 

--- a/docs/media/photo-release-cutover.md
+++ b/docs/media/photo-release-cutover.md
@@ -24,9 +24,10 @@ Upload Intent instead of registering another asset.
 2. Sign in to `/admin/media`, select both Originals together, and wait until
    both Media Assets are Ready for review. Do not upload the prepared JPEGs as
    Originals.
-3. Confirm all 640, 1024, and 1600 Renditions are progressive sRGB JPEGs and
-   that their embedded metadata is stripped. Confirm each Original remains
-   readable only through the authenticated server boundary.
+3. Confirm all 640, 1024, 1600, and 2560 Renditions are progressive sRGB
+   JPEGs at quality 90 with 4:4:4 chroma and that their embedded metadata is
+   stripped. Confirm each Original remains readable only through the
+   authenticated server boundary.
 4. Review orientation, capture date, camera details, editable Location Labels,
    and Focal Points. Generate or edit both Alt Text languages, then explicitly
    approve the pair for each Media Asset.
@@ -39,8 +40,9 @@ Upload Intent instead of registering another asset.
 1. Load `/photos` and the homepage in both locales. They must report two photos
    from one Published Photo Selection revision with no static fallback.
 2. Verify each rendered URL uses the configured Bunny CDN hostname, returns
-   `image/jpeg`, and selects a responsive Rendition. Confirm all three profile
-   URLs deliver successfully before testing an expanded photo.
+   `image/jpeg`, and selects a responsive Rendition. Confirm all four profile
+   URLs deliver successfully before testing an expanded photo, and confirm the
+   lightbox requests the 2560 profile rather than enlarging its tile source.
 3. Confirm source HTML and public responses contain no Original key or URL,
    checksum, exact coordinates, encrypted Capture Location, raw metadata, AI
    suggestion, provider response, or private error.

--- a/lib/media/CONTEXT.md
+++ b/lib/media/CONTEXT.md
@@ -33,6 +33,12 @@ _Avoid_: Pending file, temporary upload
 A public, delivery-ready version derived from an Original.
 _Avoid_: Copy, thumbnail
 
+New image processing produces no-upscale 640, 1024, 1600, and 2560 profiles as
+progressive sRGB JPEGs at quality 90 with 4:4:4 chroma. Embedded metadata is
+stripped from every Rendition while the private Original remains byte-for-byte
+unchanged. The original three-profile publication baseline remains readable;
+newly processed Media Assets add the 2560 profile for high-density lightboxes.
+
 **Display Metadata**:
 The allowlisted location, capture, and camera details that may be shown to a
 visitor. Raw embedded metadata is not Display Metadata.

--- a/lib/media/asset-review/eligibility.ts
+++ b/lib/media/asset-review/eligibility.ts
@@ -4,7 +4,7 @@ import type { MediaAssetReviewRecord } from './service'
  * Client-side mirror of the publish-eligibility invariant the server
  * enforces on Photo Selection save and publish: active, processed, with a
  * preview Rendition and approved bilingual Alt Text. The server remains
- * the authority (it additionally requires all three Rendition profiles);
+ * the authority (it additionally requires all three baseline Rendition profiles);
  * this pre-filter only decides what the admin UI offers.
  */
 export function isMediaAssetEligible(asset: MediaAssetReviewRecord) {

--- a/lib/media/ingestion/repository.test.ts
+++ b/lib/media/ingestion/repository.test.ts
@@ -26,7 +26,10 @@ const intentInput = {
 describe('Media Library ingestion repository', () => {
   const getClient = usePGliteTestClient([
     '0005_media_catalog.sql',
+    '0006_photo_selection.sql',
+    '0007_photo_publication_revision.sql',
     '0009_media_catalog_state.sql',
+    '0012_high_fidelity_photo_renditions.sql',
   ])
   let client: PGlite
   let repository: ReturnType<typeof createMediaIngestionRepository>
@@ -97,7 +100,7 @@ describe('Media Library ingestion repository', () => {
       staleBefore: new Date('2026-07-15T00:55:00.000Z'),
     })
 
-    const rendition = (profileWidth: 640 | 1024 | 1600) => ({
+    const rendition = (profileWidth: 640 | 1024 | 1600 | 2560) => ({
       mediaAssetId: asset.id,
       profileWidth,
       objectKey: `renditions/${asset.id}/${profileWidth}-${String(profileWidth).padStart(64, '0')}.jpg`,
@@ -131,7 +134,7 @@ describe('Media Library ingestion repository', () => {
         },
       },
       completedAt: now,
-      requiredRenditionCount: 3,
+      requiredRenditionCount: 4,
     }
     await expect(repository.markReady(readyInput)).rejects.toThrow(
       'Rendition manifest is incomplete',
@@ -139,6 +142,7 @@ describe('Media Library ingestion repository', () => {
 
     await repository.recordRendition(rendition(1024))
     await repository.recordRendition(rendition(1600))
+    await repository.recordRendition(rendition(2560))
     const ready = await repository.markReady(readyInput)
 
     const staleFailure = await repository.markFailure({

--- a/lib/media/ingestion/service.test.ts
+++ b/lib/media/ingestion/service.test.ts
@@ -20,7 +20,7 @@ const originalBytes = new TextEncoder().encode('approved original bytes')
 const originalChecksum = createHash('sha256').update(originalBytes).digest('hex')
 
 function processedImage() {
-  const rendition = (profileWidth: 640 | 1024 | 1600) => {
+  const rendition = (profileWidth: 640 | 1024 | 1600 | 2560) => {
     const bytes = new TextEncoder().encode(`rendition:${profileWidth}`)
     return {
       profileWidth,
@@ -50,7 +50,7 @@ function processedImage() {
       iso: 80,
       captureLocation: { latitude: 37.7749, longitude: -122.4194 },
     },
-    renditions: [rendition(640), rendition(1024), rendition(1600)],
+    renditions: [rendition(640), rendition(1024), rendition(1600), rendition(2560)],
   }
 }
 
@@ -243,7 +243,7 @@ function fixture() {
     setOriginalMissing(value: boolean) {
       originalMissing = value
     },
-    seedRendition(profileWidth: 640 | 1024 | 1600) {
+    seedRendition(profileWidth: 640 | 1024 | 1600 | 2560) {
       const rendition = processedImage().renditions.find(
         (candidate) => candidate.profileWidth === profileWidth,
       )!
@@ -332,7 +332,7 @@ describe('Media Library ingestion service', () => {
       },
     })
     expect(intent.completedAt).toEqual(new Date('2026-07-17T00:00:00.000Z'))
-    expect(f.renditions).toHaveLength(3)
+    expect(f.renditions).toHaveLength(4)
     expect(f.events).toEqual([
       'asset:original_verified',
       'asset:processing',
@@ -343,6 +343,8 @@ describe('Media Library ingestion service', () => {
       'rendition:record:1024',
       'rendition:store:1600',
       'rendition:record:1600',
+      'rendition:store:2560',
+      'rendition:record:2560',
       'location:seal',
       'asset:ready',
     ])
@@ -370,7 +372,7 @@ describe('Media Library ingestion service', () => {
     expect(replay).toBe(first)
     expect(f.events).toHaveLength(eventCount)
     expect(f.processor).toHaveBeenCalledTimes(1)
-    expect(f.storage.storeRendition).toHaveBeenCalledTimes(3)
+    expect(f.storage.storeRendition).toHaveBeenCalledTimes(4)
   })
 
   it('does not register a Media Asset when the Original bytes do not match', async () => {
@@ -488,7 +490,7 @@ describe('Media Library ingestion service', () => {
       processingState: 'ready',
       processingErrorCode: null,
     })
-    expect(f.renditions).toHaveLength(3)
+    expect(f.renditions).toHaveLength(4)
     expect(
       f.storage.storeRendition.mock.calls.filter(([call]) =>
         call.key.includes('/640-'),
@@ -526,7 +528,7 @@ describe('Media Library ingestion service', () => {
         call.key.includes('/640-'),
       ),
     ).toHaveLength(0)
-    expect(f.renditions).toHaveLength(3)
+    expect(f.renditions).toHaveLength(4)
   })
 
   it('marks a missing verified Original as repair required', async () => {

--- a/lib/media/photo-selection/public-ui.test.tsx
+++ b/lib/media/photo-selection/public-ui.test.tsx
@@ -95,7 +95,9 @@ describe('Published Photo Selection UI', () => {
 
     const dialog = getByRole('dialog', { name: 'City photograph 1' })
     expect(dialog).toBeTruthy()
-    expect(within(dialog).getByText(/Taipei · May 8, 2025/)).toBeTruthy()
+    expect(within(dialog).getByText('Location')).toBeTruthy()
+    expect(within(dialog).getByText('Taipei')).toBeTruthy()
+    expect(within(dialog).queryByText(/May 8, 2025/)).toBeNull()
     expect(within(dialog).getByText('Apple iPhone 16 Pro')).toBeTruthy()
     expect(within(dialog).getByText('24 mm')).toBeTruthy()
     // capture details render as spec-plate label/value cells

--- a/lib/media/photo-selection/public-ui.test.tsx
+++ b/lib/media/photo-selection/public-ui.test.tsx
@@ -29,7 +29,7 @@ function selection(count = 4): PublicPhotoSelection {
         zhHans: `第 ${index + 1} 张城市照片`,
         en: `City photograph ${index + 1}`,
       },
-      renditions: [640, 1024, 1600].map((profileWidth) => ({
+      renditions: [640, 1024, 1600, 2560].map((profileWidth) => ({
         profileWidth,
         src: `https://media.example.com/${index + 1}/${profileWidth}.jpg`,
         width: profileWidth,
@@ -67,7 +67,7 @@ describe('Published Photo Selection UI', () => {
     expect(html).toContain('width="4032"')
     expect(html).toContain('height="3024"')
     expect(html).toContain('alt="第 1 张城市照片"')
-    expect(html).toContain('https://media.example.com/1/1600.jpg')
+    expect(html).toContain('https://media.example.com/1/2560.jpg')
     expect(html).toContain('640w')
     // tiles stay quiet — location/capture data render only in the lightbox
     expect(html).not.toContain('台北')
@@ -102,6 +102,9 @@ describe('Published Photo Selection UI', () => {
     expect(within(dialog).getByText('ISO')).toBeTruthy()
     expect(within(dialog).getByText('80')).toBeTruthy()
     expect(dialog.querySelector('.spec-plate-flow')).toBeTruthy()
+    expect(within(dialog).getByRole('img').getAttribute('src')).toBe(
+      'https://media.example.com/1/2560.jpg',
+    )
   })
 
   it('uses the first three photos and full count for the homepage card', () => {

--- a/lib/media/photo-selection/repository.test.ts
+++ b/lib/media/photo-selection/repository.test.ts
@@ -20,6 +20,7 @@ describe('Photo Selection repository', () => {
     '0006_photo_selection.sql',
     '0007_photo_publication_revision.sql',
     '0009_media_catalog_state.sql',
+    '0012_high_fidelity_photo_renditions.sql',
   ])
   let client: PGlite
   let repository: ReturnType<typeof createPhotoSelectionRepository>
@@ -104,7 +105,7 @@ describe('Photo Selection repository', () => {
         archivedAt,
       ],
     )
-    for (const profileWidth of overrides.renditionProfiles ?? [640, 1024, 1600]) {
+    for (const profileWidth of overrides.renditionProfiles ?? [640, 1024, 1600, 2560]) {
       await client.query(
         `INSERT INTO media_renditions
           (media_asset_id, profile_width, object_key, checksum_sha256,
@@ -256,6 +257,7 @@ describe('Photo Selection repository', () => {
             },
             expect.objectContaining({ profileWidth: 1024 }),
             expect.objectContaining({ profileWidth: 1600 }),
+            expect.objectContaining({ profileWidth: 2560 }),
           ],
         },
         expect.objectContaining({ width: 4032, height: 3024 }),
@@ -274,6 +276,29 @@ describe('Photo Selection repository', () => {
     ]) {
       expect(serialized).not.toContain(privateField)
     }
+  })
+
+  it('keeps a legacy three-profile publication readable', async () => {
+    const asset = await createAsset('owner_01', {
+      renditionProfiles: [640, 1024, 1600],
+    })
+    await repository.saveDraft({
+      ownerUserId: 'owner_01',
+      expectedRevision: 0,
+      mediaAssetIds: [asset],
+      updatedAt: new Date('2026-07-15T08:00:00.000Z'),
+    })
+    await repository.publishDraft({
+      ownerUserId: 'owner_01',
+      expectedDraftRevision: 1,
+      idempotencyKey: 'publish_legacy',
+      publishedAt: new Date('2026-07-15T09:00:00.000Z'),
+    })
+
+    const selection = await publicRepository.getPublishedSelection()
+
+    expect(selection?.items[0]?.renditions.map(({ profileWidth }) => profileWidth))
+      .toEqual([640, 1024, 1600])
   })
 
   it('publishes exactly two selected Media Assets without changing an unrelated asset', async () => {

--- a/lib/media/photo-selection/repository.ts
+++ b/lib/media/photo-selection/repository.ts
@@ -27,6 +27,8 @@ type PhotoSelectionTransaction = Parameters<
   Parameters<PhotoSelectionDatabase['transaction']>[0]
 >[0]
 
+// The original public baseline remains readable while newly processed assets
+// can carry additional high-density Renditions such as the 2560px profile.
 const requiredProfiles = [640, 1024, 1600] as const
 export const PUBLIC_PHOTO_SELECTION_CACHE_TAG = 'media:published-photo-selection'
 
@@ -621,7 +623,7 @@ export function createPublicPhotoSelectionRepository(
         items: entries.map((entry) => {
           const renditions = renditionsByEntry.get(entry.id) ?? []
           if (
-            renditions.length !== requiredProfiles.length ||
+            renditions.length < requiredProfiles.length ||
             !requiredProfiles.every((profile) =>
               renditions.some(({ profileWidth }) => profileWidth === profile),
             )

--- a/lib/media/processing/image.live.test.ts
+++ b/lib/media/processing/image.live.test.ts
@@ -22,6 +22,7 @@ liveDescribe('Media Library local image contract', () => {
         [640, 480],
         [1024, 768],
         [1600, 1200],
+        [2560, 1920],
       ],
     },
     {
@@ -34,6 +35,7 @@ liveDescribe('Media Library local image contract', () => {
         [640, 859],
         [1024, 1375],
         [1600, 2148],
+        [1770, 2376],
       ],
     },
   ])('processes the approved $format Original without changing it', async (fixture) => {
@@ -52,7 +54,7 @@ liveDescribe('Media Library local image contract', () => {
     expect(result.original.cameraMake).toBeTruthy()
     expect(result.original.cameraModel).toBeTruthy()
     expect(result.original.captureLocation).not.toBeNull()
-    expect(result.renditions).toHaveLength(3)
+    expect(result.renditions).toHaveLength(4)
     expect(
       result.renditions.map((rendition) => [rendition.width, rendition.height]),
     ).toEqual(fixture.renditions)

--- a/lib/media/processing/image.test.ts
+++ b/lib/media/processing/image.test.ts
@@ -8,6 +8,7 @@ vi.mock('server-only', () => ({}))
 import {
   MediaImageError,
   processOriginalImage,
+  RENDITION_JPEG_QUALITY,
   RENDITION_PROFILE_WIDTHS,
 } from './image'
 
@@ -71,6 +72,7 @@ describe('Media Library image processing', () => {
   it('produces every no-upscale progressive JPEG Rendition without metadata', async () => {
     const result = await processOriginalImage(await orientedPhoto())
 
+    expect(RENDITION_JPEG_QUALITY).toBe(90)
     expect(result.renditions.map((rendition) => rendition.profileWidth)).toEqual(
       RENDITION_PROFILE_WIDTHS,
     )
@@ -95,6 +97,7 @@ describe('Media Library image processing', () => {
         height: 120,
         space: 'srgb',
         isProgressive: true,
+        chromaSubsampling: '4:4:4',
       })
       expect(publicMetadata.exif).toBeUndefined()
       expect(publicMetadata.xmp).toBeUndefined()

--- a/lib/media/processing/image.ts
+++ b/lib/media/processing/image.ts
@@ -5,7 +5,8 @@ import { createHash } from 'node:crypto'
 import { parse } from 'exifr'
 import sharp from 'sharp'
 
-export const RENDITION_PROFILE_WIDTHS = [640, 1024, 1600] as const
+export const RENDITION_PROFILE_WIDTHS = [640, 1024, 1600, 2560] as const
+export const RENDITION_JPEG_QUALITY = 90
 
 const MAX_IMAGE_PIXELS = 100_000_000
 const acceptedFormats = new Set(['heif', 'jpeg', 'png'])
@@ -253,7 +254,11 @@ export async function processOriginalImage(bytes: Uint8Array) {
         const { data, info } = await pipeline
           .clone()
           .resize({ width: profileWidth, fit: 'inside', withoutEnlargement: true })
-          .jpeg({ quality: 82, progressive: true })
+          .jpeg({
+            quality: RENDITION_JPEG_QUALITY,
+            progressive: true,
+            chromaSubsampling: '4:4:4',
+          })
           .toBuffer({ resolveWithObject: true })
         return {
           profileWidth,

--- a/scripts/check-production-migrations.mjs
+++ b/scripts/check-production-migrations.mjs
@@ -48,6 +48,10 @@ const reviewedMigrationDigests = new Map([
     'db/migrations/0011_ama_booking_system.sql',
     '6f0952e9bb809738875ae1eb1d4276ae91b97dc7b78de828f69ab3200b6d7cb4',
   ],
+  [
+    'db/migrations/0012_high_fidelity_photo_renditions.sql',
+    '8cc70af11f2357a3147b41a937864f13b349958e3ffa4e8382fe98bd46a129dc',
+  ],
 ])
 
 function dollarDelimiterAt(sql, index) {

--- a/scripts/check-production-migrations.test.mjs
+++ b/scripts/check-production-migrations.test.mjs
@@ -173,10 +173,16 @@ test('allows only newly added migration files in a Production release', () => {
   )
 })
 
-test('admits the exact reviewed migration baseline without weakening future checks', async () => {
-  const path = 'db/migrations/0011_ama_booking_system.sql'
+test('admits exact reviewed migration baselines without weakening future checks', async () => {
+  for (const path of [
+    'db/migrations/0011_ama_booking_system.sql',
+    'db/migrations/0012_high_fidelity_photo_renditions.sql',
+  ]) {
+    const sql = await readFile(path, 'utf8')
+    assert.deepEqual(productionMigrationFindings(path, sql), [])
+  }
+  const path = 'db/migrations/0012_high_fidelity_photo_renditions.sql'
   const sql = await readFile(path, 'utf8')
-  assert.deepEqual(productionMigrationFindings(path, sql), [])
   assert.throws(
     () =>
       productionMigrationFindings(path, `${sql}\n-- changed after review\n`),


### PR DESCRIPTION
## Summary

- Keep private Originals byte-for-byte untouched while generating 640, 1024, 1600, and 2560px public JPEG Renditions at quality 90 with 4:4:4 chroma.
- Render published tiles with `next/image` through a Bunny-aware loader, then preload and show the largest available immutable Rendition in the lightbox without a second optimization pass.
- Keep legacy three-profile publications readable and add the reviewed expand-only migration for the 2560px profile.
- Remove the public capture date, fade, scrim, and blend treatment. Location now joins the compact metadata plate, which stays near the safe-area-adjusted screen bottom while the photo reserves clear space above it.

## Root cause

The lightbox reused the source selected for a small masonry tile and enlarged it for the zoomed view. Public processing also stopped at a 1600px quality-82 JPEG. That made image softness visible on larger screens, while the overlaid metadata needed contrast treatments that competed with the photograph.

## Compatibility

Existing published assets immediately zoom from their largest recorded Rendition, normally 1600px, instead of a tile-sized source. Producing new quality-90 and 2560px files for those already processed assets still requires a separate controlled backfill.

## Verification

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run app components db lib --exclude='**/*.live.test.ts'` (111 files, 1,050 tests)
- `./node_modules/.bin/vitest run components/zoom-image.test.tsx lib/media/photo-selection/public-ui.test.tsx` (2 files, 13 tests)
- `node --test scripts/check-production-migrations.test.mjs scripts/ama-migrations.test.mjs` (17 tests)
- Browser-checked the final lightbox in light and dark themes at 1300x508 with a clear photo-to-plate gap and no overlap
- Drizzle schema generation reported no drift

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves lightbox quality by adding a 2560 px rendition at quality 90 with 4:4:4 chroma, switching tiles from a native `<img>` + `srcSet` to a Next.js `<Image>` with a Bunny-aware rendition loader, and replacing the overlay's `currentSrc` (tile-sized) with the largest pre-encoded rendition URL. The metadata plate is redesigned: capture date is removed, location moves into the spec-plate, and the bottom reservation is expressed in `rem` units that track the user's root font size.

- **Processing**: `RENDITION_PROFILE_WIDTHS` gains 2560 px; quality raised to 90 with `chromaSubsampling: '4:4:4'`; exported `RENDITION_JPEG_QUALITY` constant.
- **Schema & migration**: expand-only `NOT VALID → VALIDATE → DROP old → RENAME` pattern adds 2560 to both rendition `profile_width` CHECK constraints; `requiredProfiles` check in the repository is relaxed to `>=` so legacy three-profile publications stay readable.
- **Lightbox**: overlay switched to `<Image unoptimized>` pointing at the largest available rendition; detail-space reservation now scales with `rootFontSizePixels()` instead of fixed pixel constants; hover/focus pre-load dedup uses `preloadedSrcRef`.

<h3>Confidence Score: 4/5</h3>

Safe to merge with the preload fix applied; the lightbox functional path is unaffected, but the hover/focus pre-fetch does not fire in production.

The `src` prop passed to `ZoomImage` from `published-photo-wall.tsx` is `photo.renditions.at(-1).src` — the 2560 px URL. `expandedSrc` inside the component resolves to the same URL via `largestRendition`. The `preloadExpanded` guard (`expandedSrc === src`) therefore always short-circuits, so the hover/focus prefetch never runs in the production photo wall.

components/published-photo-wall.tsx (line 97) — the `src` prop passed to `ZoomImage` should be the smallest rendition URL so the pre-load guard resolves to false and hover/focus pre-fetching can fire.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| components/published-photo-wall.tsx | Passes `photo.renditions.at(-1).src` (2560 px URL) as `src` to ZoomImage, making `expandedSrc === src` always true and silently disabling the hover/focus pre-load in every production render |
| components/zoom-image.tsx | FLIP lightbox refactored to use rendition-aware loader and rem-based detail-space reservation; preload dedup guard (`expandedSrc === src`) is correct by design but silently disabled in the one production call-site where `src` is already the largest rendition URL |
| components/zoom-image.test.tsx | Adds preload dedup test and rem-scaling test; the preload test uses `src="/photo-640.jpg"` (≠ largest rendition) which exercises the happy path but does not match the production call-site where `src` equals the largest rendition URL |
| lib/media/processing/image.ts | Adds 2560 px profile and raises quality to 90 with 4:4:4 chroma subsampling; exports `RENDITION_JPEG_QUALITY` constant; no issues found |
| lib/media/photo-selection/repository.ts | Changed rendition completeness check from strict equality to lower-bound so legacy three-profile publications remain readable; new test covers this backward-compat path |
| db/migrations/0012_high_fidelity_photo_renditions.sql | Expand-only migration: adds v2 CHECK constraint as NOT VALID, validates it, drops the old constraint, renames v2 to canonical name — safe for live databases |
| db/schema.ts | Adds 2560 to the `profile_width` IN-list check on both rendition tables; matches the migration SQL exactly |
| app/globals.css | Removes mobile bottom-offset media query and adds spec-plate density overrides; aligns with the rem-based JS detail-space constants |
| scripts/check-production-migrations.mjs | Registers the SHA-256 digest of the new migration file so the script can verify it hasn't been altered after review |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant Tile as Next/Image (tile)
    participant Loader as renditionLoader
    participant Bunny as Bunny CDN
    participant Overlay as Image unoptimized (overlay)

    Browser->>Tile: "render (sizes="50vw / 288px")"
    Tile->>Loader: "{ width: 288 }"
    Loader->>Loader: renditionForWidth(renditions, 288) → 640px
    Loader-->>Tile: 640px URL
    Tile->>Bunny: fetch 640px rendition
    Bunny-->>Browser: JPEG q90 4:4:4

    note over Browser: User hovers / focuses button
    Browser->>Browser: "preloadExpanded() - guard: expandedSrc === src always true → skip"

    note over Browser: User clicks to zoom
    Browser->>Overlay: "render src=2560px URL (unoptimized)"
    Overlay->>Bunny: fetch 2560px rendition (eager, high priority)
    Bunny-->>Browser: JPEG q90 4:4:4
    Browser->>Browser: FLIP animation
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant Tile as Next/Image (tile)
    participant Loader as renditionLoader
    participant Bunny as Bunny CDN
    participant Overlay as Image unoptimized (overlay)

    Browser->>Tile: "render (sizes="50vw / 288px")"
    Tile->>Loader: "{ width: 288 }"
    Loader->>Loader: renditionForWidth(renditions, 288) → 640px
    Loader-->>Tile: 640px URL
    Tile->>Bunny: fetch 640px rendition
    Bunny-->>Browser: JPEG q90 4:4:4

    note over Browser: User hovers / focuses button
    Browser->>Browser: "preloadExpanded() - guard: expandedSrc === src always true → skip"

    note over Browser: User clicks to zoom
    Browser->>Overlay: "render src=2560px URL (unoptimized)"
    Overlay->>Bunny: fetch 2560px rendition (eager, high priority)
    Bunny-->>Browser: JPEG q90 4:4:4
    Browser->>Browser: FLIP animation
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(media): harden lightbox layout"](https://github.com/calicastle/cali.so/commit/5b361afb13500daf4c93209efd0b9b8752d01ae0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45397389)</sub>

<!-- /greptile_comment -->