### PR TITLE
Stop shader warning spam and reduce homepage weight

### DIFF
--- a/.github/actions/deploy-neon-vercel/action.yml
+++ b/.github/actions/deploy-neon-vercel/action.yml
@@ -135,6 +135,7 @@ runs:
             --token "$VERCEL_TOKEN" \
             --target="$DEPLOY_TARGET" \
             --build-env DATABASE_URL="$RUNTIME_DATABASE_URL" \
+            --build-env ENABLE_EXPERIMENTAL_COREPACK=1 \
             --env DATABASE_URL="$RUNTIME_DATABASE_URL" \
             --meta githubCommitRef="$DEPLOY_GIT_REF" \
             --meta githubCommitSha="$DEPLOY_COMMIT_SHA"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -66,6 +66,7 @@ jobs:
             pnpm dlx vercel@56.3.1 deploy --prod \
               --yes \
               --token "$VERCEL_TOKEN" \
+              --build-env ENABLE_EXPERIMENTAL_COREPACK=1 \
               --meta githubCommitRef="main" \
               --meta githubCommitSha="$DEPLOY_COMMIT_SHA"
           )"

--- a/app/_components/site-document.tsx
+++ b/app/_components/site-document.tsx
@@ -20,7 +20,7 @@ import { seo } from '~/lib/seo'
 import type { Locale } from '~/lib/locale-route'
 import { cn } from '~/lib/utils'
 
