### PR TITLE
fix(site): refine mobile portrait

### DIFF
--- a/components/halftone-portrait.tsx
+++ b/components/halftone-portrait.tsx
@@ -4,7 +4,9 @@ import { useEffect, useRef } from 'react'
 
 import { localize, useLocale } from '~/lib/locale-client'
 
-const CELL = 3 // CSS px between dot centers
+const MOBILE_CELL = 2 // denser mobile screen keeps facial features legible
+const DESKTOP_CELL = 3 // CSS px between dot centers
+const MOBILE_PRESENTATION_MAX = 200 // separates the 149.6px and 240px presentations
 const EDGE_FADE = 0.1 // fraction of each edge over which dots taper out
 const RADIUS = 150 // pointer influence radius (CSS px)
 const SWELL = 0.08 // max extra dot growth near the pointer
@@ -23,6 +25,7 @@ interface Cell {
 
 interface Field {
   cells: Cell[]
+  cell: number
   ink: string
 }
 
@@ -92,8 +95,10 @@ export function HalftonePortrait({
     function buildField(kind: 'light' | 'dark') {
       const img = images[kind]
       if (!img || cssW < 4) return
-      const cols = Math.max(1, Math.round(cssW / CELL))
-      const rows = Math.max(1, Math.round(cssH / CELL))
+      const cell =
+        kind === 'light' && cssW < MOBILE_PRESENTATION_MAX ? MOBILE_CELL : DESKTOP_CELL
+      const cols = Math.max(1, Math.round(cssW / cell))
+      const rows = Math.max(1, Math.round(cssH / cell))
       const off = document.createElement('canvas')
       off.width = cols
       off.height = rows
@@ -123,8 +128,8 @@ export function HalftonePortrait({
           // dark: ink ∝ light, black ground drops out.
           const tone = kind === 'light' ? (lum > 0.93 ? 0 : Math.pow(1 - lum, 0.95)) : lum
           if (tone < 0.06) continue
-          const x = (c + 0.5) * CELL
-          const y = (r + 0.5) * CELL
+          const x = (c + 0.5) * cell
+          const y = (r + 0.5) * cell
           const fx = Math.min(x, cssW - x) / (cssW * EDGE_FADE)
           // the headshot's hair meets the frame top — no top fade in light
           const fy =
@@ -134,14 +139,14 @@ export function HalftonePortrait({
           cells.push({ x, y, tone: tone * edge })
         }
       }
-      fields[kind] = { cells, ink: kind === 'light' ? INK_LIGHT : INK_DARK }
+      fields[kind] = { cell, cells, ink: kind === 'light' ? INK_LIGHT : INK_DARK }
     }
 
     function drawField(field: Field, alpha: number) {
       if (alpha <= 0.01) return false
       ctx.globalAlpha = alpha
       ctx.fillStyle = field.ink
-      const maxR = CELL * 0.52
+      const maxR = field.cell * 0.52
       let painted = false
       for (const cell of field.cells) {
         let { x, y } = cell

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -327,8 +327,9 @@ typewriter/ascii textures, measuring ticks, registration marks. Rules:
   boxed image — prints must dissolve into the paper in both themes.
 - **The halftone portrait hero** (`components/halftone-portrait.tsx`): the
   home portrait rendered as a dot screen on canvas — dot radius ∝ auto-leveled
-  luminance (p5–p95 stretch), 3px cells, dots taper through the outer 10% and
-  below a 6% floor so the figure emerges from nothing. A fine pointer swells
+  luminance (p5–p95 stretch), a denser 2px screen for the light-mode mobile
+  presentation and 3px cells everywhere else, dots taper through the outer 10%
+  and below a 6% floor so the figure emerges from nothing. A fine pointer swells
   (+8%) and repels (≤3px) dots within ~150px, smoothed per-frame (0.16
   lerp, rAF only while active). Touch and reduced motion get the static
   print. The server-rendered shell is visually empty; once the client paints


### PR DESCRIPTION
## Summary

- use a denser 2px halftone screen for the light-mode mobile portrait
- keep the existing 3px screen for desktop and dark mode
- document the responsive portrait treatment in the design language

## Why

At the 149.6px mobile presentation, the 3px screen leaves roughly 50 columns. The eye whites collapse into the surrounding dots, making the pupils look oversized and the gaze uncanny. The denser screen preserves the expression without replacing the source portrait or changing the other presentations.

## Validation

- `pnpm typecheck`
- `pnpm exec vitest run components/halftone-portrait.test.tsx`
- visual review in light-mode mobile, dark-mode mobile, and light-mode desktop

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refines the halftone portrait component for the mobile presentation by switching from a single global `CELL` constant to per-field cell sizes: a denser 2px grid for the light-mode portrait when `cssW < 200px`, and the existing 3px grid for dark mode and desktop. The `Field` interface gains a `cell` property so `drawField` uses each field's own dot pitch for `maxR` rather than a shared global.

- The threshold (`MOBILE_PRESENTATION_MAX = 200`) cleanly separates the known 149.6px mobile and 240px desktop render sizes, and the resize observer will correctly recompute cell size if the canvas crosses that boundary.
- Dark mode always keeps the 3px grid, so a light→dark crossfade on mobile will briefly blend the 2px light grid with the 3px dark grid — an intentional but visually detectable density shift during the 550ms fade worth confirming on device.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the logic is internally consistent and the change is tightly scoped to canvas rendering with no data or state implications.

The cell-size selection is correctly stored in the Field object and used in drawField, avoiding any stale-global issue. The one open question is the visual quality of the 550ms light-to-dark crossfade on mobile where the two fields have different dot pitches (2px vs 3px) — this is harmless but may be worth a quick on-device check before shipping.

components/halftone-portrait.tsx — specifically the theme crossfade path on mobile viewports.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| components/halftone-portrait.tsx | Adds per-field cell size (MOBILE_CELL=2 for light+mobile, DESKTOP_CELL=3 elsewhere) stored in the Field interface and consumed in drawField for maxR; logic is internally consistent but the crossfade between fields of different densities on mobile may look slightly jarring. |
| docs/design-language.md | Documentation updated to accurately describe the new responsive halftone treatment (2px mobile light, 3px elsewhere). |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildField called] --> B{kind === 'light'\nAND cssW < 200?}
    B -- Yes --> C[cell = MOBILE_CELL = 2]
    B -- No --> D[cell = DESKTOP_CELL = 3]
    C --> E[Build dense grid\n~75 cols at 149.6px]
    D --> F[Build standard grid\n~50 cols at 149.6px\nor ~80 cols at 240px]
    E --> G[Field stored with cell=2]
    F --> H[Field stored with cell=3]
    G --> I[drawField: maxR = 2 × 0.52 = 1.04px]
    H --> J[drawField: maxR = 3 × 0.52 = 1.56px]
    I --> K{Theme crossfade active?}
    J --> K
    K -- Yes --> L[Both fields drawn with\ndifferent opacity + different cell sizes]
    K -- No --> M[Single active field drawn]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[buildField called] --> B{kind === 'light'\nAND cssW < 200?}
    B -- Yes --> C[cell = MOBILE_CELL = 2]
    B -- No --> D[cell = DESKTOP_CELL = 3]
    C --> E[Build dense grid\n~75 cols at 149.6px]
    D --> F[Build standard grid\n~50 cols at 149.6px\nor ~80 cols at 240px]
    E --> G[Field stored with cell=2]
    F --> H[Field stored with cell=3]
    G --> I[drawField: maxR = 2 × 0.52 = 1.04px]
    H --> J[drawField: maxR = 3 × 0.52 = 1.56px]
    I --> K{Theme crossfade active?}
    J --> K
    K -- Yes --> L[Both fields drawn with\ndifferent opacity + different cell sizes]
    K -- No --> M[Single active field drawn]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `components/halftone-portrait.tsx`, line 267-272 ([link](https://github.com/calicastle/cali.so/blob/abff934b88738e2ff6396e9db6467fc3cc51d662/components/halftone-portrait.tsx#L267-L272)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Crossfade density mismatch on mobile**

   During a light→dark theme switch on mobile (`cssW < 200`), both fields are drawn simultaneously: the light field at `cell=2` (denser, ~75 cols) and the dark field at `cell=3` (sparser, ~50 cols). The 550ms crossfade will visually blend two dot grids of different pitches, which can look slightly jumpy. This is a transient effect and may be acceptable by design, but worth a deliberate visual check on a real mobile device when switching themes.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: components/halftone-portrait.tsx
   Line: 267-272

   Comment:
   **Crossfade density mismatch on mobile**

   During a light→dark theme switch on mobile (`cssW < 200`), both fields are drawn simultaneously: the light field at `cell=2` (denser, ~75 cols) and the dark field at `cell=3` (sparser, ~50 cols). The 550ms crossfade will visually blend two dot grids of different pitches, which can look slightly jumpy. This is a transient effect and may be acceptable by design, but worth a deliberate visual check on a real mobile device when switching themes.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20components%2Fhalftone-portrait.tsx%0ALine%3A%20267-272%0A%0AComment%3A%0A**Crossfade%20density%20mismatch%20on%20mobile**%0A%0ADuring%20a%20light%E2%86%92dark%20theme%20switch%20on%20mobile%20%28%60cssW%20%3C%20200%60%29%2C%20both%20fields%20are%20drawn%20simultaneously%3A%20the%20light%20field%20at%20%60cell%3D2%60%20%28denser%2C%20~75%20cols%29%20and%20the%20dark%20field%20at%20%60cell%3D3%60%20%28sparser%2C%20~50%20cols%29.%20The%20550ms%20crossfade%20will%20visually%20blend%20two%20dot%20grids%20of%20different%20pitches%2C%20which%20can%20look%20slightly%20jumpy.%20This%20is%20a%20transient%20effect%20and%20may%20be%20acceptable%20by%20design%2C%20but%20worth%20a%20deliberate%20visual%20check%20on%20a%20real%20mobile%20device%20when%20switching%20themes.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=calicastle%2Fcali.so&pr=192&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22calicastle%2Fcali.so%22%20on%20the%20existing%20branch%20%22cali%2Ffix-mobile-portrait-eyes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cali%2Ffix-mobile-portrait-eyes%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20components%2Fhalftone-portrait.tsx%0ALine%3A%20267-272%0A%0AComment%3A%0A**Crossfade%20density%20mismatch%20on%20mobile**%0A%0ADuring%20a%20light%E2%86%92dark%20theme%20switch%20on%20mobile%20%28%60cssW%20%3C%20200%60%29%2C%20both%20fields%20are%20drawn%20simultaneously%3A%20the%20light%20field%20at%20%60cell%3D2%60%20%28denser%2C%20~75%20cols%29%20and%20the%20dark%20field%20at%20%60cell%3D3%60%20%28sparser%2C%20~50%20cols%29.%20The%20550ms%20crossfade%20will%20visually%20blend%20two%20dot%20grids%20of%20different%20pitches%2C%20which%20can%20look%20slightly%20jumpy.%20This%20is%20a%20transient%20effect%20and%20may%20be%20acceptable%20by%20design%2C%20but%20worth%20a%20deliberate%20visual%20check%20on%20a%20real%20mobile%20device%20when%20switching%20themes.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=calicastle%2Fcali.so&pr=192&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acomponents%2Fhalftone-portrait.tsx%3A267-272%0A**Crossfade%20density%20mismatch%20on%20mobile**%0A%0ADuring%20a%20light%E2%86%92dark%20theme%20switch%20on%20mobile%20%28%60cssW%20%3C%20200%60%29%2C%20both%20fields%20are%20drawn%20simultaneously%3A%20the%20light%20field%20at%20%60cell%3D2%60%20%28denser%2C%20~75%20cols%29%20and%20the%20dark%20field%20at%20%60cell%3D3%60%20%28sparser%2C%20~50%20cols%29.%20The%20550ms%20crossfade%20will%20visually%20blend%20two%20dot%20grids%20of%20different%20pitches%2C%20which%20can%20look%20slightly%20jumpy.%20This%20is%20a%20transient%20effect%20and%20may%20be%20acceptable%20by%20design%2C%20but%20worth%20a%20deliberate%20visual%20check%20on%20a%20real%20mobile%20device%20when%20switching%20themes.%0A%0A&repo=calicastle%2Fcali.so&pr=192&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22calicastle%2Fcali.so%22%20on%20the%20existing%20branch%20%22cali%2Ffix-mobile-portrait-eyes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cali%2Ffix-mobile-portrait-eyes%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acomponents%2Fhalftone-portrait.tsx%3A267-272%0A**Crossfade%20density%20mismatch%20on%20mobile**%0A%0ADuring%20a%20light%E2%86%92dark%20theme%20switch%20on%20mobile%20%28%60cssW%20%3C%20200%60%29%2C%20both%20fields%20are%20drawn%20simultaneously%3A%20the%20light%20field%20at%20%60cell%3D2%60%20%28denser%2C%20~75%20cols%29%20and%20the%20dark%20field%20at%20%60cell%3D3%60%20%28sparser%2C%20~50%20cols%29.%20The%20550ms%20crossfade%20will%20visually%20blend%20two%20dot%20grids%20of%20different%20pitches%2C%20which%20can%20look%20slightly%20jumpy.%20This%20is%20a%20transient%20effect%20and%20may%20be%20acceptable%20by%20design%2C%20but%20worth%20a%20deliberate%20visual%20check%20on%20a%20real%20mobile%20device%20when%20switching%20themes.%0A%0A&repo=calicastle%2Fcali.so&pr=192&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
components/halftone-portrait.tsx:267-272
**Crossfade density mismatch on mobile**

During a light→dark theme switch on mobile (`cssW < 200`), both fields are drawn simultaneously: the light field at `cell=2` (denser, ~75 cols) and the dark field at `cell=3` (sparser, ~50 cols). The 550ms crossfade will visually blend two dot grids of different pitches, which can look slightly jumpy. This is a transient effect and may be acceptable by design, but worth a deliberate visual check on a real mobile device when switching themes.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(site): refine mobile portrait"](https://github.com/calicastle/cali.so/commit/abff934b88738e2ff6396e9db6467fc3cc51d662) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45401386)</sub>

<!-- /greptile_comment -->