### PR TITLE
Fix Staging canonical and feed origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ CLERK_SECRET_KEY=
 ADMIN_EMAIL=
 AMA_ENCRYPTION_KEY=
 RATE_LIMIT_HASH_KEY=
+# Public discovery identity for canonical links, feeds, and social metadata.
+PUBLIC_SITE_URL=https://cali.so
+# Operational origin for links, provider callbacks, and browser mutations.
+# Custom environments use their stable alias, such as https://beta.cali.so.
 SITE_URL=https://cali.so
 CRON_SECRET=
 

--- a/.env.example
+++ b/.env.example
@@ -15,10 +15,11 @@ ADMIN_EMAIL=
 AMA_ENCRYPTION_KEY=
 RATE_LIMIT_HASH_KEY=
 # Public discovery identity for canonical links, feeds, and social metadata.
-PUBLIC_SITE_URL=https://cali.so
+# Replace both origins with your deployment domain.
+PUBLIC_SITE_URL=https://your-domain.com
 # Operational origin for links, provider callbacks, and browser mutations.
 # Custom environments use their stable alias, such as https://beta.cali.so.
-SITE_URL=https://cali.so
+SITE_URL=https://your-domain.com
 CRON_SECRET=
 
 # Google Calendar OAuth (owner availability + meeting invitations)

--- a/docs/ama-booking-operations.md
+++ b/docs/ama-booking-operations.md
@@ -9,8 +9,10 @@ belong in this file, in the repository, or in issue threads.
 
 ## Environment contract
 
-Validation lives in `lib/ama/server-env-schema.ts`; misconfiguration fails at
-startup with field names only. `.env.example` mirrors this table.
+Runtime application validation lives in `lib/ama/server-env-schema.ts`, while
+`PUBLIC_SITE_URL` is validated when `lib/seo.ts` initializes public discovery.
+Misconfiguration fails at startup with field names only. `.env.example`
+mirrors this table.
 
 | Variable | Required when | Purpose |
 | --- | --- | --- |
@@ -18,7 +20,8 @@ startup with field names only. `.env.example` mirrors this table.
 | `ADMIN_EMAIL` | always | Owner data namespace and Google Calendar owner. |
 | `AMA_ENCRYPTION_KEY` | always | 32-byte base64 key: Google refresh-token envelopes and Manage Link token derivation. |
 | `RATE_LIMIT_HASH_KEY` | always | 32-byte base64 key pseudonymizing rate-limit and audit actors, including public booking clients. |
-| `SITE_URL` | Production and custom aliases | Canonical public origin for links, provider return URLs, and same-origin mutation checks. Ordinary Vercel Previews derive it from Vercel's system deployment URL; custom environments such as Staging must set it to their stable alias. |
+| `PUBLIC_SITE_URL` | optional | Public discovery identity for canonical links, feeds, alternates, and social metadata. Production builds default to `https://cali.so`; forks should set their own public origin. |
+| `SITE_URL` | Production and custom aliases | Operational origin for links, provider return URLs, and same-origin mutation checks. Ordinary Vercel Previews derive it from Vercel's system deployment URL; custom environments such as Staging must set it to their stable alias. |
 | `CRON_SECRET` | scheduled work | Bearer secret for `/api/internal/ama/work` (and media reconcile). Vercel injects it for cron invocations. |
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | availability + calendar | OAuth client for free/busy and calendar event writes. Slots and meeting creation are unavailable until configured. |
 | `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` | payments | Checkout Session and refund API access; the webhook secret signs `/api/ama/stripe/webhook` (the webhook, never the return URL, is authoritative for payment). Checkout and webhook routes return 503 until configured. |

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -25,6 +25,11 @@ Current as of July 2026.
 - Chinese keeps every established unprefixed URL. English uses the matching
   `/en` route family. Locale-specific feeds, metadata, and OG images follow the
   route, not browser-local state.
+- `PUBLIC_SITE_URL` owns the public discovery identity used by canonical links,
+  feeds, alternates, and social metadata. `SITE_URL` is the operational origin
+  for application links, provider callbacks, and same-origin mutation checks;
+  Staging therefore keeps `https://beta.cali.so` without leaking that alias into
+  production discovery output.
 - Public pages are static where possible. GitHub and YouTube social values use
   ISR-backed fetches with committed JSON snapshots as outage fallbacks.
 - Vercel Web Analytics is instrumented to collect first-party page views

--- a/docs/v3-cutover-ops-runbook.md
+++ b/docs/v3-cutover-ops-runbook.md
@@ -39,9 +39,11 @@ Neon project.
    must never be stored in the Preview or Staging GitHub environments.
 4. Keep the Vercel custom environment named `staging`. Set `SITE_URL` to its
    stable custom alias (`https://beta.cali.so`) so browser mutation