-import { fontVariables } from '../fonts'
+import { fontVariablesForLocale } from '../fonts'
 
 export const rootMetadata: Metadata = {
   metadataBase: seo.url,
@@ -42,6 +42,7 @@ export async function SiteDocument({
   restoreLocale?: boolean
 }>) {
   const english = locale === 'en'
+  const fontVariables = fontVariablesForLocale(locale)
 
   if (isAdmin) {
     // The owner admin shares the public warm paper, ambient layer, and

--- a/app/fonts.ts
+++ b/app/fonts.ts
@@ -1,6 +1,8 @@
 import { Geist, Geist_Mono } from 'next/font/google'
 import localFont from 'next/font/local'
 
+import type { Locale } from '~/lib/locale-route'
+
 const geist = Geist({
   subsets: ['latin'],
   variable: '--font-geist',
@@ -25,4 +27,10 @@ const frexSansGB = localFont({
   preload: false,
 })
 
-export const fontVariables = [geist.variable, geistMono.variable, frexSansGB.variable].join(' ')
+const latinFontVariables = [geist.variable, geistMono.variable].join(' ')
+
+export function fontVariablesForLocale(locale: Locale) {
+  return [latinFontVariables, locale === 'zh' ? frexSansGB.variable : null]
+    .filter(Boolean)
+    .join(' ')
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -7,7 +7,7 @@ import { ThemeProvider } from '~/components/theme-provider'
 import { PREPAINT_SCRIPT } from '~/lib/security/inline-scripts'
 import { cn } from '~/lib/utils'
 
-import { fontVariables } from './fonts'
+import { fontVariablesForLocale } from './fonts'
 import { ErrorPageView, type ErrorBoundaryProps } from './_views/error-page'
 
 export default function GlobalError({ retry }: ErrorBoundaryProps) {
@@ -15,7 +15,7 @@ export default function GlobalError({ retry }: ErrorBoundaryProps) {
     <html
       lang="zh-CN"
       suppressHydrationWarning
-      className={cn('font-sans', fontVariables)}
+      className={cn('font-sans', fontVariablesForLocale('zh'))}
     >
       <head>
         <title>Something went wrong | Cali Castle</title>

--- a/app/global-not-found.tsx
+++ b/app/global-not-found.tsx
@@ -9,7 +9,7 @@ import {
 } from '~/lib/non-public-metadata'
 import { cn } from '~/lib/utils'
 
-import { fontVariables } from './fonts'
+import { fontVariablesForLocale } from './fonts'
 import { NotFoundPageView } from './_views/not-found-page'
 
 export const metadata: Metadata = {
@@ -23,7 +23,11 @@ export default function GlobalNotFound() {
   // defaults to Chinese. PREPAINT_SCRIPT derives an explicit /en URL before
   // paint and updates lang/data-locale without consulting localStorage.
   return (
-    <html lang="zh-CN" suppressHydrationWarning className={cn('font-sans', fontVariables)}>
+    <html
+      lang="zh-CN"
+      suppressHydrationWarning
+      className={cn('font-sans', fontVariablesForLocale('zh'))}
+    >
       <head>
         <script dangerouslySetInnerHTML={{ __html: PREPAINT_SCRIPT }} />
       </head>

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,7 +7,7 @@
 @theme inline {
     --font-heading: var(--font-sans);
     /* Geist for Latin; Frex Sans GB catches CJK glyphs via stack order */
-    --font-sans: var(--font-geist), var(--font-frex-gb), ui-sans-serif, system-ui, sans-serif;
+    --font-sans: var(--font-geist), var(--font-frex-gb, ui-sans-serif), system-ui, sans-serif;
     --color-sidebar-ring: var(--sidebar-ring);
     --color-sidebar-border: var(--sidebar-border);
     --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -1288,7 +1288,7 @@
   padding: 0.625rem 0;
   border-top: var(--border-hairline) solid var(--border);
   border-bottom: var(--border-hairline) solid var(--border);
-  font-family: var(--font-geist-mono), var(--font-frex-gb), ui-monospace, monospace;
+  font-family: var(--font-geist-mono), var(--font-frex-gb, ui-monospace), ui-monospace, monospace;
   font-variant-numeric: tabular-nums;
   user-select: none;
 }
@@ -1336,7 +1336,7 @@
 .spec-nameplate {
   margin: 0;
   border: var(--border-hairline) solid var(--border);
-  font-family: var(--font-geist-mono), var(--font-frex-gb), ui-monospace, monospace;
+  font-family: var(--font-geist-mono), var(--font-frex-gb, ui-monospace), ui-monospace, monospace;
   font-size: 0.8125rem;
 }
 
@@ -1374,7 +1374,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.375rem;
-  font-family: var(--font-geist-mono), var(--font-frex-gb), ui-monospace, monospace;
+  font-family: var(--font-geist-mono), var(--font-frex-gb, ui-monospace), ui-monospace, monospace;
   font-size: 0.6875rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -1423,7 +1423,7 @@
   padding: 0.375rem 0.75rem;
   border: var(--border-hairline) solid color-mix(in oklab, var(--foreground) 55%, transparent);
   color: var(--gray-11, var(--foreground));
-  font-family: var(--font-geist-mono), var(--font-frex-gb), ui-monospace, monospace;
+  font-family: var(--font-geist-mono), var(--font-frex-gb, ui-monospace), ui-monospace, monospace;
   font-size: 0.6875rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -1437,7 +1437,7 @@
   align-items: stretch;
   gap: 0;
   color: var(--gray-8, var(--muted-foreground));
-  font-family: var(--font-geist-mono), var(--font-frex-gb), ui-monospace, monospace;
+  font-family: var(--font-geist-mono), var(--font-frex-gb, ui-monospace), ui-monospace, monospace;
   font-size: 0.75rem;
   font-weight: var(--font-weight-normal);
   letter-spacing: 0.08em;
@@ -1603,7 +1603,7 @@
 
 .page-eyebrow {
   color: var(--gray-8, var(--muted-foreground));
-  font-family: var(--font-geist-mono), var(--font-frex-gb), ui-monospace, monospace;
+  font-family: var(--font-geist-mono), var(--font-frex-gb, ui-monospace), ui-monospace, monospace;
   font-size: 0.75rem;
   font-weight: var(--font-weight-normal);
   letter-spacing: 0.08em;
@@ -1624,7 +1624,7 @@
 
 .post-related-label {
   color: color-mix(in oklab, var(--muted-foreground) 72%, transparent);
-  font-family: var(--font-geist-mono), var(--font-frex-gb), ui-monospace, monospace;
+  font-family: var(--font-geist-mono), var(--font-frex-gb, ui-monospace), ui-monospace, monospace;
   font-size: 0.6875rem;
   font-weight: var(--font-weight-normal);
   letter-spacing: 0.08em;
@@ -1733,7 +1733,7 @@
 .prose .post-figcaption {
   margin-top: 0.625rem;
   text-align: left;
-  font-family: var(--font-geist-mono), var(--font-frex-gb), ui-monospace, monospace;
+  font-family: var(--font-geist-mono), var(--font-frex-gb, ui-monospace), ui-monospace, monospace;
   font-size: 0.75rem;
   letter-spacing: 0.02em;
   line-height: 1.5;
@@ -2078,7 +2078,7 @@ img.tweet-card-avatar {
   padding: 0.5rem 1rem;
   border-top: var(--border-hairline) solid var(--border);
   color: color-mix(in oklab, var(--muted-foreground) 72%, transparent);
-  font-family: var(--font-geist-mono), var(--font-frex-gb), ui-monospace, monospace;
+  font-family: var(--font-geist-mono), var(--font-frex-gb, ui-monospace), ui-monospace, monospace;
   font-size: 0.6875rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -4181,7 +4181,7 @@ a:focus-visible .external-label .external-mark {
 /* handles are machine text */
 .service-card-sub {
   color: var(--muted-foreground);
-  font-family: var(--font-geist-mono), var(--font-frex-gb), ui-monospace, monospace;
+  font-family: var(--font-geist-mono), var(--font-frex-gb, ui-monospace), ui-monospace, monospace;
   font-size: 0.75rem;
   letter-spacing: 0.02em;
 }
@@ -4204,7 +4204,7 @@ a:focus-visible .external-label .external-mark {
   padding-top: 0.5rem;
   border-top: var(--border-hairline) solid var(--border);
   color: var(--muted-foreground);
-  font-family: var(--font-geist-mono), var(--font-frex-gb), ui-monospace, monospace;
+  font-family: var(--font-geist-mono), var(--font-frex-gb, ui-monospace), ui-monospace, monospace;
   font-size: 0.6875rem;
   letter-spacing: 0.02em;
   font-variant-numeric: tabular-nums;

--- a/app/site-document.test.tsx
+++ b/app/site-document.test.tsx
@@ -1,6 +1,12 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const { fontVariablesForLocale } = vi.hoisted(() => ({
+  fontVariablesForLocale: vi.fn((locale: 'zh' | 'en') =>
+    locale === 'zh' ? 'latin-font cjk-font' : 'latin-font',
+  ),
+}))
+
 vi.mock('react', async (importOriginal) => {
   const react = await importOriginal<typeof import('react')>()
 
@@ -49,7 +55,7 @@ vi.mock('~/components/route-motion-controller', () => ({
   ),
 }))
 vi.mock('./fonts', () => ({
-  fontVariables: '',
+  fontVariablesForLocale,
 }))
 
 import { SiteDocument } from './_components/site-document'
@@ -60,6 +66,20 @@ beforeEach(() => {
 })
 
 describe('SiteDocument analytics', () => {
+  it('activates the CJK font only for Chinese documents', async () => {
+    const chinese = renderToStaticMarkup(
+      await SiteDocument({ children: <p>中文页面</p>, locale: 'zh' }),
+    )
+    const english = renderToStaticMarkup(
+      await SiteDocument({ children: <p>English page</p>, locale: 'en' }),
+    )
+
+    expect(chinese).toContain('cjk-font')
+    expect(english).not.toContain('cjk-font')
+    expect(fontVariablesForLocale).toHaveBeenCalledWith('zh')
+    expect(fontVariablesForLocale).toHaveBeenCalledWith('en')
+  })
+
   it('collects page views across the public route families', async () => {
     for (const locale of ['zh', 'en'] as const) {
       const html = renderToStaticMarkup(

--- a/components/dither-veil.test.tsx
+++ b/components/dither-veil.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { DitheredImage } from './dither-veil'
+
+vi.mock('next/image', async () => {
+  const { forwardRef } = await import('react')
+
+  return {
+    default: forwardRef<
+      HTMLImageElement,
+      React.ImgHTMLAttributes<HTMLImageElement> & {
+        src: string | { src: string }
+      }
+    >(function MockImage({ src, ...props }, ref) {
+      return (
+        <img
+          {...props}
+          ref={ref}
+          src={typeof src === 'string' ? src : src.src}
+        />
+      )
+    }),
+  }
+})
+
+class ResizeObserverStub {
+  observe() {}
+  disconnect() {}
+}
+
+beforeEach(() => {
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+    {} as CanvasRenderingContext2D,
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('DitheredImage', () => {
+  it('samples the rendered optimized image without creating another request', () => {
+    const imageConstructor = vi.fn()
+    vi.stubGlobal('Image', imageConstructor)
+
+    const { container } = render(
+      <DitheredImage
+        src="/_next/image?url=%2Fcover.png&w=128&q=75"
+        alt=""
+        width={64}
+        height={44}
+      />,
+    )
+
+    expect(container.querySelectorAll('img')).toHaveLength(1)
+    expect(imageConstructor).not.toHaveBeenCalled()
+  })
+})

--- a/components/dither-veil.tsx
+++ b/components/dither-veil.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Image, { type ImageProps } from 'next/image'
 import { useEffect, useRef } from 'react'
 
 import { playCoverSound } from '~/lib/sound'
@@ -56,6 +57,24 @@ function hashOf(s: string): number {
   return Math.abs(h)
 }
 
+export function DitheredImage({
+  ditherMode = 'dither',
+  src,
+  ...imageProps
+}: Omit<ImageProps, 'src'> & {
+  ditherMode?: 'dither' | 'collage'
+  src: string
+}) {
+  const imageRef = useRef<HTMLImageElement>(null)
+
+  return (
+    <>
+      <Image {...imageProps} ref={imageRef} src={src} />
+      <DitherVeil imageRef={imageRef} seed={src} mode={ditherMode} />
+    </>
+  )
+}
+
 // Physical print veil for covers, theme-invariant (paper + ink — the
 // print is an object, not an interface).
 // mode="dither": a full ordered-dither print that develops into the
@@ -66,20 +85,28 @@ function hashOf(s: string): number {
 // through a BAYER DISSOLVE: cells materialize in the order of the
 // matrix's own 16 thresholds — the image passes through its own screen.
 // Works on touch too. Reduced motion swaps instantly; glitch is skipped.
-export function DitherVeil({ src, mode = 'dither' }: { src: string; mode?: 'dither' | 'collage' }) {
+function DitherVeil({
+  imageRef,
+  seed,
+  mode,
+}: {
+  imageRef: React.RefObject<HTMLImageElement | null>
+  seed: string
+  mode: 'dither' | 'collage'
+}) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
   useEffect(() => {
     const canvasEl = canvasRef.current
     if (!canvasEl) return
+    const sourceImage = imageRef.current
+    if (!sourceImage) return
+    const img: HTMLImageElement = sourceImage
     const canvas: HTMLCanvasElement = canvasEl
     const maybeCtx = canvas.getContext('2d')
     if (!maybeCtx) return
     const ctx: CanvasRenderingContext2D = maybeCtx
 
-    const img = new Image()
-    img.crossOrigin = 'anonymous'
-    img.src = src
     let playing = false
     let prepared: { rect: DOMRect; dither: Grid; ascii: Grid; full: FullGrid } | null = null
     const timers: ReturnType<typeof setTimeout>[] = []
@@ -201,7 +228,7 @@ export function DitherVeil({ src, mode = 'dither' }: { src: string; mode?: 'dith
     }
 
     function prepare(rect: DOMRect) {
-      const rand = mulberry(hashOf(src))
+      const rand = mulberry(hashOf(seed))
       const seeds: Array<{ x: number; y: number }> = []
       for (let i = 0; i < SEEDS; i++)
         seeds.push({ x: rand() * rect.width, y: rand() * rect.height })
@@ -376,7 +403,7 @@ export function DitherVeil({ src, mode = 'dither' }: { src: string; mode?: 'dith
       if (stepTimer) clearTimeout(stepTimer)
       for (const t of timers) clearTimeout(t)
     }
-  }, [src, mode])
+  }, [imageRef, seed, mode])
 
   return <canvas ref={canvasRef} aria-hidden className="dither-veil" />
 }

--- a/components/polaroid-cover.tsx
+++ b/components/polaroid-cover.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image'
 
-import { DitherVeil } from '~/components/dither-veil'
+import { DitheredImage } from '~/components/dither-veil'
 import type { PostCover } from '~/lib/content'
 import { tiltFromSlug } from '~/lib/polaroid'
 import { cn } from '~/lib/utils'
@@ -44,16 +44,28 @@ export function PolaroidCover({
       }
     >
       <span className="polaroid-photo">
-        <Image
-          src={cover.src}
-          alt={alt ?? ''}
-          width={cover.width}
-          height={cover.height}
-          priority={priority}
-          sizes={sizes}
-          className="w-full"
-        />
-        {print && <DitherVeil src={cover.src} mode={print === 'collage' ? 'collage' : 'dither'} />}
+        {print ? (
+          <DitheredImage
+            src={cover.src}
+            alt={alt ?? ''}
+            width={cover.width}
+            height={cover.height}
+            priority={priority}
+            sizes={sizes}
+            className="w-full"
+            ditherMode={print === 'collage' ? 'collage' : 'dither'}
+          />
+        ) : (
+          <Image
+            src={cover.src}
+            alt={alt ?? ''}
+            width={cover.width}
+            height={cover.height}
+            priority={priority}
+            sizes={sizes}
+            className="w-full"
+          />
+        )}
       </span>
       <figcaption className="polaroid-caption">{caption ?? cover.caption ?? ' '}</figcaption>
     </figure>

--- a/components/post-row.tsx
+++ b/components/post-row.tsx
@@ -1,6 +1,4 @@
-import Image from 'next/image'
-
-import { DitherVeil } from '~/components/dither-veil'
+import { DitheredImage } from '~/components/dither-veil'
 import { PostTransitionLink } from '~/components/post-transition-link'
 import type { Post } from '~/lib/content'
 import { formatMonthDay, formatShortDate } from '~/lib/date'
@@ -43,8 +41,14 @@ export function PostRow({
             className="print-thumb"
             style={{ viewTransitionName: coverTransitionName } as React.CSSProperties}
           >
-            <Image src={post.cover.src} alt="" width={64} height={44} sizes="64px" className="print-thumb-img" />
-            <DitherVeil src={post.cover.src} />
+            <DitheredImage
+              src={post.cover.src}
+              alt=""
+              width={64}
+              height={44}
+              sizes="64px"
+              className="print-thumb-img"
+            />
           </span>
         ) : (
           <span className="print-thumb print-thumb-empty" />

--- a/lib/security/typegpu-csp-fallback.test.ts
+++ b/lib/security/typegpu-csp-fallback.test.ts
@@ -1,0 +1,39 @@
+import { spawnSync } from 'node:child_process'
+import { globSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { expect, it } from 'vitest'
+
+const CSP_FALLBACK_WARNING =
+  'This environment does not allow eval - using default writer as fallback'
+
+it('warns only once when TypeGPU falls back under a strict CSP', () => {
+  const [compiledIoRelativePath] = globSync(
+    'node_modules/.pnpm/typegpu@*/node_modules/typegpu/data/compiledIO.js',
+    { cwd: process.cwd() },
+  )
+
+  expect(compiledIoRelativePath).toBeDefined()
+  const compiledIoPath = resolve(process.cwd(), compiledIoRelativePath!)
+
+  const script = `
+    const { getCompiledWriter } = await import(${JSON.stringify(pathToFileURL(compiledIoPath!).href)})
+    getCompiledWriter({})
+    getCompiledWriter({})
+    getCompiledWriter({})
+  `
+  const result = spawnSync(
+    process.execPath,
+    [
+      '--disallow-code-generation-from-strings',
+      '--input-type=module',
+      '--eval',
+      script,
+    ],
+    { encoding: 'utf8' },
+  )
+
+  expect(result.status, result.stderr).toBe(0)
+  expect(result.stderr.match(new RegExp(CSP_FALLBACK_WARNING, 'g'))).toHaveLength(1)
+})

--- a/patches/typegpu@0.11.9.patch
+++ b/patches/typegpu@0.11.9.patch
@@ -1,0 +1,12 @@
+diff --git a/data/compiledIO.js b/data/compiledIO.js
+index bae66ba574cdc04dd09202b9fbdb58ab65c7a68e..3c6c9d56c4da5de1c69a973e50d2003d494e0980 100644
+--- a/data/compiledIO.js
++++ b/data/compiledIO.js
+@@ -18,0 +19 @@ const compiledWriters = /* @__PURE__ */ new WeakMap();
++let didWarnAboutEvalFallback = false;
+@@ -214 +215,4 @@ function getCompiledWriter(schema) {
+-		console.warn("This environment does not allow eval - using default writer as fallback");
++		if (!didWarnAboutEvalFallback) {
++			console.warn("This environment does not allow eval - using default writer as fallback");
++			didWarnAboutEvalFallback = true;
++		}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  typegpu@0.11.9:
+    hash: 73830f6db95f6bf18e659e522e37e95c9af1b512af37cac7cc1171e5aeb456c2
+    path: patches/typegpu@0.11.9.patch
+
 importers:
 
   .:
@@ -7714,7 +7719,7 @@ snapshots:
 
   shaders@3.0.440(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      typegpu: 0.11.9
+      typegpu: 0.11.9(patch_hash=73830f6db95f6bf18e659e522e37e95c9af1b512af37cac7cc1171e5aeb456c2)
     optionalDependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -7968,7 +7973,7 @@ snapshots:
 
   typed-binary@4.3.3: {}
 
-  typegpu@0.11.9:
+  typegpu@0.11.9(patch_hash=73830f6db95f6bf18e659e522e37e95c9af1b512af37cac7cc1171e5aeb456c2):
     dependencies:
       tinyest: 0.3.2
       tsover-runtime: 0.0.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+patchedDependencies:
+  typegpu@0.11.9: patches/typegpu@0.11.9.patch

--- a/scripts/deployment-workflows.test.mjs
+++ b/scripts/deployment-workflows.test.mjs
@@ -158,6 +158,10 @@ test('main uses protected Production credentials and deploys only after migratio
     (step) => step.name === 'Deploy Vercel Production',
   )
   assert.match(deploy.run, /vercel@56\.3\.1 deploy --prod/)
+  assert.match(
+    deploy.run,
+    /--build-env ENABLE_EXPERIMENTAL_COREPACK=1/,
+  )
   assert.match(deploy.run, /GITHUB_STEP_SUMMARY/)
   assert.equal(deploy.env.MIGRATION_DATABASE_URL, undefined)
   assert.equal(deploy.env.DATABASE_URL, undefined)
@@ -305,6 +309,10 @@ test('shared non-production action keeps migration credentials out of Vercel', a
   assert.match(deploy.run, /vercel@56\.3\.1 deploy/)
   assert.match(deploy.run, /--target=/)
   assert.match(deploy.run, /--build-env DATABASE_URL=/)
+  assert.match(
+    deploy.run,
+    /--build-env ENABLE_EXPERIMENTAL_COREPACK=1/,
+  )
   assert.match(deploy.run, /--env DATABASE_URL=/)
   assert.doesNotMatch(deploy.run, /MIGRATION_DATABASE_URL/)
   assert.doesNotMatch(deploy.run, /\$\{\{ inputs\.(?:git-ref|target) \}\}/)


### PR DESCRIPTION
## Summary

- patch TypeGPU 0.11.9 so its strict-CSP fallback warning is emitted once instead of once per shader writer lookup
- scope Frex Sans GB to Chinese documents so English pages do not download the 1.62 MB CJK font
- let dither canvases reuse the rendered Next Image element instead of fetching original cover assets in parallel
- add regression coverage for the CSP fallback, locale-aware font classes, and dither image lifecycle

## Why

Staging's Content Security Policy blocks runtime `eval`, which makes TypeGPU use its supported default writer. The fallback was harmless, but TypeGPU logged the same warning on every lookup, producing hundreds of console messages per second.

The homepage also loaded assets that were not needed: English documents received the Chinese font variable, and each dithered cover downloaded both an optimized thumbnail and its original source image.

## Performance

Local mobile Lighthouse before and after this branch:

| Metric | Before | After |
| --- | ---: | ---: |
| Performance score | 56 | 81 |
| Transfer size | 4.55 MB | 1.22 MB |
| First Contentful Paint | 9.32 s | 1.20 s |
| Largest Contentful Paint | 13.82 s | 5.24 s |

English pages now make zero Frex requests, homepage dither covers make zero original-image requests, and Chinese routes continue to load Frex.

## Verification

- `pnpm typecheck`
- `pnpm test:unit` (119 files, 1,084 tests)
- `pnpm test:localization` (148 checks)
- `pnpm build` with localhost-only placeholder environment values
- strict-CSP browser check: one initial TypeGPU fallback warning, then zero repeated warnings
- browser lifecycle check: optimized images still paint the dither canvases
- same-viewport visual comparison: no visible regression

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses three independent performance and DX issues: patches TypeGPU 0.11.9 to emit its CSP eval-fallback warning only once, scopes the 1.62 MB Frex Sans GB font to Chinese pages only, and refactors dither covers to reuse Next.js's already-rendered `<img>` element instead of fetching the original cover asset a second time.

- **TypeGPU patch** (`patches/typegpu@0.11.9.patch`, `pnpm-workspace.yaml`) — adds a module-level `didWarnAboutEvalFallback` guard so the warning fires at most once per process instead of on every `getCompiledWriter` call; covered by a `spawnSync` integration test.
- **Font scoping** (`app/fonts.ts`, `site-document.tsx`, global-error/not-found) — replaces the static `fontVariables` export with `fontVariablesForLocale(locale)`, which omits the `--font-frex-gb` variable on English routes; CSS stacks updated with `var(--font-frex-gb, ui-sans-serif)` fallback so undefined custom properties degrade gracefully.
- **DitheredImage component** (`dither-veil.tsx`, `polaroid-cover.tsx`, `post-row.tsx`) — new `DitheredImage` wrapper passes a `ref` to the Next.js `Image` and hands it to the now-private `DitherVeil`; the canvas reads pixel data from the already-decoded optimised thumbnail, eliminating a second network round-trip to the original cover URL.

<h3>Confidence Score: 5/5</h3>

All three changes are independent, well-scoped, and each is paired with targeted tests; no regressions found.

The TypeGPU patch is a minimal two-line guard in a vendored file with an integration test that exercises the exact code path under restricted eval. The font scoping change correctly pairs the JS locale gate with CSS custom-property fallbacks so undefined variables degrade gracefully rather than invalidating the entire font-family stack. The DitheredImage refactor preserves the same DOM structure and effect lifecycle while eliminating a redundant image fetch; the ref is set before effects run in React's commit ordering, so the canvas always has a valid source element. CI targets Node 24, so the globSync import in the CSP test is compatible. No logic bugs, broken interfaces, or dropped behaviour detected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| components/dither-veil.tsx | Adds public DitheredImage wrapper that forwards a ref to Next.js Image and passes it to the now-private DitherVeil; canvas logic now reads from the optimised img element instead of creating a second Image() request. Effect dependency array, ref commit ordering, and load/resize lifecycle all look correct. |
| app/fonts.ts | Replaces static fontVariables export with fontVariablesForLocale(locale); Frex Sans GB variable is included only for 'zh' locale, saving ~1.62 MB on English routes. |
| app/globals.css | Updates font stacks to use var(--font-frex-gb, ui-sans-serif/ui-monospace) so that when the CJK variable is absent on English pages the property resolves to a valid system font instead of becoming invalid at computed time. |
| patches/typegpu@0.11.9.patch | Minimal two-hunk patch: adds module-level didWarnAboutEvalFallback flag and guards the console.warn call, suppressing repeated warnings under strict CSP. Patch is correctly registered in pnpm-workspace.yaml and pnpm-lock.yaml. |
| lib/security/typegpu-csp-fallback.test.ts | Integration test spawns a child Node.js process with --disallow-code-generation-from-strings and calls getCompiledWriter three times, asserting stderr contains the warning exactly once. Uses globSync from node:fs (Node 22+); confirmed safe since CI targets Node 24. |
| components/dither-veil.test.tsx | New jsdom test renders DitheredImage and asserts exactly one img element and zero Image() constructor calls, directly covering the key regression (no parallel original-image fetch). |
| components/polaroid-cover.tsx | Switches from separate Image + DitherVeil pair to DitheredImage; when print is falsy a plain Image is rendered, preserving the no-dither code path. DOM structure unchanged. |
| components/post-row.tsx | Replaces Image + DitherVeil pair with DitheredImage; ditherMode defaults to 'dither', matching the old implicit default. |
| pnpm-workspace.yaml | New file declaring patchedDependencies for typegpu@0.11.9; correct pnpm v9/v10 location for this config. No packages field so workspace mode is not inadvertently activated. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant NI as NextImage
    participant DI as DitheredImage
    participant DV as DitherVeil
    participant CV as Canvas

    Note over Browser,CV: Before — two fetches per cover
    Browser->>NI: render optimised thumbnail
    Browser->>DV: create new Image with original src
    DV->>CV: drawImage with original

    Note over Browser,CV: After — one fetch per cover
    Browser->>DI: render DitheredImage
    DI->>NI: Image with ref forwarded
    NI-->>Browser: optimised thumbnail loaded
    DI->>DV: pass imageRef to DitherVeil
    DV->>CV: drawImage from imageRef.current
    Note over DV: zero new Image() calls
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant NI as NextImage
    participant DI as DitheredImage
    participant DV as DitherVeil
    participant CV as Canvas

    Note over Browser,CV: Before — two fetches per cover
    Browser->>NI: render optimised thumbnail
    Browser->>DV: create new Image with original src
    DV->>CV: drawImage with original

    Note over Browser,CV: After — one fetch per cover
    Browser->>DI: render DitheredImage
    DI->>NI: Image with ref forwarded
    NI-->>Browser: optimised thumbnail loaded
    DI->>DV: pass imageRef to DitherVeil
    DV->>CV: drawImage from imageRef.current
    Note over DV: zero new Image() calls
```

</a>

<sub>Reviews (1): Last reviewed commit: ["perf(web): reduce homepage asset weight"](https://github.com/calicastle/cali.so/commit/ea0a31f32d2265d21c03dde4d3c5862b282155ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45449787)</sub>

<!-- /greptile_comment -->