### PR TITLE
Add automated browser release gates

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -52,3 +52,11 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           GIT_BRANCH: ${{ github.ref_name }}
         run: node scripts/comment-preview-deployment.mjs
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Verify Preview in browser
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ steps.deployment.outputs.deployment-url }}
+        run: pnpm test:browser:hosted

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Deploy Staging
+        id: deployment
         uses: ./.github/actions/deploy-neon-vercel
         with:
           branch-name: staging
@@ -38,3 +39,11 @@ jobs:
           vercel-org-id: ${{ vars.VERCEL_ORG_ID }}
           vercel-project-id: ${{ vars.VERCEL_PROJECT_ID }}
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Verify Staging in browser
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ steps.deployment.outputs.deployment-url }}
+        run: pnpm test:browser:hosted

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -124,6 +124,12 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium webkit
+
+      - name: Test browser release gate
+        run: pnpm test:browser
+
       - name: Verify public links
         run: pnpm verify:links
         env:

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -85,6 +85,9 @@ Current as of July 2026.
 - Security baseline controls from PR #97 remain mandatory: CSP and security
   headers, same-origin mutation policy, rate limits, kill switches,
   privacy-safe audit events, isolated credentials, and security automation.
+- Playwright is the browser release gate. Quality runs the complete production-
+  build Chromium suite plus a WebKit smoke matrix, while Preview and Staging
+  rerun the read-only hosted subset against the exact deployment URL.
 - The Bunny-backed Media Library in ADR-0007 owns the curated photo workflow.
   Private Originals stay server-only, while `/photos` and homepage previews
   consume the active Published Photo Selection from Bunny Renditions. Media
@@ -130,6 +133,8 @@ pnpm test:localization
 pnpm test:port-post
 pnpm test:ama
 pnpm test:deployment
+pnpm build
+pnpm test:browser
 pnpm test:security
 pnpm test:media:storage
 pnpm test:media:catalog
@@ -143,7 +148,6 @@ pnpm test:media:photo-selection
 pnpm test:media:purge
 pnpm test:media:reconciliation
 pnpm db:validate
-pnpm build
 pnpm verify:legacy-urls
 pnpm verify:links
 pnpm verify:public-discovery

--- a/docs/v3-cutover-readiness.md
+++ b/docs/v3-cutover-readiness.md
@@ -1,6 +1,6 @@
 # v3 cutover readiness
 
-Last checked: 2026-07-18.
+Last checked: 2026-07-19.
 
 The controlled deployment architecture is active: `dev` is the integration
 branch, `staging` is the persistent non-production database branch, and the
@@ -18,10 +18,11 @@ found that its runtime contract, including the database and media provider
 configuration, was not ready for v3. Required checks on `main`, Staging runtime
 grant and signed-in owner verification, Production database and provider proof,
 Vercel dashboard checks, Analytics ingestion proof, and rollback proof remain
-open. The final complete-diff reviews also found unresolved motion and layer
-standards plus two literal issue-acceptance gaps: the repository has no
-automated browser-test command, and the reviewed custom Staging environment has
-not been explicitly accepted as the issue's requested feature Preview.
+open. PR #189 resolved the motion implementations, but the complete-diff
+Standards and Spec reviews still need to be refreshed; the documented layer
+finding and one literal issue-acceptance gap remain because the reviewed custom
+Staging environment has not been explicitly accepted as the issue's requested
+feature Preview.
 
 Unknown hosted state is not counted as passed. This report does not authorize
 merging to `main`, changing production settings, accessing production data, or
@@ -53,11 +54,11 @@ Renditions. The retired static photo fallback has been removed.
 | Gate | Status | Evidence or blocker |
 | --- | --- | --- |
 | Frozen install | PASS | `pnpm install --frozen-lockfile` completed from the audited commit. |
-| Repository validation | PARTIAL | Every existing command and count in the automated evidence section passed, but the repository no longer has an automated browser-test command. Issue #107 explicitly requires browser tests in addition to its manual browser matrix. |
+| Repository validation | PASS (LOCAL) / AWAITING CI AND HOSTED PROOF | The new `pnpm test:browser` production-build gate passes 19 Chromium behavior cases plus six WebKit smoke executions locally. `Quality` runs the complete suite, while Preview and Staging deployments run the 13 read-only `@hosted` cases against their exact deployment URL. Remote workflow proof remains pending on this branch. |
 | Public browser behavior | PASS | Local and Staging review covered desktop and mobile, both locales, light and dark appearance, reduced motion, keyboard navigation, metadata, overflow, feeds, generated social images, and Instant Navigation. |
 | Owner admin boundary | PASS (Staging signed-out path) / AWAITING OWNER AND PRODUCTION PROOF | A clean browser navigation to Staging `/admin` completes Clerk's development-instance handshake and reaches the isolated sign-in UI. The complete remote security-boundary verifier passes. Signed-in owner reads and mutations still require authorized operator access and the database gate below; confirm the Production Clerk keys and owner metadata at cutover. |
