### PR TITLE
feat(mdx): render mermaid diagrams in blog posts

### DIFF
--- a/app/_views/blog-post-page.tsx
+++ b/app/_views/blog-post-page.tsx
@@ -26,6 +26,7 @@ import { T } from '~/lib/i18n'
 import { localeMetadata } from '~/lib/locale-metadata'
 import type { Locale } from '~/lib/locale-route'
 import rehypePrefixIds from '~/lib/rehype-prefix-ids'
+import remarkMermaid from '~/lib/remark-mermaid'
 import { postViewTransitionName } from '~/lib/view-transition-name'
 
 export function generatePostStaticParams() {
@@ -141,7 +142,7 @@ async function CachedPostBody({
       components={mdxComponents(slug, locale)}
       options={{
         mdxOptions: {
-          remarkPlugins: [remarkGfm],
+          remarkPlugins: [remarkGfm, remarkMermaid],
           rehypePlugins,
         },
       }}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1853,6 +1853,48 @@ figure[data-rehype-pretty-code-figure] {
   }
 }
 
+/* ── Mermaid diagrams (beautiful-mermaid, server-rendered svg) ────── */
+
+/* the diagram rests on the same sheet treatment as code: hairline frame,
+   one step up the surface ladder, edge fades tinted to match */
+.mermaid-frame {
+  border: var(--border-hairline) solid var(--border);
+  background: var(--surface-1);
+  --scroll-fade-surface: var(--surface-1);
+}
+
+/* natural svg size, centered when narrower than the column; wider
+   diagrams keep 1:1 scale and scroll instead of shrinking their text */
+.mermaid-sheet {
+  display: flex;
+  justify-content: center;
+  width: max-content;
+  min-width: 100%;
+  padding: 0.5rem;
+}
+
+.mermaid-sheet svg {
+  display: block;
+  /* the svg derives its palette from --bg/--fg with var(--muted, …)-style
+     fallbacks; the page's shadcn tokens (--muted, --accent, --border) would
+     leak in as *background* colors, so reset them to keep the derivation */
+  --line: initial;
+  --accent: initial;
+  --muted: initial;
+  --surface: initial;
+  --border: initial;
+}
+
+/* the library's font imports are stripped server-side; restore the site
+   stacks over the svg's internal rules */
+.mermaid-sheet svg text {
+  font-family: var(--font-sans);
+}
+
+.mermaid-sheet svg .mono {
+  font-family: var(--font-geist-mono), var(--font-frex-gb), ui-monospace, monospace;
+}
+
 figure[data-rehype-pretty-code-figure] figcaption[data-rehype-pretty-code-title] {
   display: flex;
   align-items: center;

--- a/components/mdx/mdx-components.tsx
+++ b/components/mdx/mdx-components.tsx
@@ -41,7 +41,9 @@ function PostImage({ slug, src, alt, title }: { slug: string; src: string; alt?:
 export function mdxComponents(slug: string, locale: Locale = 'zh'): MDXComponents {
   return {
     pre: (props) => <CodeBlockPre {...props} />,
-    MermaidDiagram,
+    MermaidDiagram: (props: { code: string; caption?: string }) => (
+      <MermaidDiagram {...props} locale={locale} />
+    ),
     Tweet: ({ id }: { id: string }) => <Tweet slug={slug} id={id} />,
     img: (props) => (
       <PostImage slug={slug} src={props.src as string} alt={props.alt} title={props.title} />

--- a/components/mdx/mdx-components.tsx
+++ b/components/mdx/mdx-components.tsx
@@ -1,6 +1,7 @@
 import type { MDXComponents } from 'mdx/types'
 
 import { CodeBlockPre } from './code-block'
+import { MermaidDiagram } from './mermaid-diagram'
 import { Tweet } from './tweet'
 import { ExternalLink } from '~/components/external-link'
 import { ZoomImage } from '~/components/zoom-image'
@@ -40,6 +41,7 @@ function PostImage({ slug, src, alt, title }: { slug: string; src: string; alt?:
 export function mdxComponents(slug: string, locale: Locale = 'zh'): MDXComponents {
   return {
     pre: (props) => <CodeBlockPre {...props} />,
+    MermaidDiagram,
     Tweet: ({ id }: { id: string }) => <Tweet slug={slug} id={id} />,
     img: (props) => (
       <PostImage slug={slug} src={props.src as string} alt={props.alt} title={props.title} />

--- a/components/mdx/mermaid-diagram.tsx
+++ b/components/mdx/mermaid-diagram.tsx
@@ -1,0 +1,47 @@
+import { renderMermaidSVG } from 'beautiful-mermaid'
+
+import { ScrollAreaX } from '~/components/ui/scroll-area'
+
+// The library inlines Google Fonts imports for its default typefaces; fonts
+// are self-hosted here, so drop them and let .mermaid-figure css restore the
+// site stacks.
+const FONT_IMPORTS = /^\s*@import url\('https:\/\/fonts\.googleapis\.com[^']*'\);\n?/gm
+
+export function MermaidDiagram({ code, caption }: { code: string; caption?: string }) {
+  let svg: string
+  try {
+    // Colors are emitted as CSS variables on the svg element, so light/dark
+    // both resolve at paint time from the same markup — no dual render.
+    svg = renderMermaidSVG(code, {
+      bg: 'var(--surface-1)',
+      fg: 'var(--foreground)',
+      muted: 'var(--muted-foreground)',
+      transparent: true,
+      padding: 24,
+    })
+  } catch (error) {
+    throw new Error(
+      `mermaid diagram failed to render: ${error instanceof Error ? error.message : String(error)}\n${code}`,
+    )
+  }
+
+  const sheet = (
+    <div className="mermaid-frame">
+      <ScrollAreaX>
+        <div
+          className="mermaid-sheet"
+          role="img"
+          aria-label={caption}
+          dangerouslySetInnerHTML={{ __html: svg.replace(FONT_IMPORTS, '') }}
+        />
+      </ScrollAreaX>
+    </div>
+  )
+  if (!caption) return <figure className="mermaid-figure">{sheet}</figure>
+  return (
+    <figure className="post-figure mermaid-figure">
+      {sheet}
+      <figcaption className="post-figcaption">{caption}</figcaption>
+    </figure>
+  )
+}

--- a/components/mdx/mermaid-diagram.tsx
+++ b/components/mdx/mermaid-diagram.tsx
@@ -1,13 +1,22 @@
 import { renderMermaidSVG } from 'beautiful-mermaid'
 
 import { ScrollAreaX } from '~/components/ui/scroll-area'
+import { localize, type Locale } from '~/lib/locale-route'
 
 // The library inlines Google Fonts imports for its default typefaces; fonts
 // are self-hosted here, so drop them and let .mermaid-figure css restore the
 // site stacks.
 const FONT_IMPORTS = /^\s*@import url\('https:\/\/fonts\.googleapis\.com[^']*'\);\n?/gm
 
-export function MermaidDiagram({ code, caption }: { code: string; caption?: string }) {
+export function MermaidDiagram({
+  code,
+  caption,
+  locale = 'zh',
+}: {
+  code: string
+  caption?: string
+  locale?: Locale
+}) {
   let svg: string
   try {
     // Colors are emitted as CSS variables on the svg element, so light/dark
@@ -31,7 +40,12 @@ export function MermaidDiagram({ code, caption }: { code: string; caption?: stri
         <div
           className="mermaid-sheet"
           role="img"
-          aria-label={caption}
+          // role="img" needs a name even without a caption; the generic
+          // fallback beats AT reading the svg's positioned text fragments
+          aria-label={caption ?? localize(locale, '图表', 'Diagram')}
+          // trusted-input boundary: diagram source is repo-committed MDX
+          // rendered at build time, never user-supplied — revisit with a
+          // sanitizer before ever feeding this component runtime input
           dangerouslySetInnerHTML={{ __html: svg.replace(FONT_IMPORTS, '') }}
         />
       </ScrollAreaX>

--- a/lib/remark-mermaid.test.ts
+++ b/lib/remark-mermaid.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+
+import remarkMermaid from './remark-mermaid'
+
+interface Node {
+  type: string
+  lang?: string | null
+  meta?: string | null
+  value?: string
+  children?: Node[]
+  name?: string
+  attributes?: { type: string; name: string; value: string }[]
+}
+
+function transform(tree: Node) {
+  remarkMermaid()(tree)
+  return tree
+}
+
+function code(lang: string | null, value: string, meta: string | null = null): Node {
+  return { type: 'code', lang, meta, value }
+}
+
+describe('remark-mermaid', () => {
+  it('rewrites a mermaid fence to the diagram component', () => {
+    const tree = transform({
+      type: 'root',
+      children: [code('mermaid', 'flowchart LR\n  A --> B')],
+    })
+
+    expect(tree.children?.[0]).toMatchObject({
+      type: 'mdxJsxFlowElement',
+      name: 'MermaidDiagram',
+      attributes: [
+        { type: 'mdxJsxAttribute', name: 'code', value: 'flowchart LR\n  A --> B' },
+      ],
+    })
+  })
+
+  it('carries a caption from the fence meta', () => {
+    const tree = transform({
+      type: 'root',
+      children: [code('mermaid', 'flowchart LR\n  A --> B', 'caption="RSS 订阅流程"')],
+    })
+
+    expect(tree.children?.[0].attributes).toContainEqual({
+      type: 'mdxJsxAttribute',
+      name: 'caption',
+      value: 'RSS 订阅流程',
+    })
+  })
+
+  it('leaves other code fences for the syntax highlighter', () => {
+    const tree = transform({
+      type: 'root',
+      children: [code('ts', 'const a = 1'), code(null, 'plain text')],
+    })
+
+    expect(tree.children?.map((child) => child.type)).toEqual(['code', 'code'])
+  })
+
+  it('rewrites fences nested inside other content', () => {
+    const tree = transform({
+      type: 'root',
+      children: [
+        {
+          type: 'blockquote',
+          children: [code('mermaid', 'flowchart TD\n  A --> B')],
+        },
+      ],
+    })
+
+    expect(tree.children?.[0].children?.[0]).toMatchObject({
+      name: 'MermaidDiagram',
+    })
+  })
+})

--- a/lib/remark-mermaid.ts
+++ b/lib/remark-mermaid.ts
@@ -1,0 +1,37 @@
+interface MdastNode {
+  type: string
+  lang?: string | null
+  meta?: string | null
+  value?: string
+  children?: MdastNode[]
+}
+
+// ```mermaid fences become <MermaidDiagram> before rehype-pretty-code can
+// claim them as code blocks. Caption rides on the fence meta:
+// ```mermaid caption="..."
+export default function remarkMermaid() {
+  return function transform(tree: MdastNode) {
+    function visit(node: MdastNode) {
+      node.children?.forEach((child, index) => {
+        if (child.type === 'code' && child.lang === 'mermaid') {
+          const caption = child.meta?.match(/caption="([^"]+)"/)?.[1]
+          node.children![index] = {
+            type: 'mdxJsxFlowElement',
+            name: 'MermaidDiagram',
+            attributes: [
+              { type: 'mdxJsxAttribute', name: 'code', value: child.value ?? '' },
+              ...(caption
+                ? [{ type: 'mdxJsxAttribute', name: 'caption', value: caption }]
+                : []),
+            ],
+            children: [],
+          } as MdastNode
+          return
+        }
+        visit(child)
+      })
+    }
+
+    visit(tree)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@vercel/analytics": "^2.0.1",
     "@vercel/functions": "^3.7.5",
     "ai": "^6.0.226",
+    "beautiful-mermaid": "^1.1.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cuelume": "0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       ai:
         specifier: ^6.0.226
         version: 6.0.226(zod@4.4.3)
+      beautiful-mermaid:
+        specifier: ^1.1.3
+        version: 1.1.3
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1863,6 +1866,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  beautiful-mermaid@1.1.3:
+    resolution: {integrity: sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg==}
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -2216,6 +2222,9 @@ packages:
   electron-to-chromium@1.5.389:
     resolution: {integrity: sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==}
 
+  elkjs@0.11.1:
+    resolution: {integrity: sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -2233,6 +2242,10 @@ packages:
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   entities@8.0.0:
@@ -5627,6 +5640,11 @@ snapshots:
 
   baseline-browser-mapping@2.10.42: {}
 
+  beautiful-mermaid@1.1.3:
+    dependencies:
+      elkjs: 0.11.1
+      entities: 7.0.1
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -5860,6 +5878,8 @@ snapshots:
 
   electron-to-chromium@1.5.389: {}
 
+  elkjs@0.11.1: {}
+
   emoji-regex@10.6.0: {}
 
   encodeurl@2.0.0: {}
@@ -5875,6 +5895,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   entities@8.0.0: {}
 


### PR DESCRIPTION
Adds a ```mermaid fence to the blog post pipeline so posts can carry diagrams, rendered server-side with [beautiful-mermaid](https://github.com/lukilabs/beautiful-mermaid) — Craft's open-sourced renderer (MIT, zero DOM dependencies).

## Authoring

````markdown
```mermaid caption="RSS 订阅流程"
flowchart LR
  A[博客文章] --> B[RSS 生成器] --> C{feed.xml}
```
````

Caption is optional; when present it joins the existing `FIG. 01 —` / `图 01 —` plate-annotation counter alongside post images. Supports flowcharts, sequence, state, class, ER diagrams, and XY charts. Text metrics handle fullwidth CJK, so Chinese labels size correctly.

## Why this renderer

It renders synchronously with no DOM, which means diagrams stay inside the existing `'use cache'` RSC post body:

- **No client JS and no loading flash** — diagrams ship as markup, unlike the usual `mermaid.js` hydrate-then-draw dance.
- **One SVG serves both themes** — colors are emitted as CSS custom properties driven by the site tokens (`--surface-1`, `--foreground`, `--muted-foreground`), so light/dark resolve at paint time with no dual render.
- **No new content framework** — this is a ~35-line remark plugin plus a server component, consistent with [ADR 0002](docs/adr/0002-mdx-pipeline-owned-not-framework.md) keeping the MDX pipeline a thin owned layer.

## Changes

- `lib/remark-mermaid.ts` — rewrites the fence to `<MermaidDiagram>` before `rehype-pretty-code` can claim it as a code block; `caption="…"` rides on the fence meta.
- `components/mdx/mermaid-diagram.tsx` — server component; strips the Google Fonts `@import` the library injects (fonts are self-hosted here) and wraps the sheet in the existing `ScrollAreaX`.
- `app/globals.css` — the diagram sheet reuses the code-block treatment (hairline frame, one step up the surface ladder, matching edge fades) and restores the site font stacks over the SVG's internal rules.
- Registered in `mdx-components.tsx`, plugin added in `blog-post-page.tsx`.

## Notes for review

- **Token leak, fixed.** The library derives its palette via `var(--muted, …)`-style fallbacks. The site's shadcn `--muted` / `--accent` / `--border` were being picked up as *background* colors, which rendered sequence-diagram labels near-black on dark. Those properties are reset to `initial` on the SVG and `--muted-foreground` is passed explicitly for secondary text.
- **Wide diagrams scroll at 1:1** rather than scaling down, so label text never shrinks below the 13px code size. `flowchart TD` reads better than `LR` past ~4 nodes in the 600px column.
- **Invalid syntax throws at build time**, matching how `PostImage` treats malformed content — errors surface before deploy rather than rendering a broken diagram.
- No animation was added, so there's no `prefers-reduced-motion` branch to review.

## Verification

Typecheck clean; full unit suite passes (1081 tests), including 4 new cases covering the fence transform. Rendered a flowchart and a sequence diagram into a real post and checked both themes in the browser; test content reverted before commit.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds server-side Mermaid diagram rendering to the blog post pipeline using the `beautiful-mermaid` library. The approach renders SVGs synchronously at build time inside the existing `'use cache'` RSC boundary, with colors emitted as CSS custom properties so both light and dark themes resolve at paint time from a single markup pass.

- A remark plugin (`lib/remark-mermaid.ts`) intercepts ` ```mermaid ` fences before `rehype-pretty-code`, rewrites them to a `<MermaidDiagram>` JSX element, and optionally carries a `caption="…"` from fence metadata.
- The `MermaidDiagram` server component strips the library's Google Fonts `@import` statements, wraps the SVG in `ScrollAreaX` for wide diagrams, and falls back to a locale-keyed accessible name when no caption is provided.
- Four unit tests cover the remark transform, and CSS is added to match the code-block treatment (hairline border, `surface-1` background, font-stack restoration over the SVG's internal rules).

<h3>Confidence Score: 5/5</h3>

Safe to merge — diagram rendering is fully build-time and cached, with no runtime user input path.

All rendering happens synchronously inside the existing 'use cache' RSC boundary, so invalid syntax is caught at build time rather than at runtime. The remark plugin, server component, and CSS additions are self-contained and don't touch any existing logic paths. The accessible-name fallback and CSS token-reset are correct. No breaking changes to the MDX pipeline.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/remark-mermaid.ts | Remark plugin that rewrites mermaid fences to MermaidDiagram JSX elements before rehype-pretty-code; handles nested nodes recursively and correctly extracts caption from fence meta. |
| components/mdx/mermaid-diagram.tsx | Server component that renders SVG via beautiful-mermaid, strips Google Fonts @import statements, provides accessible aria-label fallback, and wraps in ScrollAreaX; trust boundary and locale-aware fallback correctly implemented. |
| lib/remark-mermaid.test.ts | Four unit tests covering basic rewrite, caption extraction, passthrough for non-mermaid fences, and nested content; good coverage of the plugin's surface area. |
| app/_views/blog-post-page.tsx | Adds remarkMermaid to the plugin array inside the 'use cache' RSC; plugin ordering is correct (runs before rehype-pretty-code). |
| app/globals.css | Adds mermaid-frame/mermaid-sheet styles matching the code-block treatment, resets shadcn token leakage, and restores site font stacks over the SVG's internal rules. |
| components/mdx/mdx-components.tsx | Registers MermaidDiagram in the component map and correctly threads the locale prop from the post context. |
| package.json | Adds beautiful-mermaid ^1.1.3 dependency; elkjs and entities are its only transitive deps, no supply-chain concern. |
| pnpm-lock.yaml | Lock file updated correctly; beautiful-mermaid 1.1.3 resolves with valid SHA-512 integrity hash and minimal dependency tree (elkjs, entities). |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant MDX as MDX Source
    participant RM as remarkMermaid plugin
    participant RPC as rehype-pretty-code
    participant MD as MermaidDiagram (RSC)
    participant BM as beautiful-mermaid

    MDX->>RM: ```mermaid fence node (mdast code)
    RM->>RM: Extract caption from fence meta
    RM-->>RPC: mdxJsxFlowElement MermaidDiagram
    Note over RPC: Skips — not a code node
    RPC-->>MD: Renders component at build time
    MD->>BM: "renderMermaidSVG(code, { bg, fg, muted })"
    BM-->>MD: SVG string with CSS var() color tokens
    MD->>MD: "Strip Google Fonts @import"
    MD-->>MDX: figure with SVG via dangerouslySetInnerHTML
    Note over MDX: Cached at use cache boundary (cacheLife max)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant MDX as MDX Source
    participant RM as remarkMermaid plugin
    participant RPC as rehype-pretty-code
    participant MD as MermaidDiagram (RSC)
    participant BM as beautiful-mermaid

    MDX->>RM: ```mermaid fence node (mdast code)
    RM->>RM: Extract caption from fence meta
    RM-->>RPC: mdxJsxFlowElement MermaidDiagram
    Note over RPC: Skips — not a code node
    RPC-->>MD: Renders component at build time
    MD->>BM: "renderMermaidSVG(code, { bg, fg, muted })"
    BM-->>MD: SVG string with CSS var() color tokens
    MD->>MD: "Strip Google Fonts @import"
    MD-->>MDX: figure with SVG via dangerouslySetInnerHTML
    Note over MDX: Cached at use cache boundary (cacheLife max)
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(mdx): give uncaptioned mermaid diagr..."](https://github.com/calicastle/cali.so/commit/1021714de77abf9fb133435ac686b29a8789ae3d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45444963)</sub>

<!-- /greptile_comment -->