### PR TITLE
Record the successful v3 Production release

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -10,11 +10,12 @@ Current as of July 2026.
   [PR #195](https://github.com/CaliCastle/cali.so/pull/195), at merge commit
   `4f071ab`. `dev` was restored at that same commit after GitHub's automatic
   branch cleanup and is protected against deletion and force pushes.
-- The first protected Production run
-  [#29696010332](https://github.com/CaliCastle/cali.so/actions/runs/29696010332)
-  received an empty migration credential and stopped before database access or
-  Vercel deployment. The hotfix provisions split Production roles and makes
-  the replacement run automatic when its reviewed commit reaches `main`.
+- [PR #206](https://github.com/CaliCastle/cali.so/pull/206) completed the
+  Production hotfix at merge commit `d891463`. Attempt 3 of
+  [Deploy Production run #29707454879](https://github.com/CaliCastle/cali.so/actions/runs/29707454879)
+  passed the expand-only check, applied migrations with the dedicated
+  `cali_migrator` role, and deployed that exact commit automatically. The live
+  public and signed-out admin boundaries pass at `https://cali.so`.
 - Git **`dev`** is the long-lived Staging and integration branch. `main` drives
   Production; a reviewed `dev` to `main` pull request is the release path.
 - Release scope and evidence are preserved in closed issues

--- a/docs/security/verification.md
+++ b/docs/security/verification.md
@@ -121,9 +121,14 @@ Project API checks refreshed on 2026-07-20 verified:
   Production environment; Vercel stores only the pooled CRUD runtime URL. The
   runtime role cannot create schema, and the migration role cannot manage roles
   or databases.
-- [ ] Confirm the automatic Production workflow applies migrations `0001`
-  through `0012`, deploys the exact `main` commit, and passes smoke checks.
+- [x] Attempt 3 of
+  [Deploy Production run #29707454879](https://github.com/CaliCastle/cali.so/actions/runs/29707454879)
+  passed the expand-only policy, applied migrations `0001` through `0012`, and
+  deployed the exact `main@d891463` commit automatically. Post-deploy checks
+  verified the public security boundary, all 13 hosted browser cases, and a
+  signed-out `401` from `/api/admin/media/assets` rather than a server error.
 
 Clerk provider configuration and owner recovery remain tracked by issue #93.
-Production provider values remain a post-merge deployment and verification
-concern until the automatic Production workflow and smoke checks complete.
+Signed-in owner operations and end-to-end checks for each configured external
+provider remain separate operational follow-ups; they are not deployment
+workflow blockers.

--- a/docs/v3-cutover-ops-runbook.md
+++ b/docs/v3-cutover-ops-runbook.md
@@ -7,6 +7,12 @@ Production workflow itself runs automatically after a reviewed commit reaches
 `main`. Nothing in this file contains a secret; commands that need one prompt
 for it interactively.
 
+The v3.0 Production deployment completed on July 20, 2026. Attempt 3 of
+[Deploy Production run #29707454879](https://github.com/CaliCastle/cali.so/actions/runs/29707454879)
+applied migrations and deployed `main@d891463` without a manual approval step.
+Treat the provisioning commands below as a rebuild and rotation reference, not
+as a statement that Production is still unconfigured.
+
 ## Vercel CLI scope
 
 The team slug `cali` collides with the personal account, so slug-based scope
@@ -128,10 +134,11 @@ JSON
 
 ## 4. Provision the Production environment
 
-Production currently satisfies none of the v3 contract in `.env.example`.
-Each `env add` prompts for its value; generate fresh secrets rather than
-copying Preview's, and never add `MIGRATION_DATABASE_URL` to any Vercel
-environment.
+Production satisfied this contract for the v3.0 deployment on July 20, 2026.
+Before rebuilding or rotating it, inventory the live environment and change
+only the intended values. Each `env add` prompts for its value; generate fresh
+secrets rather than copying Preview's, and never add
+`MIGRATION_DATABASE_URL` to any Vercel environment.
 
 ```bash
 add() { npx vercel env add "$1" production $SCOPE; }
@@ -148,10 +155,10 @@ add NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 add CLERK_SECRET_KEY
 add CRON_SECRET              # openssl rand -hex 32
 
-# Server-only key material — generate per environment, never reuse Preview's.
-add AMA_ENCRYPTION_KEY       # openssl rand -hex 32
-add RATE_LIMIT_HASH_KEY      # openssl rand -hex 32
-add MEDIA_ENCRYPTION_KEY     # openssl rand -hex 32
+# Server-only key material — 32 decoded bytes of base64 per environment.
+add AMA_ENCRYPTION_KEY       # openssl rand -base64 32
+add RATE_LIMIT_HASH_KEY      # openssl rand -base64 32
+add MEDIA_ENCRYPTION_KEY     # openssl rand -base64 32
 
 # Rate limits (values from .env.example defaults unless tuned).
 add ADMIN_MUTATION_RATE_LIMIT_MAX_REQUESTS

--- a/docs/v3-cutover-readiness.md
+++ b/docs/v3-cutover-readiness.md
@@ -15,12 +15,21 @@ Quality, and CodeQL.
 The first Deploy Production run
 [#29696010332](https://github.com/CaliCastle/cali.so/actions/runs/29696010332)
 passed its no-secret review but received an empty `MIGRATION_DATABASE_URL`, so
-Drizzle stopped before connecting and Vercel deployment was skipped. The
-follow-up hotfix configures dedicated Production migration and CRUD-only runtime
-roles, makes each `main` push migrate and deploy automatically, and keeps the
-credentials isolated to their GitHub and Vercel consumers. Its merge triggers
-the replacement Production run; this record does not claim success until that
-run and its smoke checks pass.
+Drizzle stopped before connecting and Vercel deployment was skipped.
+[PR #206](https://github.com/CaliCastle/cali.so/pull/206) then added dedicated
+Production migration and CRUD-only runtime roles, made each `main` push migrate
+and deploy automatically, and kept each credential isolated to its GitHub or
+Vercel consumer.
+
+PR #206 merged as `d891463`. Attempt 3 of
+[Deploy Production run #29707454879](https://github.com/CaliCastle/cali.so/actions/runs/29707454879)
+passed the expand-only check, applied migrations `0001` through `0012`, and
+deployed that exact commit to
+`https://cali-nnstyrz6o-cali.vercel.app`. The exact deployment and
+`https://cali.so` return 200. The post-deploy security-boundary verifier and all
+13 hosted browser cases pass against Production; the signed-out Media API now
+returns 401 instead of the pre-fix 500. Automated Production deployment and
+public smoke proof are complete.
 
 ## Pre-cutover verdict (historical)
 
@@ -63,7 +72,7 @@ Production deployment status.
 | Repository validation | PASS (LOCAL AND FEATURE PREVIEW) / AWAITING QUALITY AND STAGING | The new `pnpm test:browser` production-build gate passes 19 Chromium behavior cases plus six WebKit smoke executions locally. Feature Preview run [29671775136](https://github.com/CaliCastle/cali.so/actions/runs/29671775136) passed all 13 read-only `@hosted` cases against `https://cali-lonkhb5df-cali.vercel.app` for `2336124`. `Quality` and the Staging deployment remain pending. |
 | Public browser behavior | PASS | Local and Staging review covered desktop and mobile, both locales, light and dark appearance, reduced motion, keyboard navigation, metadata, overflow, feeds, generated social images, and Instant Navigation. |
 | Owner admin boundary | PASS (Staging signed-out path) / AWAITING OWNER AND PRODUCTION PROOF | A clean browser navigation to Staging `/admin` completes Clerk's development-instance handshake and reaches the isolated sign-in UI. The complete remote security-boundary verifier passes. Signed-in owner reads and mutations still require authorized operator access and the database gate below; confirm the Production Clerk keys and owner metadata at cutover. |
-| Complete diff Standards review | PARTIAL / AWAITING RE-REVIEW | PR #189 landed the credential-driven AMA and owner-auth decisions plus keyboard-instant Preview-card, lightbox, and article-map behavior. The browser gate now verifies those motion paths. Issues #184 through #186 remain open because their PR merged to `dev`, not the default branch; the layer-scale finding and judgement-level `app/globals.css` disposition still need a recorded resolution before the refreshed review can pass. |
+| Complete diff Standards review | PARTIAL / AWAITING RE-REVIEW | PR #189 landed the credential-driven AMA and owner-auth decisions plus keyboard-instant Preview-card, lightbox, and article-map behavior. The browser gate now verifies those motion paths. At this snapshot, issues #184 through #186 remained open because their PR had merged to `dev`, not the default branch; the layer-scale finding and judgement-level `app/globals.css` disposition still needed a recorded resolution before the refreshed review could pass. |
 | Complete diff Spec review | PARTIAL / AWAITING RE-REVIEW | No scope creep was found, and the missing automated browser-test command plus automated feature Preview evidence are now implemented. Analytics dashboard proof remains absent, and Domain evidence was overstated. The Clerk redirect-shape verifier intentionally stops at the first 307, but the separate clean-browser matrix completed the development handshake and rendered Clerk sign-in. |
 | Production-like Staging | PASS (public and signed-out boundaries) | `https://beta.cali.so` serves `dev@8802607`. The complete public route, link, discovery, legacy-URL, security-boundary, and manual browser matrix passed. Signed-in owner operations and provider-backed workflows remain separate gates. |
 | Issue #107 feature Preview evidence | PASS (AUTOMATED MATRIX) / AWAITING MANUAL HOSTED EVIDENCE | The exact feature Preview for `2336124` passed the 13-case hosted matrix across both locales, appearance and viewport profiles, reduced motion, metadata, feeds, social images, Instant Navigation, public Analytics inclusion, and the signed-out admin boundary. Fresh Analytics dashboard proof and signed-in owner evidence remain separate manual gates. |
@@ -204,8 +213,8 @@ Final review artifacts after the accessibility corrections:
   paths. The Playwright production-build gate now verifies zero card and cell
   motion on keyboard Preview-card focus, synchronous lightbox open and Escape
   focus restoration, instant article-map toggles, and zero running Web
-  Animations under reduced motion. Issues #184 through #186 remain open because
-  their PR merged to `dev` rather than the default branch.
+  Animations under reduced motion. Issues #184 through #186 shipped on `main`
+  through PR #189 and were closed during the release-record cleanup.
 - Earlier design-contract findings around selection weight, contrast, scroll
   reveals, and chrome typography are closed. The final review newly found that
   the implementation uses local and page-level numeric stacking values beyond
@@ -258,18 +267,17 @@ configuration, and an active Published Photo Selection. Git remains
 authoritative for writing and ordinary site content, but not for the curated
 photo wall.
 
-Before accepting a successful Production deployment, an authorized operator
-must:
+For the v3.0 deployment, the authorized operator confirmed the Production
+runtime role has only the required CRUD grants, confirmed Vercel has no
+migration credential, and isolated the direct migration credential in the
+`main`-restricted GitHub Production environment. Run #29707454879 applied the
+complete additive migration history before deploying the exact commit. Public
+site, discovery, URL, link, security-boundary, and signed-out admin checks pass
+against Production.
 
-1. confirm the production runtime role has only the required CRUD grants;
-2. confirm Vercel has no migration credential;
-3. apply the separately approved pending Media migrations with the migration
-   role, preserving the additive migration history;
-4. verify private Originals, public Renditions, and the active Published Photo
-   Selection against the production Bunny and Neon boundary;
-5. verify each configured AMA provider uses a complete Production-only
-   credential pair; and
-6. smoke-test the public site and every configured AMA provider workflow.
+Signed-in owner verification, the private Originals and public Renditions
+storage contract, the active Published Photo Selection, and complete
+end-to-end exercises for each configured AMA provider remain operator checks.
 
 Production database or sensitive cloud-data inspection requires two fresh,
 explicit confirmations immediately before access.
@@ -290,36 +298,29 @@ remain in place during application rollback; destructive down migrations are
 not part of the procedure. Record the known-good deployment identifier and an
 operator before accepting a Production deployment.
 
-## Unverified or deferred at merge
+## Post-release follow-ups
 
 Maintainer-operated commands for the hosted actions below are collected in
 `docs/v3-cutover-ops-runbook.md`.
 
-1. Refresh the complete-diff Standards and Spec reviews, record the disposition
-   of issues #184 through #186 now that their implementation is on `main`, and
-   reconcile the implementation with the documented closed layer scale. The
+1. Refresh the complete-diff Standards and Spec reviews and reconcile the
+   implementation with the documented closed layer scale. Issues #184 through
+   #186 are shipped and closed. The
    judgement-level `app/globals.css` divergent-change finding may remain a
    follow-up only if the maintainer records that disposition.
-2. Review and accept the recorded automated Feature Preview evidence for
-   `2336124`, then use that exact deployment for the remaining Analytics
-   dashboard and other manual hosted evidence.
+2. Confirm fresh Chinese and English Production pageviews are visible in the
+   existing `cali-so` Analytics dashboard.
 3. With two fresh confirmations, verify Staging migrations `0010` and `0011`,
    Media and AMA tables, and the runtime role's CRUD-only grants. Then sign in
    as the marked owner and prove one non-destructive read plus the required
    mutation boundaries. Until then, treat signed-in Staging admin operations as
    unvalidated.
-4. Verify the configured Production migration role, CRUD-only runtime role,
-   required secrets, rate limits, intended AMA provider credential pairs, and
-   complete Bunny and media configuration against the deployed application.
-5. In the Vercel dashboard, verify logs, drains, retention, firewall rules,
+4. In the Vercel dashboard, verify logs, drains, retention, firewall rules,
    the production-branch mapping, and the certificate.
-6. Verify the automatic Production workflow applies the reviewed migration
-   baseline before deploying the exact `main` commit. Direct operator database
-   inspection still requires two fresh confirmations.
-7. Verify the production Bunny and Neon Media boundary, run the protected live
+5. Verify the Production Bunny and Neon Media boundary, run the protected live
    storage contract, and publish the intended two-photo Published Photo
    Selection through the owner admin.
-8. Confirm fresh Chinese and English pageviews from the recorded Feature
-    Preview are visible in the existing `cali-so` Analytics dashboard.
-9. Confirm the rollback procedure against the recorded known-good deployment.
-10. Complete the automatic Production deployment and post-deploy smoke tests.
+6. Sign in as the marked Production owner and exercise each configured AMA
+   provider workflow without exposing customer or credential data.
+7. Confirm the rollback procedure against the now-recorded Production
+   deployment.

--- a/scripts/verify-production-security-boundary.mjs
+++ b/scripts/verify-production-security-boundary.mjs
@@ -291,7 +291,19 @@ async function verifyPublicAmaApiBoundary(baseUrl) {
     const outcome = outcomes.find(({ status }) => response.status === status)
     assert.ok(outcome, `${path} boundary status ${response.status}`)
     if (outcome.error) {
-      assert.deepEqual(JSON.parse(responseBody), { error: outcome.error })
+      let parsedBody
+      try {
+        parsedBody = JSON.parse(responseBody)
+      } catch {
+        assert.fail(
+          `${path} response body is not JSON: ${responseBody.slice(0, 200)}`,
+        )
+      }
+      assert.deepEqual(
+        parsedBody,
+        { error: outcome.error },
+        `${path} boundary body`,
+      )
     }
     assert.equal(response.headers.get('cache-control'), 'no-store')
     assert.equal(response.headers.get('set-cookie'), null)

--- a/scripts/verify-production-security-boundary.mjs
+++ b/scripts/verify-production-security-boundary.mjs
@@ -236,32 +236,63 @@ async function verifyPublicAmaApiBoundary(baseUrl) {
   }
   const holdId = '00000000-0000-4000-8000-000000000000'
   // Public mutations are enabled by default: empty submissions stop at
-  // validation, while routes whose provider (Stripe, Resend) is not
-  // configured in this environment keep failing closed with 503.
+  // validation. Provider-backed routes have two exact safe outcomes: a
+  // configured provider rejects the synthetic resource or signature, while
+  // an unconfigured provider fails closed with 503.
   const requests = [
-    { path: '/api/ama/holds', body: '{}', status: 400 },
-    { path: `/api/ama/holds/${holdId}/checkout`, body: '{}', status: 503 },
-    { path: '/api/ama/stripe/webhook', body: '{}', status: 503 },
-    { path: '/api/ama/alternate-time-requests', body: '{}', status: 400 },
+    {
+      path: '/api/ama/holds',
+      requestBody: '{}',
+      outcomes: [{ status: 400 }],
+    },
+    {
+      path: `/api/ama/holds/${holdId}/checkout`,
+      requestBody: '{}',
+      outcomes: [
+        { status: 404, error: 'not_found' },
+        { status: 503 },
+      ],
+    },
+    {
+      path: '/api/ama/stripe/webhook',
+      requestBody: '{}',
+      outcomes: [
+        { status: 400, error: 'invalid_signature' },
+        { status: 503 },
+      ],
+    },
+    {
+      path: '/api/ama/alternate-time-requests',
+      requestBody: '{}',
+      outcomes: [{ status: 400 }],
+    },
     {
       path: '/api/ama/manage/security-boundary-token/cancel',
-      body: '{}',
-      status: 503,
+      requestBody: '{}',
+      outcomes: [{ status: 503 }],
     },
     {
       path: '/api/ama/manage/security-boundary-token/reschedule',
-      body: '{}',
-      status: 503,
+      requestBody: '{}',
+      outcomes: [{ status: 503 }],
     },
   ]
 
-  for (const { path, body, status } of requests) {
-    const { response } = await fetchBoundary(baseUrl, path, {
-      method: 'POST',
-      headers: sameOriginHeaders,
-      body,
-    })
-    assert.equal(response.status, status, `${path} boundary status`)
+  for (const { path, requestBody, outcomes } of requests) {
+    const { response, body: responseBody } = await fetchBoundary(
+      baseUrl,
+      path,
+      {
+        method: 'POST',
+        headers: sameOriginHeaders,
+        body: requestBody,
+      },
+    )
+    const outcome = outcomes.find(({ status }) => response.status === status)
+    assert.ok(outcome, `${path} boundary status ${response.status}`)
+    if (outcome.error) {
+      assert.deepEqual(JSON.parse(responseBody), { error: outcome.error })
+    }
     assert.equal(response.headers.get('cache-control'), 'no-store')
     assert.equal(response.headers.get('set-cookie'), null)
   }

--- a/tests/browser/admin-boundary.spec.ts
+++ b/tests/browser/admin-boundary.spec.ts
@@ -29,7 +29,13 @@ test('@hosted signed-out admin navigation stops at the authentication boundary',
   expect(responseBody).not.toContain('/_vercel/insights/script.js')
 
   if (response.status() === 404) {
-    expect(headers['x-clerk-auth-reason']).toBe('protect-rewrite, dev-browser-missing')
+    // Clerk reports the same fail-closed rewrite with an environment-specific
+    // signed-out reason: Preview lacks the development browser token, while
+    // Production lacks both a session token and UAT.
+    expect([
+      'protect-rewrite, dev-browser-missing',
+      'protect-rewrite, session-token-and-uat-missing',
+    ]).toContain(headers['x-clerk-auth-reason'])
     return
   }
 


### PR DESCRIPTION
## Summary

- record the successful automatic Production deployment and remaining post-release operator checks
- correct the runbook to generate 32-byte base64 encryption and hash keys
- keep hosted verification exact across Production and Preview Clerk and AMA provider states

## Production proof

- Deploy Production run #29707454879 attempt 3 passed migrations and Vercel deployment for `main@d891463`
- `https://cali.so` and the exact Vercel deployment return 200
- `/api/admin/media/assets` returns the signed-out 401 boundary instead of 500

## Verification

- `pnpm typecheck`
- `SECURITY_BOUNDARY_BASE_URL=https://cali.so pnpm verify:security-boundary`
- `SECURITY_BOUNDARY_BASE_URL=https://beta.cali.so pnpm verify:security-boundary`
- `PLAYWRIGHT_BASE_URL=https://cali.so pnpm test:browser:hosted` (13 passed)
- Staging hosted admin boundary (3 passed)
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR records the successful v3.0 Production deployment and applies a set of post-release housekeeping changes: documentation is updated throughout to reflect the completed run, the security-boundary verification script is generalised to tolerate multiple valid outcome statuses (configured vs. unconfigured AMA provider), and the browser test is widened to accept both the Preview and Production Clerk signed-out header values.

- **Docs** (`handoff.md`, `security/verification.md`, `v3-cutover-readiness.md`, `v3-cutover-ops-runbook.md`): pending checklist items are marked complete, deployment evidence and run links are added, and the pre-deployment operator checklist is replaced with a post-release follow-up list.
- **Runbook key-generation fix** (`v3-cutover-ops-runbook.md`): `openssl rand -hex 32` is corrected to `openssl rand -base64 32` for `AMA_ENCRYPTION_KEY`, `RATE_LIMIT_HASH_KEY`, and `MEDIA_ENCRYPTION_KEY`, aligning the commands with the 32-decoded-byte base64 format the application expects.
- **Script + test** (`verify-production-security-boundary.mjs`, `admin-boundary.spec.ts`): verification logic is adapted to accept environment-specific responses that differ between a configured Production Stripe/Resend setup and an unconfigured Preview deployment.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the substantive changes are a verification-script generalisation and a test fix, both of which make the tooling more accurate against Production without loosening any actual security check.

The only non-documentation logic change is in the AMA boundary verification loop: `JSON.parse(responseBody)` is called without a try/catch, so an unexpected non-JSON body would surface as a `SyntaxError` rather than a clean assertion failure. This does not affect deployed code, but it could produce a confusing diagnostic if a regressed endpoint returns an HTML error page while still matching the expected status code. Everything else — the Clerk header assertion, key-generation command correction, and doc updates — is straightforward and low-risk.

scripts/verify-production-security-boundary.mjs — specifically the `JSON.parse(responseBody)` call inside the outcome-error branch.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/verify-production-security-boundary.mjs | Refactored AMA boundary checks to support multiple valid outcome statuses per endpoint (configured vs. unconfigured provider), with optional response-body validation via JSON.parse — minor unhandled parse-failure risk |
| tests/browser/admin-boundary.spec.ts | Expanded Clerk auth-reason assertion to accept both Preview and Production signed-out header values, correctly accommodating environment-specific Clerk behaviour |
| docs/v3-cutover-ops-runbook.md | Corrected key-generation commands from openssl rand -hex 32 to openssl rand -base64 32 and updated deployment status prose |
| docs/handoff.md | Replaced the pending-hotfix note with confirmed-deployment details; documentation-only change |
| docs/security/verification.md | Marked the Production workflow verification checklist item as complete and updated the post-deploy narrative; documentation-only change |
| docs/v3-cutover-readiness.md | Updated readiness table rows and post-release follow-up list to reflect completed Production deployment and closed issues; documentation-only changes |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["verifyPublicAmaApiBoundary(baseUrl)"]
    A --> B["For each request in requests[]"]
    B --> C["fetchBoundary(POST, path, body)"]
    C --> D["outcomes.find(status matches)"]
    D -->|"No match"| E["assert.ok fails — unexpected status"]
    D -->|"Match found"| F{"outcome.error set?"}
    F -->|"No"| G["assert cache-control / set-cookie headers"]
    F -->|"Yes"| H["JSON.parse(responseBody)"]
    H -->|"parse error"| I["SyntaxError thrown (unhandled)"]
    H -->|"valid JSON"| J["assert.deepEqual body matches error key"]
    J --> G
    G --> B
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["verifyPublicAmaApiBoundary(baseUrl)"]
    A --> B["For each request in requests[]"]
    B --> C["fetchBoundary(POST, path, body)"]
    C --> D["outcomes.find(status matches)"]
    D -->|"No match"| E["assert.ok fails — unexpected status"]
    D -->|"Match found"| F{"outcome.error set?"}
    F -->|"No"| G["assert cache-control / set-cookie headers"]
    F -->|"Yes"| H["JSON.parse(responseBody)"]
    H -->|"parse error"| I["SyntaxError thrown (unhandled)"]
    H -->|"valid JSON"| J["assert.deepEqual body matches error key"]
    J --> G
    G --> B
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fverify-production-security-boundary.mjs%3A293-295%0AWhen%20%60outcome.error%60%20is%20set%20and%20the%20response%20body%20is%20not%20valid%20JSON%20%28e.g.%2C%20a%20Next.js-rendered%20HTML%20error%20page%20slips%20through%20for%20the%20matched%20status%20code%29%2C%20%60JSON.parse%28responseBody%29%60%20throws%20a%20%60SyntaxError%60%20that%20bypasses%20the%20%60assert%60%20machinery.%20The%20failure%20is%20still%20caught%2C%20but%20the%20error%20message%20will%20point%20at%20a%20JSON%20parse%20position%20rather%20than%20the%20endpoint%20path%2C%20making%20it%20harder%20to%20diagnose%20which%20route%20regressed.%20Wrapping%20in%20a%20try%2Fcatch%20and%20re-throwing%20as%20an%20assertion%20keeps%20the%20output%20consistent%20with%20the%20rest%20of%20the%20script.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20%28outcome.error%29%20%7B%0A%20%20%20%20%20%20let%20parsed%0A%20%20%20%20%20%20try%20%7B%0A%20%20%20%20%20%20%20%20parsed%20%3D%20JSON.parse%28responseBody%29%0A%20%20%20%20%20%20%7D%20catch%20%7B%0A%20%20%20%20%20%20%20%20assert.fail%28%60%24%7Bpath%7D%20response%20body%20is%20not%20JSON%3A%20%24%7BresponseBody.slice%280%2C%20200%29%7D%60%29%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20assert.deepEqual%28parsed%2C%20%7B%20error%3A%20outcome.error%20%7D%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=calicastle%2Fcali.so&pr=207&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22calicastle%2Fcali.so%22%20on%20the%20existing%20branch%20%22cali%2Frecord-production-release%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cali%2Frecord-production-release%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fverify-production-security-boundary.mjs%3A293-295%0AWhen%20%60outcome.error%60%20is%20set%20and%20the%20response%20body%20is%20not%20valid%20JSON%20%28e.g.%2C%20a%20Next.js-rendered%20HTML%20error%20page%20slips%20through%20for%20the%20matched%20status%20code%29%2C%20%60JSON.parse%28responseBody%29%60%20throws%20a%20%60SyntaxError%60%20that%20bypasses%20the%20%60assert%60%20machinery.%20The%20failure%20is%20still%20caught%2C%20but%20the%20error%20message%20will%20point%20at%20a%20JSON%20parse%20position%20rather%20than%20the%20endpoint%20path%2C%20making%20it%20harder%20to%20diagnose%20which%20route%20regressed.%20Wrapping%20in%20a%20try%2Fcatch%20and%20re-throwing%20as%20an%20assertion%20keeps%20the%20output%20consistent%20with%20the%20rest%20of%20the%20script.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20%28outcome.error%29%20%7B%0A%20%20%20%20%20%20let%20parsed%0A%20%20%20%20%20%20try%20%7B%0A%20%20%20%20%20%20%20%20parsed%20%3D%20JSON.parse%28responseBody%29%0A%20%20%20%20%20%20%7D%20catch%20%7B%0A%20%20%20%20%20%20%20%20assert.fail%28%60%24%7Bpath%7D%20response%20body%20is%20not%20JSON%3A%20%24%7BresponseBody.slice%280%2C%20200%29%7D%60%29%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20assert.deepEqual%28parsed%2C%20%7B%20error%3A%20outcome.error%20%7D%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=calicastle%2Fcali.so&pr=207&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
scripts/verify-production-security-boundary.mjs:293-295
When `outcome.error` is set and the response body is not valid JSON (e.g., a Next.js-rendered HTML error page slips through for the matched status code), `JSON.parse(responseBody)` throws a `SyntaxError` that bypasses the `assert` machinery. The failure is still caught, but the error message will point at a JSON parse position rather than the endpoint path, making it harder to diagnose which route regressed. Wrapping in a try/catch and re-throwing as an assertion keeps the output consistent with the rest of the script.

```suggestion
    if (outcome.error) {
      let parsed
      try {
        parsed = JSON.parse(responseBody)
      } catch {
        assert.fail(`${path} response body is not JSON: ${responseBody.slice(0, 200)}`)
      }
      assert.deepEqual(parsed, { error: outcome.error })
    }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): align production checks"](https://github.com/calicastle/cali.so/commit/9e9bf01b73751bd3748ecb0926959ef17deb742c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45494557)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->