-   checks match the URL maintainers use. Copy only approved non-production
-   application settings into it; database URLs are supplied per deployment by
-   GitHub Actions.
+   checks match the URL maintainers use. Public discovery uses the independent
+   `PUBLIC_SITE_URL` origin and stays canonical to `https://cali.so`; it must
+   not inherit the Staging alias. Copy only approved non-production application
+   settings into Staging; database URLs are supplied per deployment by GitHub
+   Actions.
 5. Create these GitHub deployment environments:
 
 | Environment | Variables | Secrets | Protection |
@@ -138,6 +140,7 @@ npx vercel env rm DATABASE_URL production $SCOPE
 add DATABASE_URL
 
 # Identity and runtime ownership.
+add PUBLIC_SITE_URL          # https://cali.so
 add SITE_URL                 # https://cali.so
 add ADMIN_EMAIL
 add NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY

--- a/lib/seo.test.ts
+++ b/lib/seo.test.ts
@@ -1,6 +1,10 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('public site origin', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
   afterEach(() => {
     vi.unstubAllEnvs()
     vi.resetModules()
@@ -28,6 +32,13 @@ describe('public site origin', () => {
   it('rejects an insecure non-local public site origin', async () => {
     vi.stubEnv('NODE_ENV', 'production')
     vi.stubEnv('PUBLIC_SITE_URL', 'http://example.com')
+
+    await expect(import('./seo')).rejects.toThrowError(/PUBLIC_SITE_URL/)
+  })
+
+  it('names a malformed public site origin in the startup error', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.stubEnv('PUBLIC_SITE_URL', 'not-a-url')
 
     await expect(import('./seo')).rejects.toThrowError(/PUBLIC_SITE_URL/)
   })

--- a/lib/seo.test.ts
+++ b/lib/seo.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('public site origin', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('keeps Staging discovery canonical to the public site', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.stubEnv('SITE_URL', 'https://beta.cali.so')
+
+    const { seo } = await import('./seo')
+
+    expect(seo.url.href).toBe('https://cali.so/')
+  })
+
+  it('accepts an explicit public site origin independently of the runtime origin', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.stubEnv('PUBLIC_SITE_URL', 'https://example.com')
+    vi.stubEnv('SITE_URL', 'https://staging.example.com')
+
+    const { seo } = await import('./seo')
+
+    expect(seo.url.href).toBe('https://example.com/')
+  })
+
+  it('rejects an insecure non-local public site origin', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.stubEnv('PUBLIC_SITE_URL', 'http://example.com')
+
+    await expect(import('./seo')).rejects.toThrowError(/PUBLIC_SITE_URL/)
+  })
+})

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,12 +1,23 @@
 import { publicPageMetadata } from './public-page-metadata'
 
+function publicSiteUrl() {
+  const url = new URL(
+    process.env.PUBLIC_SITE_URL ??
+      (process.env.NODE_ENV === 'production' ? 'https://cali.so' : 'http://localhost:3199'),
+  )
+  if (
+    url.protocol !== 'https:' &&
+    !['localhost', '127.0.0.1'].includes(url.hostname)
+  ) {
+    throw new Error('PUBLIC_SITE_URL must use HTTPS outside local development')
+  }
+  return url
+}
+
 export const seo = {
   title: publicPageMetadata.home.zh.title,
   description: publicPageMetadata.home.zh.description,
-  url: new URL(
-    process.env.SITE_URL ??
-      (process.env.NODE_ENV === 'production' ? 'https://cali.so' : 'http://localhost:3199'),
-  ),
+  url: publicSiteUrl(),
 } as const
 
 export const seoEn = {

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,10 +1,15 @@
 import { publicPageMetadata } from './public-page-metadata'
 
 function publicSiteUrl() {
-  const url = new URL(
+  const raw =
     process.env.PUBLIC_SITE_URL ??
-      (process.env.NODE_ENV === 'production' ? 'https://cali.so' : 'http://localhost:3199'),
-  )
+    (process.env.NODE_ENV === 'production' ? 'https://cali.so' : 'http://localhost:3199')
+  let url: URL
+  try {
+    url = new URL(raw)
+  } catch {
+    throw new Error('PUBLIC_SITE_URL must be a valid URL')
+  }
   if (
     url.protocol !== 'https:' &&
     !['localhost', '127.0.0.1'].includes(url.hostname)


### PR DESCRIPTION
Supports [#107](https://github.com/CaliCastle/cali.so/issues/107) and unblocks [#195](https://github.com/CaliCastle/cali.so/pull/195).

## Summary

- separate the public discovery origin from the operational application origin
- keep Staging callbacks and browser mutations pinned to https://beta.cali.so
- keep canonical links, language alternates, feeds, and social metadata pinned to https://cali.so
- document the split for production operations and repository forks
- add regression coverage for Staging, explicit fork configuration, malformed values, and insecure origins

## Validation

- pnpm typecheck
- focused SEO, metadata, route, and server-environment tests: 36 passed
- pnpm test:unit: 116 files and 1,075 tests passed
- production build with SITE_URL=https://beta.cali.so and no PUBLIC_SITE_URL override
- pnpm test:browser:hosted against that build: 13 passed
- git diff --check
- Standards review: no findings
- Spec review: no findings
- Greptile review: all findings addressed and threads resolved
