### PR TITLE
refactor(ama): render public AMA page per locale instead of CSS block swap

### DIFF
--- a/app/(en)/en/ama/page.tsx
+++ b/app/(en)/en/ama/page.tsx
@@ -3,5 +3,5 @@ import { amaPageMetadata, AmaPageView } from '../../../_views/ama-page'
 export const metadata = amaPageMetadata('en')
 
 export default function EnglishAmaPage() {
-  return <AmaPageView />
+  return <AmaPageView locale="en" />
 }

--- a/app/(zh)/ama/page.tsx
+++ b/app/(zh)/ama/page.tsx
@@ -3,5 +3,5 @@ import { amaPageMetadata, AmaPageView } from '../../_views/ama-page'
 export const metadata = amaPageMetadata('zh')
 
 export default function ChineseAmaPage() {
-  return <AmaPageView />
+  return <AmaPageView locale="zh" />
 }

--- a/app/_views/ama-page.test.tsx
+++ b/app/_views/ama-page.test.tsx
@@ -23,28 +23,41 @@ afterEach(() => {
 })
 
 describe('AmaPageView', () => {
-  it('presents the AMA Session spec sheet in both languages', () => {
-    const { container } = render(<AmaPageView />)
+  it('presents the Chinese AMA Session spec sheet without English copy', () => {
+    const { container } = render(<AmaPageView locale="zh" />)
 
     expect(screen.getByText('一对一')).toBeTruthy()
-    expect(screen.getByText('AMA')).toBeTruthy()
     expect(screen.getByText(/答案越来越便宜/)).toBeTruthy()
     expect(screen.getByText(/不妨聊聊/)).toBeTruthy()
     expect(container.textContent).not.toContain(
       '这个 AMA，就是留出一小时，把这些事聊清楚。',
     )
-    expect(screen.getByText(/Answers are getting cheaper/)).toBeTruthy()
+    expect(container.textContent).not.toContain('Answers are getting cheaper')
+    expect(container.textContent).not.toContain('60 minutes')
 
     // Price and duration read straight off the spec sheet.
-    expect(screen.getAllByText('US$99').length).toBe(2)
-    expect(screen.getByText('60 minutes')).toBeTruthy()
+    expect(screen.getByText('US$99')).toBeTruthy()
     expect(screen.getByText('60 分钟')).toBeTruthy()
-    expect(container.textContent).toContain('24 hours')
-    expect(container.textContent).toContain('Next 30 days')
+    expect(container.textContent).toContain('24 小时')
+    expect(container.textContent).toContain('未来 30 天')
     expect(
       screen.getByText('付款会跳到 Stripe，银行卡信息不会经过本站。'),
     ).toBeTruthy()
     expect(container.textContent).not.toContain('付款会跳到 Stripe Checkout')
+  })
+
+  it('presents the English AMA Session spec sheet without Chinese copy', () => {
+    const { container } = render(<AmaPageView locale="en" />)
+
+    expect(screen.getByText('AMA')).toBeTruthy()
+    expect(screen.getByText(/Answers are getting cheaper/)).toBeTruthy()
+    expect(container.textContent).not.toContain('答案越来越便宜')
+    expect(container.textContent).not.toContain('60 分钟')
+
+    expect(screen.getByText('US$99')).toBeTruthy()
+    expect(screen.getByText('60 minutes')).toBeTruthy()
+    expect(container.textContent).toContain('24 hours')
+    expect(container.textContent).toContain('Next 30 days')
 
     const introductionStage = container.querySelector(
       '[data-ama-introduction-stage]',
@@ -60,8 +73,8 @@ describe('AmaPageView', () => {
     expect(introductionStage?.contains(nameplate)).toBe(false)
   })
 
-  it('lists all seven topics in both languages', () => {
-    const { container } = render(<AmaPageView />)
+  it('lists all seven topics in each locale', () => {
+    const zh = render(<AmaPageView locale="zh" />)
 
     expect(AMA_TOPICS.length).toBe(7)
 
@@ -77,6 +90,22 @@ describe('AmaPageView', () => {
       expect(screen.getByText(zhLabel)).toBeTruthy()
     }
 
+    expect(zh.container.textContent).toContain('software factory')
+    expect(zh.container.textContent).toContain('OpenClaw')
+    expect(zh.container.textContent).toContain('PM、财务和日常运营')
+    expect(zh.container.textContent).toContain('佐玩不是一人公司')
+    expect(zh.container.textContent).toContain('公司文化里少不了的一部分')
+    for (const tool of ['Linear', 'Codex', 'Claude Code', 'Slack', 'Cursor']) {
+      expect(zh.container.textContent).toContain(tool)
+      expect(
+        zh.container.querySelectorAll(`[data-ama-product-name="${tool}"]`),
+      ).toHaveLength(1)
+    }
+    expect(zh.container.querySelectorAll('.ama-product-logo')).toHaveLength(5)
+
+    cleanup()
+    const en = render(<AmaPageView locale="en" />)
+
     for (const enLabel of [
       'Web, iOS, and full-stack engineering',
       'Product strategy and design',
@@ -89,78 +118,82 @@ describe('AmaPageView', () => {
       expect(screen.getByText(enLabel)).toBeTruthy()
     }
 
-    expect(container.textContent).toContain('software factory')
-    expect(container.textContent).toContain('OpenClaw')
-    expect(container.textContent).toContain('PM、财务和日常运营')
-    expect(container.textContent).toContain('佐玩不是一人公司')
-    expect(container.textContent).toContain('公司文化里少不了的一部分')
-    expect(container.textContent).toContain('self-hosted OpenClaw')
-    expect(container.textContent).toContain('teams at Apple, Insta360')
-    expect(container.textContent).toContain('game studios in Seattle')
-    expect(container.textContent).toContain('Niantic, Microsoft, and Google')
-    expect(container.textContent).toContain('Zolplay isn’t a one-person company')
-    expect(container.textContent).not.toContain('one-person company (OPC)')
-    expect(container.textContent).toContain('essential part of company culture')
+    expect(en.container.textContent).toContain('self-hosted OpenClaw')
+    expect(en.container.textContent).toContain('teams at Apple, Insta360')
+    expect(en.container.textContent).toContain('game studios in Seattle')
+    expect(en.container.textContent).toContain('Niantic, Microsoft, and Google')
+    expect(en.container.textContent).toContain('Zolplay isn’t a one-person company')
+    expect(en.container.textContent).not.toContain('one-person company (OPC)')
+    expect(en.container.textContent).toContain('essential part of company culture')
     for (const tool of ['Linear', 'Codex', 'Claude Code', 'Slack', 'Cursor']) {
-      expect(container.textContent).toContain(tool)
       expect(
-        container.querySelectorAll(`[data-ama-product-name="${tool}"]`),
-      ).toHaveLength(2)
+        en.container.querySelectorAll(`[data-ama-product-name="${tool}"]`),
+      ).toHaveLength(1)
     }
-    expect(container.querySelectorAll('.ama-product-logo')).toHaveLength(10)
+    expect(en.container.querySelectorAll('.ama-product-logo')).toHaveLength(5)
     expect(
-      container.querySelectorAll(
+      en.container.querySelectorAll(
         '[data-ama-product-name="Codex"] img[src="/images/codex.svg"]',
       ),
-    ).toHaveLength(2)
+    ).toHaveLength(1)
   })
 
   it('states the 24 hour policy and carries the testimonials', () => {
-    const { container } = render(<AmaPageView />)
+    const zh = render(<AmaPageView locale="zh" />)
 
-    expect(container.textContent).toContain('If we’re at least 24 hours out')
-    expect(container.textContent).toContain('refunds are no longer automatic')
-    expect(container.textContent).toContain('离开始还有 24 小时以上')
-
+    expect(zh.container.textContent).toContain('离开始还有 24 小时以上')
     expect(
       screen.getByText(/目前我已经拿到了 3 个 offer，选择了一个/),
     ).toBeTruthy()
+    expect(screen.getByText(/公司立刻把我转正/)).toBeTruthy()
+    expect(screen.getByText(/解答了我很多问题/)).toBeTruthy()
+    expect(screen.getByText('一位大学生，2026')).toBeTruthy()
+    expect(zh.container.textContent).not.toContain('一位来访者，2026')
+    expect(zh.container.textContent).not.toContain('这 300')
+    expect(zh.container.textContent).not.toContain('¥300')
+
+    cleanup()
+    const en = render(<AmaPageView locale="en" />)
+
+    expect(en.container.textContent).toContain('If we’re at least 24 hours out')
+    expect(en.container.textContent).toContain('refunds are no longer automatic')
     expect(
       screen.getByText(/I have since received three offers and accepted one/),
     ).toBeTruthy()
-    expect(screen.getByText(/公司立刻把我转正/)).toBeTruthy()
     expect(
       screen.getByText(/skipping the three month probation/),
     ).toBeTruthy()
-    expect(screen.getByText(/解答了我很多问题/)).toBeTruthy()
     expect(screen.getAllByText('An engineer, 2023').length).toBe(2)
-    expect(screen.getByText('一位大学生，2026')).toBeTruthy()
     expect(screen.getByText('A university student, 2026')).toBeTruthy()
-    expect(container.textContent).not.toContain('An AMA guest, 2026')
-    expect(container.textContent).not.toContain('一位来访者，2026')
-    expect(container.textContent).not.toContain('这 300')
-    expect(container.textContent).not.toContain('¥300')
+    expect(en.container.textContent).not.toContain('An AMA guest, 2026')
   })
 
-  it('links both locale CTAs to the booking flow and nothing legacy', () => {
-    const { container } = render(<AmaPageView />)
+  it('links each locale CTA to its booking flow and nothing legacy', () => {
+    const zh = render(<AmaPageView locale="zh" />)
 
     const zhCtas = screen.getAllByRole('link', { name: '约个时间' })
-    const enCtas = screen.getAllByRole('link', { name: 'Book an hour' })
-
     expect(zhCtas).toHaveLength(2)
-    expect(enCtas).toHaveLength(2)
     for (const link of zhCtas) expect(link.getAttribute('href')).toBe('/ama/book')
-    for (const link of enCtas) expect(link.getAttribute('href')).toBe('/en/ama/book')
+    expect(zh.container.textContent).not.toContain('Book an hour')
 
-    const ctaGroups = container.querySelectorAll('.ama-booking-cta')
+    const ctaGroups = zh.container.querySelectorAll('.ama-booking-cta')
     expect(ctaGroups).toHaveLength(2)
     expect(ctaGroups[0]?.nextElementSibling?.getAttribute('aria-labelledby')).toBe(
       'ama-who-heading',
     )
 
-    const html = container.innerHTML.toLowerCase()
+    cleanup()
+    const en = render(<AmaPageView locale="en" />)
+
+    const enCtas = screen.getAllByRole('link', { name: 'Book an hour' })
+    expect(enCtas).toHaveLength(2)
+    for (const link of enCtas) expect(link.getAttribute('href')).toBe('/en/ama/book')
+    expect(en.container.textContent).not.toContain('约个时间')
+
+    const html = en.container.innerHTML.toLowerCase()
     expect(html).not.toContain('alipay')
     expect(html).not.toContain('cal.com')
+    expect(html).not.toContain('data-zh-block')
+    expect(html).not.toContain('data-en-block')
   })
 })

--- a/app/_views/ama-page.tsx
+++ b/app/_views/ama-page.tsx
@@ -7,10 +7,9 @@ import { AmaIntroductionStage } from '~/components/ama/ama-introduction-stage'
 import { Favicon } from '~/components/favicon'
 import { PixelCluster } from '~/components/pixel-cluster'
 import { AMA_TOPICS, type AmaTopic } from '~/lib/ama/booking/topics'
-import { T } from '~/lib/i18n'
 import { faviconUrl } from '~/lib/link-previews'
 import { localeMetadata } from '~/lib/locale-metadata'
-import { localePath, type Locale } from '~/lib/locale-route'
+import { localePath, localize, type Locale } from '~/lib/locale-route'
 import { publicPageMetadata } from '~/lib/public-page-metadata'
 
 export function amaPageMetadata(locale: Locale): Metadata {
@@ -181,30 +180,23 @@ function AmaProductName({ name }: { name: AmaProduct }) {
   )
 }
 
-function AmaBookingCta() {
+function AmaBookingCta({ locale }: { locale: Locale }) {
   return (
-    <>
-      <span data-zh-block>
-        <Link href={localePath('zh', '/ama/book')} className="btn-cta">
-          约个时间
-        </Link>
-      </span>
-      <span data-en-block>
-        <Link href={localePath('en', '/ama/book')} className="btn-cta">
-          Book an hour
-        </Link>
-      </span>
-    </>
+    <Link href={localePath(locale, '/ama/book')} className="btn-cta">
+      {localize(locale, '约个时间', 'Book an hour')}
+    </Link>
   )
 }
 
 function SectionHeading({
   index,
+  locale,
   zh,
   en,
   delay,
 }: {
   index: string
+  locale: Locale
   zh: string
   en: string
   delay: number
@@ -218,46 +210,44 @@ function SectionHeading({
         {index}
       </span>
       <span className="section-tag-hatch" aria-hidden />
-      <span className="section-tag-label">
-        <T zh={zh} en={en} />
-      </span>
+      <span className="section-tag-label">{localize(locale, zh, en)}</span>
     </h2>
   )
 }
 
 /**
  * The public AMA service page: a spec sheet, not a sales page. Everything
- * transactional lives one step away at /ama/book.
+ * transactional lives one step away at /ama/book. The route segment fixes
+ * the locale, so each render carries a single language.
  */
-export function AmaPageView() {
+export function AmaPageView({ locale }: { locale: Locale }) {
   return (
     <div className="mx-auto w-full max-w-[37.5rem] px-6">
       <AmaIntroductionStage>
         <div className="flex items-start justify-between gap-4">
           <header className="max-w-[34rem]">
-            <h1 className="page-eyebrow enter">
-              <T zh="一对一" en="AMA" />
-            </h1>
+            <h1 className="page-eyebrow enter">{localize(locale, '一对一', 'AMA')}</h1>
             <div
               className="page-introduction enter mt-4 text-balance"
               style={{ '--enter-delay': '70ms' } as React.CSSProperties}
             >
-              <div data-zh-block className="flex flex-col gap-3">
-                <p>答案越来越便宜，判断越来越值钱。</p>
-                <p>
-                  这几年，我一直在做产品设计、工程、独立开发、创业和出海。一路下来，我也把自己的工作方式围着
-                  AI 重新搭了一遍。
-                </p>
-                <p>
-                  AI 工具是最简单的一层。真正花时间的，是把经验变成 Prompt、Workflow、Memory 和
-                  Agent。
-                </p>
-                <p>
-                  这样确实能放大一个人的能力。但做什么、不做什么、下一步往哪里走，最后还是得靠判断。
-                </p>
-                <p>如果你也在想这些，不妨聊聊。</p>
-              </div>
-              <div data-en-block>
+              {locale === 'zh' ? (
+                <div className="flex flex-col gap-3">
+                  <p>答案越来越便宜，判断越来越值钱。</p>
+                  <p>
+                    这几年，我一直在做产品设计、工程、独立开发、创业和出海。一路下来，我也把自己的工作方式围着
+                    AI 重新搭了一遍。
+                  </p>
+                  <p>
+                    AI 工具是最简单的一层。真正花时间的，是把经验变成 Prompt、Workflow、Memory 和
+                    Agent。
+                  </p>
+                  <p>
+                    这样确实能放大一个人的能力。但做什么、不做什么、下一步往哪里走，最后还是得靠判断。
+                  </p>
+                  <p>如果你也在想这些，不妨聊聊。</p>
+                </div>
+              ) : (
                 <div className="flex flex-col gap-4">
                   <p>Answers are getting cheaper. Judgment is getting more valuable.</p>
                   <p>
@@ -274,7 +264,7 @@ export function AmaPageView() {
                   </p>
                   <p>If you’re working through questions like that, let’s talk.</p>
                 </div>
-              </div>
+              )}
             </div>
           </header>
           <PixelCluster variant={5} className="enter shrink-0" />
@@ -289,12 +279,8 @@ export function AmaPageView() {
         <dl className="spec-nameplate">
           {SPEC_ROWS.map((row) => (
             <div key={row.enLabel}>
-              <dt>
-                <T zh={row.zhLabel} en={row.enLabel} />
-              </dt>
-              <dd>
-                <T zh={row.zhValue} en={row.enValue} />
-              </dd>
+              <dt>{localize(locale, row.zhLabel, row.enLabel)}</dt>
+              <dd>{localize(locale, row.zhValue, row.enValue)}</dd>
             </div>
           ))}
         </dl>
@@ -304,41 +290,42 @@ export function AmaPageView() {
         className="ama-booking-cta enter mt-6"
         style={{ '--enter-delay': '150ms' } as React.CSSProperties}
       >
-        <AmaBookingCta />
+        <AmaBookingCta locale={locale} />
       </div>
 
       <section className="mt-12" aria-labelledby="ama-who-heading">
         <div id="ama-who-heading">
-          <SectionHeading index="01" zh="关于我" en="About me" delay={170} />
+          <SectionHeading index="01" locale={locale} zh="关于我" en="About me" delay={170} />
         </div>
         <div className="mt-4">
-          <div data-zh-block className="flex flex-col gap-3 page-introduction">
-            <p>
-              我是 Cali，佐玩（Zolplay）的创始人。Web、iOS、工程、产品设计和独立产品都亲手做过。通过佐玩，我也帮
-              Apple、Insta360 和多家 YC 创业公司做过策略、产品设计和产品落地。
-            </p>
-            <p>
-              更早之前，我在西雅图的游戏工作室参与过 Niantic、Microsoft 和 Google 的大型项目。
-            </p>
-            <p>
-              现在，我把产品判断、设计、工程和运营连成了一套 software factory。想法从{' '}
-              <AmaProductName name="Linear" /> 里的 issue 开始，
-              <AmaProductName name="Codex" />、<AmaProductName name="Claude Code" /> 和{' '}
-              <AmaProductName name="Cursor" /> 参与调研、拆 scope、实现和 review，最后回到{' '}
-              <AmaProductName name="Slack" />，跟团队继续推进。
-            </p>
-            <p>
-              我也自己部署了一套 OpenClaw，调度负责 PM、财务和日常运营的
-              agents。很多流程已经可以从头到尾自己跑完。
-            </p>
-            <p>
-              佐玩不是一人公司，但我会借用这套模式里好用的部分：把经验留进系统，把重复工作交给
-              agents，把人的注意力留给判断和品味。
-            </p>
-            <p>我相信，AI Native 最后会变成公司文化里少不了的一部分。</p>
-          </div>
-          <div data-en-block className="page-introduction">
-            <div className="flex flex-col gap-4">
+          {locale === 'zh' ? (
+            <div className="page-introduction flex flex-col gap-3">
+              <p>
+                我是 Cali，佐玩（Zolplay）的创始人。Web、iOS、工程、产品设计和独立产品都亲手做过。通过佐玩，我也帮
+                Apple、Insta360 和多家 YC 创业公司做过策略、产品设计和产品落地。
+              </p>
+              <p>
+                更早之前，我在西雅图的游戏工作室参与过 Niantic、Microsoft 和 Google 的大型项目。
+              </p>
+              <p>
+                现在，我把产品判断、设计、工程和运营连成了一套 software factory。想法从{' '}
+                <AmaProductName name="Linear" /> 里的 issue 开始，
+                <AmaProductName name="Codex" />、<AmaProductName name="Claude Code" /> 和{' '}
+                <AmaProductName name="Cursor" /> 参与调研、拆 scope、实现和 review，最后回到{' '}
+                <AmaProductName name="Slack" />，跟团队继续推进。
+              </p>
+              <p>
+                我也自己部署了一套 OpenClaw，调度负责 PM、财务和日常运营的
+                agents。很多流程已经可以从头到尾自己跑完。
+              </p>
+              <p>
+                佐玩不是一人公司，但我会借用这套模式里好用的部分：把经验留进系统，把重复工作交给
+                agents，把人的注意力留给判断和品味。
+              </p>
+              <p>我相信，AI Native 最后会变成公司文化里少不了的一部分。</p>
+            </div>
+          ) : (
+            <div className="page-introduction flex flex-col gap-4">
               <p>
                 I’m Cali, founder of Zolplay. My work spans web, iOS, engineering, product design,
                 and indie products. Through Zolplay, I’ve helped teams at Apple, Insta360, and
@@ -369,46 +356,43 @@ export function AmaPageView() {
                 I believe an AI-native approach will become an essential part of company culture.
               </p>
             </div>
-          </div>
+          )}
         </div>
       </section>
 
       <section className="mt-12" aria-labelledby="ama-topics-heading">
         <div id="ama-topics-heading">
-          <SectionHeading index="02" zh="聊什么" en="Topics" delay={200} />
+          <SectionHeading index="02" locale={locale} zh="聊什么" en="Topics" delay={200} />
         </div>
-        <div data-zh-block className="page-introduction mt-4 flex flex-col gap-3">
-          <p>不一定非要从 AI 开始。</p>
-          <p>
-            职业、产品、工程和出海，看起来是不同的问题，最后经常都落到同一个判断上：什么值得做，什么可以交给系统，什么还是得自己来。
-          </p>
-        </div>
-        <div data-en-block className="page-introduction mt-4">
-          <div className="flex flex-col gap-3">
-            <p>AI doesn’t have to be the starting point.</p>
-            <p>
-              Careers, products, and engineering can look like separate problems. Often they come
-              down to the same judgment: what’s worth doing, what a system can handle, and what
-              still needs your judgment.
-            </p>
-          </div>
+        <div className="page-introduction mt-4 flex flex-col gap-3">
+          {locale === 'zh' ? (
+            <>
+              <p>不一定非要从 AI 开始。</p>
+              <p>
+                职业、产品、工程和出海，看起来是不同的问题，最后经常都落到同一个判断上：什么值得做，什么可以交给系统，什么还是得自己来。
+              </p>
+            </>
+          ) : (
+            <>
+              <p>AI doesn’t have to be the starting point.</p>
+              <p>
+                Careers, products, and engineering can look like separate problems. Often they come
+                down to the same judgment: what’s worth doing, what a system can handle, and what
+                still needs your judgment.
+              </p>
+            </>
+          )}
         </div>
         <ul className="mt-4 text-sm">
           {AMA_TOPICS.map((topic) => {
             const pageCopy = AMA_TOPIC_PAGE_COPY[topic]
             return (
               <li key={topic} className="hairline-top py-3 first:border-t-0">
-                <span data-zh-block className="block">
-                  <span className="block">{pageCopy.zhLabel}</span>
-                  <span className="mt-1 block text-[13px] leading-5 text-muted-foreground">
-                    {pageCopy.zhDescription}
-                  </span>
+                <span className="block">
+                  {localize(locale, pageCopy.zhLabel, pageCopy.enLabel)}
                 </span>
-                <span data-en-block className="block">
-                  <span className="block">{pageCopy.enLabel}</span>
-                  <span className="mt-1 block text-[13px] leading-5 text-muted-foreground">
-                    {pageCopy.enDescription}
-                  </span>
+                <span className="mt-1 block text-[13px] leading-5 text-muted-foreground">
+                  {localize(locale, pageCopy.zhDescription, pageCopy.enDescription)}
                 </span>
               </li>
             )
@@ -418,7 +402,7 @@ export function AmaPageView() {
 
       <section className="mt-12" aria-labelledby="ama-process-heading">
         <div id="ama-process-heading">
-          <SectionHeading index="03" zh="怎么预约" en="Booking" delay={230} />
+          <SectionHeading index="03" locale={locale} zh="怎么预约" en="Booking" delay={230} />
         </div>
         <ol className="mt-4 flex flex-col gap-3 text-sm">
           {STEPS.map((step, index) => (
@@ -429,9 +413,7 @@ export function AmaPageView() {
               <span aria-hidden className="step-index">
                 {String(index + 1).padStart(2, '0')}
               </span>
-              <span className="text-balance">
-                <T zh={step.zh} en={step.en} />
-              </span>
+              <span className="text-balance">{localize(locale, step.zh, step.en)}</span>
             </li>
           ))}
         </ol>
@@ -439,19 +421,32 @@ export function AmaPageView() {
 
       <section className="mt-12" aria-labelledby="ama-policy-heading">
         <div id="ama-policy-heading">
-          <SectionHeading index="04" zh="改期与退款" en="Rescheduling and refunds" delay={260} />
+          <SectionHeading
+            index="04"
+            locale={locale}
+            zh="改期与退款"
+            en="Rescheduling and refunds"
+            delay={260}
+          />
         </div>
         <p className="page-introduction mt-4">
-          <T
-            zh="离开始还有 24 小时以上，改期和取消都免费；取消后会自动全额退款。不到 24 小时就不再自动退款。"
-            en="If we’re at least 24 hours out, you can reschedule or cancel for free. Cancellations are refunded automatically. Inside 24 hours, refunds are no longer automatic."
-          />
+          {localize(
+            locale,
+            '离开始还有 24 小时以上，改期和取消都免费；取消后会自动全额退款。不到 24 小时就不再自动退款。',
+            'If we’re at least 24 hours out, you can reschedule or cancel for free. Cancellations are refunded automatically. Inside 24 hours, refunds are no longer automatic.',
+          )}
         </p>
       </section>
 
       <section className="mt-12" aria-labelledby="ama-notes-heading">
         <div id="ama-notes-heading">
-          <SectionHeading index="05" zh="聊过的人说" en="What people said" delay={290} />
+          <SectionHeading
+            index="05"
+            locale={locale}
+            zh="聊过的人说"
+            en="What people said"
+            delay={290}
+          />
         </div>
         <div className="mt-4 flex flex-col gap-6">
           {TESTIMONIALS.map((testimonial, index) => (
@@ -462,10 +457,10 @@ export function AmaPageView() {
               className={index === 0 ? '' : 'hairline-top pt-4'}
             >
               <blockquote className="text-sm leading-6">
-                <T zh={`「${testimonial.zh}」`} en={`"${testimonial.en}"`} />
+                {localize(locale, `「${testimonial.zh}」`, `"${testimonial.en}"`)}
               </blockquote>
               <figcaption className="mt-2 text-[13px] text-muted-foreground">
-                <T zh={testimonial.zhAttribution} en={testimonial.enAttribution} />
+                {localize(locale, testimonial.zhAttribution, testimonial.enAttribution)}
               </figcaption>
             </figure>
           ))}
@@ -476,7 +471,7 @@ export function AmaPageView() {
         className="ama-booking-cta enter mt-12 pb-4"
         style={{ '--enter-delay': '320ms' } as React.CSSProperties}
       >
-        <AmaBookingCta />
+        <AmaBookingCta locale={locale} />
       </div>
     </div>
   )

--- a/app/globals.css
+++ b/app/globals.css
@@ -4420,7 +4420,12 @@ a:focus-visible .external-label .external-mark {
   }
 }
 
-/* ── Bilingual chrome (lib/i18n.tsx) — CSS-swapped, no hydration ──── */
+/* ── Bilingual chrome (lib/i18n.tsx) — CSS-swapped, no hydration ────
+   Public routes render a single language per segment, so only the inline
+   [data-zh]/[data-en] pair from <T> appears there. The block variant
+   survives solely for admin, which swaps locale in place (no route
+   change) and needs both DOM branches present — e.g. the dual weekday
+   selects in AvailabilityWindowForm. */
 
 [data-en] {
   display: none;

--- a/lib/locale-client.ts
+++ b/lib/locale-client.ts
@@ -6,6 +6,7 @@ import { useSyncExternalStore } from 'react'
 import { localeFromPathname, type Locale } from '~/lib/locale-route'
 
 export type { Locale } from '~/lib/locale-route'
+export { localize } from '~/lib/locale-route'
 
 export const LOCALE_CHANGE_EVENT = 'cali:locale-change'
 
@@ -30,6 +31,3 @@ export function useLocale(): Locale {
   return localeFromPathname(pathname)
 }
 
-export function localize(locale: Locale, zh: string, en: string) {
-  return locale === 'en' ? en : zh
-}

--- a/lib/locale-route.ts
+++ b/lib/locale-route.ts
@@ -80,3 +80,7 @@ export function localePath(locale: Locale, path: string) {
   const localized = unlocalized === '/' ? ENGLISH_PREFIX : `${ENGLISH_PREFIX}${unlocalized}`
   return `${localized}${suffix}`
 }
+
+export function localize(locale: Locale, zh: string, en: string) {
+  return locale === 'en' ? en : zh
+}


### PR DESCRIPTION
## Why

Language is now separated by route segment (`/ama` is Chinese, `/en/ama` is English), so keeping both languages in the DOM and toggling them with `data-zh-block`/`data-en-block` CSS selectors no longer makes sense on public routes. Each URL was shipping the other language's entire hidden copy.

## What

- `AmaPageView` now takes a `locale` prop and renders a single language directly — no more block-selector pairs or inline `<T>` on this page. The route pages pass `locale` the same way they already call `amaPageMetadata`.
- Moved `localize()` into `lib/locale-route.ts` (server-safe); `lib/locale-client.ts` re-exports it so existing client imports are untouched.
- Flattened the English-only wrapper divs that existed solely to dodge the `[data-en-block] { display: block }` override of `display: flex`.
- **Kept** the block selectors in the admin availability form: admin swaps locale in place (no route change), and both weekday selects must stay in the DOM for the no-JS `weekdayZh`/`weekdayEn`/`weekdayOriginal` reconciliation in `lib/ama/admin/http.ts`. The `globals.css` comment now documents that the block variant is admin-only.

## Verification

- Rewrote `ama-page.test.tsx` to render each locale separately, asserting the other language and any `data-*-block` attribute are absent.
- Full unit suite (1073 tests), localization script tests (148), and `tsc --noEmit` all pass.
- Dev-server check: `/ama` renders only Chinese with CTAs → `/ama/book`; `/en/ama` renders only English with CTAs → `/en/ama/book`; zero block attributes on either page; no console errors.

## Note

Inline `data-zh`/`data-en` from `<T>` still double-renders on public routes at small scale across shared chrome (~40 files). Retiring that is a much larger refactor, deliberately out of scope here.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the public AMA page to render a single locale per route segment instead of shipping both languages in the DOM and toggling visibility via CSS `data-zh-block`/`data-en-block` selectors. `localize()` is moved from `lib/locale-client.ts` (client-only) to `lib/locale-route.ts` (server-safe), with a re-export from the client module so all existing callers are unaffected.

- `AmaPageView` gains a required `locale` prop; both route pages (`/ama` → `zh`, `/en/ama` → `en`) now pass it explicitly, and complex JSX blocks use direct `locale === 'zh' ? … : …` conditionals while simple strings use `localize()`.
- The English-only wrapper `div` that existed solely to prevent `[data-en-block] { display: block }` from overriding `display: flex` is removed now that block selectors are no longer on public routes.
- Tests are rewritten to render each locale separately and assert the other language's content and block attributes are absent from the DOM.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change removes hidden bilingual DOM duplication from public AMA routes with no functional regressions; admin block-swap behavior is explicitly preserved.

The refactor is narrow in scope and mechanically straightforward: locale is already known at the route level, so passing it as a prop and switching on it is strictly simpler than CSS toggling. The localize() relocation to locale-route.ts is server-safe (pure function, no browser APIs), and the re-export from locale-client.ts keeps all 24 existing client callers intact without any code changes on their side. Tests now render each locale in isolation and assert the other language is absent, which is the right shape for this kind of change. No auth, data, or API surface is touched.

No files require special attention. The globals.css block-selector rules are intentionally preserved for admin routes, and the updated comment now documents that boundary clearly.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/_views/ama-page.tsx | Core refactor: AmaPageView gains a required locale prop; all bilingual CSS-swap patterns replaced with localize() calls or locale conditionals. Wrapper divs that existed solely to work around data-en-block CSS are correctly removed. |
| lib/locale-route.ts | Receives the localize() pure function moved from locale-client.ts; server-safe (no browser APIs), correct logic, and backward compatible via re-export. |
| lib/locale-client.ts | Removes the localize() definition and re-exports it from locale-route.ts. All 24 existing client-side callers are unaffected. |
| app/_views/ama-page.test.tsx | Tests rewritten to render each locale in isolation; cleanup() called between renders inside test bodies (idempotent with afterEach). Coverage confirms the other language and block attributes are absent per render. |
| app/(en)/en/ama/page.tsx | Trivial change: passes locale="en" to AmaPageView, consistent with how amaPageMetadata is already called. |
| app/(zh)/ama/page.tsx | Trivial change: passes locale="zh" to AmaPageView, consistent with how amaPageMetadata is already called. |
| app/globals.css | Comment updated to document that data-*-block selectors are now admin-only; no CSS logic changed. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["/ama route segment"] -->|locale = zh| C[ChineseAmaPage]
    B["/en/ama route segment"] -->|locale = en| D[EnglishAmaPage]
    C --> E[AmaPageView]
    D --> E
    E --> F{locale === zh?}
    F -->|Yes| G[Renders Chinese content only]
    F -->|No| H[Renders English content only]
    G --> I["CTA href=/ama/book\nHeadings and copy in Chinese"]
    H --> J["CTA href=/en/ama/book\nHeadings and copy in English"]

    subgraph localeRoute ["lib/locale-route.ts - server safe"]
        K["localize(locale, zh, en)"]
        L["localePath(locale, path)"]
    end

    subgraph localeClient ["lib/locale-client.ts - client"]
        M["re-exports localize from locale-route"]
    end

    E --> K
    E --> L
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["/ama route segment"] -->|locale = zh| C[ChineseAmaPage]
    B["/en/ama route segment"] -->|locale = en| D[EnglishAmaPage]
    C --> E[AmaPageView]
    D --> E
    E --> F{locale === zh?}
    F -->|Yes| G[Renders Chinese content only]
    F -->|No| H[Renders English content only]
    G --> I["CTA href=/ama/book\nHeadings and copy in Chinese"]
    H --> J["CTA href=/en/ama/book\nHeadings and copy in English"]

    subgraph localeRoute ["lib/locale-route.ts - server safe"]
        K["localize(locale, zh, en)"]
        L["localePath(locale, path)"]
    end

    subgraph localeClient ["lib/locale-client.ts - client"]
        M["re-exports localize from locale-route"]
    end

    E --> K
    E --> L
```

</a>

<sub>Reviews (1): Last reviewed commit: ["refactor(ama): render public AMA page pe..."](https://github.com/calicastle/cali.so/commit/0e51e067643c604b897970f2362737048c67db6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45443141)</sub>

<!-- /greptile_comment -->