-| Complete diff Standards review | FAIL | The final review found outdated AMA capability and owner step-up decisions, keyboard animation in Preview cards, undocumented global/local layer values, and a judgement-level divergent-change smell in `app/globals.css`. ADR-0011, ADR-0012, and the security baseline now resolve the first two conflicts. Preview-card keyboard motion remains tracked by [#184](https://github.com/CaliCastle/cali.so/issues/184); the layer-scale finding still needs a fix, a dedicated issue, or explicit maintainer rejection. |
-| Complete diff Spec review | PARTIAL | No scope creep was found. Automated browser tests are absent, the issue literally requests feature Preview evidence while the current matrix used Staging, Analytics dashboard proof remains absent, and Domain evidence was overstated. The Clerk redirect-shape verifier intentionally stops at the first 307, but the separate clean-browser matrix completed the development handshake and rendered Clerk sign-in. |
+| Complete diff Standards review | PARTIAL / AWAITING RE-REVIEW | PR #189 landed the credential-driven AMA and owner-auth decisions plus keyboard-instant Preview-card, lightbox, and article-map behavior. The browser gate now verifies those motion paths. Issues #184 through #186 remain open because their PR merged to `dev`, not the default branch; the layer-scale finding and judgement-level `app/globals.css` disposition still need a recorded resolution before the refreshed review can pass. |
+| Complete diff Spec review | PARTIAL / AWAITING RE-REVIEW | No scope creep was found, and the missing automated browser-test command is now implemented. The issue still literally requests feature Preview evidence while the current matrix used Staging, Analytics dashboard proof remains absent, and Domain evidence was overstated. The Clerk redirect-shape verifier intentionally stops at the first 307, but the separate clean-browser matrix completed the development handshake and rendered Clerk sign-in. |
 | Production-like Staging | PASS (public and signed-out boundaries) | `https://beta.cali.so` serves `dev@8802607`. The complete public route, link, discovery, legacy-URL, security-boundary, and manual browser matrix passed. Signed-in owner operations and provider-backed workflows remain separate gates. |
 | Issue #107 feature Preview evidence | PARTIAL | The accepted deployment architecture promotes `dev` continuously to a stable custom Staging environment, which is a stronger repeatable target than an ephemeral feature Preview. The issue text still says Preview; obtain an explicit maintainer acceptance of Staging as the substitute or repeat the complete matrix on a recorded feature Preview URL and SHA. |
 | Vercel Web Analytics | AWAITING DASHBOARD CONFIRMATION | Chinese and English Staging routes load the first-party Insights client; owner-admin navigation does not load it before the Clerk redirect. Confirm fresh pageviews from the accepted production-like target in the existing `cali-so` Analytics dashboard: Staging if the maintainer accepts it as the Preview substitute, otherwise the recorded feature Preview. |
@@ -101,6 +102,12 @@ The following passed from the frozen installation:
 - 11 Media reconciliation tests.
 - 4 port-post tests.
 - Production build with 72 generated pages using the isolated CI environment.
+- Playwright production-build gate: 19 Chromium behavior cases plus six WebKit
+  smoke executions, covering both locales, desktop and mobile, light and dark,
+  reduced motion, prefetched Instant Navigation before streamed data releases,
+  history, focus
+  restoration, metadata, feeds, social images, public Insights inclusion, and
+  signed-out admin Insights exclusion.
 - 53 legacy URL probes against the production server.
 - 400 internal links and 147 external targets across all 30 sitemap pages; one
   aggregate fetch was transiently inconclusive and returned 200 on direct
@@ -117,6 +124,14 @@ migration remains byte-for-byte immutable and absent from the v3 Drizzle
 journal.
 
 ## Browser review
+
+Playwright now turns the browser matrix into a repository gate. `Quality` runs
+all 19 Chromium cases and repeats the six public smoke profiles in WebKit.
+Feature Preview and Staging deployment workflows run the 13 read-only
+`@hosted` cases against the exact deployment URL, so deployment-specific
+Insights, navigation, metadata, feed, social-image, locale, appearance, motion,
+and responsive failures block the workflow. Screenshots, video, and traces are
+retained only on failure.
 
 Local production-build review covered the homepage and a representative blog
 post in Chinese and English at desktop and mobile widths. Staging repeated the
@@ -175,10 +190,12 @@ Final review artifacts after the accessibility corrections:
   rather than making repository release status depend on another service's
   uptime. The final aggregate run had one inconclusive X/Twitter fetch; a direct
   retry returned HTTP 200.
-- The Preferences keyboard path and reduced-motion behavior pass, but the final
-  review found that Preview-card keyboard focus still runs its card and cell
-  animations. Issue #184 owns that defect. The same keyboard hard rule is
-  already tracked for lightbox and article-map actions in issues #185 and #186.
+- PR #189 landed the keyboard-instant Preview-card, lightbox, and article-map
+  paths. The Playwright production-build gate now verifies zero card and cell
+  motion on keyboard Preview-card focus, synchronous lightbox open and Escape
+  focus restoration, instant article-map toggles, and zero running Web
+  Animations under reduced motion. Issues #184 through #186 remain open because
+  their PR merged to `dev` rather than the default branch.
 - Earlier design-contract findings around selection weight, contrast, scroll
   reveals, and chrome typography are closed. The final review newly found that
   the implementation uses local and page-level numeric stacking values beyond
@@ -199,11 +216,13 @@ Final review artifacts after the accessibility corrections:
 - The final complete-diff Standards review found two stale decision conflicts.
   ADR-0011 now records credential-driven AMA capabilities, ADR-0012 records the
   removal of owner step-up prompts, and the superseded ADR and security-baseline
-  text is explicit. The motion and layer findings above still fail this gate.
-- The final complete-diff Spec review found no scope creep. It did find missing
-  automated browser tests, Staging substituted for the issue's literal Preview
-  requirement, and the overstated Domain row corrected above. Production and
-  dashboard blockers remain unchanged.
+  text is explicit. PR #189 resolves the motion finding in code; the layer
+  finding and a refreshed complete-diff review remain open.
+- The final complete-diff Spec review found no scope creep. The automated
+  browser-test gap is now closed locally and wired into Quality, Preview, and
+  Staging. Staging still substitutes for the issue's literal Preview
+  requirement, and the overstated Domain row is corrected above. Production
+  and dashboard blockers remain unchanged.
 - Remaining type below 14 pixels is limited to the design language's explicit
   13-pixel code exception and text printed onto physical craft objects such as
   polaroids, record sleeves, book covers, and the illustrated envelope. It is
@@ -263,42 +282,40 @@ operator before cutover.
 Maintainer-operated commands for the hosted actions below are collected in
 `docs/v3-cutover-ops-runbook.md`.
 
-1. Resolve or explicitly reject the remaining Standards blockers with recorded
-   reasoning: complete keyboard-instant issues #184 through #186 and reconcile
-   the implementation with the documented closed layer scale. The
+1. Refresh the complete-diff Standards and Spec reviews, record the disposition
+   of issues #184 through #186 now that their implementation is in `dev`, and
+   reconcile the implementation with the documented closed layer scale. The
    judgement-level `app/globals.css` divergent-change finding may remain a
    follow-up only if the maintainer records that disposition.
-2. Restore an automated browser-test command and CI gate, or explicitly revise
-   issue #107's browser-test acceptance criterion with maintainer reasoning.
-3. Either record maintainer acceptance that the stable custom Staging
+2. Either record maintainer acceptance that the stable custom Staging
    environment supersedes the issue's ephemeral Preview wording, or repeat the
    full matrix on a recorded feature Preview URL and SHA.
-4. With two fresh confirmations, verify Staging migrations `0010` and `0011`,
+3. With two fresh confirmations, verify Staging migrations `0010` and `0011`,
    Media and AMA tables, and the runtime role's CRUD-only grants. Then sign in
    as the marked owner and prove one non-destructive read plus the required
    mutation boundaries. Until then, treat signed-in Staging admin operations as
    unvalidated.
-5. Provision the Production environment for the v3 contract: replace the
+4. Provision the Production environment for the v3 contract: replace the
    legacy `DATABASE_URL` with the CRUD-only Neon runtime role and add the
    missing secrets, rate limits, intended AMA provider credential pairs, and
    complete Bunny and media configuration.
-6. Add required `Quality` and `CodeQL` checks to protected `main`; `dev` already
+5. Add required `Quality` and `CodeQL` checks to protected `main`; `dev` already
    requires both.
-7. In the Vercel dashboard, verify logs, drains, retention, firewall rules,
+6. In the Vercel dashboard, verify logs, drains, retention, firewall rules,
    the production-branch mapping, and the certificate.
-8. With two fresh confirmations, verify Production runtime grants and the
+7. With two fresh confirmations, verify Production runtime grants and the
    reviewed initial migration baseline. Configure and approve the no-secret
    `production-migration-review` environment first, then approve the protected
    `production` environment only after confirming the workflow will migrate
    before deploy.
-9. Verify the production Bunny and Neon Media boundary, run the protected live
+8. Verify the production Bunny and Neon Media boundary, run the protected live
    storage contract, and publish the intended two-photo Published Photo
    Selection through the owner admin.
-10. Confirm fresh Chinese and English pageviews from the accepted
+9. Confirm fresh Chinese and English pageviews from the accepted
     production-like target are visible in the existing `cali-so` Analytics
-    dashboard: Staging if action 3 accepts it as the substitute, otherwise the
+    dashboard: Staging if action 2 accepts it as the substitute, otherwise the
     recorded feature Preview.
-11. Confirm the rollback procedure against the recorded known-good deployment.
-12. Only after every blocker above is passed, merge `dev` to `main`, approve
+10. Confirm the rollback procedure against the recorded known-good deployment.
+11. Only after every blocker above is passed, merge `dev` to `main`, approve
     both Production deployment gates in order, and complete the cutover smoke
     tests.

--- a/docs/v3-cutover-readiness.md
+++ b/docs/v3-cutover-readiness.md
@@ -20,9 +20,8 @@ grant and signed-in owner verification, Production database and provider proof,
 Vercel dashboard checks, Analytics ingestion proof, and rollback proof remain
 open. PR #189 resolved the motion implementations, but the complete-diff
 Standards and Spec reviews still need to be refreshed; the documented layer
-finding and one literal issue-acceptance gap remain because the reviewed custom
-Staging environment has not been explicitly accepted as the issue's requested
-feature Preview.
+finding remains. Automated Feature Preview evidence now passes, while manual
+hosted and Analytics evidence remains open.
 
 Unknown hosted state is not counted as passed. This report does not authorize
 merging to `main`, changing production settings, accessing production data, or
@@ -54,14 +53,14 @@ Renditions. The retired static photo fallback has been removed.
 | Gate | Status | Evidence or blocker |
 | --- | --- | --- |
 | Frozen install | PASS | `pnpm install --frozen-lockfile` completed from the audited commit. |
-| Repository validation | PASS (LOCAL) / AWAITING CI AND HOSTED PROOF | The new `pnpm test:browser` production-build gate passes 19 Chromium behavior cases plus six WebKit smoke executions locally. `Quality` runs the complete suite, while Preview and Staging deployments run the 13 read-only `@hosted` cases against their exact deployment URL. Remote workflow proof remains pending on this branch. |
+| Repository validation | PASS (LOCAL AND FEATURE PREVIEW) / AWAITING QUALITY AND STAGING | The new `pnpm test:browser` production-build gate passes 19 Chromium behavior cases plus six WebKit smoke executions locally. Feature Preview run [29671775136](https://github.com/CaliCastle/cali.so/actions/runs/29671775136) passed all 13 read-only `@hosted` cases against `https://cali-lonkhb5df-cali.vercel.app` for `2336124`. `Quality` and the Staging deployment remain pending. |
 | Public browser behavior | PASS | Local and Staging review covered desktop and mobile, both locales, light and dark appearance, reduced motion, keyboard navigation, metadata, overflow, feeds, generated social images, and Instant Navigation. |
 | Owner admin boundary | PASS (Staging signed-out path) / AWAITING OWNER AND PRODUCTION PROOF | A clean browser navigation to Staging `/admin` completes Clerk's development-instance handshake and reaches the isolated sign-in UI. The complete remote security-boundary verifier passes. Signed-in owner reads and mutations still require authorized operator access and the database gate below; confirm the Production Clerk keys and owner metadata at cutover. |
 | Complete diff Standards review | PARTIAL / AWAITING RE-REVIEW | PR #189 landed the credential-driven AMA and owner-auth decisions plus keyboard-instant Preview-card, lightbox, and article-map behavior. The browser gate now verifies those motion paths. Issues #184 through #186 remain open because their PR merged to `dev`, not the default branch; the layer-scale finding and judgement-level `app/globals.css` disposition still need a recorded resolution before the refreshed review can pass. |
-| Complete diff Spec review | PARTIAL / AWAITING RE-REVIEW | No scope creep was found, and the missing automated browser-test command is now implemented. The issue still literally requests feature Preview evidence while the current matrix used Staging, Analytics dashboard proof remains absent, and Domain evidence was overstated. The Clerk redirect-shape verifier intentionally stops at the first 307, but the separate clean-browser matrix completed the development handshake and rendered Clerk sign-in. |
+| Complete diff Spec review | PARTIAL / AWAITING RE-REVIEW | No scope creep was found, and the missing automated browser-test command plus automated feature Preview evidence are now implemented. Analytics dashboard proof remains absent, and Domain evidence was overstated. The Clerk redirect-shape verifier intentionally stops at the first 307, but the separate clean-browser matrix completed the development handshake and rendered Clerk sign-in. |
 | Production-like Staging | PASS (public and signed-out boundaries) | `https://beta.cali.so` serves `dev@8802607`. The complete public route, link, discovery, legacy-URL, security-boundary, and manual browser matrix passed. Signed-in owner operations and provider-backed workflows remain separate gates. |
-| Issue #107 feature Preview evidence | PARTIAL | The accepted deployment architecture promotes `dev` continuously to a stable custom Staging environment, which is a stronger repeatable target than an ephemeral feature Preview. The issue text still says Preview; obtain an explicit maintainer acceptance of Staging as the substitute or repeat the complete matrix on a recorded feature Preview URL and SHA. |
-| Vercel Web Analytics | AWAITING DASHBOARD CONFIRMATION | Chinese and English Staging routes load the first-party Insights client; owner-admin navigation does not load it before the Clerk redirect. Confirm fresh pageviews from the accepted production-like target in the existing `cali-so` Analytics dashboard: Staging if the maintainer accepts it as the Preview substitute, otherwise the recorded feature Preview. |
+| Issue #107 feature Preview evidence | PASS (AUTOMATED MATRIX) / AWAITING MANUAL HOSTED EVIDENCE | The exact feature Preview for `2336124` passed the 13-case hosted matrix across both locales, appearance and viewport profiles, reduced motion, metadata, feeds, social images, Instant Navigation, public Analytics inclusion, and the signed-out admin boundary. Fresh Analytics dashboard proof and signed-in owner evidence remain separate manual gates. |
+| Vercel Web Analytics | AWAITING DASHBOARD CONFIRMATION | Chinese and English Feature Preview and Staging routes load the first-party Insights client; the signed-out owner-admin boundary excludes it. Confirm fresh Chinese and English pageviews from the recorded Feature Preview in the existing `cali-so` Analytics dashboard. |
 | GitHub security settings | PASS | Secret scanning, push protection, Dependabot security updates, read-only Actions defaults, and full-SHA action policy are enabled. |
 | Required GitHub checks | PARTIAL | The `dev` ruleset requires `Quality` and `CodeQL`; `main` branch protection still requires neither. The maintainer-operated command is in `docs/v3-cutover-ops-runbook.md`. |
 | Deployment environments | PASS | GitHub has Preview, Staging, `production-migration-review`, and Production environments with the intended branch policies; the last two require maintainer review. |
@@ -132,6 +131,10 @@ Feature Preview and Staging deployment workflows run the 13 read-only
 Insights, navigation, metadata, feed, social-image, locale, appearance, motion,
 and responsive failures block the workflow. Screenshots, video, and traces are
 retained only on failure.
+
+The exact Feature Preview for `2336124` passed all 13 hosted cases at
+`https://cali-lonkhb5df-cali.vercel.app` in GitHub Actions run
+[29671775136](https://github.com/CaliCastle/cali.so/actions/runs/29671775136).
 
 Local production-build review covered the homepage and a representative blog
 post in Chinese and English at desktop and mobile widths. Staging repeated the
@@ -287,9 +290,9 @@ Maintainer-operated commands for the hosted actions below are collected in
    reconcile the implementation with the documented closed layer scale. The
    judgement-level `app/globals.css` divergent-change finding may remain a
    follow-up only if the maintainer records that disposition.
-2. Either record maintainer acceptance that the stable custom Staging
-   environment supersedes the issue's ephemeral Preview wording, or repeat the
-   full matrix on a recorded feature Preview URL and SHA.
+2. Review and accept the recorded automated Feature Preview evidence for
+   `2336124`, then use that exact deployment for the remaining Analytics
+   dashboard and other manual hosted evidence.
 3. With two fresh confirmations, verify Staging migrations `0010` and `0011`,
    Media and AMA tables, and the runtime role's CRUD-only grants. Then sign in
    as the marked owner and prove one non-destructive read plus the required
@@ -311,10 +314,8 @@ Maintainer-operated commands for the hosted actions below are collected in
 8. Verify the production Bunny and Neon Media boundary, run the protected live
    storage contract, and publish the intended two-photo Published Photo
    Selection through the owner admin.
-9. Confirm fresh Chinese and English pageviews from the accepted
-    production-like target are visible in the existing `cali-so` Analytics
-    dashboard: Staging if action 2 accepts it as the substitute, otherwise the
-    recorded feature Preview.
+9. Confirm fresh Chinese and English pageviews from the recorded Feature
+    Preview are visible in the existing `cali-so` Analytics dashboard.
 10. Confirm the rollback procedure against the recorded known-good deployment.
 11. Only after every blocker above is passed, merge `dev` to `main`, approve
     both Production deployment gates in order, and complete the cutover smoke

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "db:migrate": "drizzle-kit migrate",
     "db:validate": "node --test scripts/ama-migrations.test.mjs",
     "test:deployment": "node --test scripts/check-production-migrations.test.mjs scripts/comment-preview-deployment.test.mjs scripts/delete-vercel-branch-deployments.test.mjs scripts/deployment-workflows.test.mjs",
+    "test:browser": "playwright test",
+    "test:browser:hosted": "playwright test --project=chromium --grep @hosted",
     "start": "next start",
     "test:ama": "vitest run lib/ama && pnpm db:validate",
     "test:security": "vitest run lib/security",
@@ -86,6 +88,8 @@
   },
   "devDependencies": {
     "@electric-sql/pglite": "^0.5.4",
+    "@next/playwright": "16.3.0-preview.6",
+    "@playwright/test": "1.61.1",
     "@tailwindcss/postcss": "^4.1.0",
     "@testing-library/react": "^16.3.2",
     "@types/mdx": "^2.0.14",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,72 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const hostedBaseUrl = process.env.PLAYWRIGHT_BASE_URL
+const baseURL = hostedBaseUrl ?? 'http://127.0.0.1:3210'
+const localServerEnv = {
+  ...process.env,
+  ADMIN_EMAIL: process.env.ADMIN_EMAIL ?? 'owner@example.com',
+  AMA_ENCRYPTION_KEY:
+    process.env.AMA_ENCRYPTION_KEY ?? 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+  BUNNY_CDN_API_KEY: process.env.BUNNY_CDN_API_KEY ?? 'ci-cdn-api-key',
+  BUNNY_MEDIA_REGION: process.env.BUNNY_MEDIA_REGION ?? 'ny',
+  BUNNY_ORIGINALS_PASSWORD:
+    process.env.BUNNY_ORIGINALS_PASSWORD ?? 'ci-originals-password',
+  BUNNY_ORIGINALS_ZONE: process.env.BUNNY_ORIGINALS_ZONE ?? 'ci-media-originals',
+  BUNNY_RENDITIONS_CDN_URL:
+    process.env.BUNNY_RENDITIONS_CDN_URL ?? 'https://media-ci.example.com',
+  BUNNY_RENDITIONS_PASSWORD:
+    process.env.BUNNY_RENDITIONS_PASSWORD ?? 'ci-renditions-password',
+  BUNNY_RENDITIONS_ZONE:
+    process.env.BUNNY_RENDITIONS_ZONE ?? 'ci-media-renditions',
+  CLERK_SECRET_KEY: process.env.CLERK_SECRET_KEY ?? 'sk_live_ci_secret_not_real',
+  DATABASE_URL:
+    process.env.DATABASE_URL ?? 'postgresql://runtime:runtime@127.0.0.1:5432/cali',
+  MEDIA_ENCRYPTION_KEY:
+    process.env.MEDIA_ENCRYPTION_KEY ?? 'BQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQU=',
+  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ?? 'pk_live_Y2xlcmsuY2FsaS5zbyQ',
+  RATE_LIMIT_HASH_KEY:
+    process.env.RATE_LIMIT_HASH_KEY ?? 'AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI=',
+  SITE_URL: process.env.SITE_URL ?? 'https://cali.so',
+}
+
+export default defineConfig({
+  testDir: './tests/browser',
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? [['line'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+  },
+  webServer: hostedBaseUrl
+    ? undefined
+    : {
+        command: 'pnpm start --hostname 127.0.0.1 --port 3210',
+        env: localServerEnv,
+        reuseExistingServer: false,
+        timeout: 120_000,
+        url: baseURL,
+      },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1440, height: 900 },
+      },
+    },
+    {
+      name: 'webkit-smoke',
+      grep: /@smoke/,
+      use: {
+        ...devices['Desktop Safari'],
+        viewport: { width: 1440, height: 900 },
+      },
+    },
+  ],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@clerk/nextjs':
         specifier: ^7.5.19
-        version: 7.5.19(next@16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 7.5.19(next@16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@hugeicons/core-free-icons':
         specifier: ^4.2.2
         version: 4.2.2
@@ -46,7 +46,7 @@ importers:
         version: 1.38.0
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.1(next@16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       '@vercel/functions':
         specifier: ^3.7.5
         version: 3.7.5(@aws-sdk/credential-provider-web-identity@3.972.63)
@@ -73,7 +73,7 @@ importers:
         version: 12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       geist:
         specifier: ^1.7.2
-        version: 1.7.2(next@16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+        version: 1.7.2(next@16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
@@ -91,7 +91,7 @@ importers:
         version: 12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next:
         specifier: 16.3.0-preview.6
-        version: 16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-mdx-remote:
         specifier: ^6.0.0
         version: 6.0.0(@types/react@19.2.17)(react@19.2.7)
@@ -147,6 +147,12 @@ importers:
       '@electric-sql/pglite':
         specifier: ^0.5.4
         version: 0.5.4
+      '@next/playwright':
+        specifier: 16.3.0-preview.6
+        version: 16.3.0-preview.6(@playwright/test@1.61.1)
+      '@playwright/test':
+        specifier: 1.61.1
+        version: 1.61.1
       '@tailwindcss/postcss':
         specifier: ^4.1.0
         version: 4.3.2
@@ -1230,6 +1236,14 @@ packages:
   '@next/env@16.3.0-preview.6':
     resolution: {integrity: sha512-tdsih48yzumsL060VIsZ9BwDYlZk0AAMT8HccspSbPUzp6ntCZ9xOMFU4W0SmqaOCEpPmTyP+5e6WT36mqN2fw==}
 
+  '@next/playwright@16.3.0-preview.6':
+    resolution: {integrity: sha512-lyko3T6yY2oaJF0wUW0fzfTdFp4UZTMr2JZj++Q4BgStwSl4OkcbwKNaWeORs2V+l9DWSHESeRiVaT653jYFaA==}
+    peerDependencies:
+      '@playwright/test': '>=1.0.0'
+    peerDependenciesMeta:
+      '@playwright/test':
+        optional: true
+
   '@next/swc-darwin-arm64@16.3.0-preview.6':
     resolution: {integrity: sha512-cQB2whnW1PD/Q+AxoI2X4LU3af1B+aFxWx+kmAiCCKDyjoO5Nh+9GyNu+nDAbP/WoloohbOWgO8m1U9j1EIZuw==}
     engines: {node: '>= 10'}
@@ -1303,6 +1317,11 @@ packages:
     peerDependencies:
       react: '>= 16.8'
       react-dom: '>= 16.8'
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rolldown/binding-android-arm64@1.1.5':
     resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
@@ -2414,6 +2433,11 @@ packages:
     resolution: {integrity: sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3335,6 +3359,16 @@ packages:
   pkg-up@3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-selector-parser@7.1.4:
     resolution: {integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==}
@@ -4536,12 +4570,12 @@ snapshots:
       - react
       - react-dom
 
-  '@clerk/nextjs@7.5.19(next@16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@clerk/nextjs@7.5.19(next@16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@clerk/backend': 3.11.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@clerk/react': 6.12.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@clerk/shared': 4.25.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      next: 16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       server-only: 0.0.1
@@ -5081,6 +5115,10 @@ snapshots:
 
   '@next/env@16.3.0-preview.6': {}
 
+  '@next/playwright@16.3.0-preview.6(@playwright/test@1.61.1)':
+    optionalDependencies:
+      '@playwright/test': 1.61.1
+
   '@next/swc-darwin-arm64@16.3.0-preview.6':
     optional: true
 
@@ -5125,6 +5163,10 @@ snapshots:
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
 
   '@rolldown/binding-android-arm64@1.1.5':
     optional: true
@@ -5448,9 +5490,9 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@2.0.1(next@16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@vercel/analytics@2.0.1(next@16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     optionalDependencies:
-      next: 16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
 
   '@vercel/cli-config@0.2.0':
@@ -6142,6 +6184,9 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6149,9 +6194,9 @@ snapshots:
 
   fuzzysort@3.1.0: {}
 
-  geist@1.7.2(next@16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)):
+  geist@1.7.2(next@16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)):
     dependencies:
-      next: 16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   gensync@1.0.0-beta.2: {}
 
@@ -7088,7 +7133,7 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  next@16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.3.0-preview.6
       '@swc/helpers': 0.5.15
@@ -7108,6 +7153,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.3.0-preview.6
       '@next/swc-win32-x64-msvc': 16.3.0-preview.6
       '@opentelemetry/api': 1.9.1
+      '@playwright/test': 1.61.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -7294,6 +7340,14 @@ snapshots:
   pkg-up@3.1.0:
     dependencies:
       find-up: 3.0.0
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-selector-parser@7.1.4:
     dependencies:

--- a/scripts/deployment-workflows.test.mjs
+++ b/scripts/deployment-workflows.test.mjs
@@ -65,10 +65,28 @@ test('feature pushes branch from Staging, migrate, then deploy Preview', async (
   assert.equal(comment.env.GIT_BRANCH, '${{ github.ref_name }}')
   assert.equal(comment.env.COMMIT_SHA, '${{ github.sha }}')
   assert.match(comment.run, /comment-preview-deployment\.mjs/)
+  const browserCheck = job.steps.find(
+    (step) => step.name === 'Verify Preview in browser',
+  )
+  assert.equal(
+    browserCheck.env.PLAYWRIGHT_BASE_URL,
+    '${{ steps.deployment.outputs.deployment-url }}',
+  )
+  assert.match(browserCheck.run, /pnpm test:browser:hosted/)
   assertOrdered(
     job.steps,
     'Deploy Preview',
     'Comment Preview URL on pull request',
+  )
+  assertOrdered(
+    job.steps,
+    'Comment Preview URL on pull request',
+    'Verify Preview in browser',
+  )
+  assertOrdered(
+    job.steps,
+    'Install Playwright Chromium',
+    'Verify Preview in browser',
   )
 })
 
@@ -80,9 +98,24 @@ test('dev continuously migrates and deploys the persistent Staging environment',
   assert.equal(job.environment, 'staging')
   assert.equal(job.if, "github.ref == 'refs/heads/dev'")
   const deploy = job.steps.find((step) => step.name === 'Deploy Staging')
+  assert.equal(deploy.id, 'deployment')
   assert.equal(deploy.uses, './.github/actions/deploy-neon-vercel')
   assert.equal(deploy.with['branch-name'], 'staging')
   assert.equal(deploy.with.target, 'staging')
+  const browserCheck = job.steps.find(
+    (step) => step.name === 'Verify Staging in browser',
+  )
+  assert.equal(
+    browserCheck.env.PLAYWRIGHT_BASE_URL,
+    '${{ steps.deployment.outputs.deployment-url }}',
+  )
+  assert.match(browserCheck.run, /pnpm test:browser:hosted/)
+  assertOrdered(job.steps, 'Deploy Staging', 'Verify Staging in browser')
+  assertOrdered(
+    job.steps,
+    'Install Playwright Chromium',
+    'Verify Staging in browser',
+  )
 })
 
 test('main uses protected Production credentials and deploys only after migration', async () => {
@@ -144,6 +177,11 @@ test('release pull requests reject unsafe migrations before merging to main', as
   assert.match(check.run, /check-production-migrations\.mjs/)
   assert.equal(check.env.BASE_SHA, '${{ github.event.pull_request.base.sha }}')
   assert.equal(check.env.HEAD_SHA, '${{ github.event.pull_request.head.sha }}')
+  const browserCheck = job.steps.find(
+    (step) => step.name === 'Test browser release gate',
+  )
+  assert.match(browserCheck.run, /pnpm test:browser/)
+  assertOrdered(job.steps, 'Build', 'Test browser release gate')
 })
 
 test('branch deletion cleans only ephemeral Neon and Vercel Previews', async () => {

--- a/tests/browser/admin-boundary.spec.ts
+++ b/tests/browser/admin-boundary.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@playwright/test'
+
+import { prepareBrowserPage, watchBrowserErrors } from './support'
+
+for (const publicPath of ['/', '/en']) {
+  test(`@hosted ${publicPath} loads Insights without loading Clerk`, async ({ page }) => {
+    await prepareBrowserPage(page)
+    const browserErrors = watchBrowserErrors(page)
+    await page.goto(publicPath)
+
+    await expect(page.locator('script[src="/_vercel/insights/script.js"]')).toHaveCount(1)
+    await expect(page.locator('script[src*="clerk"]')).toHaveCount(0)
+    expect(browserErrors).toEqual([])
+  })
+}
+
+test('@hosted signed-out admin navigation stops at the authentication boundary', async ({
+  request,
+}) => {
+  const response = await request.get('/admin', { maxRedirects: 0 })
+  const headers = response.headers()
+  const responseBody = await response.text()
+
+  expect(headers['x-clerk-auth-status']).toBe('signed-out')
+  expect(responseBody).not.toContain('/_vercel/insights/script.js')
+
+  if (response.status() === 404) {
+    expect(headers['x-clerk-auth-reason']).toBe('protect-rewrite, dev-browser-missing')
+    return
+  }
+
+  expect([302, 307]).toContain(response.status())
+  const location = new URL(headers.location)
+  expect(location.origin).toBe('https://accounts.cali.so')
+  expect(location.pathname).toBe('/sign-in')
+  expect(new URL(location.searchParams.get('redirect_url')!).pathname).toBe('/admin')
+})

--- a/tests/browser/admin-boundary.spec.ts
+++ b/tests/browser/admin-boundary.spec.ts
@@ -8,7 +8,11 @@ for (const publicPath of ['/', '/en']) {
     const browserErrors = watchBrowserErrors(page)
     await page.goto(publicPath)
 
-    await expect(page.locator('script[src="/_vercel/insights/script.js"]')).toHaveCount(1)
+    const insightsScript = page.locator('script[data-sdkn="@vercel/analytics/next"]')
+    await expect(insightsScript).toHaveCount(1)
+    const insightsUrl = new URL((await insightsScript.getAttribute('src'))!, page.url())
+    expect(insightsUrl.origin).toBe(new URL(page.url()).origin)
+    expect(insightsUrl.pathname).toMatch(/\/script\.js$/)
     await expect(page.locator('script[src*="clerk"]')).toHaveCount(0)
     expect(browserErrors).toEqual([])
   })

--- a/tests/browser/discovery.spec.ts
+++ b/tests/browser/discovery.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test'
+
+import { prepareBrowserPage, watchBrowserErrors } from './support'
+
+const metadataCases = [
+  {
+    locale: 'Chinese',
+    path: '/projects',
+    canonical: 'https://cali.so/projects',
+    openGraphLocale: 'zh_CN',
+    socialLocale: 'zh',
+  },
+  {
+    locale: 'English',
+    path: '/en/projects',
+    canonical: 'https://cali.so/en/projects',
+    openGraphLocale: 'en_US',
+    socialLocale: 'en',
+  },
+]
+
+for (const metadata of metadataCases) {
+  test(`@hosted ${metadata.locale} metadata keeps its canonical locale contract`, async ({
+    page,
+  }) => {
+    await prepareBrowserPage(page)
+    const browserErrors = watchBrowserErrors(page)
+    await page.goto(metadata.path)
+
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+      'href',
+      metadata.canonical,
+    )
+    await expect(page.locator('link[rel="alternate"][hreflang="zh-CN"]')).toHaveAttribute(
+      'href',
+      'https://cali.so/projects',
+    )
+    await expect(page.locator('link[rel="alternate"][hreflang="en"]')).toHaveAttribute(
+      'href',
+      'https://cali.so/en/projects',
+    )
+    await expect(page.locator('meta[property="og:locale"]')).toHaveAttribute(
+      'content',
+      metadata.openGraphLocale,
+    )
+
+    const socialImage = await page
+      .locator('meta[property="og:image"]')
+      .getAttribute('content')
+    expect(socialImage).not.toBeNull()
+    const socialImageUrl = new URL(socialImage!)
+    expect(socialImageUrl.origin).toBe('https://cali.so')
+    expect(socialImageUrl.pathname).toBe('/og')
+    expect(socialImageUrl.searchParams.get('locale')).toBe(metadata.socialLocale)
+    expect(socialImageUrl.searchParams.get('path')).toBe('/projects')
+    expect(browserErrors).toEqual([])
+  })
+}
+
+test('@hosted feeds and localized social images return their public media contracts', async ({
+  request,
+}) => {
+  const chineseFeed = await request.get('/feed.xml')
+  const englishFeed = await request.get('/feed.en.xml')
+  const socialImage = await request.get('/og?locale=en&path=%2Fprojects')
+
+  expect(chineseFeed.status()).toBe(200)
+  expect(chineseFeed.headers()['content-type']).toContain('xml')
+  expect(await chineseFeed.text()).toContain('https://cali.so/blog/')
+
+  expect(englishFeed.status()).toBe(200)
+  expect(englishFeed.headers()['content-type']).toContain('xml')
+  expect(await englishFeed.text()).toContain('https://cali.so/en/blog/')
+
+  expect(socialImage.status()).toBe(200)
+  expect(socialImage.headers()['content-type']).toContain('image/png')
+  expect((await socialImage.body()).byteLength).toBeGreaterThan(10_000)
+})

--- a/tests/browser/interactions.spec.ts
+++ b/tests/browser/interactions.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from '@playwright/test'
+
+import { prepareBrowserPage, watchBrowserErrors } from './support'
+
+async function runningAnimationCount(pageOrLocator: {
+  evaluate<Result>(callback: () => Result): Promise<Result>
+}) {
+  return pageOrLocator.evaluate(
+    () => document.getAnimations().filter((animation) => animation.playState === 'running').length,
+  )
+}
+
+test('keyboard preview cards open without card or contribution-cell motion', async ({ page }) => {
+  await prepareBrowserPage(page)
+  const browserErrors = watchBrowserErrors(page)
+  await page.goto('/en')
+  await expect(page.getByRole('button', { name: 'Preferences' })).toBeEnabled()
+
+  const trigger = page.locator('main a[href="https://github.com/CaliCastle"]:visible')
+  await expect(trigger).toHaveCount(1)
+  await trigger.focus()
+
+  const card = page.locator('.link-card')
+  await expect(card).toBeVisible()
+  await expect(card).toHaveClass(/preview-card-instant/)
+  await expect(card.locator('.contrib-grid i')).toHaveCount(182)
+  expect(
+    await card.evaluate(
+      (element) =>
+        element
+          .getAnimations({ subtree: true })
+          .filter((animation) => animation.playState === 'running').length,
+    ),
+  ).toBe(0)
+  expect(browserErrors).toEqual([])
+})
+
+test('keyboard lightbox opens and closes immediately with focus restoration', async ({
+  page,
+}) => {
+  await prepareBrowserPage(page)
+  const browserErrors = watchBrowserErrors(page)
+  await page.goto('/en/blog/how-to-protect-your-site-with-upstash')
+  await expect(page.getByRole('button', { name: 'Preferences' })).toBeEnabled()
+
+  const trigger = page.locator('.zoom-trigger:visible').first()
+  await expect(trigger).toBeVisible()
+  await trigger.focus()
+  await trigger.press('Enter')
+
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toBeVisible()
+  await expect(dialog).toHaveAttribute('data-state', 'open')
+  expect(
+    await dialog.evaluate(
+      (element) =>
+        element
+          .getAnimations({ subtree: true })
+          .filter((animation) => animation.playState === 'running').length,
+    ),
+  ).toBe(0)
+
+  await page.keyboard.press('Escape')
+  await expect(dialog).toBeHidden()
+  await expect(trigger).toBeFocused()
+  expect(browserErrors).toEqual([])
+})
+
+test('keyboard article-map toggles settle without transition motion', async ({ page }) => {
+  await prepareBrowserPage(page)
+  const browserErrors = watchBrowserErrors(page)
+  await page.goto('/en/blog/how-to-protect-your-site-with-upstash')
+  await expect(page.getByRole('button', { name: 'Preferences' })).toBeEnabled()
+
+  const root = page.locator('.post-minimap-root')
+  const closeToggle = page.getByRole('button', { name: 'Close article map' })
+  await expect(closeToggle).toBeVisible()
+  await expect.poll(() => runningAnimationCount(page)).toBe(0)
+  await closeToggle.focus()
+  await closeToggle.press('Enter')
+
+  await expect(root).not.toHaveAttribute('data-open', '')
+  await expect(root).toHaveAttribute('data-toggle-motion', 'instant')
+  await expect.poll(() => runningAnimationCount(page)).toBe(0)
+
+  const openToggle = page.getByRole('button', { name: 'Open article map' })
+  await openToggle.press('Enter')
+  await expect(root).toHaveAttribute('data-open', 'true')
+  await expect(page.getByRole('navigation', { name: 'Article map' })).toBeVisible()
+  await expect.poll(() => runningAnimationCount(page)).toBe(0)
+  expect(browserErrors).toEqual([])
+})
+
+test('reduced motion leaves the public shell with no running web animations', async ({
+  page,
+}) => {
+  await prepareBrowserPage(page)
+  const browserErrors = watchBrowserErrors(page)
+  await page.emulateMedia({ reducedMotion: 'reduce' })
+  await page.goto('/en')
+  await expect(page.getByRole('button', { name: 'Preferences' })).toBeEnabled()
+
+  await expect.poll(() => runningAnimationCount(page)).toBe(0)
+  expect(browserErrors).toEqual([])
+})

--- a/tests/browser/interactions.spec.ts
+++ b/tests/browser/interactions.spec.ts
@@ -1,6 +1,10 @@
 import { expect, test } from '@playwright/test'
 
-import { prepareBrowserPage, watchBrowserErrors } from './support'
+import {
+  gotoBrowserArticleFixture,
+  prepareBrowserPage,
+  watchBrowserErrors,
+} from './support'
 
 async function runningAnimationCount(pageOrLocator: {
   evaluate<Result>(callback: () => Result): Promise<Result>
@@ -40,7 +44,7 @@ test('keyboard lightbox opens and closes immediately with focus restoration', as
 }) => {
   await prepareBrowserPage(page)
   const browserErrors = watchBrowserErrors(page)
-  await page.goto('/en/blog/how-to-protect-your-site-with-upstash')
+  await gotoBrowserArticleFixture(page)
   await expect(page.getByRole('button', { name: 'Preferences' })).toBeEnabled()
 
   const trigger = page.locator('.zoom-trigger:visible').first()
@@ -69,7 +73,7 @@ test('keyboard lightbox opens and closes immediately with focus restoration', as
 test('keyboard article-map toggles settle without transition motion', async ({ page }) => {
   await prepareBrowserPage(page)
   const browserErrors = watchBrowserErrors(page)
-  await page.goto('/en/blog/how-to-protect-your-site-with-upstash')
+  await gotoBrowserArticleFixture(page)
   await expect(page.getByRole('button', { name: 'Preferences' })).toBeEnabled()
 
   const root = page.locator('.post-minimap-root')

--- a/tests/browser/navigation.spec.ts
+++ b/tests/browser/navigation.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from '@playwright/test'
+import { instant } from '@next/playwright'
+
+import { prepareBrowserPage, watchBrowserErrors } from './support'
+
+test('@hosted prefetched dock navigation renders instantly and preserves history', async ({
+  page,
+}) => {
+  await prepareBrowserPage(page)
+  const browserErrors = watchBrowserErrors(page)
+  const projectsPrefetch = page.waitForResponse((response) => {
+    const headers = response.request().headers()
+
+    return (
+      new URL(response.url()).pathname === '/en/projects' &&
+      (headers['next-router-prefetch'] === '1' ||
+        headers['next-router-segment-prefetch'] !== undefined)
+    )
+  })
+  await page.goto('/en/blog')
+  await expect(page.getByRole('heading', { level: 1, name: 'Writing' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Preferences' })).toBeEnabled()
+  await projectsPrefetch
+
+  const historyLength = await page.evaluate(() => window.history.length)
+  await page.evaluate(() => {
+    ;(window as Window & { __browserReleaseMarker?: string }).__browserReleaseMarker =
+      'mounted'
+  })
+
+  await instant(page, async () => {
+    await page.getByRole('link', { name: 'Projects, G then J' }).click()
+
+    await expect(page).toHaveURL(/\/en\/projects$/)
+    await expect(page.getByRole('heading', { level: 1, name: 'Projects' })).toBeVisible()
+    await expect(page.locator('main [data-list-stage-row]')).not.toHaveCount(0)
+    expect(
+      await page.evaluate(
+        () => (window as Window & { __browserReleaseMarker?: string }).__browserReleaseMarker,
+      ),
+    ).toBe('mounted')
+    expect(await page.evaluate(() => window.history.length)).toBe(historyLength + 1)
+  })
+
+  await expect(page.locator('main a[target="_blank"]')).not.toHaveCount(0)
+  await page.goBack()
+  await expect(page).toHaveURL(/\/en\/blog$/)
+  await expect(page.getByRole('heading', { level: 1, name: 'Writing' })).toBeVisible()
+  expect(
+    await page.evaluate(
+      () => (window as Window & { __browserReleaseMarker?: string }).__browserReleaseMarker,
+    ),
+  ).toBe('mounted')
+  expect(await page.evaluate(() => window.history.length)).toBe(historyLength + 1)
+  expect(browserErrors).toEqual([])
+})
+
+test('Preferences applies theme from the keyboard and restores trigger focus', async ({
+  page,
+}) => {
+  await prepareBrowserPage(page)
+  const browserErrors = watchBrowserErrors(page)
+  await page.goto('/en')
+
+  const trigger = page.getByRole('button', { name: 'Preferences' })
+  await expect(trigger).toBeEnabled()
+  await trigger.focus()
+  await trigger.press('Enter')
+
+  const panel = page.getByRole('dialog', { name: 'Preferences' })
+  await expect(panel).toBeVisible()
+  await panel
+    .getByRole('tablist', { name: 'Theme' })
+    .getByRole('tab', { name: 'Dark' })
+    .click()
+
+  await expect(page.locator('html')).toHaveClass(/dark/)
+  expect(await page.evaluate(() => localStorage.getItem('theme'))).toBe('dark')
+
+  await page.keyboard.press('Escape')
+  await expect(panel).toBeHidden()
+  await expect(trigger).toBeFocused()
+  expect(browserErrors).toEqual([])
+})
+
+test('Preferences keeps the current route when switching languages', async ({ page }) => {
+  await prepareBrowserPage(page)
+  const browserErrors = watchBrowserErrors(page)
+  await page.goto('/projects')
+
+  const trigger = page.getByRole('button', { name: '偏好设置' })
+  await expect(trigger).toBeEnabled()
+  await trigger.click()
+
+  const panel = page.getByRole('dialog', { name: '偏好设置' })
+  await panel
+    .getByRole('tablist', { name: '语言' })
+    .getByRole('tab', { name: 'English' })
+    .click()
+
+  await expect(page).toHaveURL(/\/en\/projects$/)
+  await expect(page.locator('html')).toHaveAttribute('lang', 'en')
+  await expect(page.getByRole('heading', { level: 1, name: 'Projects' })).toBeVisible()
+  expect(browserErrors).toEqual([])
+})

--- a/tests/browser/public-smoke.spec.ts
+++ b/tests/browser/public-smoke.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from '@playwright/test'
+
+import {
+  expectHealthyPublicDocument,
+  prepareBrowserPage,
+  watchBrowserErrors,
+} from './support'
+
+const profiles = [
+  {
+    name: 'Chinese home on light desktop',
+    path: '/',
+    lang: 'zh-CN' as const,
+    viewport: { width: 1440, height: 900 },
+    colorScheme: 'light' as const,
+    reducedMotion: 'no-preference' as const,
+  },
+  {
+    name: 'English projects on dark desktop',
+    path: '/en/projects',
+    lang: 'en' as const,
+    viewport: { width: 1440, height: 900 },
+    colorScheme: 'dark' as const,
+    reducedMotion: 'no-preference' as const,
+  },
+  {
+    name: 'Chinese writing on mobile',
+    path: '/blog',
+    lang: 'zh-CN' as const,
+    viewport: { width: 390, height: 844 },
+    colorScheme: 'light' as const,
+    reducedMotion: 'no-preference' as const,
+  },
+  {
+    name: 'English photos on reduced-motion mobile',
+    path: '/en/photos',
+    lang: 'en' as const,
+    viewport: { width: 390, height: 844 },
+    colorScheme: 'dark' as const,
+    reducedMotion: 'reduce' as const,
+  },
+  {
+    name: 'Chinese AMA on desktop',
+    path: '/ama',
+    lang: 'zh-CN' as const,
+    viewport: { width: 1440, height: 900 },
+    colorScheme: 'light' as const,
+    reducedMotion: 'no-preference' as const,
+  },
+  {
+    name: 'English article on desktop',
+    path: '/en/blog/how-to-protect-your-site-with-upstash',
+    lang: 'en' as const,
+    viewport: { width: 1440, height: 900 },
+    colorScheme: 'light' as const,
+    reducedMotion: 'no-preference' as const,
+  },
+]
+
+for (const profile of profiles) {
+  test(`@smoke @hosted ${profile.name} renders as a healthy public document`, async ({
+    page,
+  }) => {
+    await prepareBrowserPage(page)
+    const browserErrors = watchBrowserErrors(page)
+    await page.setViewportSize(profile.viewport)
+    await page.emulateMedia({
+      colorScheme: profile.colorScheme,
+      reducedMotion: profile.reducedMotion,
+    })
+
+    await expectHealthyPublicDocument(page, profile.path, profile.lang)
+
+    await expect(page).toHaveTitle(/Cali/)
+    expect(browserErrors).toEqual([])
+  })
+}

--- a/tests/browser/public-smoke.spec.ts
+++ b/tests/browser/public-smoke.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test'
 
 import {
+  browserArticleFixture,
   expectHealthyPublicDocument,
   prepareBrowserPage,
   watchBrowserErrors,
@@ -49,7 +50,7 @@ const profiles = [
   },
   {
     name: 'English article on desktop',
-    path: '/en/blog/how-to-protect-your-site-with-upstash',
+    path: browserArticleFixture.path,
     lang: 'en' as const,
     viewport: { width: 1440, height: 900 },
     colorScheme: 'light' as const,

--- a/tests/browser/support.ts
+++ b/tests/browser/support.ts
@@ -1,0 +1,40 @@
+import { expect, type Page } from '@playwright/test'
+
+export async function prepareBrowserPage(page: Page) {
+  if (process.env.PLAYWRIGHT_BASE_URL) return
+
+  // Vercel serves this first-party endpoint only on hosted deployments.
+  // Keep local production-build checks focused on application errors while
+  // the hosted smoke suite verifies the real Insights script.
+  await page.route('**/_vercel/insights/script.js', (route) =>
+    route.fulfill({ body: '', contentType: 'application/javascript' }),
+  )
+}
+
+export function watchBrowserErrors(page: Page) {
+  const errors: string[] = []
+  page.on('console', (message) => {
+    if (message.type() === 'error') errors.push(message.text())
+  })
+  page.on('pageerror', (error) => errors.push(error.message))
+  return errors
+}
+
+export async function expectHealthyPublicDocument(
+  page: Page,
+  path: string,
+  lang: 'en' | 'zh-CN',
+) {
+  const response = await page.goto(path)
+
+  expect(response?.status()).toBe(200)
+  await expect(page.locator('html')).toHaveAttribute('lang', lang)
+  await expect(page.locator('main h1')).toBeVisible()
+  await expect(page.locator('nav.dock button:not([disabled])')).toHaveCount(1)
+  await expect(page.locator('nextjs-portal')).toHaveCount(0)
+  expect(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+    ),
+  ).toBe(true)
+}

--- a/tests/browser/support.ts
+++ b/tests/browser/support.ts
@@ -1,5 +1,10 @@
 import { expect, type Page } from '@playwright/test'
 
+export const browserArticleFixture = {
+  description: 'English article with a zoomable image and article map',
+  path: '/en/blog/how-to-protect-your-site-with-upstash',
+} as const
+
 export async function prepareBrowserPage(page: Page) {
   if (process.env.PLAYWRIGHT_BASE_URL) return
 
@@ -19,7 +24,7 @@ export function watchBrowserErrors(page: Page) {
     const text = message.text()
     const isBlockedVercelFeedbackToolbar =
       Boolean(process.env.PLAYWRIGHT_BASE_URL) &&
-      text.includes('https://vercel.live/_next-live/feedback/feedback.js') &&
+      text.includes('vercel.live') &&
       text.includes('Content Security Policy')
 
     // Vercel injects its Preview feedback toolbar outside the application.
@@ -31,6 +36,16 @@ export function watchBrowserErrors(page: Page) {
   return errors
 }
 
+export async function gotoBrowserArticleFixture(page: Page) {
+  const response = await page.goto(browserArticleFixture.path)
+
+  expect(
+    response?.status(),
+    `Browser fixture is missing: ${browserArticleFixture.description} at ${browserArticleFixture.path}`,
+  ).toBe(200)
+  await expect(page.locator('article h1')).toBeVisible()
+}
+
 export async function expectHealthyPublicDocument(
   page: Page,
   path: string,
@@ -38,7 +53,7 @@ export async function expectHealthyPublicDocument(
 ) {
   const response = await page.goto(path)
 
-  expect(response?.status()).toBe(200)
+  expect(response?.status(), `Browser test route must return 200: ${path}`).toBe(200)
   await expect(page.locator('html')).toHaveAttribute('lang', lang)
   await expect(page.locator('main h1')).toBeVisible()
   await expect(page.locator('nav.dock button:not([disabled])')).toHaveCount(1)

--- a/tests/browser/support.ts
+++ b/tests/browser/support.ts
@@ -14,7 +14,18 @@ export async function prepareBrowserPage(page: Page) {
 export function watchBrowserErrors(page: Page) {
   const errors: string[] = []
   page.on('console', (message) => {
-    if (message.type() === 'error') errors.push(message.text())
+    if (message.type() !== 'error') return
+
+    const text = message.text()
+    const isBlockedVercelFeedbackToolbar =
+      Boolean(process.env.PLAYWRIGHT_BASE_URL) &&
+      text.includes('https://vercel.live/_next-live/feedback/feedback.js') &&
+      text.includes('Content Security Policy')
+
+    // Vercel injects its Preview feedback toolbar outside the application.
+    // The site's strict first-party CSP intentionally blocks that external
+    // script, so this exact platform warning is not an application failure.
+    if (!isBlockedVercelFeedbackToolbar) errors.push(text)
   })
   page.on('pageerror', (error) => errors.push(error.message))
   return errors


### PR DESCRIPTION
Advances [#107](https://github.com/CaliCastle/cali.so/issues/107).

## What changed

- Added a pinned Playwright release gate with 19 Chromium behavior cases and six focused WebKit smoke executions.
- Wired the complete production-build suite into Quality and the 13-case read-only hosted subset into Feature Preview and Staging.
- Covered both locales, responsive and appearance profiles, reduced motion, navigation and history, metadata, feeds, social images, focus behavior, motion boundaries, public Analytics inclusion, and signed-out admin exclusion.
- Retained screenshots, video, and traces only when a browser test fails.
- Updated the handoff and cutover report with the exact passing Feature Preview evidence.

## Why

Issue #107 requires automated browser proof and validation against the exact deployment URL. The previous readiness evidence was primarily manual, so regressions in navigation, motion, discovery, Analytics, or the admin boundary could reach a deployment before being caught.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm build` (72 generated pages)
- `pnpm typecheck`
- `pnpm test:unit` (1,068 tests)
- `pnpm test:deployment` (25 tests)
- `pnpm test:browser` (25 executions)
- Feature Preview hosted suite: [13 passed](https://github.com/CaliCastle/cali.so/actions/runs/29671946254)
- Standards and Spec review: no remaining findings for this change

## Remaining release work

This PR does not mark #107 READY or change Production. Analytics dashboard ingestion, signed-in owner and database-grant proof, refreshed complete-diff reviews, Production provisioning, and rollback evidence remain tracked in the cutover report.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes the automated browser-testing gap from issue #107 by introducing a Playwright release gate (pinned at v1.61.1) with 19 Chromium behavioral tests and six WebKit smoke executions, wired into the Quality, Feature Preview, and Staging deployment workflows.

- **New browser test suites** cover both locales, responsive and appearance profiles, reduced motion, Instant Navigation with history preservation, keyboard focus behavior, Analytics inclusion/exclusion, and the signed-out admin boundary.
- **Workflow integration**: Preview and Staging run the 13-case `@hosted` subset against the exact deployment URL via `PLAYWRIGHT_BASE_URL`; Security/Quality runs the full local production-build suite after `pnpm build`.
- **Artifacts** (screenshots, video, traces) are retained only on failure; workflow structure is validated by updated `deployment-workflows.test.mjs` assertions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change adds test infrastructure and CI wiring with no modifications to application code.

All changed files are test specs, Playwright configuration, CI workflow additions, and documentation updates. Application source is untouched. Workflows are correctly wired and new workflow-structure tests verify ordering. The one nit is a hardcoded grid-cell count that could cause a misleading failure if the contribution data width changes, but does not affect correctness today.

tests/browser/interactions.spec.ts — the .contrib-grid i count assertion on line 30 is worth a second look if the GitHub contribution grid data is not a fixed-width constant.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| playwright.config.ts | New Playwright config with dual-mode setup (local webServer vs hosted URL), pinned browsers, CI-tuned retries and workers, and failure-only artifact retention. |
| tests/browser/support.ts | Shared helpers for route stubbing, browser-error collection, and document health checks. CSP exclusion is topic-based rather than URL-exact. |
| tests/browser/navigation.spec.ts | Covers prefetch-before-navigation, Instant Navigation via @next/playwright instant(), history-length invariants, theme persistence, and language-switch routing. All patterns correct. |
| tests/browser/interactions.spec.ts | Motion-boundary tests for keyboard preview card, lightbox, and article-map. Hardcoded .contrib-grid i count of 182 is a brittleness risk if the grid dataset width changes. |
| tests/browser/admin-boundary.spec.ts | Verifies Analytics inclusion on public paths, Clerk JS absence on public paths, and signed-out admin redirect/404 boundary. Handles both production and development Clerk behaviors. |
| tests/browser/discovery.spec.ts | Checks canonical/alternate/OG metadata per locale and validates feed and OG image endpoints. |
| tests/browser/public-smoke.spec.ts | Six profiles (both locales, desktop/mobile, light/dark, reduced-motion) exercised against expectHealthyPublicDocument. |
| .github/workflows/deploy-preview.yml | Appends Playwright Chromium install and hosted browser gate. The Deploy Preview step already carried id: deployment before this PR. |
| .github/workflows/deploy-staging.yml | Adds id: deployment to Deploy Staging and appends hosted browser gate. deploy-neon-vercel composite action runs pnpm install first. |
| .github/workflows/security.yml | Adds Chromium + WebKit install and pnpm test:browser after the build step, correctly using the local webServer path. |
| scripts/deployment-workflows.test.mjs | Extends workflow-structure tests to assert id: deployment, PLAYWRIGHT_BASE_URL wiring, test:browser:hosted invocation, and step ordering. |
| package.json | Adds test:browser and test:browser:hosted scripts plus pinned @playwright/test@1.61.1 and @next/playwright@16.3.0-preview.6 devDependencies. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Push / PR] --> B{Branch?}
    B -- feature branch --> C[Deploy Preview workflow]
    B -- dev --> D[Deploy Staging workflow]
    B -- PR to main --> E[Security / Quality workflow]
    C --> C1[deploy-neon-vercel\npnpm install + Vercel deploy]
    C1 --> C2[Comment Preview URL]
    C2 --> C3[playwright install chromium]
    C3 --> C4[pnpm test:browser:hosted\n13 cases vs deployment URL]
    D --> D1[deploy-neon-vercel\npnpm install + Vercel deploy]
    D1 --> D2[playwright install chromium]
    D2 --> D3[pnpm test:browser:hosted\n13 cases vs deployment URL]
    E --> E1[pnpm build]
    E1 --> E2[playwright install chromium + webkit]
    E2 --> E3[pnpm test:browser\n19 Chromium + 6 WebKit smoke]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Push / PR] --> B{Branch?}
    B -- feature branch --> C[Deploy Preview workflow]
    B -- dev --> D[Deploy Staging workflow]
    B -- PR to main --> E[Security / Quality workflow]
    C --> C1[deploy-neon-vercel\npnpm install + Vercel deploy]
    C1 --> C2[Comment Preview URL]
    C2 --> C3[playwright install chromium]
    C3 --> C4[pnpm test:browser:hosted\n13 cases vs deployment URL]
    D --> D1[deploy-neon-vercel\npnpm install + Vercel deploy]
    D1 --> D2[playwright install chromium]
    D2 --> D3[pnpm test:browser:hosted\n13 cases vs deployment URL]
    E --> E1[pnpm build]
    E1 --> E2[playwright install chromium + webkit]
    E2 --> E3[pnpm test:browser\n19 Chromium + 6 WebKit smoke]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["test: clarify browser fixtures"](https://github.com/calicastle/cali.so/commit/a8464da45af0b4160e06ceccf7b17c6ed34d2647) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45402778)</sub>

<!-- /greptile_comment -->