### PR TITLE
Industrial design pass: admin + AMA guest surfaces on shared fluid components

### DIFF
--- a/app/_views/ama-manage-page.tsx
+++ b/app/_views/ama-manage-page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 
+import { AmaStage } from '~/components/ama/booking-success-stage'
 import { ManageBooking } from '~/components/ama/manage-booking'
 import { PixelCluster } from '~/components/pixel-cluster'
 import { T } from '~/lib/i18n'
@@ -32,8 +33,13 @@ export function AmaManagePageView({ token }: { token: string }) {
         <PixelCluster variant={2} className="enter shrink-0" />
       </header>
 
-      <div className="enter mt-10 pb-4" style={{ '--enter-delay': '70ms' } as React.CSSProperties}>
-        <ManageBooking token={token} />
+      {/* The manage surface shares the confirmation's dark stage shell —
+          shader field and flipped tokens — without the celebration extras
+          (confetti and the seal stay exclusive to the paid confirmation). */}
+      <div className="enter mt-6" style={{ '--enter-delay': '70ms' } as React.CSSProperties}>
+        <AmaStage align="start">
+          <ManageBooking token={token} />
+        </AmaStage>
       </div>
     </div>
   )

--- a/app/admin/(protected)/AdminOverview.test.tsx
+++ b/app/admin/(protected)/AdminOverview.test.tsx
@@ -33,7 +33,7 @@ describe('Admin overview', () => {
     const { container } = render(<AdminOverview {...fixtures} />)
     const text = container.textContent!
 
-    const attentionRow = linkWithHref(container, '/admin/ama')!
+    const attentionRow = linkWithHref(container, '/admin/ama/bookings')!
     expect(attentionRow).not.toBeNull()
     expect(text).toContain('Needs attention')
     expect(text).toContain('2')

--- a/app/admin/(protected)/AdminOverview.tsx
+++ b/app/admin/(protected)/AdminOverview.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 
+import { PixelCluster } from '~/components/pixel-cluster'
 import { T } from '~/lib/i18n'
 
 export type NextBookingViewModel = {
@@ -30,7 +31,7 @@ const nextSessionOptions: Intl.DateTimeFormatOptions = {
   hour12: false,
 }
 const nextSessionFormatters = {
-  zh: new Intl.DateTimeFormat('zh-TW', nextSessionOptions),
+  zh: new Intl.DateTimeFormat('zh-CN', nextSessionOptions),
   en: new Intl.DateTimeFormat('en-US', nextSessionOptions),
 }
 
@@ -79,20 +80,25 @@ export function AdminOverview({
 }: AdminOverviewProps) {
   return (
     <div className="pb-10">
-      <h1 className="text-sm font-medium text-muted-foreground">
-        <T zh="总览" en="Overview" />
-      </h1>
+      <div className="flex items-center justify-between gap-4">
+        <h1 className="page-eyebrow">
+          <T zh="总览" en="Overview" />
+        </h1>
+        <PixelCluster variant={6} className="shrink-0" />
+      </div>
 
       <ul className="mt-6 hairline-top pt-4">
         <OverviewRow
-          href="/admin/ama"
+          href="/admin/ama/bookings"
           label={<T zh="需要处理" en="Needs attention" />}
           value={attentionCount}
           destructive={attentionCount > 0}
         />
         <OverviewRow
           href={
-            nextBooking ? `/admin/ama/bookings/${nextBooking.id}` : '/admin/ama'
+            nextBooking
+              ? `/admin/ama/bookings/${nextBooking.id}`
+              : '/admin/ama/bookings'
           }
           label={<T zh="下一场咨询" en="Next session" />}
           value={
@@ -111,7 +117,7 @@ export function AdminOverview({
           }
         />
         <OverviewRow
-          href="/admin/ama"
+          href="/admin/ama/bookings"
           label={<T zh="时间请求" en="Time requests" />}
           value={
             <>

--- a/app/admin/(protected)/ama/AmaOperations.tsx
+++ b/app/admin/(protected)/ama/AmaOperations.tsx
@@ -3,10 +3,11 @@
 import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
 
+import { SectionTag } from '~/components/section-tag'
+import { Button } from '~/components/ui/button'
 import { T } from '~/lib/i18n'
 import { localize, useLocale } from '~/lib/locale-client'
 
-import { AmaSettings, type AmaSettingsProps } from './AmaSettings'
 import {
   BookingStatusBadge,
   OperationsList,
@@ -26,7 +27,6 @@ export type AmaOperationsProps = {
   attention: BookingRowViewModel[]
   timeRequests: AlternateTimeRequestViewModel[]
   failedOperations: OperationViewModel[]
-  settings: AmaSettingsProps
 }
 
 function BookingRow({
@@ -176,7 +176,7 @@ function AlternateTimeRequests({
                 <div className="min-w-0 max-w-xl">
                   <p className="flex flex-wrap items-baseline gap-x-3 gap-y-0.5">
                     <span className="font-medium">{request.guestName}</span>
-                    <span className="break-all text-muted-foreground">
+                    <span className="break-all font-mono text-xs text-muted-foreground">
                       {request.guestEmail}
                     </span>
                   </p>
@@ -200,31 +200,27 @@ function AlternateTimeRequests({
                     </p>
                   )}
                 </div>
+                {/* Dense stacked rows: the row itself is the tap target — no
+                    hit-area extension on these compact pills. */}
                 <div className="flex items-center gap-2">
-                  <button
-                    type="button"
+                  <Button
+                    variant="primary"
+                    size="sm"
                     disabled={pending !== null}
+                    loading={pending === `${request.id}:resolve`}
                     onClick={() => void act(request, 'resolve')}
-                    className="min-h-11 rounded-full bg-foreground px-4 text-sm font-medium text-background outline-none transition-transform duration-100 active:scale-[0.97] disabled:opacity-50 focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-2 motion-reduce:transform-none"
                   >
-                    {pending === `${request.id}:resolve` ? (
-                      <T zh="正在标记…" en="Resolving…" />
-                    ) : (
-                      <T zh="标记已处理" en="Resolve" />
-                    )}
-                  </button>
-                  <button
-                    type="button"
+                    <T zh="标记已处理" en="Resolve" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
                     disabled={pending !== null}
+                    loading={pending === `${request.id}:dismiss`}
                     onClick={() => void act(request, 'dismiss')}
-                    className="min-h-11 px-3 text-sm text-muted-foreground outline-none disabled:opacity-50 focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
                   >
-                    {pending === `${request.id}:dismiss` ? (
-                      <T zh="正在忽略…" en="Dismissing…" />
-                    ) : (
-                      <T zh="忽略" en="Dismiss" />
-                    )}
-                  </button>
+                    <T zh="忽略" en="Dismiss" />
+                  </Button>
                 </div>
               </li>
             ))}
@@ -253,10 +249,10 @@ export function AmaOperations({
   attention,
   timeRequests,
   failedOperations,
-  settings,
 }: AmaOperationsProps) {
   const locale = useLocale()
   const [handledCount, setHandledCount] = useState(0)
+  const [pastOpen, setPastOpen] = useState(false)
   const attentionTotal = Math.max(
     0,
     attention.length + failedOperations.length + timeRequests.length - handledCount,
@@ -268,9 +264,6 @@ export function AmaOperations({
 
   return (
     <div className="pb-10">
-      <h1 className="text-sm font-medium text-muted-foreground">
-        <T zh="咨询" en="AMA" />
-      </h1>
       <p className="mt-1 text-sm tabular-nums text-muted-foreground">
         {upcoming.length} <T zh="场即将进行" en="upcoming" />
         {' · '}
@@ -278,9 +271,9 @@ export function AmaOperations({
       </p>
 
       <section aria-labelledby="attention-heading" className="mt-6 hairline-top pt-6">
-        <h2 id="attention-heading" className="text-sm font-medium">
+        <SectionTag index={1} id="attention-heading">
           <T zh="需要处理" en="Needs attention" />
-        </h2>
+        </SectionTag>
         {allClear ? (
           <p className="mt-2 text-sm leading-6 text-muted-foreground">
             <T zh="一切正常。" en="All clear." />
@@ -317,9 +310,9 @@ export function AmaOperations({
       </section>
 
       <section aria-labelledby="upcoming-heading" className="mt-8 hairline-top pt-6">
-        <h2 id="upcoming-heading" className="text-sm font-medium">
+        <SectionTag index={2} id="upcoming-heading">
           <T zh="即将进行" en="Upcoming" />
-        </h2>
+        </SectionTag>
         {upcoming.length === 0 ? (
           <p className="mt-2 text-sm leading-6 text-muted-foreground">
             <T zh="没有即将进行的预约。" en="There are no upcoming Bookings." />
@@ -336,43 +329,48 @@ export function AmaOperations({
       <section aria-labelledby="past-heading" className="mt-8 hairline-top pt-6">
         {past.length === 0 ? (
           <>
-            <h2 id="past-heading" className="text-sm font-medium">
+            <SectionTag index={3} id="past-heading">
               <T zh="已结束" en="Past" />
-            </h2>
+            </SectionTag>
             <p className="mt-2 text-sm leading-6 text-muted-foreground">
               <T zh="还没有已结束的预约。" en="There are no past Bookings yet." />
             </p>
           </>
         ) : (
-          <details className="group">
-            <summary
-              aria-label={localize(locale, '已结束的预约', 'Past Bookings')}
-              className="flex min-h-11 list-none items-center justify-between gap-4 outline-none focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground [&::-webkit-details-marker]:hidden"
-            >
-              <h2 id="past-heading" className="text-sm font-medium">
+          <>
+            <div className="flex min-h-11 items-center justify-between gap-4">
+              <SectionTag index={3} id="past-heading">
                 <T zh="已结束" en="Past" />
-              </h2>
-              <span className="text-sm tabular-nums text-muted-foreground">
-                {past.length}
-                <span aria-hidden="true"> · </span>
-                <span className="group-open:hidden">
-                  <T zh="展开" en="Show" />
-                </span>
-                <span className="hidden group-open:inline">
-                  <T zh="收起" en="Hide" />
-                </span>
-              </span>
-            </summary>
-            <ul className="mt-3 divide-y divide-border/70">
-              {past.map((booking) => (
-                <BookingRow key={booking.id} booking={booking} />
-              ))}
-            </ul>
-          </details>
+              </SectionTag>
+              <Button
+                variant="ghost"
+                size="sm"
+                active={pastOpen}
+                expandHitArea
+                aria-expanded={pastOpen}
+                aria-controls="past-bookings"
+                aria-label={localize(
+                  locale,
+                  pastOpen ? '收起已结束的预约' : '展开已结束的预约',
+                  pastOpen ? 'Hide past Bookings' : 'Show past Bookings',
+                )}
+                onClick={() => setPastOpen((current) => !current)}
+              >
+                <span className="tabular-nums">{past.length}</span>
+                <span aria-hidden> · </span>
+                {pastOpen ? <T zh="收起" en="Hide" /> : <T zh="展开" en="Show" />}
+              </Button>
+            </div>
+            {pastOpen && (
+              <ul id="past-bookings" className="mt-3 divide-y divide-border/70">
+                {past.map((booking) => (
+                  <BookingRow key={booking.id} booking={booking} />
+                ))}
+              </ul>
+            )}
+          </>
         )}
       </section>
-
-      <AmaSettings {...settings} />
     </div>
   )
 }

--- a/app/admin/(protected)/ama/AmaSettings.tsx
+++ b/app/admin/(protected)/ama/AmaSettings.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useRef, useState, type FormEvent } from 'react'
 
+import { SectionTag } from '~/components/section-tag'
+import { Button } from '~/components/ui/button'
 import { T } from '~/lib/i18n'
 
 import {
@@ -62,11 +64,11 @@ const previewTimeOptions: Intl.DateTimeFormatOptions = {
   hour12: false,
 }
 const previewDateFormatters = {
-  zh: new Intl.DateTimeFormat('zh-TW', previewDateOptions),
+  zh: new Intl.DateTimeFormat('zh-CN', previewDateOptions),
   en: new Intl.DateTimeFormat('en-US', previewDateOptions),
 }
 const previewTimeFormatters = {
-  zh: new Intl.DateTimeFormat('zh-TW', previewTimeOptions),
+  zh: new Intl.DateTimeFormat('zh-CN', previewTimeOptions),
   en: new Intl.DateTimeFormat('en-US', previewTimeOptions),
 }
 
@@ -236,9 +238,9 @@ function GoogleCalendarSection({
     >
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div className="max-w-md">
-          <h3 id="google-heading" className="text-sm font-medium">
+          <SectionTag index={2} id="google-heading">
             <T zh="Google 日历" en="Google Calendar" />
-          </h3>
+          </SectionTag>
           <p className="mt-2 text-sm leading-6 text-muted-foreground">
             <T zh={copy.zh} en={copy.en} />
           </p>
@@ -251,17 +253,16 @@ function GoogleCalendarSection({
               method="post"
               onSubmit={connect}
             >
-              <button
+              <Button
+                variant="primary"
+                size="md"
                 type="submit"
                 disabled={pending !== null}
-                className="min-h-11 touch-manipulation rounded-full bg-foreground px-4 text-sm font-medium text-background outline-none transition-transform duration-100 active:scale-[0.97] disabled:pointer-events-none disabled:opacity-60 focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-reduce:transform-none motion-reduce:transition-none"
+                loading={pending === 'connect'}
+                expandHitArea
               >
-                {pending === 'connect' ? (
-                  <T zh="正在连接…" en="Connecting…" />
-                ) : (
-                  <T zh={connectLabel.zh} en={connectLabel.en} />
-                )}
-              </button>
+                <T zh={connectLabel.zh} en={connectLabel.en} />
+              </Button>
             </form>
           )}
           {connection.status !== 'disconnected' && (
@@ -270,23 +271,21 @@ function GoogleCalendarSection({
               method="post"
               onSubmit={disconnect}
             >
-              <button
+              <Button
+                variant="ghost"
+                size="md"
                 type="submit"
                 disabled={pending !== null}
-                className={`min-h-11 touch-manipulation rounded-full px-3 text-sm outline-none transition-transform duration-100 active:scale-[0.97] disabled:pointer-events-none disabled:opacity-60 focus-visible:ring-1 motion-reduce:transform-none motion-reduce:transition-none ${
-                  disconnectArmed
-                    ? 'text-destructive focus-visible:ring-destructive'
-                    : 'text-muted-foreground focus-visible:ring-foreground'
-                }`}
+                loading={pending === 'disconnect'}
+                destructive={disconnectArmed}
+                expandHitArea
               >
-                {pending === 'disconnect' ? (
-                  <T zh="正在断开…" en="Disconnecting…" />
-                ) : disconnectArmed ? (
+                {disconnectArmed ? (
                   <T zh="确认断开？" en="Confirm disconnect?" />
                 ) : (
                   <T zh="断开" en="Disconnect" />
                 )}
-              </button>
+              </Button>
             </form>
           )}
         </div>
@@ -307,20 +306,26 @@ function GoogleCalendarSection({
       />
 
       {connection.identity && (
-        <dl className="mt-4 grid gap-x-6 gap-y-2 text-sm sm:grid-cols-[7rem_minmax(0,1fr)]">
-          <dt className="text-muted-foreground">
-            <T zh="日历" en="Calendar" />
-          </dt>
-          <dd className="min-w-0 break-words">
-            {connection.identity.summary || connection.identity.email || connection.identity.calendarId}
-          </dd>
+        <dl className="spec-nameplate mt-4 mb-6">
+          <div>
+            <dt>
+              <T zh="日历" en="Calendar" />
+            </dt>
+            <dd className="min-w-0 break-words">
+              {connection.identity.summary ||
+                connection.identity.email ||
+                connection.identity.calendarId}
+            </dd>
+          </div>
           {connection.identity.email && (
-            <>
-              <dt className="text-muted-foreground">
+            <div>
+              <dt>
                 <T zh="账号" en="Account" />
               </dt>
-              <dd className="min-w-0 break-words">{connection.identity.email}</dd>
-            </>
+              <dd className="min-w-0 break-words">
+                {connection.identity.email}
+              </dd>
+            </div>
           )}
         </dl>
       )}
@@ -334,9 +339,9 @@ function SlotPreview({ slots }: { slots: readonly PreviewSlotViewModel[] }) {
   return (
     <section className="mt-8 hairline-top pt-6" aria-labelledby="preview-heading">
       <div className="flex flex-wrap items-baseline justify-between gap-2">
-        <h3 id="preview-heading" className="text-sm font-medium">
+        <SectionTag index={3} id="preview-heading">
           <T zh="开放时间预览" en="Open-time preview" />
-        </h3>
+        </SectionTag>
         <span className="text-sm text-muted-foreground tabular-nums">
           Asia/Taipei · UTC+8
         </span>
@@ -400,10 +405,7 @@ export function AmaSettings({
   notices,
 }: AmaSettingsProps) {
   return (
-    <section aria-labelledby="settings-heading" className="mt-10 hairline-top pt-6">
-      <h2 id="settings-heading" className="text-sm font-medium text-muted-foreground">
-        <T zh="设置" en="Settings" />
-      </h2>
+    <div className="pb-10">
       <p className="mt-1 text-sm leading-6 text-muted-foreground">
         <T
           zh="每次 60 分钟 · 至少提前 24 小时 · 开放未来 30 天 · 前后各留 15 分钟"
@@ -411,11 +413,11 @@ export function AmaSettings({
         />
       </p>
 
-      <section className="mt-6" aria-labelledby="availability-heading">
+      <section className="mt-6 hairline-top pt-6" aria-labelledby="availability-heading">
         <div className="max-w-md">
-          <h3 id="availability-heading" className="text-sm font-medium">
+          <SectionTag index={1} id="availability-heading">
             <T zh="每周可预约时段" en="Weekly Availability Windows" />
-          </h3>
+          </SectionTag>
           <p className="mt-2 text-sm leading-6 text-muted-foreground">
             <T
               zh="所有时间都按 Asia/Taipei 解释。可以在同一天添加多个时段。"
@@ -471,6 +473,6 @@ export function AmaSettings({
         }
       />
       <SlotPreview slots={previewSlots} />
-    </section>
+    </div>
   )
 }

--- a/app/admin/(protected)/ama/AvailabilityWindowForm.tsx
+++ b/app/admin/(protected)/ama/AvailabilityWindowForm.tsx
@@ -1,7 +1,14 @@
 'use client'
 
-import { useEffect, useId, useRef, useState, type FormEvent } from 'react'
+import { useEffect, useRef, useState, type FormEvent } from 'react'
 
+import { Button } from '~/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from '~/components/ui/select'
 import { T } from '~/lib/i18n'
 import { localize, useLocale } from '~/lib/locale-client'
 
@@ -47,7 +54,6 @@ export function AvailabilityWindowForm({
   describedBy,
 }: AvailabilityWindowFormProps) {
   const locale = useLocale()
-  const weekdayId = useId()
   const [weekday, setWeekday] = useState(availabilityWindow?.isoWeekday ?? 1)
   const [pending, setPending] = useState<'save' | 'delete' | null>(null)
   const [deleteArmed, setDeleteArmed] = useState(false)
@@ -103,119 +109,129 @@ export function AvailabilityWindowForm({
         <input type="hidden" name="id" value={availabilityWindow.id} />
       )}
 
+      {/* One localized Select replaces the CSS-swapped zh/en native pair. Its
+          hidden input posts the direct `weekday` field, which the server
+          parser reads ahead of the legacy weekdayZh/weekdayEn/weekdayOriginal
+          trio. */}
       <div className="grid gap-1.5 text-sm">
-        <input
-          type="hidden"
-          name="weekdayOriginal"
-          value={availabilityWindow?.isoWeekday ?? 1}
-        />
-        {(['zh', 'en'] as const).map((language) => {
-          const selectId = `${weekdayId}-weekday-${language}`
-          return (
-            <label
-              key={language}
-              htmlFor={selectId}
-              data-zh-block={language === 'zh' ? true : undefined}
-              data-en-block={language === 'en' ? true : undefined}
-              className="grid gap-1.5"
-            >
-              <span className="text-muted-foreground">
-                {language === 'zh' ? '星期' : 'Day'}
-              </span>
-              <select
-                id={selectId}
-                name={language === 'zh' ? 'weekdayZh' : 'weekdayEn'}
-                value={weekday}
-                disabled={pending !== null}
-                onChange={(event) => setWeekday(Number(event.target.value))}
-                className="min-h-11 w-full touch-manipulation rounded-md bg-background px-3 text-base shadow-[0_0_0_1px_var(--border)] outline-none focus-visible:shadow-[0_0_0_1px_var(--foreground)]"
+        <span className="text-muted-foreground">
+          <T zh="星期" en="Day" />
+        </span>
+        <Select
+          name="weekday"
+          value={String(weekday)}
+          onValueChange={(value) => setWeekday(Number(value))}
+          disabled={pending !== null}
+        >
+          <SelectTrigger
+            aria-label={localize(locale, '星期', 'Day')}
+            className="w-full"
+          />
+          <SelectContent>
+            {weekdays.map((option, index) => (
+              <SelectItem
+                key={option.value}
+                value={String(option.value)}
+                index={index}
               >
-                {weekdays.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option[language]}
-                  </option>
-                ))}
-              </select>
-            </label>
-          )
-        })}
+                {localize(locale, option.zh, option.en)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
-      <label className="grid gap-1.5 text-sm">
+      <div className="grid gap-1.5 text-sm">
         <span className="text-muted-foreground">
           <T zh="开始" en="Start" />
         </span>
-        <select
+        <Select
           name="start"
           defaultValue={formatMinute(availabilityWindow?.startMinute ?? 9 * 60)}
           disabled={pending !== null}
-          aria-label={localize(locale, '开始时间', 'Start time')}
-          className="min-h-11 touch-manipulation rounded-md bg-background px-3 text-base tabular-nums shadow-[0_0_0_1px_var(--border)] outline-none focus-visible:shadow-[0_0_0_1px_var(--foreground)]"
         >
-          {startOptions.map((minute) => (
-            <option key={minute} value={formatMinute(minute)}>
-              {formatMinute(minute)}
-            </option>
-          ))}
-        </select>
-      </label>
+          <SelectTrigger
+            aria-label={localize(locale, '开始时间', 'Start time')}
+            className="w-full tabular-nums"
+          />
+          <SelectContent>
+            {startOptions.map((minute, index) => (
+              <SelectItem
+                key={minute}
+                value={formatMinute(minute)}
+                index={index}
+                className="tabular-nums"
+              >
+                {formatMinute(minute)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
 
-      <label className="grid gap-1.5 text-sm">
+      <div className="grid gap-1.5 text-sm">
         <span className="text-muted-foreground">
           <T zh="结束" en="End" />
         </span>
-        <select
+        <Select
           name="end"
           defaultValue={formatMinute(availabilityWindow?.endMinute ?? 12 * 60)}
           disabled={pending !== null}
-          aria-label={localize(locale, '结束时间', 'End time')}
-          className="min-h-11 touch-manipulation rounded-md bg-background px-3 text-base tabular-nums shadow-[0_0_0_1px_var(--border)] outline-none focus-visible:shadow-[0_0_0_1px_var(--foreground)]"
         >
-          {endOptions.map((minute) => (
-            <option key={minute} value={formatMinute(minute)}>
-              {formatMinute(minute)}
-            </option>
-          ))}
-        </select>
-      </label>
+          <SelectTrigger
+            aria-label={localize(locale, '结束时间', 'End time')}
+            className="w-full tabular-nums"
+          />
+          <SelectContent>
+            {endOptions.map((minute, index) => (
+              <SelectItem
+                key={minute}
+                value={formatMinute(minute)}
+                index={index}
+                className="tabular-nums"
+              >
+                {formatMinute(minute)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
 
-      <div className="flex min-h-11 items-center gap-2 sm:justify-end">
-        <button
+      {/* No min-height wrapper: the buttons are 32px like the selects, so the
+          grid's items-end lines every control on one baseline; hit targets
+          come from expandHitArea. */}
+      <div className="flex items-center gap-2 sm:justify-end">
+        <Button
+          variant="primary"
+          size="lg"
           type="submit"
           name="intent"
           value={isExisting ? 'update' : 'create'}
           disabled={pending !== null}
-          className="min-h-11 min-w-[5.5rem] touch-manipulation rounded-full bg-foreground px-4 text-sm font-medium text-background outline-none transition-transform duration-100 active:scale-[0.97] disabled:pointer-events-none disabled:opacity-60 focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-reduce:transform-none motion-reduce:transition-none"
+          loading={pending === 'save'}
+          expandHitArea
         >
-          {pending === 'save' ? (
-            <T zh="正在保存…" en="Saving…" />
-          ) : isExisting ? (
-            <T zh="保存" en="Save" />
-          ) : (
-            <T zh="添加" en="Add" />
-          )}
-        </button>
+          {isExisting ? <T zh="保存" en="Save" /> : <T zh="添加" en="Add" />}
+        </Button>
         {isExisting && (
-          <button
+          <Button
+            variant="ghost"
+            size="lg"
             type="submit"
             name="intent"
             value="delete"
             formNoValidate
             disabled={pending !== null}
-            className={`min-h-11 min-w-[6rem] touch-manipulation rounded-full px-3 text-sm outline-none transition-transform duration-100 active:scale-[0.97] disabled:pointer-events-none disabled:opacity-60 focus-visible:ring-1 motion-reduce:transform-none motion-reduce:transition-none ${
-              deleteArmed
-                ? 'text-destructive focus-visible:ring-destructive'
-                : 'text-muted-foreground focus-visible:ring-foreground'
-            }`}
+            loading={pending === 'delete'}
+            destructive={deleteArmed}
+            expandHitArea
           >
-            {pending === 'delete' ? (
-              <T zh="正在删除…" en="Deleting…" />
-            ) : deleteArmed ? (
+            {deleteArmed ? (
               <T zh="确认删除？" en="Confirm delete?" />
             ) : (
               <T zh="删除" en="Delete" />
             )}
-          </button>
+          </Button>
         )}
       </div>
     </form>

--- a/app/admin/(protected)/ama/bookings/[bookingId]/BookingDetail.tsx
+++ b/app/admin/(protected)/ama/bookings/[bookingId]/BookingDetail.tsx
@@ -3,7 +3,11 @@
 import { useRouter } from 'next/navigation'
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
 
+import { PixelCluster } from '~/components/pixel-cluster'
+import { Button } from '~/components/ui/button'
 import { InputCopy } from '~/components/ui/input-copy'
+import { Switch } from '~/components/ui/switch'
+import { TabItem, Tabs, TabsList } from '~/components/ui/tabs'
 import { AMA_TOPIC_LABELS, type AmaTopic } from '~/lib/ama/booking/topics'
 import type {
   BookingLocale,
@@ -68,6 +72,14 @@ type SlotViewModel = { startsAt: string; endsAt: string }
 
 const MANAGE_CUTOFF_MS = 24 * 60 * 60 * 1000
 
+// Decorative reinforcement of the lifecycle the badge already announces —
+// rendered only for the linear states (diverged states have no honest rung).
+const LADDER_STEPS = [
+  { zh: '敲定中', en: 'Finalizing' },
+  { zh: '已确认', en: 'Confirmed' },
+  { zh: '已举行', en: 'Session held' },
+] as const
+
 function formatAmount(amountTotal: number, currency: string, locale: Locale) {
   try {
     return new Intl.NumberFormat(locale === 'zh' ? 'zh-CN' : 'en-US', {
@@ -123,9 +135,9 @@ function dayLabel(iso: string, zone: string, locale: Locale) {
       day: 'numeric',
     }
     try {
-      formatter = new Intl.DateTimeFormat(locale === 'zh' ? 'zh-TW' : 'en-US', options)
+      formatter = new Intl.DateTimeFormat(locale === 'zh' ? 'zh-CN' : 'en-US', options)
     } catch {
-      formatter = new Intl.DateTimeFormat(locale === 'zh' ? 'zh-TW' : 'en-US', {
+      formatter = new Intl.DateTimeFormat(locale === 'zh' ? 'zh-CN' : 'en-US', {
         ...options,
         timeZone: 'UTC',
       })
@@ -167,6 +179,9 @@ function isFlatDetail(detail: Record<string, unknown>) {
   )
 }
 
+// One nameplate row (label cell | value cell). The booking data reads as the
+// session's own specification, so it takes the AMA page's boxed plate
+// register — selectable, links intact, only the frame and type are chrome.
 function DefinitionRow({
   term,
   children,
@@ -175,10 +190,10 @@ function DefinitionRow({
   children: React.ReactNode
 }) {
   return (
-    <>
-      <dt className="text-muted-foreground">{term}</dt>
+    <div>
+      <dt>{term}</dt>
       <dd className="min-w-0 break-words">{children}</dd>
-    </>
+    </div>
   )
 }
 
@@ -402,6 +417,17 @@ export function BookingDetail({
 
   const pickerZone = zoneView === 'owner' ? OWNER_TIME_ZONE : booking.guestTimeZone
   const sessionIsPast = Date.parse(endsAt) < Date.now()
+  // finalizing → step 1 lit; confirmed upcoming → step 2 lit; confirmed past →
+  // all rungs done (no lit cell — the cert stamp takes over). Diverged states
+  // (needs_reschedule, cancelled) render no ladder at all.
+  const ladderCurrent =
+    status === 'finalizing'
+      ? 0
+      : status === 'confirmed'
+        ? sessionIsPast
+          ? LADDER_STEPS.length
+          : 1
+        : null
   const canCancel = status !== 'cancelled'
   const canReschedule = status !== 'cancelled'
   const canGrantRefundException =
@@ -416,9 +442,12 @@ export function BookingDetail({
 
   return (
     <div className="pb-10">
-      <p className="text-sm font-medium text-muted-foreground">
-        <T zh="咨询预约" en="AMA Booking" />
-      </p>
+      <div className="flex items-center justify-between gap-4">
+        <p className="page-eyebrow">
+          <T zh="咨询预约" en="AMA Booking" />
+        </p>
+        <PixelCluster variant={10} className="shrink-0" />
+      </div>
       <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1">
         <h1 className="text-sm font-medium">{booking.guestName}</h1>
         <BookingStatusBadge status={status} />
@@ -434,44 +463,84 @@ export function BookingDetail({
         )}
       </div>
 
+      {ladderCurrent !== null && (
+        <ol className="status-ladder mt-3" aria-hidden>
+          {LADDER_STEPS.map((step, index) => (
+            <li
+              key={step.en}
+              data-state={
+                index < ladderCurrent
+                  ? 'done'
+                  : index === ladderCurrent
+                    ? 'current'
+                    : 'pending'
+              }
+            >
+              <span className="status-ladder-index">
+                {String(index + 1).padStart(2, '0')}
+              </span>
+              <span>
+                <T zh={step.zh} en={step.en} />
+              </span>
+              <span className="status-ladder-cell" />
+            </li>
+          ))}
+        </ol>
+      )}
+      {status === 'confirmed' && sessionIsPast && (
+        <p className="cert-stamp mt-3 self-start" aria-hidden>
+          <span className="spec-signal" />
+          <T zh="已举行" en="Session held" /> +
+        </p>
+      )}
+
       {/* Actions */}
       <section aria-labelledby="actions-heading" className="mt-6">
         <h2 id="actions-heading" className="sr-only">
           <T zh="操作" en="Actions" />
         </h2>
-        <div className="flex flex-wrap gap-2">
+        {/* gap-y-4 keeps the buttons' 44px hit-area extensions from
+            overlapping when the row wraps. */}
+        <div className="flex flex-wrap gap-x-2 gap-y-4">
           {canReschedule && (
-            <button
-              type="button"
+            <Button
+              variant="tertiary"
+              size="md"
               disabled={pending !== null}
               onClick={() => openPanel('reschedule')}
               aria-expanded={panel === 'reschedule'}
-              className="min-h-11 rounded-md border border-border px-4 text-sm font-medium outline-none disabled:opacity-50 focus-visible:border-foreground"
+              active={panel === 'reschedule'}
+              expandHitArea
             >
               <T zh="改期" en="Reschedule" />
-            </button>
+            </Button>
           )}
           {canCancel && (
-            <button
-              type="button"
+            <Button
+              variant="ghost"
+              size="md"
+              destructive
               disabled={pending !== null}
               onClick={() => openPanel('cancel')}
               aria-expanded={panel === 'cancel'}
-              className="min-h-11 rounded-md px-4 text-sm text-destructive outline-none disabled:opacity-50 focus-visible:ring-1 focus-visible:ring-destructive"
+              active={panel === 'cancel'}
+              expandHitArea
             >
               <T zh="取消预约" en="Cancel Booking" />
-            </button>
+            </Button>
           )}
           {canGrantRefundException && (
-            <button
-              type="button"
+            <Button
+              variant="tertiary"
+              size="md"
               disabled={pending !== null}
               onClick={() => openPanel('refund')}
               aria-expanded={panel === 'refund'}
-              className="min-h-11 rounded-md border border-border px-4 text-sm font-medium outline-none disabled:opacity-50 focus-visible:border-foreground"
+              active={panel === 'refund'}
+              expandHitArea
             >
               <T zh="批准退款例外" en="Grant refund exception" />
-            </button>
+            </Button>
           )}
         </div>
 
@@ -481,32 +550,21 @@ export function BookingDetail({
               <h3 className="text-sm font-medium">
                 <T zh="选择新的时间" en="Pick a new time" />
               </h3>
-              <div
-                className="flex items-center gap-1"
-                role="tablist"
-                aria-label="Time zone view"
+              <Tabs
+                value={zoneView}
+                onValueChange={(value) => setZoneView(value as 'owner' | 'guest')}
               >
-                {(['owner', 'guest'] as const).map((zone) => (
-                  <button
-                    key={zone}
-                    type="button"
-                    role="tab"
-                    aria-selected={zoneView === zone}
-                    onClick={() => setZoneView(zone)}
-                    className={`min-h-11 rounded-full px-3 text-sm outline-none focus-visible:ring-1 focus-visible:ring-foreground ${
-                      zoneView === zone
-                        ? 'bg-foreground text-background'
-                        : 'text-muted-foreground hover:bg-hover hover:text-foreground'
-                    }`}
-                  >
-                    {zone === 'owner' ? (
-                      <T zh="我的时区" en="Owner time" />
-                    ) : (
-                      <T zh="访客时区" en="Guest time" />
-                    )}
-                  </button>
-                ))}
-              </div>
+                <TabsList variant="subtle" aria-label="Time zone view">
+                  <TabItem
+                    value="owner"
+                    label={localize(locale, '我的时区', 'Owner time')}
+                  />
+                  <TabItem
+                    value="guest"
+                    label={localize(locale, '访客时区', 'Guest time')}
+                  />
+                </TabsList>
+              </Tabs>
             </div>
             <p className="mt-1 text-sm text-muted-foreground">{pickerZone}</p>
 
@@ -565,26 +623,23 @@ export function BookingDetail({
                   </div>
                 ))}
                 <div className="flex flex-wrap items-center gap-2 hairline-top pt-4">
-                  <button
-                    type="button"
+                  <Button
+                    variant="primary"
+                    size="md"
                     disabled={pending !== null || !selectedSlot}
+                    loading={pending === 'reschedule'}
                     onClick={() => void reschedule()}
-                    className="min-h-11 rounded-full bg-foreground px-4 text-sm font-medium text-background outline-none transition-transform duration-100 active:scale-[0.97] disabled:opacity-50 focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-2 motion-reduce:transform-none"
                   >
-                    {pending === 'reschedule' ? (
-                      <T zh="正在改期…" en="Rescheduling…" />
-                    ) : (
-                      <T zh="确认改期" en="Confirm reschedule" />
-                    )}
-                  </button>
-                  <button
-                    type="button"
+                    <T zh="确认改期" en="Confirm reschedule" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
                     disabled={pending !== null}
                     onClick={() => setPanel('none')}
-                    className="min-h-11 px-3 text-sm text-muted-foreground outline-none disabled:opacity-50 focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
                   >
                     <T zh="关闭" en="Close" />
-                  </button>
+                  </Button>
                 </div>
               </div>
             )}
@@ -602,36 +657,31 @@ export function BookingDetail({
                 en="The Guest is emailed, and the meeting and calendar event are removed."
               />
             </p>
-            <label className="mt-4 flex min-h-11 items-center gap-3 text-sm">
-              <input
-                type="checkbox"
-                checked={refundChecked}
-                onChange={(event) => setRefundChecked(event.target.checked)}
-                className="h-4 w-4 accent-foreground"
-              />
-              <T zh="同时全额退款" en="Issue full refund" />
-            </label>
+            <Switch
+              className="mt-4"
+              label={<T zh="同时全额退款" en="Issue full refund" />}
+              checked={refundChecked}
+              onCheckedChange={setRefundChecked}
+            />
             <div className="mt-4 flex flex-wrap items-center gap-2">
-              <button
-                type="button"
+              <Button
+                variant="primary"
+                size="md"
+                destructive
                 disabled={pending !== null}
+                loading={pending === 'cancel'}
                 onClick={() => void cancelBooking()}
-                className="min-h-11 rounded-full bg-destructive px-4 text-sm font-medium text-white outline-none disabled:opacity-50 focus-visible:ring-1 focus-visible:ring-destructive focus-visible:ring-offset-2"
               >
-                {pending === 'cancel' ? (
-                  <T zh="正在取消…" en="Cancelling…" />
-                ) : (
-                  <T zh="确认取消预约" en="Confirm cancellation" />
-                )}
-              </button>
-              <button
-                type="button"
+                <T zh="确认取消预约" en="Confirm cancellation" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
                 disabled={pending !== null}
                 onClick={() => setPanel('none')}
-                className="min-h-11 px-3 text-sm text-muted-foreground outline-none disabled:opacity-50 focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
               >
                 <T zh="保留预约" en="Keep the Booking" />
-              </button>
+              </Button>
             </div>
           </div>
         )}
@@ -648,26 +698,23 @@ export function BookingDetail({
               />
             </p>
             <div className="mt-4 flex flex-wrap items-center gap-2">
-              <button
-                type="button"
+              <Button
+                variant="primary"
+                size="md"
                 disabled={pending !== null}
+                loading={pending === 'refund'}
                 onClick={() => void grantRefundException()}
-                className="min-h-11 rounded-full bg-foreground px-4 text-sm font-medium text-background outline-none disabled:opacity-50 focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-2"
               >
-                {pending === 'refund' ? (
-                  <T zh="正在退款…" en="Refunding…" />
-                ) : (
-                  <T zh="确认退款例外" en="Confirm refund exception" />
-                )}
-              </button>
-              <button
-                type="button"
+                <T zh="确认退款例外" en="Confirm refund exception" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
                 disabled={pending !== null}
                 onClick={() => setPanel('none')}
-                className="min-h-11 px-3 text-sm text-muted-foreground outline-none disabled:opacity-50 focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
               >
                 <T zh="返回" en="Go back" />
-              </button>
+              </Button>
             </div>
           </div>
         )}
@@ -687,12 +734,12 @@ export function BookingDetail({
       {/* Schedule */}
       <section
         aria-labelledby="schedule-heading"
-        className="mt-8 hairline-top pt-6"
+        className="mt-8 hairline-top pb-4 pt-6"
       >
         <h2 id="schedule-heading" className="text-sm font-medium">
           <T zh="日程" en="Schedule" />
         </h2>
-        <dl className="mt-3 grid gap-x-6 gap-y-2 text-sm sm:grid-cols-[9rem_minmax(0,1fr)]">
+        <dl className="spec-nameplate mt-3 mb-6">
           <DefinitionRow term={<T zh="开始" en="Starts" />}>
             <ZonedTimes iso={startsAt} guestTimeZone={booking.guestTimeZone} />
           </DefinitionRow>
@@ -720,12 +767,12 @@ export function BookingDetail({
       {/* Identity */}
       <section
         aria-labelledby="guest-heading"
-        className="mt-8 hairline-top pt-6"
+        className="mt-8 hairline-top pb-4 pt-6"
       >
         <h2 id="guest-heading" className="text-sm font-medium">
           <T zh="访客" en="Guest" />
         </h2>
-        <dl className="mt-3 grid gap-x-6 gap-y-2 text-sm sm:grid-cols-[9rem_minmax(0,1fr)]">
+        <dl className="spec-nameplate mt-3 mb-6">
           <DefinitionRow term={<T zh="姓名" en="Name" />}>{booking.guestName}</DefinitionRow>
           <DefinitionRow term={<T zh="邮箱" en="Email" />}>
             <span className="break-all">{booking.guestEmail}</span>
@@ -791,12 +838,12 @@ export function BookingDetail({
       {/* Payment */}
       <section
         aria-labelledby="payment-heading"
-        className="mt-8 hairline-top pt-6"
+        className="mt-8 hairline-top pb-4 pt-6"
       >
         <h2 id="payment-heading" className="text-sm font-medium">
           <T zh="付款" en="Payment" />
         </h2>
-        <dl className="mt-3 grid gap-x-6 gap-y-2 text-sm sm:grid-cols-[9rem_minmax(0,1fr)]">
+        <dl className="spec-nameplate mt-3 mb-6">
           <DefinitionRow term={<T zh="金额" en="Amount" />}>
             <span className="tabular-nums">
               <T
@@ -837,13 +884,13 @@ export function BookingDetail({
       {/* Meeting */}
       <section
         aria-labelledby="meeting-heading"
-        className="mt-8 hairline-top pt-6"
+        className="mt-8 hairline-top pb-4 pt-6"
       >
         <h2 id="meeting-heading" className="text-sm font-medium">
           <T zh="会议" en="Meeting" />
         </h2>
         {booking.meetingUrl || booking.googleCalendarEventId || booking.tencentMeetingId ? (
-          <dl className="mt-3 grid gap-x-6 gap-y-2 text-sm sm:grid-cols-[9rem_minmax(0,1fr)]">
+          <dl className="spec-nameplate mt-3 mb-6">
             {booking.meetingUrl && (
               <DefinitionRow term={<T zh="会议链接" en="Meeting link" />}>
                 <a
@@ -910,8 +957,10 @@ export function BookingDetail({
               <li key={event.id} className="py-2.5 text-sm">
                 <div className="flex flex-wrap items-baseline justify-between gap-x-6 gap-y-1">
                   <span className="min-w-0">
-                    <span className="font-medium">{event.event}</span>
-                    <span className="ml-3 text-muted-foreground">{event.actor}</span>
+                    <span className="font-mono text-xs font-medium">{event.event}</span>
+                    <span className="ml-3 font-mono text-xs text-muted-foreground">
+                      {event.actor}
+                    </span>
                   </span>
                   <time
                     dateTime={event.occurredAt}

--- a/app/admin/(protected)/ama/bookings/[bookingId]/page.tsx
+++ b/app/admin/(protected)/ama/bookings/[bookingId]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { Suspense } from 'react'
 
+import { PixelCluster } from '~/components/pixel-cluster'
 import { requireOwnerPage } from '~/lib/admin/server'
 import { getAmaAdminServices } from '~/lib/ama/admin/server'
 import { T } from '~/lib/i18n'
@@ -83,10 +84,13 @@ function operationViewModel(operation: DurableOperationRecord): OperationViewMod
 function BookingFallback() {
   return (
     <div className="pb-10" aria-busy="true">
-      <p className="text-sm font-medium tracking-[-0.011em] text-muted-foreground">
-        <T zh="咨询预约" en="AMA BOOKING" />
-      </p>
-      <div className="mt-2 h-5 w-44 rounded-sm bg-surface-1" aria-hidden />
+      <div className="flex items-center justify-between gap-4">
+        <p className="page-eyebrow">
+          <T zh="咨询预约" en="AMA Booking" />
+        </p>
+        <PixelCluster variant={10} className="shrink-0" />
+      </div>
+      <div className="mt-1 h-5 w-44 rounded-sm bg-surface-1" aria-hidden />
       <div className="mt-6 grid gap-4 hairline-top pt-4" aria-hidden>
         <div className="h-4 w-full max-w-80 rounded-sm bg-surface-1" />
         <div className="h-4 w-full max-w-64 rounded-sm bg-surface-1" />

--- a/app/admin/(protected)/ama/bookings/page.tsx
+++ b/app/admin/(protected)/ama/bookings/page.tsx
@@ -1,0 +1,141 @@
+import type { Metadata } from 'next'
+import { Suspense } from 'react'
+
+import { AdminBackLink } from '~/components/admin-nav'
+import { PixelCluster } from '~/components/pixel-cluster'
+import { requireOwnerPage } from '~/lib/admin/server'
+import { getAmaAdminServices } from '~/lib/ama/admin/server'
+import { T } from '~/lib/i18n'
+import type {
+  AlternateTimeRequestRecord,
+  BookingRecord,
+} from '~/lib/ama/booking/repository'
+import type { DurableOperationRecord } from '~/lib/ama/operations/repository'
+import { nonPublicRobots } from '~/lib/non-public-metadata'
+
+import { AmaOperations } from '../AmaOperations'
+import type {
+  AlternateTimeRequestViewModel,
+  BookingRowViewModel,
+  OperationViewModel,
+} from '../shared'
+
+export const metadata: Metadata = {
+  title: 'AMA Bookings',
+  robots: nonPublicRobots,
+}
+
+export const instant = true
+
+function bookingRow(booking: BookingRecord): BookingRowViewModel {
+  return {
+    id: booking.id,
+    status: booking.status,
+    guestName: booking.guestName,
+    guestEmail: booking.guestEmail,
+    guestTimeZone: booking.guestTimeZone,
+    meetingProvider: booking.meetingProvider,
+    startsAt: booking.startsAt.toISOString(),
+    endsAt: booking.endsAt.toISOString(),
+    refundStatus: booking.refundStatus,
+    hasMeetingLink: booking.meetingUrl !== null,
+    hasBrief:
+      booking.briefPurgedAt === null &&
+      (booking.briefText !== null || (booking.briefUrls?.length ?? 0) > 0),
+  }
+}
+
+function operationRow(operation: DurableOperationRecord): OperationViewModel {
+  return {
+    id: operation.id,
+    kind: operation.kind,
+    bookingId: operation.bookingId,
+    status: operation.status,
+    attemptCount: operation.attemptCount,
+    maxAttempts: operation.maxAttempts,
+    nextAttemptAt: operation.nextAttemptAt.toISOString(),
+    lastErrorCode: operation.lastErrorCode,
+  }
+}
+
+function timeRequestRow(
+  request: AlternateTimeRequestRecord,
+): AlternateTimeRequestViewModel {
+  return {
+    id: request.id,
+    guestName: request.guestName,
+    guestEmail: request.guestEmail,
+    guestTimeZone: request.guestTimeZone,
+    preferredWindows: request.preferredWindows,
+    note: request.note,
+    createdAt: request.createdAt.toISOString(),
+  }
+}
+
+function BookingsHeader() {
+  return (
+    <>
+      <AdminBackLink href="/admin/ama">
+        <T zh="咨询" en="AMA" />
+      </AdminBackLink>
+      <div className="flex items-center justify-between gap-4">
+        <h1 className="page-eyebrow">
+          <T zh="预约" en="Bookings" />
+        </h1>
+        <PixelCluster variant={7} className="shrink-0" />
+      </div>
+    </>
+  )
+}
+
+function BookingsFallback() {
+  return (
+    <div className="pb-10" aria-busy="true">
+      <BookingsHeader />
+      <p className="mt-1 text-sm tabular-nums text-muted-foreground">…</p>
+      <ul className="mt-6 hairline-top pt-4">
+        {Array.from({ length: 3 }, (_, index) => (
+          <li key={index} className="flex min-h-11 items-center py-1.5" aria-hidden>
+            <span className="h-4 w-full max-w-72 rounded-sm bg-surface-1" />
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+async function BookingsLoader() {
+  await requireOwnerPage('/admin/ama/bookings')
+  const { bookingAdmin } = getAmaAdminServices()
+  const [upcoming, past, attention, timeRequests, operations] =
+    await Promise.all([
+      bookingAdmin.listBookings('upcoming'),
+      bookingAdmin.listBookings('past'),
+      bookingAdmin.listBookings('attention'),
+      bookingAdmin.listAlternateTimeRequests('new'),
+      bookingAdmin.listUnresolvedOperations(),
+    ])
+
+  return (
+    <>
+      <BookingsHeader />
+      <AmaOperations
+        upcoming={upcoming.map(bookingRow)}
+        past={past.map(bookingRow)}
+        attention={attention.map(bookingRow)}
+        timeRequests={timeRequests.map(timeRequestRow)}
+        failedOperations={operations
+          .filter((operation) => operation.status === 'failed')
+          .map(operationRow)}
+      />
+    </>
+  )
+}
+
+export default function AdminAmaBookingsPage() {
+  return (
+    <Suspense fallback={<BookingsFallback />}>
+      <BookingsLoader />
+    </Suspense>
+  )
+}

--- a/app/admin/(protected)/ama/page.tsx
+++ b/app/admin/(protected)/ama/page.tsx
@@ -1,23 +1,12 @@
 import type { Metadata } from 'next'
 import { Suspense } from 'react'
 
+import { AdminMenu, AdminMenuRow } from '~/components/admin-nav'
+import { PixelCluster } from '~/components/pixel-cluster'
 import { requireOwnerPage } from '~/lib/admin/server'
 import { getAmaAdminServices } from '~/lib/ama/admin/server'
 import { T } from '~/lib/i18n'
-import type {
-  AlternateTimeRequestRecord,
-  BookingRecord,
-} from '~/lib/ama/booking/repository'
-import type { DurableOperationRecord } from '~/lib/ama/operations/repository'
 import { nonPublicRobots } from '~/lib/non-public-metadata'
-
-import { AmaOperations } from './AmaOperations'
-import type { AmaSettingsNotices, GoogleConnectionStatus } from './AmaSettings'
-import type {
-  AlternateTimeRequestViewModel,
-  BookingRowViewModel,
-  OperationViewModel,
-} from './shared'
 
 export const metadata: Metadata = {
   title: 'AMA',
@@ -26,106 +15,24 @@ export const metadata: Metadata = {
 
 export const instant = true
 
-function bookingRow(booking: BookingRecord): BookingRowViewModel {
-  return {
-    id: booking.id,
-    status: booking.status,
-    guestName: booking.guestName,
-    guestEmail: booking.guestEmail,
-    guestTimeZone: booking.guestTimeZone,
-    meetingProvider: booking.meetingProvider,
-    startsAt: booking.startsAt.toISOString(),
-    endsAt: booking.endsAt.toISOString(),
-    refundStatus: booking.refundStatus,
-    hasMeetingLink: booking.meetingUrl !== null,
-    hasBrief:
-      booking.briefPurgedAt === null &&
-      (booking.briefText !== null || (booking.briefUrls?.length ?? 0) > 0),
-  }
+function AmaHeader() {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <h1 className="page-eyebrow">
+        <T zh="咨询" en="AMA" />
+      </h1>
+      <PixelCluster variant={7} className="shrink-0" />
+    </div>
+  )
 }
-
-function operationRow(operation: DurableOperationRecord): OperationViewModel {
-  return {
-    id: operation.id,
-    kind: operation.kind,
-    bookingId: operation.bookingId,
-    status: operation.status,
-    attemptCount: operation.attemptCount,
-    maxAttempts: operation.maxAttempts,
-    nextAttemptAt: operation.nextAttemptAt.toISOString(),
-    lastErrorCode: operation.lastErrorCode,
-  }
-}
-
-function timeRequestRow(
-  request: AlternateTimeRequestRecord,
-): AlternateTimeRequestViewModel {
-  return {
-    id: request.id,
-    guestName: request.guestName,
-    guestEmail: request.guestEmail,
-    guestTimeZone: request.guestTimeZone,
-    preferredWindows: request.preferredWindows,
-    note: request.note,
-    createdAt: request.createdAt.toISOString(),
-  }
-}
-
-const availabilityNotices = new Set(['saved', 'invalid', 'failed'] as const)
-const calendarNotices = new Set([
-  'disconnected',
-  'connected',
-  'expired',
-  'revoked',
-  'denied-scope',
-  'unavailable',
-] as const)
-
-function first(value: string | string[] | undefined) {
-  return Array.isArray(value) ? value[0] : value
-}
-
-function queryNotices(input: {
-  availability?: string | string[]
-  calendar?: string | string[]
-}): AmaSettingsNotices {
-  const availability = first(input.availability)
-  const calendar = first(input.calendar)
-  return {
-    availability: availabilityNotices.has(
-      availability as AmaSettingsNotices['availability'] & string,
-    )
-      ? (availability as AmaSettingsNotices['availability'])
-      : undefined,
-    calendar: calendarNotices.has(calendar as GoogleConnectionStatus)
-      ? (calendar as GoogleConnectionStatus)
-      : undefined,
-  }
-}
-
-function connectionStatus(status: string | undefined): GoogleConnectionStatus {
-  if (status === 'connected' || status === 'expired' || status === 'revoked') {
-    return status
-  }
-  if (status === 'denied_scope') return 'denied-scope'
-  if (status === 'error') return 'unavailable'
-  return 'disconnected'
-}
-
-type AmaSearchParams = Promise<{
-  availability?: string | string[]
-  calendar?: string | string[]
-}>
 
 function AmaFallback() {
   return (
     <div className="pb-10" aria-busy="true">
-      <h1 className="text-sm font-medium text-muted-foreground">
-        <T zh="咨询" en="AMA" />
-      </h1>
-      <p className="mt-1 text-sm text-muted-foreground">…</p>
+      <AmaHeader />
+      <p className="mt-1 text-sm tabular-nums text-muted-foreground">…</p>
       <ul className="mt-6 hairline-top pt-4">
-        {Array.from({ length: 3 }, (_, index) => (
+        {Array.from({ length: 2 }, (_, index) => (
           <li key={index} className="flex min-h-11 items-center py-1.5" aria-hidden>
             <span className="h-4 w-full max-w-72 rounded-sm bg-surface-1" />
           </li>
@@ -135,82 +42,81 @@ function AmaFallback() {
   )
 }
 
-async function AmaLoader({ searchParams }: { searchParams: AmaSearchParams }) {
+async function AmaMenuLoader() {
   await requireOwnerPage('/admin/ama')
   const { availability, bookingAdmin, google } = getAmaAdminServices()
-  const [
-    upcoming,
-    past,
-    attention,
-    timeRequests,
-    operations,
-    windows,
-    connection,
-    preview,
-    params,
-  ] = await Promise.all([
-    bookingAdmin.listBookings('upcoming'),
-    bookingAdmin.listBookings('past'),
-    bookingAdmin.listBookings('attention'),
-    bookingAdmin.listAlternateTimeRequests('new'),
-    bookingAdmin.listUnresolvedOperations(),
-    availability.list(),
-    google.getConnection(),
-    availability.preview(),
-    searchParams,
-  ])
+  const [upcoming, attention, timeRequests, operations, windows, connection] =
+    await Promise.all([
+      bookingAdmin.listBookings('upcoming'),
+      bookingAdmin.listBookings('attention'),
+      bookingAdmin.listAlternateTimeRequests('new'),
+      bookingAdmin.listUnresolvedOperations(),
+      availability.list(),
+      google.getConnection(),
+    ])
 
-  const persistedStatus = connectionStatus(connection?.status)
-  const status =
-    persistedStatus === 'connected' && preview.status !== 'connected'
-      ? preview.status
-      : persistedStatus
+  const needsAttention =
+    attention.length +
+    timeRequests.length +
+    operations.filter((operation) => operation.status === 'failed').length
+  const calendarConnected =
+    connection !== null && connection.status === 'connected'
 
   return (
-    <AmaOperations
-      upcoming={upcoming.map(bookingRow)}
-      past={past.map(bookingRow)}
-      attention={attention.map(bookingRow)}
-      timeRequests={timeRequests.map(timeRequestRow)}
-      failedOperations={operations
-        .filter((operation) => operation.status === 'failed')
-        .map(operationRow)}
-      settings={{
-        windows: windows.map(({ id, isoWeekday, startMinute, endMinute }) => ({
-          id,
-          isoWeekday,
-          startMinute,
-          endMinute,
-        })),
-        googleConnection: {
-          status,
-          identity:
-            connection?.calendarId && connection.status !== 'disconnected'
-              ? {
-                  calendarId: connection.calendarId,
-                  summary: connection.calendarSummary,
-                  email: connection.calendarEmail,
-                }
-              : null,
-        },
-        previewSlots: preview.slots.map((slot) => ({
-          startsAt: slot.startsAt.toISOString(),
-          endsAt: slot.endsAt.toISOString(),
-        })),
-        notices: queryNotices(params),
-      }}
-    />
+    <div className="pb-10">
+      <AmaHeader />
+      <p className="mt-1 text-sm tabular-nums text-muted-foreground">
+        {upcoming.length} <T zh="场即将进行" en="upcoming" />
+        {needsAttention > 0 && (
+          <>
+            {' · '}
+            {needsAttention} <T zh="项待处理" en="need attention" />
+          </>
+        )}
+      </p>
+
+      <AdminMenu>
+        <AdminMenuRow
+          href="/admin/ama/bookings"
+          label={<T zh="预约" en="Bookings" />}
+          destructive={needsAttention > 0}
+          value={
+            needsAttention > 0 ? (
+              <>
+                {needsAttention} <T zh="项待处理" en="need attention" />
+              </>
+            ) : (
+              <>
+                {upcoming.length} <T zh="场即将进行" en="upcoming" />
+              </>
+            )
+          }
+        />
+        <AdminMenuRow
+          href="/admin/ama/settings"
+          label={<T zh="设置" en="Settings" />}
+          value={
+            <>
+              {windows.length} <T zh="个时段" en="windows" />
+              {' · '}
+              {calendarConnected ? (
+                <T zh="日历已连接" en="calendar connected" />
+              ) : (
+                <T zh="日历未连接" en="calendar off" />
+              )}
+            </>
+          }
+        />
+      </AdminMenu>
+    </div>
   )
 }
 
-export default function AdminAmaPage({
-  searchParams,
-}: {
-  searchParams: AmaSearchParams
-}) {
+// The AMA surface is a menu: Bookings and Settings each own their page.
+export default function AdminAmaPage() {
   return (
     <Suspense fallback={<AmaFallback />}>
-      <AmaLoader searchParams={searchParams} />
+      <AmaMenuLoader />
     </Suspense>
   )
 }

--- a/app/admin/(protected)/ama/settings/page.tsx
+++ b/app/admin/(protected)/ama/settings/page.tsx
@@ -1,0 +1,156 @@
+import type { Metadata } from 'next'
+import { Suspense } from 'react'
+
+import { AdminBackLink } from '~/components/admin-nav'
+import { PixelCluster } from '~/components/pixel-cluster'
+import { requireOwnerPage } from '~/lib/admin/server'
+import { getAmaAdminServices } from '~/lib/ama/admin/server'
+import { T } from '~/lib/i18n'
+import { nonPublicRobots } from '~/lib/non-public-metadata'
+
+import { AmaSettings } from '../AmaSettings'
+import type { AmaSettingsNotices, GoogleConnectionStatus } from '../AmaSettings'
+
+export const metadata: Metadata = {
+  title: 'AMA Settings',
+  robots: nonPublicRobots,
+}
+
+export const instant = true
+
+const availabilityNotices = new Set(['saved', 'invalid', 'failed'] as const)
+const calendarNotices = new Set([
+  'disconnected',
+  'connected',
+  'expired',
+  'revoked',
+  'denied-scope',
+  'unavailable',
+] as const)
+
+function first(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value
+}
+
+function queryNotices(input: {
+  availability?: string | string[]
+  calendar?: string | string[]
+}): AmaSettingsNotices {
+  const availability = first(input.availability)
+  const calendar = first(input.calendar)
+  return {
+    availability: availabilityNotices.has(
+      availability as AmaSettingsNotices['availability'] & string,
+    )
+      ? (availability as AmaSettingsNotices['availability'])
+      : undefined,
+    calendar: calendarNotices.has(calendar as GoogleConnectionStatus)
+      ? (calendar as GoogleConnectionStatus)
+      : undefined,
+  }
+}
+
+function connectionStatus(status: string | undefined): GoogleConnectionStatus {
+  if (status === 'connected' || status === 'expired' || status === 'revoked') {
+    return status
+  }
+  if (status === 'denied_scope') return 'denied-scope'
+  if (status === 'error') return 'unavailable'
+  return 'disconnected'
+}
+
+type SettingsSearchParams = Promise<{
+  availability?: string | string[]
+  calendar?: string | string[]
+}>
+
+function SettingsHeader() {
+  return (
+    <>
+      <AdminBackLink href="/admin/ama">
+        <T zh="咨询" en="AMA" />
+      </AdminBackLink>
+      <div className="flex items-center justify-between gap-4">
+        <h1 className="page-eyebrow">
+          <T zh="设置" en="Settings" />
+        </h1>
+        <PixelCluster variant={7} className="shrink-0" />
+      </div>
+    </>
+  )
+}
+
+function SettingsFallback() {
+  return (
+    <div className="pb-10" aria-busy="true">
+      <SettingsHeader />
+      <p className="mt-1 text-sm leading-6 text-muted-foreground">…</p>
+      <div className="mt-6 hairline-top pt-5" aria-hidden>
+        <span className="block h-4 w-full max-w-72 rounded-sm bg-surface-1" />
+      </div>
+    </div>
+  )
+}
+
+async function SettingsLoader({
+  searchParams,
+}: {
+  searchParams: SettingsSearchParams
+}) {
+  await requireOwnerPage('/admin/ama/settings')
+  const { availability, google } = getAmaAdminServices()
+  const [windows, connection, preview, params] = await Promise.all([
+    availability.list(),
+    google.getConnection(),
+    availability.preview(),
+    searchParams,
+  ])
+
+  const persistedStatus = connectionStatus(connection?.status)
+  const status =
+    persistedStatus === 'connected' && preview.status !== 'connected'
+      ? preview.status
+      : persistedStatus
+
+  return (
+    <>
+      <SettingsHeader />
+      <AmaSettings
+        windows={windows.map(({ id, isoWeekday, startMinute, endMinute }) => ({
+          id,
+          isoWeekday,
+          startMinute,
+          endMinute,
+        }))}
+        googleConnection={{
+          status,
+          identity:
+            connection?.calendarId && connection.status !== 'disconnected'
+              ? {
+                  calendarId: connection.calendarId,
+                  summary: connection.calendarSummary,
+                  email: connection.calendarEmail,
+                }
+              : null,
+        }}
+        previewSlots={preview.slots.map((slot) => ({
+          startsAt: slot.startsAt.toISOString(),
+          endsAt: slot.endsAt.toISOString(),
+        }))}
+        notices={queryNotices(params)}
+      />
+    </>
+  )
+}
+
+export default function AdminAmaSettingsPage({
+  searchParams,
+}: {
+  searchParams: SettingsSearchParams
+}) {
+  return (
+    <Suspense fallback={<SettingsFallback />}>
+      <SettingsLoader searchParams={searchParams} />
+    </Suspense>
+  )
+}

--- a/app/admin/(protected)/ama/shared.tsx
+++ b/app/admin/(protected)/ama/shared.tsx
@@ -3,6 +3,8 @@
 import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
 
+import { Button } from '~/components/ui/button'
+
 import type {
   BookingStatus,
   MeetingProviderName,
@@ -78,10 +80,10 @@ function zonedFormatter(zone: string, locale: Locale) {
       hour12: false,
     }
     try {
-      formatter = new Intl.DateTimeFormat(locale === 'zh' ? 'zh-TW' : 'en-US', options)
+      formatter = new Intl.DateTimeFormat(locale === 'zh' ? 'zh-CN' : 'en-US', options)
     } catch {
       // An unknown stored time zone must not break the page; fall back to UTC.
-      formatter = new Intl.DateTimeFormat(locale === 'zh' ? 'zh-TW' : 'en-US', {
+      formatter = new Intl.DateTimeFormat(locale === 'zh' ? 'zh-CN' : 'en-US', {
         ...options,
         timeZone: 'UTC',
       })
@@ -176,11 +178,6 @@ export function OperationStatusBadge({ status }: { status: DurableOperationStatu
     </span>
   )
 }
-
-const actionButtonClass =
-  'min-h-11 rounded-md border border-border px-3 text-sm font-medium outline-none disabled:opacity-50 focus-visible:border-foreground'
-const quietButtonClass =
-  'min-h-11 px-3 text-sm text-muted-foreground outline-none disabled:opacity-50 focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground'
 
 /**
  * Durable operation rows with Retry and Mark resolved recovery actions.
@@ -338,53 +335,50 @@ export function OperationsList({
                   </p>
                 </div>
                 {actionable && (
+                  // Dense stacked rows: the row itself is the tap target — no
+                  // hit-area extension on these compact pills.
                   <div className="flex flex-wrap items-center gap-2">
                     {operation.status === 'failed' && (
-                      <button
-                        type="button"
+                      <Button
+                        variant="tertiary"
+                        size="sm"
                         disabled={pending !== null}
+                        loading={pending === `${operation.id}:retry`}
                         onClick={() => void act(operation, 'retry')}
-                        className={actionButtonClass}
                       >
-                        {pending === `${operation.id}:retry` ? (
-                          <T zh="正在重试…" en="Retrying…" />
-                        ) : (
-                          <T zh="重试" en="Retry" />
-                        )}
-                      </button>
+                        <T zh="重试" en="Retry" />
+                      </Button>
                     )}
                     {confirming ? (
                       <>
-                        <button
-                          type="button"
+                        <Button
+                          variant="tertiary"
+                          size="sm"
+                          destructive
                           disabled={pending !== null}
+                          loading={pending === `${operation.id}:resolve`}
                           onClick={() => void act(operation, 'resolve')}
-                          className={`${actionButtonClass} text-destructive focus-visible:border-destructive`}
                         >
-                          {pending === `${operation.id}:resolve` ? (
-                            <T zh="正在标记…" en="Resolving…" />
-                          ) : (
-                            <T zh="确认已在系统外完成" en="Confirm done outside the system" />
-                          )}
-                        </button>
-                        <button
-                          type="button"
+                          <T zh="确认已在系统外完成" en="Confirm done outside the system" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
                           disabled={pending !== null}
                           onClick={() => setConfirmingId(null)}
-                          className={quietButtonClass}
                         >
                           <T zh="返回" en="Keep it" />
-                        </button>
+                        </Button>
                       </>
                     ) : (
-                      <button
-                        type="button"
+                      <Button
+                        variant="ghost"
+                        size="sm"
                         disabled={pending !== null}
                         onClick={() => setConfirmingId(operation.id)}
-                        className={quietButtonClass}
                       >
                         <T zh="标记为已解决" en="Mark resolved" />
-                      </button>
+                      </Button>
                     )}
                   </div>
                 )}

--- a/app/admin/(protected)/media/MediaLibrary.tsx
+++ b/app/admin/(protected)/media/MediaLibrary.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { Dialog } from '@base-ui/react/dialog'
 import {
   useEffect,
   useMemo,
@@ -12,7 +11,16 @@ import {
   type MouseEvent,
 } from 'react'
 
-import { Elevated } from '~/lib/elevated'
+import { PixelCluster } from '~/components/pixel-cluster'
+import { Button } from '~/components/ui/button'
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogTitle,
+} from '~/components/ui/dialog'
+import { Input } from '~/components/ui/input'
+import { TabItem, Tabs, TabsList } from '~/components/ui/tabs'
 import { T } from '~/lib/i18n'
 import { localize, useLocale } from '~/lib/locale-client'
 import { isMediaAssetEligible } from '~/lib/media/asset-review/eligibility'
@@ -112,6 +120,15 @@ function assetName(asset: MediaAssetReviewRecord) {
   )
 }
 
+function assetNameIsIdFallback(asset: MediaAssetReviewRecord) {
+  return !(
+    asset.locationLabelEn ||
+    asset.locationLabelZhHans ||
+    asset.altTextEn ||
+    asset.altTextZhHans
+  )
+}
+
 const queueErrorCopy: Record<string, { zh: string; en: string }> = {
   invalid_file: {
     zh: '不支持的类型，或超过 50 MiB',
@@ -197,13 +214,15 @@ function DropZone({
             JPEG · PNG · HEIC · ≤ 50 MiB
           </p>
         </div>
-        <button
+        <Button
           type="button"
+          variant="primary"
+          size="md"
+          expandHitArea
           onClick={() => inputRef.current?.click()}
-          className="min-h-11 rounded-full bg-foreground px-4 text-sm font-medium text-background outline-none transition-transform duration-100 active:scale-[0.97] focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-2 motion-reduce:transform-none"
         >
           <T zh="选择文件" en="Choose files" />
-        </button>
+        </Button>
         <input
           ref={inputRef}
           type="file"
@@ -241,13 +260,17 @@ function DropZone({
                   </p>
                 </div>
                 {item.status === 'failed' ? (
-                  <button
+                  // Dense stacked rows — the row's own min-h-11 is the tap
+                  // target, so no expandHitArea here.
+                  <Button
                     type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="shrink-0"
                     onClick={() => onRetry(item)}
-                    className="min-h-11 shrink-0 px-3 text-sm font-medium outline-none focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
                   >
                     <T zh="重试" en="Retry" />
-                  </button>
+                  </Button>
                 ) : (
                   <span className="shrink-0 text-sm tabular-nums text-muted-foreground">
                     {(item.file.size / 1024 / 1024).toFixed(1)} MiB
@@ -259,27 +282,6 @@ function DropZone({
         </ol>
       )}
     </div>
-  )
-}
-
-function Field({
-  label,
-  value,
-  onChange,
-}: {
-  label: React.ReactNode
-  value: string
-  onChange(value: string): void
-}) {
-  return (
-    <label className="grid gap-1.5 text-sm text-muted-foreground">
-      {label}
-      <input
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-        className="min-h-11 rounded-md border border-border bg-background px-3 text-base text-foreground outline-none focus:border-foreground"
-      />
-    </label>
   )
 }
 
@@ -589,27 +591,49 @@ function Inspector({
         day: 'numeric',
       }).format(new Date(asset.capturedAt))
     : null
-  const camera = [
-    captured,
-    [asset.cameraMake, asset.cameraModel].filter(Boolean).join(' ') || null,
-    asset.lens,
-    asset.focalLengthMillimeters ? `${asset.focalLengthMillimeters} mm` : null,
-    asset.aperture ? `ƒ/${asset.aperture}` : null,
-    asset.shutterSpeedSeconds
-      ? asset.shutterSpeedSeconds < 1
-        ? `1/${Math.round(1 / asset.shutterSpeedSeconds)}`
-        : `${asset.shutterSpeedSeconds}s`
-      : null,
-    asset.iso ? `ISO ${asset.iso}` : null,
-  ].filter(Boolean)
+  // The capture data as spec-plate fields — the same register the
+  // published wall's lightbox uses; only non-null cells render.
+  const cameraBody = [asset.cameraMake, asset.cameraModel]
+    .filter(Boolean)
+    .join(' ')
+  const captureFields: { zh: string; en: string; value: string }[] = [
+    ...(captured ? [{ zh: '日期', en: 'Date', value: captured }] : []),
+    ...(cameraBody ? [{ zh: '相机', en: 'Camera', value: cameraBody }] : []),
+    ...(asset.lens ? [{ zh: '镜头', en: 'Lens', value: asset.lens }] : []),
+    ...(asset.focalLengthMillimeters
+      ? [{ zh: '焦距', en: 'Focal', value: `${asset.focalLengthMillimeters} mm` }]
+      : []),
+    ...(asset.aperture
+      ? [{ zh: '光圈', en: 'Aperture', value: `ƒ/${asset.aperture}` }]
+      : []),
+    ...(asset.shutterSpeedSeconds
+      ? [
+          {
+            zh: '快门',
+            en: 'Shutter',
+            value:
+              asset.shutterSpeedSeconds < 1
+                ? `1/${Math.round(1 / asset.shutterSpeedSeconds)} s`
+                : `${asset.shutterSpeedSeconds} s`,
+          },
+        ]
+      : []),
+    ...(asset.iso ? [{ zh: '感光度', en: 'ISO', value: String(asset.iso) }] : []),
+  ]
   const editable = asset.catalogState === 'active'
 
   return (
     <>
       <div className="flex items-baseline justify-between gap-4">
-        <Dialog.Title className="min-w-0 truncate text-sm font-medium">
+        <DialogTitle
+          className={
+            assetNameIsIdFallback(asset)
+              ? 'min-w-0 truncate font-mono'
+              : 'min-w-0 truncate'
+          }
+        >
           {assetName(asset)}
-        </Dialog.Title>
+        </DialogTitle>
         <p className="shrink-0 text-sm text-muted-foreground">
           <T zh={processingLabel(asset).zh} en={processingLabel(asset).en} />
         </p>
@@ -618,18 +642,17 @@ function Inspector({
       {['original_verified', 'processing', 'retryable_failure'].includes(
         asset.processingState,
       ) && (
-        <button
+        <Button
           type="button"
+          variant="tertiary"
+          size="md"
+          className="mt-4"
+          loading={pending === 'resume'}
           disabled={pending !== null || !editable}
           onClick={resumeProcessing}
-          className="mt-4 min-h-11 rounded-md border border-border px-4 text-sm font-medium outline-none disabled:opacity-50 focus-visible:border-foreground"
         >
-          {pending === 'resume' ? (
-            <T zh="正在恢复…" en="Resuming…" />
-          ) : (
-            <T zh="恢复处理" en="Resume processing" />
-          )}
-        </button>
+          <T zh="恢复处理" en="Resume processing" />
+        </Button>
       )}
 
       {asset.previewRendition && (
@@ -670,10 +693,17 @@ function Inspector({
         </>
       )}
 
-      {camera.length > 0 && (
-        <p className="mt-3 text-sm leading-5 tabular-nums text-muted-foreground">
-          {camera.join(' · ')}
-        </p>
+      {captureFields.length > 0 && (
+        <dl className="spec-plate spec-plate-flow mt-3">
+          {captureFields.map((field) => (
+            <div key={field.en}>
+              <dt>
+                <T zh={field.zh} en={field.en} />
+              </dt>
+              <dd>{field.value}</dd>
+            </div>
+          ))}
+        </dl>
       )}
 
       <div className="mt-5 grid gap-4 hairline-top pt-4">
@@ -682,29 +712,27 @@ function Inspector({
             <T zh="地点" en="Location" />
           </h3>
           {asset.hasCaptureLocation && (
-            <button
+            <Button
               type="button"
+              variant="ghost"
+              size="sm"
+              loading={pending === 'location'}
               disabled={pending !== null || !editable}
               onClick={suggestLocationLabel}
-              className="min-h-11 px-2 text-sm text-muted-foreground outline-none disabled:opacity-50 focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
             >
-              {pending === 'location' ? (
-                <T zh="正在查询…" en="Looking up…" />
-              ) : (
-                <T zh="根据拍摄位置填写" en="Fill from Capture Location" />
-              )}
-            </button>
+              <T zh="根据拍摄位置填写" en="Fill from Capture Location" />
+            </Button>
           )}
         </div>
-        <Field
+        <Input
           label={<T zh="地点（中文）" en="Location (Chinese)" />}
           value={locationZh}
-          onChange={setLocationZh}
+          onChange={(event) => setLocationZh(event.target.value)}
         />
-        <Field
+        <Input
           label={<T zh="地点（英文）" en="Location (English)" />}
           value={locationEn}
-          onChange={setLocationEn}
+          onChange={(event) => setLocationEn(event.target.value)}
         />
       </div>
 
@@ -713,28 +741,26 @@ function Inspector({
           <h3 className="text-sm font-medium">
             <T zh="替代文本" en="Alt Text" />
           </h3>
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
+            loading={pending === 'suggestion'}
             disabled={pending !== null || !editable}
             onClick={regenerate}
-            className="min-h-11 px-2 text-sm text-muted-foreground outline-none disabled:opacity-50 focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
           >
-            {pending === 'suggestion' ? (
-              <T zh="生成中…" en="Generating…" />
-            ) : (
-              <T zh="重新生成" en="Regenerate" />
-            )}
-          </button>
+            <T zh="重新生成" en="Regenerate" />
+          </Button>
         </div>
-        <Field
+        <Input
           label={<T zh="替代文本（中文）" en="Alt Text (Chinese)" />}
           value={altZh}
-          onChange={setAltZh}
+          onChange={(event) => setAltZh(event.target.value)}
         />
-        <Field
+        <Input
           label={<T zh="替代文本（英文）" en="Alt Text (English)" />}
           value={altEn}
-          onChange={setAltEn}
+          onChange={(event) => setAltEn(event.target.value)}
         />
       </div>
 
@@ -752,54 +778,62 @@ function Inspector({
       <div className="mt-5 flex flex-wrap items-center justify-between gap-3 hairline-top pt-4">
         <div className="flex flex-wrap items-center gap-2">
           {asset.catalogState === 'active' && (
-            <button
+            <Button
               type="button"
+              variant="ghost"
+              size="sm"
+              destructive={archiveArmed}
               disabled={pending !== null}
               onClick={requestArchive}
-              className="min-h-11 px-3 text-sm text-muted-foreground outline-none disabled:opacity-50 focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
             >
               {archiveArmed ? (
                 <T zh="确认归档？" en="Confirm archive?" />
               ) : (
                 <T zh="归档" en="Archive" />
               )}
-            </button>
+            </Button>
           )}
           {asset.catalogState === 'archived' && (
-            <button
+            <Button
               type="button"
+              variant="ghost"
+              size="sm"
               disabled={pending !== null}
               onClick={() => void changeCatalogState('restore')}
-              className="min-h-11 px-3 text-sm text-muted-foreground outline-none disabled:opacity-50 focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
             >
               <T zh="恢复" en="Restore" />
-            </button>
+            </Button>
           )}
           {(asset.catalogState === 'archived' ||
             asset.catalogState === 'purging') && (
-            <button
+            <Button
               type="button"
+              variant="ghost"
+              size="sm"
+              destructive
               disabled={pending !== null}
               onClick={() => setPurgeArmed((current) => !current)}
-              className="min-h-11 px-3 text-sm text-destructive outline-none disabled:opacity-50 focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-destructive"
             >
               {asset.catalogState === 'purging' ? (
                 <T zh="重试清除" en="Retry Purge" />
               ) : (
                 <T zh="永久清除" en="Purge" />
               )}
-            </button>
+            </Button>
           )}
         </div>
         {editable && (
-          <button
+          <Button
             type="button"
+            variant="primary"
+            size="md"
+            expandHitArea
+            loading={pending === 'save'}
             disabled={pending !== null}
             onClick={() => void save()}
-            className="min-h-11 rounded-full bg-foreground px-5 text-sm font-medium text-background outline-none transition-transform duration-100 active:scale-[0.97] disabled:opacity-50 focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-2 motion-reduce:transform-none"
           >
-            {pending === 'save' ? <T zh="正在保存…" en="Saving…" /> : <T zh="保存" en="Save" />}
-          </button>
+            <T zh="保存" en="Save" />
+          </Button>
         )}
       </div>
 
@@ -812,25 +846,25 @@ function Inspector({
             />
           </p>
           <div className="flex flex-wrap items-center gap-2">
-            <input
+            <Input
+              destructive
               value={purgeText}
               onChange={(event) => setPurgeText(event.target.value)}
               placeholder="PURGE"
               aria-label={localize(locale, '输入 PURGE 确认', 'Type PURGE to confirm')}
-              className="min-h-11 w-32 rounded-md border border-border bg-background px-3 text-base outline-none placeholder:text-muted-foreground focus:border-destructive"
+              className="w-32"
             />
-            <button
+            <Button
               type="button"
+              variant="primary"
+              size="md"
+              destructive
+              loading={pending === 'purge'}
               disabled={pending !== null || purgeText !== 'PURGE'}
               onClick={() => void purge()}
-              className="min-h-11 rounded-full bg-destructive px-4 text-sm font-medium text-white outline-none disabled:opacity-50 focus-visible:ring-1 focus-visible:ring-destructive focus-visible:ring-offset-2"
             >
-              {pending === 'purge' ? (
-                <T zh="正在清除…" en="Purging…" />
-              ) : (
-                <T zh="确认清除" en="Confirm purge" />
-              )}
-            </button>
+              <T zh="确认清除" en="Confirm purge" />
+            </Button>
           </div>
         </div>
       )}
@@ -1065,9 +1099,12 @@ export function MediaLibrary({
 
   return (
     <div className="pb-10">
-      <h1 className="text-sm font-medium text-muted-foreground">
-        <T zh="媒体" en="Media" />
-      </h1>
+      <div className="flex items-center justify-between gap-4">
+        <h1 className="page-eyebrow">
+          <T zh="媒体" en="Media" />
+        </h1>
+        <PixelCluster variant={8} className="shrink-0" />
+      </div>
       <p className="mt-1 text-sm tabular-nums text-muted-foreground">
         {active.length} <T zh="张使用中" en="active" />
         {archived.length > 0 && (
@@ -1085,42 +1122,27 @@ export function MediaLibrary({
       />
 
       <div className="mt-6 flex flex-wrap items-center justify-between gap-3">
-        <div
-          className="flex items-center gap-1"
-          role="tablist"
-          aria-label={localize(locale, '媒体视图', 'Media view')}
-        >
-          {(['active', 'archived'] as const).map((item) => (
-            <button
-              key={item}
-              type="button"
-              role="tab"
-              aria-selected={view === item}
-              onClick={() => setView(item)}
-              className={`min-h-11 rounded-full px-3 text-sm outline-none focus-visible:ring-1 focus-visible:ring-foreground ${
-                view === item
-                  ? 'bg-foreground text-background'
-                  : 'text-muted-foreground hover:bg-hover hover:text-foreground'
-              }`}
-            >
-              {item === 'active' ? (
-                <T zh="使用中" en="Active" />
-              ) : (
-                <T zh="已归档" en="Archived" />
-              )}
-            </button>
-          ))}
-        </div>
+        <Tabs value={view} onValueChange={(value) => setView(value as LibraryView)}>
+          <TabsList
+            variant="subtle"
+            aria-label={localize(locale, '媒体视图', 'Media view')}
+          >
+            <TabItem value="active" label={localize(locale, '使用中', 'Active')} />
+            <TabItem
+              value="archived"
+              label={localize(locale, '已归档', 'Archived')}
+            />
+          </TabsList>
+        </Tabs>
         <label className="relative min-w-0 flex-1 sm:max-w-56">
           <span className="sr-only">
             <T zh="搜索" en="Search" />
           </span>
-          <input
+          <Input
             type="search"
             value={search}
             onChange={(event) => setSearch(event.target.value)}
             placeholder={localize(locale, '地点、日期、描述…', 'Place, date, alt text…')}
-            className="min-h-11 w-full rounded-md border border-border bg-background px-3 text-base outline-none placeholder:text-muted-foreground focus:border-foreground"
           />
         </label>
       </div>
@@ -1152,7 +1174,7 @@ export function MediaLibrary({
                   onClick={() => setOpenId(asset.id)}
                   aria-label={assetName(asset)}
                   aria-haspopup="dialog"
-                  className="group relative block aspect-square w-full overflow-hidden rounded-md bg-surface-1 outline-none focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                  className="group photo-frame relative block aspect-square w-full overflow-hidden bg-surface-1 outline-none focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                 >
                   {asset.previewRendition ? (
                     // Bunny is the delivery and cache layer for Renditions.
@@ -1190,6 +1212,7 @@ export function MediaLibrary({
                       <T zh="选用" en="In use" />
                     </span>
                   )}
+                  <span className="calibration-corners" aria-hidden />
                 </button>
               </li>
             )
@@ -1206,18 +1229,14 @@ export function MediaLibrary({
         </p>
       )}
 
-      <Dialog.Root
+      <Dialog
         open={open !== null}
         onOpenChange={(next) => {
           if (!next) setOpenId(null)
         }}
       >
-        <Dialog.Portal>
-          <Dialog.Backdrop className="fixed inset-0 z-[var(--z-card)] bg-background/70 backdrop-blur-[6px] transition-opacity duration-200 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 motion-reduce:transition-none" />
-          <Dialog.Popup
-            render={<Elevated offset={4} shadowLevel={4} />}
-            className="fixed left-1/2 top-1/2 z-[var(--z-card)] max-h-[85dvh] w-[min(34rem,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-xl p-5 outline-none transition-[opacity,transform] duration-200 ease-[var(--ease-swift)] data-[ending-style]:scale-[0.97] data-[ending-style]:opacity-0 data-[starting-style]:scale-[0.97] data-[starting-style]:opacity-0 motion-reduce:transition-none"
-          >
+        <DialogContent size="lg">
+          <DialogBody>
             {open && (
               <Inspector
                 key={open.id}
@@ -1226,9 +1245,9 @@ export function MediaLibrary({
                 onClose={() => setOpenId(null)}
               />
             )}
-          </Dialog.Popup>
-        </Dialog.Portal>
-      </Dialog.Root>
+          </DialogBody>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/app/admin/(protected)/media/page.tsx
+++ b/app/admin/(protected)/media/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { Suspense } from 'react'
 
+import { PixelCluster } from '~/components/pixel-cluster'
 import { requireOwnerPage } from '~/lib/admin/server'
 import { T } from '~/lib/i18n'
 import { getMediaAdminPageServices } from '~/lib/media/admin/server'
@@ -18,10 +19,13 @@ export const instant = true
 function MediaFallback() {
   return (
     <div className="pb-10" aria-busy="true">
-      <h1 className="text-sm font-medium text-muted-foreground">
-        <T zh="媒体" en="Media" />
-      </h1>
-      <p className="mt-1 text-sm text-muted-foreground">…</p>
+      <div className="flex items-center justify-between gap-4">
+        <h1 className="page-eyebrow">
+          <T zh="媒体" en="Media" />
+        </h1>
+        <PixelCluster variant={8} className="shrink-0" />
+      </div>
+      <p className="mt-1 text-sm tabular-nums text-muted-foreground">…</p>
       <div className="mt-6 rounded-lg border border-dashed border-border px-5 py-4">
         <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3">
           <div>
@@ -32,18 +36,19 @@ function MediaFallback() {
               JPEG · PNG · HEIC · ≤ 50 MiB
             </p>
           </div>
-          <span className="inline-flex min-h-11 items-center rounded-full bg-surface-1 px-4 text-sm text-muted-foreground">
+          <span className="inline-flex h-7 items-center rounded-full bg-surface-1 px-3 text-[12px] text-muted-foreground">
             <T zh="选择文件" en="Choose files" />
           </span>
         </div>
       </div>
-      <div className="mt-6 flex min-h-11 items-center" />
+      {/* The subtle Tabs row is 32px tall (h-8 chips, no track). */}
+      <div className="mt-6 flex min-h-8 items-center" />
       <ul className="mt-4 grid grid-cols-3 gap-2">
         {Array.from({ length: 6 }, (_, index) => (
           <li
             key={index}
             aria-hidden
-            className="aspect-square rounded-md bg-surface-1"
+            className="aspect-square rounded-[2px] bg-surface-1"
           />
         ))}
       </ul>

--- a/app/admin/(protected)/page.tsx
+++ b/app/admin/(protected)/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { Suspense } from 'react'
 
+import { PixelCluster } from '~/components/pixel-cluster'
 import { requireOwnerPage } from '~/lib/admin/server'
 import { getAmaAdminServices } from '~/lib/ama/admin/server'
 import { T } from '~/lib/i18n'
@@ -28,9 +29,12 @@ const FALLBACK_ROWS = [
 function OverviewFallback() {
   return (
     <div className="pb-10">
-      <h1 className="text-sm font-medium text-muted-foreground">
-        <T zh="总览" en="Overview" />
-      </h1>
+      <div className="flex items-center justify-between gap-4">
+        <h1 className="page-eyebrow">
+          <T zh="总览" en="Overview" />
+        </h1>
+        <PixelCluster variant={6} className="shrink-0" />
+      </div>
       <ul className="mt-6 hairline-top pt-4" aria-busy="true">
         {FALLBACK_ROWS.map((row) => (
           <li

--- a/app/admin/(protected)/photos/PhotoCuration.tsx
+++ b/app/admin/(protected)/photos/PhotoCuration.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { Dialog } from '@base-ui/react/dialog'
 import { useRouter } from 'next/navigation'
 import {
   useCallback,
@@ -11,7 +10,17 @@ import {
   type DragEvent,
 } from 'react'
 
-import { Elevated } from '~/lib/elevated'
+import { PixelCluster } from '~/components/pixel-cluster'
+import { Button } from '~/components/ui/button'
+import {
+  Dialog,
+  DialogBody,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '~/components/ui/dialog'
 import { T } from '~/lib/i18n'
 import { localize, useLocale } from '~/lib/locale-client'
 import {
@@ -57,7 +66,7 @@ function Print({
       className="polaroid polaroid-tilted block rounded-[3px] pb-0"
       style={{ '--tilt': `${(tiltFromSlug(asset?.id ?? 'missing') / 2).toFixed(2)}deg` } as React.CSSProperties}
     >
-      <span className="polaroid-photo aspect-square overflow-hidden">
+      <span className="polaroid-photo photo-frame relative aspect-square overflow-hidden">
         {asset?.previewRendition ? (
           // Bunny is the delivery and cache layer for Renditions.
           // eslint-disable-next-line @next/next/no-img-element
@@ -78,6 +87,7 @@ function Print({
             <T zh="成品不可用" en="No Rendition" />
           </span>
         )}
+        <span className="calibration-corners" aria-hidden />
       </span>
       <span className="polaroid-caption justify-between tabular-nums">
         <span>{String(index + 1).padStart(2, '0')}</span>
@@ -315,39 +325,42 @@ export function PhotoCuration({
 
   return (
     <div className="pb-10">
-      <div className="flex flex-wrap items-end justify-between gap-x-4 gap-y-2">
-        <div>
-          <h1 className="text-sm font-medium text-muted-foreground">
-            <T zh="照片选集" en="Photo Selection" />
-          </h1>
-          <p className="mt-1 text-sm tabular-nums text-muted-foreground">
-            {order.length} <T zh="张照片 · 前三张在首页" en="photos · first three on the homepage" />
-          </p>
-        </div>
+      <div className="flex items-center justify-between gap-4">
+        <h1 className="page-eyebrow">
+          <T zh="照片选集" en="Photo Selection" />
+        </h1>
+        <PixelCluster variant={9} className="shrink-0" />
+      </div>
+      <div className="mt-1 flex min-h-8 flex-wrap items-center justify-between gap-x-4 gap-y-2">
+        <p className="text-sm tabular-nums text-muted-foreground">
+          {order.length}{' '}
+          <T
+            zh="张照片 · 前三张兼作首页预览"
+            en="photos · first three double as the homepage preview"
+          />
+        </p>
         <div className="flex items-center gap-3">
           <span aria-live="polite" className="text-sm text-muted-foreground">
             {saveState === 'saving' && <T zh="保存中…" en="Saving…" />}
             {saveState === 'saved' && <T zh="草稿已保存" en="Draft saved" />}
             {saveState === 'error' && (
-              <button
-                type="button"
-                onClick={() => void runSave()}
-                className="min-h-11 text-sm underline decoration-dotted underline-offset-4 outline-none focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
-              >
+              <Button variant="ghost" size="sm" onClick={() => void runSave()}>
                 <T zh="保存失败 · 重试" en="Save failed · retry" />
-              </button>
+              </Button>
             )}
           </span>
-          <button
-            type="button"
+          <Button
+            variant="primary"
+            size="lg"
+            active={confirming}
+            expandHitArea
             disabled={
               busy || conflict || saveState === 'error' || ineligibleIds.length > 0
             }
             onClick={() => setConfirming((current) => !current)}
-            className="min-h-11 rounded-full bg-foreground px-5 text-sm font-medium text-background outline-none transition-transform duration-100 active:scale-[0.97] disabled:opacity-50 focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-2 motion-reduce:transform-none"
           >
             <T zh="发布" en="Publish" />
-          </button>
+          </Button>
         </div>
       </div>
 
@@ -359,13 +372,9 @@ export function PhotoCuration({
               en="The Draft changed in another tab."
             />
           </p>
-          <button
-            type="button"
-            onClick={() => router.refresh()}
-            className="min-h-11 px-3 text-sm font-medium outline-none focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
-          >
+          <Button variant="secondary" size="sm" onClick={() => router.refresh()}>
             <T zh="重新载入草稿" en="Reload draft" />
-          </button>
+          </Button>
         </div>
       )}
 
@@ -408,26 +417,22 @@ export function PhotoCuration({
             )}
           </p>
           <div className="flex items-center gap-1">
-            <button
-              type="button"
+            <Button
+              variant="ghost"
+              size="sm"
               disabled={busy}
               onClick={() => setConfirming(false)}
-              className="min-h-11 px-3 text-sm text-muted-foreground outline-none focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
             >
               <T zh="取消" en="Cancel" />
-            </button>
-            <button
-              type="button"
-              disabled={busy}
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              loading={publishing}
               onClick={() => void publish()}
-              className="min-h-11 rounded-full bg-foreground px-4 text-sm font-medium text-background outline-none disabled:opacity-50 focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-2"
             >
-              {publishing ? (
-                <T zh="正在发布…" en="Publishing…" />
-              ) : (
-                <T zh="确认发布" en="Confirm publish" />
-              )}
-            </button>
+              <T zh="确认发布" en="Confirm publish" />
+            </Button>
           </div>
         </div>
       )}
@@ -453,55 +458,55 @@ export function PhotoCuration({
       )}
 
       {selectedId && selectedIndex >= 0 && (
-        <div className="mt-4 flex flex-wrap items-center gap-1 rounded-md bg-surface-1 px-3 py-1.5">
+        <div className="mt-4 flex min-h-11 flex-wrap items-center gap-1 rounded-md bg-surface-1 px-3 py-1.5">
           <span className="px-2 text-sm tabular-nums text-muted-foreground">
             {String(selectedIndex + 1).padStart(2, '0')} / {order.length}
           </span>
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="icon-sm"
             disabled={busy || selectedIndex === 0}
             onClick={() => moveTo(selectedId, selectedIndex - 1)}
             aria-label={localize(locale, '前移', 'Move earlier')}
-            className="min-h-11 min-w-11 text-sm outline-none disabled:opacity-30 focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
           >
             ←
-          </button>
-          <button
-            type="button"
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
             disabled={busy || selectedIndex === order.length - 1}
             onClick={() => moveTo(selectedId, selectedIndex + 1)}
             aria-label={localize(locale, '后移', 'Move later')}
-            className="min-h-11 min-w-11 text-sm outline-none disabled:opacity-30 focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
           >
             →
-          </button>
-          <button
-            type="button"
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
             disabled={busy || selectedIndex === 0}
             onClick={() => moveTo(selectedId, 0)}
-            className="min-h-11 px-3 text-sm outline-none disabled:opacity-30 focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
           >
             <T zh="移到最前" en="To front" />
-          </button>
-          <button
-            type="button"
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
             disabled={busy}
             onClick={() => {
               applyOrder(orderRef.current.filter((id) => id !== selectedId))
               setSelectedId(null)
             }}
-            className="min-h-11 px-3 text-sm text-muted-foreground outline-none focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
           >
             <T zh="移除" en="Remove" />
-          </button>
-          <button
-            type="button"
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
             onClick={() => setSelectedId(null)}
             aria-label={localize(locale, '取消选择', 'Deselect')}
-            className="min-h-11 min-w-11 text-sm text-muted-foreground outline-none focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
           >
             ✕
-          </button>
+          </Button>
         </div>
       )}
 
@@ -579,34 +584,30 @@ export function PhotoCuration({
         </li>
       </ul>
 
-      <Dialog.Root open={pickerOpen} onOpenChange={setPickerOpen}>
-        <Dialog.Portal>
-          <Dialog.Backdrop className="fixed inset-0 z-[var(--z-card)] bg-background/70 backdrop-blur-[6px] transition-opacity duration-200 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 motion-reduce:transition-none" />
-          <Dialog.Popup
-            render={<Elevated offset={4} shadowLevel={4} />}
-            className="fixed left-1/2 top-1/2 z-[var(--z-card)] max-h-[85dvh] w-[min(34rem,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-xl p-5 outline-none transition-[opacity,transform] duration-200 ease-[var(--ease-swift)] data-[ending-style]:scale-[0.97] data-[ending-style]:opacity-0 data-[starting-style]:scale-[0.97] data-[starting-style]:opacity-0 motion-reduce:transition-none"
-          >
-            <div className="flex items-baseline justify-between gap-4">
-              <Dialog.Title className="text-sm font-medium">
-                <T zh="从档案添加" en="Add from the archive" />
-              </Dialog.Title>
-              <Dialog.Close className="min-h-11 px-2 text-sm text-muted-foreground outline-none focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground">
-                <T zh="完成" en="Done" />
-              </Dialog.Close>
-            </div>
-            {candidates.length === 0 ? (
-              <p className="mt-4 text-sm leading-6 text-muted-foreground">
-                <T
-                  zh="档案里的照片都已经在选集里了。"
-                  en="Every archive photo is already in the selection."
-                />
-              </p>
-            ) : (
-              <>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  <T zh="点一下即可加入选集末尾。" en="Tap a photo to append it to the selection." />
-                </p>
-                <ul className="mt-4 grid grid-cols-3 gap-2">
+      <Dialog open={pickerOpen} onOpenChange={setPickerOpen}>
+        <DialogContent size="lg">
+          <DialogHeader>
+            <DialogTitle>
+              <T zh="从档案添加" en="Add from the archive" />
+            </DialogTitle>
+            <DialogClose>
+              <T zh="完成" en="Done" />
+            </DialogClose>
+          </DialogHeader>
+          {candidates.length === 0 ? (
+            <p className="mt-4 text-sm leading-6 text-muted-foreground">
+              <T
+                zh="档案里的照片都已经在选集里了。"
+                en="Every archive photo is already in the selection."
+              />
+            </p>
+          ) : (
+            <>
+              <DialogDescription>
+                <T zh="点一下即可加入选集末尾。" en="Tap a photo to append it to the selection." />
+              </DialogDescription>
+              <DialogBody className="mt-4">
+                <ul className="grid grid-cols-3 gap-2">
                   {candidates.map((asset) => {
                     const reason = ineligibilityReason(asset)
                     return (
@@ -662,11 +663,11 @@ export function PhotoCuration({
                     />
                   </p>
                 )}
-              </>
-            )}
-          </Dialog.Popup>
-        </Dialog.Portal>
-      </Dialog.Root>
+              </DialogBody>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/app/admin/(protected)/photos/page.tsx
+++ b/app/admin/(protected)/photos/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { Suspense } from 'react'
 
+import { PixelCluster } from '~/components/pixel-cluster'
 import { requireOwnerPage } from '~/lib/admin/server'
 import { T } from '~/lib/i18n'
 import { getMediaAdminPageServices } from '~/lib/media/admin/server'
@@ -19,10 +20,15 @@ export const instant = true
 function PhotosFallback() {
   return (
     <div className="pb-10" aria-busy="true">
-      <h1 className="text-sm font-medium text-muted-foreground">
-        <T zh="照片选集" en="Photo Selection" />
-      </h1>
-      <p className="mt-1 text-sm text-muted-foreground">…</p>
+      <div className="flex items-center justify-between gap-4">
+        <h1 className="page-eyebrow">
+          <T zh="照片选集" en="Photo Selection" />
+        </h1>
+        <PixelCluster variant={9} className="shrink-0" />
+      </div>
+      <div className="mt-1 flex min-h-8 flex-wrap items-center justify-between gap-x-4 gap-y-2">
+        <p className="text-sm tabular-nums text-muted-foreground">…</p>
+      </div>
       <ul className="mt-6 grid grid-cols-3 gap-x-4 gap-y-6">
         {Array.from({ length: 6 }, (_, index) => (
           <li

--- a/app/api/ama/holds/[holdId]/route.test.ts
+++ b/app/api/ama/holds/[holdId]/route.test.ts
@@ -28,8 +28,21 @@ describe('local AMA confirmation fixtures', () => {
     )
 
     expect(response.status).toBe(200)
+    // Session facts mirror the real paid payload; the fixture dates are
+    // relative to now, so only their presence and shape are asserted.
     await expect(response.json()).resolves.toEqual({
-      hold: { state: 'paid', bookingStatus },
+      hold: {
+        state: 'paid',
+        bookingStatus,
+        startsAt: expect.stringMatching(/T.*Z$/),
+        endsAt: expect.stringMatching(/T.*Z$/),
+        meetingProvider: 'google-meet',
+        guestTimeZone: 'Asia/Taipei',
+        meetingUrl:
+          bookingStatus === 'confirmed'
+            ? 'https://meet.google.com/abc-defg-hij'
+            : null,
+      },
     })
     expect(getAmaBookingServices).not.toHaveBeenCalled()
   })

--- a/app/api/ama/holds/[holdId]/route.ts
+++ b/app/api/ama/holds/[holdId]/route.ts
@@ -24,8 +24,21 @@ export async function GET(
   const { holdId } = await params
   const fixture = getLocalConfirmationFixture(holdId)
   if (fixture) {
+    // Session facts mirror the real paid payload so the confirmation
+    // plate renders in local development.
+    const startsAt = new Date(Date.now() + 72 * 60 * 60 * 1000)
     return Response.json({
-      hold: { state: 'paid', bookingStatus: fixture },
+      hold: {
+        state: 'paid',
+        bookingStatus: fixture,
+        startsAt: startsAt.toISOString(),
+        endsAt: new Date(startsAt.getTime() + 60 * 60 * 1000).toISOString(),
+        meetingProvider: 'google-meet',
+        guestTimeZone: 'Asia/Taipei',
+        // Finalizing has no link yet, mirroring the real lifecycle.
+        meetingUrl:
+          fixture === 'confirmed' ? 'https://meet.google.com/abc-defg-hij' : null,
+      },
     })
   }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -1853,6 +1853,71 @@ figure[data-rehype-pretty-code-figure] {
   }
 }
 
+/* ── Fluid vertical scroll area (components/ui/scroll-area.tsx) ──── */
+
+/* flex column so a flexed parent (dialog body) sizes the viewport;
+   standalone use still sizes to content */
+.scroll-area-y {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.scroll-area-y-viewport {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.scroll-area-y-viewport::-webkit-scrollbar {
+  width: 8px;
+}
+
+.scroll-area-y-viewport::-webkit-scrollbar-thumb {
+  background: color-mix(in oklab, var(--foreground) 20%, transparent);
+  border-radius: 4px;
+}
+
+/* edge fades: visible only while content continues in that direction */
+.scroll-area-y-fade {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2.5rem;
+  pointer-events: none;
+  user-select: none;
+  opacity: 0;
+  transition: opacity 150ms ease;
+}
+
+.scroll-area-y-fade-start {
+  top: 0;
+  background: linear-gradient(
+    to bottom,
+    var(--scroll-fade-surface, var(--background)),
+    transparent
+  );
+}
+
+.scroll-area-y-fade-end {
+  bottom: 0;
+  background: linear-gradient(
+    to top,
+    var(--scroll-fade-surface, var(--background)),
+    transparent
+  );
+}
+
+.scroll-area-y-fade[data-visible] {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scroll-area-y-fade {
+    transition: none;
+  }
+}
+
 figure[data-rehype-pretty-code-figure] figcaption[data-rehype-pretty-code-title] {
   display: flex;
   align-items: center;
@@ -5997,6 +6062,19 @@ body:has(.ama-success-stage) {
   --border: rgb(241 238 229 / 0.16);
   --foreground: #f1eee5;
   --muted-foreground: rgb(241 238 229 / 0.68);
+  --muted: rgb(241 238 229 / 0.09);
+  --hover: rgb(241 238 229 / 0.08);
+  --active: rgb(241 238 229 / 0.14);
+  /* A solid stage surface ramp so ladder-riding sheets (dialogs, popovers)
+     stay dark here regardless of the page theme. */
+  --surface-1: #121014;
+  --surface-2: #161418;
+  --surface-3: #1a181d;
+  --surface-4: #1f1d22;
+  --surface-5: #242227;
+  --surface-6: #29272c;
+  --surface-7: #2e2c31;
+  --surface-8: #333136;
 
   background: #08070a;
   color: #f1eee5;
@@ -6057,27 +6135,43 @@ body:has(.ama-success-stage) main {
   overflow: hidden;
 }
 
+/* Ballistic confetti in three layers: the piece drives horizontally with a
+   touch of drag, the fall layer rises and drops with gravity easings that
+   flip at the apex, and the card tumbles in 3D. All transform/opacity,
+   nothing loops. */
 .ama-success-confetti-piece {
   position: absolute;
   top: 0;
   left: 0;
+  opacity: 0;
+  will-change: transform, opacity;
+  animation: ama-confetti-drive var(--ama-confetti-duration)
+    cubic-bezier(0.22, 0.52, 0.56, 0.9) var(--ama-confetti-delay) both;
+}
+
+.ama-success-confetti-fall {
+  display: block;
+  animation: ama-confetti-fall var(--ama-confetti-duration) linear
+    var(--ama-confetti-delay) both;
+}
+
+.ama-success-confetti-card {
+  display: block;
   width: 0.35rem;
   height: 0.7rem;
   border-radius: 1px;
   background: var(--ama-confetti-color);
-  color: transparent;
-  opacity: 0;
   transform-origin: center;
-  animation: ama-success-confetti-burst var(--ama-confetti-duration)
-    var(--ease-swift) var(--ama-confetti-delay) both;
+  animation: ama-confetti-tumble var(--ama-confetti-duration) linear
+    var(--ama-confetti-delay) both;
 }
 
-.ama-success-confetti-piece:nth-child(3n) {
+.ama-success-confetti-piece:nth-child(3n) .ama-success-confetti-card {
   width: 0.5rem;
   height: 0.18rem;
 }
 
-.ama-success-confetti-piece:nth-child(4n) {
+.ama-success-confetti-piece:nth-child(4n) .ama-success-confetti-card {
   border-radius: 50%;
 }
 
@@ -6093,58 +6187,274 @@ body:has(.ama-success-stage) main {
   align-items: center;
 }
 
+/* Form-like stage content (the guest manage page) stays left-aligned. */
+.ama-success-stage-content--start {
+  text-align: left;
+}
+
+.ama-success-stage-content--start [role='status'] {
+  align-items: stretch;
+}
+
 .ama-success-stage .text-muted-foreground {
   color: rgb(241 238 229 / 0.72);
 }
 
+/* The ladder and cert stamp read in the stage's paper ink on the dark
+   field, independent of the page theme — their default token colors would
+   vanish here in light mode. The lit signal cell stays chromatic. */
+.ama-success-stage .status-ladder {
+  min-width: 10rem;
+  color: rgb(241 238 229 / 0.6);
+}
+
+.ama-success-stage .status-ladder [data-state='current'] {
+  color: rgb(241 238 229 / 0.92);
+}
+
+.ama-success-stage .status-ladder [data-state='done'] .status-ladder-cell {
+  background: rgb(241 238 229 / 0.62);
+}
+
+.ama-success-stage .status-ladder [data-state='pending'] .status-ladder-cell {
+  box-shadow: inset 0 0 0 var(--border-hairline) rgb(241 238 229 / 0.45);
+}
+
+.ama-success-stage .cert-stamp {
+  border-color: rgb(241 238 229 / 0.5);
+  color: rgb(241 238 229 / 0.9);
+}
+
+/* The confirmation's status stamp: the heading-ornament (section-tag)
+   composition — boxed signal cell, hazard-hatch chip, tracked mono label —
+   pressed at a slight angle over the session plate's top rule, like a
+   rubber stamp on the document. Static; a stamp never animates. */
+.ama-plate-stamp {
+  position: relative;
+  z-index: 1;
+  margin-bottom: -0.5625rem;
+  margin-right: 0.75rem;
+  transform: rotate(-3deg);
+  background: rgb(8 7 10 / 0.82);
+  color: rgb(241 238 229 / 0.85);
+}
+
+.ama-plate-stamp .section-tag-index {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Dialog glass: keep the ladder's surface color but drop its alpha so the
+   page reads through the sheet, with a blur so text over it stays legible.
+   color-mix against transparent preserves whatever surface level Elevated
+   assigned (warm paper in the admin, the dark ramp on the AMA stage).
+   backdrop-filter must stay in a stylesheet rule the CSS pipeline keeps —
+   it is a class here, not a raw property on a utility. */
+.dialog-glass {
+  background: color-mix(in oklab, var(--surface-5) 82%, transparent);
+  backdrop-filter: blur(20px) saturate(1.4);
+}
+
+@supports not (backdrop-filter: blur(1px)) {
+  .dialog-glass {
+    background: var(--surface-5);
+  }
+}
+
+/* A standalone hatch chip (no index cell in front) keeps its left rule. */
+.section-tag-hatch:first-child {
+  border-left: var(--border-hairline) solid
+    color-mix(in oklab, var(--muted-foreground) 45%, transparent);
+}
+
+/* The cancel dialog is a hazard-marked sheet: a full-width tape band
+   along its top edge, clipped by the panel's own radius. */
+.ama-cancel-dialog {
+  overflow: hidden;
+}
+
+.ama-cancel-dialog::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 0.5rem;
+  pointer-events: none;
+  border-bottom: var(--border-hairline) solid
+    color-mix(in oklab, var(--destructive) 40%, transparent);
+  background: repeating-linear-gradient(
+    -45deg,
+    color-mix(in oklab, var(--destructive) 50%, transparent) 0,
+    color-mix(in oklab, var(--destructive) 50%, transparent) var(--border-hairline),
+    transparent var(--border-hairline),
+    transparent 5px
+  );
+}
+
+/* Hazard tape flanking a destructive doorway: a short bordered strip of
+   fine diagonal strokes in destructive ink at low alpha. */
+.ama-hazard-strip {
+  width: 2.5rem;
+  height: 0.875rem;
+  border: var(--border-hairline) solid
+    color-mix(in oklab, var(--destructive) 45%, transparent);
+  background: repeating-linear-gradient(
+    -45deg,
+    color-mix(in oklab, var(--destructive) 55%, transparent) 0,
+    color-mix(in oklab, var(--destructive) 55%, transparent) var(--border-hairline),
+    transparent var(--border-hairline),
+    transparent 5px
+  );
+}
+
+/* The session plate prints in the stage's paper ink, same theme
+   independence as the ladder above. */
+.ama-success-stage .spec-nameplate {
+  border-color: rgb(241 238 229 / 0.3);
+}
+
+.ama-success-stage .spec-nameplate > div + div {
+  border-top-color: rgb(241 238 229 / 0.3);
+}
+
+.ama-success-stage .spec-nameplate dt {
+  border-right-color: rgb(241 238 229 / 0.3);
+  color: rgb(241 238 229 / 0.55);
+}
+
+/* Ornamental proof-sheet foot; the label sets in the plate's faded ink. */
+.ama-success-barcode {
+  align-self: center;
+  margin-top: 1.25rem;
+  width: 8.5rem;
+  color: rgb(241 238 229 / 0.44);
+}
+
+.ama-success-barcode svg {
+  /* The strip fills the container so bars and label share one box and one
+     center; preserveAspectRatio="none" keeps the stretch harmless. */
+  width: 100%;
+}
+
+.ama-success-barcode .barcode-label {
+  text-align: center;
+  letter-spacing: 0.22em;
+}
+
+/* The confirmation seal in the print register: a square hairline plate on
+   the 2px corner with calibration brackets outside it, stamped at the
+   arrive animation's settled -4° — an inspection stamp, not a badge. */
 .ama-success-mark {
+  position: relative;
   display: grid;
   width: 4rem;
   height: 4rem;
   margin: 0 auto 1.75rem;
   place-items: center;
-  border-radius: 50%;
-  background: #f1eee5;
-  color: #131216;
-  box-shadow: 0 0 0 0.45rem rgb(217 239 98 / 0.46);
-  font-size: 1.5rem;
+  border-radius: 2px;
+  border: var(--border-hairline) solid rgb(241 238 229 / 0.55);
+  background: rgb(241 238 229 / 0.05);
+  color: #f1eee5;
+  font-size: 1.375rem;
   line-height: 1;
   animation: ama-success-mark-arrive 350ms var(--ease-swift) both;
 }
 
-@keyframes ama-success-confetti-burst {
+/* Hazard-hatch bands along the plate's top and bottom edges — the fine
+   diagonal-stroke chip from the section-tag register, behind the check. */
+.ama-success-mark::after {
+  content: '';
+  position: absolute;
+  inset: 3px;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    repeating-linear-gradient(
+        -45deg,
+        currentColor 0,
+        currentColor var(--border-hairline),
+        transparent var(--border-hairline),
+        transparent 4px
+      )
+      top / 100% 0.4375rem no-repeat,
+    repeating-linear-gradient(
+        -45deg,
+        currentColor 0,
+        currentColor var(--border-hairline),
+        transparent var(--border-hairline),
+        transparent 4px
+      )
+      bottom / 100% 0.4375rem no-repeat;
+  opacity: 0.34;
+}
+
+/* Viewfinder corner brackets, 8px outside the plate (9px arms). */
+.ama-success-mark::before {
+  content: '';
+  position: absolute;
+  inset: -0.5rem;
+  pointer-events: none;
+  opacity: 0.62;
+  background:
+    linear-gradient(currentColor, currentColor) left top / 9px var(--border-hairline) no-repeat,
+    linear-gradient(currentColor, currentColor) left top / var(--border-hairline) 9px no-repeat,
+    linear-gradient(currentColor, currentColor) right top / 9px var(--border-hairline) no-repeat,
+    linear-gradient(currentColor, currentColor) right top / var(--border-hairline) 9px no-repeat,
+    linear-gradient(currentColor, currentColor) left bottom / 9px var(--border-hairline) no-repeat,
+    linear-gradient(currentColor, currentColor) left bottom / var(--border-hairline) 9px no-repeat,
+    linear-gradient(currentColor, currentColor) right bottom / 9px var(--border-hairline) no-repeat,
+    linear-gradient(currentColor, currentColor) right bottom / var(--border-hairline) 9px no-repeat;
+}
+
+/* Horizontal drive: launch speed decays to a drift (air drag); the piece
+   fades while still moving, never hanging in place. */
+@keyframes ama-confetti-drive {
   0% {
     opacity: 0;
-    transform: translate3d(
-        var(--ama-confetti-origin-x),
-        var(--ama-confetti-origin-y),
-        0
-      )
-      scale(0.72) rotate(0deg);
+    transform: translate3d(var(--ama-confetti-x-from), 0, 0);
   }
 
-  8% {
+  5% {
     opacity: 1;
   }
 
-  52% {
-    opacity: 0.94;
-    transform: translate3d(
-        var(--ama-confetti-apex-x),
-        var(--ama-confetti-apex-y),
-        0
-      )
-      scale(1) rotate(var(--ama-confetti-mid-rotation));
+  72% {
+    opacity: 0.95;
   }
 
   100% {
     opacity: 0;
-    transform: translate3d(
-        var(--ama-confetti-end-x),
-        var(--ama-confetti-end-y),
-        0
-      )
-      scale(0.86) rotate(var(--ama-confetti-rotation));
+    transform: translate3d(var(--ama-confetti-x-to), 0, 0);
+  }
+}
+
+/* Vertical ballistics: decelerate to the apex, then gravity takes over —
+   the easing flips per keyframe so the arc reads as a true parabola. */
+@keyframes ama-confetti-fall {
+  0% {
+    transform: translate3d(0, var(--ama-confetti-y-from), 0);
+    animation-timing-function: cubic-bezier(0.16, 0.8, 0.38, 1);
+  }
+
+  44% {
+    transform: translate3d(0, var(--ama-confetti-y-apex), 0);
+    animation-timing-function: cubic-bezier(0.52, 0.04, 0.86, 0.42);
+  }
+
+  100% {
+    transform: translate3d(0, var(--ama-confetti-y-fall), 0);
+  }
+}
+
+/* Finite 3D tumble — the rotateX flutter shows the paper's thin edge. */
+@keyframes ama-confetti-tumble {
+  0% {
+    transform: rotateZ(var(--ama-confetti-tilt)) rotateX(0deg);
+  }
+
+  100% {
+    transform: rotateZ(calc(var(--ama-confetti-tilt) + var(--ama-confetti-spin-z)))
+      rotateX(var(--ama-confetti-spin-x));
   }
 }
 

--- a/components/admin-nav.tsx
+++ b/components/admin-nav.tsx
@@ -1,0 +1,63 @@
+import Link from 'next/link'
+
+// Admin wayfinding: surfaces are menus of catalog rows that go one level
+// deeper, and every subpage carries a back mark to its parent. Structure
+// comes from depth, not from stacking every section on one screen.
+
+/**
+ * A menu row: label, dotted leader, and the surface's own summary value —
+ * the same catalog grammar the Overview uses.
+ */
+export function AdminMenuRow({
+  href,
+  label,
+  value,
+  destructive = false,
+}: {
+  href: string
+  label: React.ReactNode
+  value: React.ReactNode
+  destructive?: boolean
+}) {
+  return (
+    <li>
+      <Link
+        href={href}
+        className="group flex min-h-11 items-center gap-3 py-1.5 text-sm outline-none focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground"
+      >
+        <span className="shrink-0">{label}</span>
+        <span aria-hidden="true" className="blog-row-leader" />
+        <span
+          className={`shrink-0 text-right tabular-nums ${
+            destructive ? 'text-destructive' : 'text-muted-foreground'
+          }`}
+        >
+          {value}
+        </span>
+      </Link>
+    </li>
+  )
+}
+
+export function AdminMenu({ children }: { children: React.ReactNode }) {
+  return <ul className="mt-6 hairline-top pt-4">{children}</ul>
+}
+
+/** The back mark above a subpage's header, in the eyebrow's mono register. */
+export function AdminBackLink({
+  href,
+  children,
+}: {
+  href: string
+  children: React.ReactNode
+}) {
+  return (
+    <Link
+      href={href}
+      className="inline-flex min-h-11 items-center gap-1.5 font-mono text-[11px] uppercase tracking-[0.08em] text-muted-foreground outline-none transition-colors duration-150 hover:text-foreground focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-foreground motion-reduce:transition-none"
+    >
+      <span aria-hidden>←</span>
+      {children}
+    </Link>
+  )
+}

--- a/components/ama/booking-confirmation.tsx
+++ b/components/ama/booking-confirmation.tsx
@@ -4,7 +4,9 @@ import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import { useEffect, useRef, useState } from 'react'
 
+import { Barcode } from '~/components/barcode'
 import { BookingSuccessStage } from '~/components/ama/booking-success-stage'
+import { Tooltip } from '~/components/ui/tooltip'
 import { trackFunnelEvent } from '~/lib/analytics'
 import { T } from '~/lib/i18n'
 import { localize, useLocale } from '~/lib/locale-client'
@@ -14,12 +16,26 @@ const POLL_INTERVAL_MS = 3000
 /** ~2 minutes of polling before settling into the still-processing note. */
 const MAX_POLLS = 40
 
+/** The session facts the paid endpoint prints on the confirmation plate. */
+type PaidSession = {
+  startsAt: string
+  endsAt: string
+  meetingProvider: 'google-meet' | 'tencent-meeting'
+  guestTimeZone: string
+  /** Present once finalization has created the meeting. */
+  meetingUrl: string | null
+}
+
 type ConfirmationState =
   | { kind: 'missing' }
   | { kind: 'checking' }
   | { kind: 'processing' }
   | { kind: 'still-processing' }
-  | { kind: 'paid'; bookingStatus: 'finalizing' | 'confirmed' | 'needs_reschedule' }
+  | {
+      kind: 'paid'
+      bookingStatus: 'finalizing' | 'confirmed' | 'needs_reschedule'
+      session: PaidSession | null
+    }
   | { kind: 'expired' }
   | { kind: 'cancelled' }
 
@@ -55,6 +71,99 @@ function StatusLadder({ current }: { current: number }) {
   )
 }
 
+const PROVIDER_LABELS: Record<PaidSession['meetingProvider'], { zh: string; en: string }> = {
+  'google-meet': { zh: 'Google Meet', en: 'Google Meet' },
+  'tencent-meeting': { zh: '腾讯会议', en: 'Tencent Meeting' },
+}
+
+function sessionTime(iso: string, timeZone: string, locale: 'zh' | 'en') {
+  const options: Intl.DateTimeFormatOptions = {
+    timeZone,
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }
+  try {
+    return new Intl.DateTimeFormat(locale === 'zh' ? 'zh-CN' : 'en-US', options).format(
+      new Date(iso),
+    )
+  } catch {
+    return new Intl.DateTimeFormat(locale === 'zh' ? 'zh-CN' : 'en-US', {
+      ...options,
+      timeZone: 'UTC',
+    }).format(new Date(iso))
+  }
+}
+
+// The booked session as its spec sheet — the nameplate register, printed in
+// the stage's paper ink. Rendered only from server-sent facts.
+function SessionPlate({ session }: { session: PaidSession }) {
+  const minutes = Math.round(
+    (Date.parse(session.endsAt) - Date.parse(session.startsAt)) / 60_000,
+  )
+  const provider = PROVIDER_LABELS[session.meetingProvider] ?? {
+    zh: session.meetingProvider,
+    en: session.meetingProvider,
+  }
+  return (
+    <dl className="spec-nameplate text-left">
+      {/* The zone label is supplementary: hovering the time reveals it as a
+          tooltip. The printed time is already in the guest's own zone. */}
+      <div>
+        <dt>
+          <T zh="时间" en="Time" />
+        </dt>
+        <dd className="min-w-0 break-words">
+          <Tooltip content={session.guestTimeZone}>
+            <span>
+              <T
+                zh={sessionTime(session.startsAt, session.guestTimeZone, 'zh')}
+                en={sessionTime(session.startsAt, session.guestTimeZone, 'en')}
+              />
+            </span>
+          </Tooltip>
+        </dd>
+      </div>
+      <div>
+        <dt>
+          <T zh="时长" en="Length" />
+        </dt>
+        <dd className="min-w-0">
+          {minutes} <T zh="分钟" en="minutes" />
+        </dd>
+      </div>
+      <div>
+        <dt>
+          <T zh="会议方式" en="Meeting" />
+        </dt>
+        <dd className="min-w-0 break-words">
+          <T zh={provider.zh} en={provider.en} />
+        </dd>
+      </div>
+      {session.meetingUrl && (
+        <div>
+          <dt>
+            <T zh="会议链接" en="Link" />
+          </dt>
+          <dd className="min-w-0 break-all">
+            <a
+              href={session.meetingUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="underline decoration-current/35 underline-offset-2 outline-none transition-colors duration-150 hover:decoration-current focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-current motion-reduce:transition-none"
+            >
+              {session.meetingUrl.replace(/^https?:\/\//, '')}
+            </a>
+          </dd>
+        </div>
+      )}
+    </dl>
+  )
+}
+
 /**
  * The post-checkout landing. It never claims success it cannot prove: the
  * page reflects the server's hold state and keeps polling while payment is
@@ -86,10 +195,29 @@ export function BookingConfirmation() {
           const body = (await response.json()) as {
             hold:
               | { state: 'active' | 'processing' | 'expired' | 'cancelled' }
-              | { state: 'paid'; bookingStatus: 'finalizing' | 'confirmed' | 'needs_reschedule' }
+              | ({
+                  state: 'paid'
+                  bookingStatus: 'finalizing' | 'confirmed' | 'needs_reschedule'
+                } & Partial<PaidSession>)
           }
           if (body.hold.state === 'paid') {
-            next = { kind: 'paid', bookingStatus: body.hold.bookingStatus }
+            // Session facts are printed only when the server sent them —
+            // the page never fabricates plate content.
+            const { startsAt, endsAt, meetingProvider, guestTimeZone } = body.hold
+            next = {
+              kind: 'paid',
+              bookingStatus: body.hold.bookingStatus,
+              session:
+                startsAt && endsAt && meetingProvider && guestTimeZone
+                  ? {
+                      startsAt,
+                      endsAt,
+                      meetingProvider,
+                      guestTimeZone,
+                      meetingUrl: body.hold.meetingUrl ?? null,
+                    }
+                  : null,
+            }
           } else if (body.hold.state === 'expired') {
             next = { kind: 'expired' }
           } else if (body.hold.state === 'cancelled') {
@@ -250,36 +378,57 @@ export function BookingConfirmation() {
     )
   }
 
-  const confirmed = state.bookingStatus === 'confirmed'
-
   return (
     <BookingSuccessStage>
       <div role="status" className="flex flex-col gap-3">
-        {confirmed && (
-          <p className="cert-stamp self-start" aria-hidden>
-            <span className="spec-signal" />
-            <T zh="已确认" en="Confirmed" /> +
-          </p>
-        )}
         <p className="text-sm font-medium">
           <T zh="付款已确认。" en="Payment confirmed." />
         </p>
         {state.bookingStatus === 'finalizing' ? (
-          <p className="text-sm leading-6 text-muted-foreground">
+          <p className="text-balance text-sm leading-6 text-muted-foreground">
             <T
               zh="会议细节正在生成，确认邮件很快就到。日历邀请、会议链接和管理链接都会发到你的邮箱。"
               en="Your meeting details are being finalized; the confirmation email is on its way. The calendar invite, meeting link, and your Manage Link all arrive by email."
             />
           </p>
         ) : (
-          <p className="text-sm leading-6 text-muted-foreground">
+          <p className="text-balance text-sm leading-6 text-muted-foreground">
             <T
               zh="确认邮件已经出发，里面有日历邀请、会议链接和专属管理链接。到时见。"
               en="A confirmation email is on its way with the calendar invite, meeting link, and your private Manage Link. See you then."
             />
           </p>
         )}
-        <StatusLadder current={confirmed ? 4 : 3} />
+        {state.session && (
+          <div className="mt-3">
+            {state.bookingStatus === 'confirmed' && (
+              // The heading-ornament composition as a stamp: boxed signal
+              // cell, hazard-hatch chip, tracked mono label — pressed over
+              // the plate's top rule. Terminal states only; the heading
+              // still announces the state.
+              <div className="flex justify-end">
+                <p className="section-tag ama-plate-stamp" aria-hidden>
+                  <span className="section-tag-index">
+                    <span className="spec-signal" />
+                  </span>
+                  <span className="section-tag-hatch" />
+                  <span className="section-tag-label">
+                    <T zh="已确认" en="Confirmed" /> +
+                  </span>
+                </p>
+              </div>
+            )}
+            <SessionPlate session={state.session} />
+          </div>
+        )}
+        {/* Ornamental proof-sheet foot: the barcode derives from the hold id,
+            so every confirmation prints its own label. Ornament, not data. */}
+        {holdId && (
+          <Barcode
+            code={`AMA-${holdId.split('-')[0].toUpperCase()}`}
+            className="ama-success-barcode"
+          />
+        )}
       </div>
     </BookingSuccessStage>
   )

--- a/components/ama/booking-success-stage.test.tsx
+++ b/components/ama/booking-success-stage.test.tsx
@@ -111,32 +111,42 @@ describe('BookingSuccessStage', () => {
 
     expect(container.querySelector('[data-success-shader-ready]')).toBeNull()
     expect(container.querySelector('.ama-success-static-background')).not.toBeNull()
-    expect(container.querySelectorAll('[data-ama-confetti-piece]').length).toBe(24)
+    expect(container.querySelectorAll('[data-ama-confetti-piece]').length).toBe(36)
     expect(
       container.querySelectorAll('[data-ama-confetti-origin="left"]').length,
-    ).toBe(12)
+    ).toBe(18)
     expect(
       container.querySelectorAll('[data-ama-confetti-origin="right"]').length,
-    ).toBe(12)
+    ).toBe(18)
 
+    // Left pieces launch from beyond the left edge and drive rightward;
+    // right pieces mirror. The fall layer starts below the viewport.
     const leftBurst = container.querySelector<HTMLElement>(
       '[data-ama-confetti-origin="left"]',
     )
     const rightBurst = container.querySelector<HTMLElement>(
       '[data-ama-confetti-origin="right"]',
     )
-    expect(
-      leftBurst?.style.getPropertyValue('--ama-confetti-origin-x'),
-    ).toContain('safe-area-inset-left')
-    expect(leftBurst?.style.getPropertyValue('--ama-confetti-apex-x')).toBe(
-      '30vw',
+    expect(leftBurst?.style.getPropertyValue('--ama-confetti-x-from')).toBe(
+      '-4vw',
     )
     expect(
-      rightBurst?.style.getPropertyValue('--ama-confetti-origin-x'),
-    ).toContain('safe-area-inset-right')
-    expect(rightBurst?.style.getPropertyValue('--ama-confetti-apex-x')).toBe(
-      '70vw',
+      Number.parseFloat(
+        leftBurst?.style.getPropertyValue('--ama-confetti-x-to') ?? '',
+      ),
+    ).toBeGreaterThan(-4)
+    expect(rightBurst?.style.getPropertyValue('--ama-confetti-x-from')).toBe(
+      '104vw',
     )
+    expect(
+      Number.parseFloat(
+        rightBurst?.style.getPropertyValue('--ama-confetti-x-to') ?? '',
+      ),
+    ).toBeLessThan(104)
+    expect(leftBurst?.style.getPropertyValue('--ama-confetti-y-from')).toBe(
+      '104dvh',
+    )
+    expect(leftBurst?.querySelector('.ama-success-confetti-card')).not.toBeNull()
   })
 
   it('does not mount a pending shader after reduced motion is enabled', async () => {

--- a/components/ama/booking-success-stage.tsx
+++ b/components/ama/booking-success-stage.tsx
@@ -16,33 +16,33 @@ const UndertonesEightField = dynamic(
 const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)'
 
 type ConfettiStyle = CSSProperties & {
-  '--ama-confetti-apex-x': string
-  '--ama-confetti-apex-y': string
   '--ama-confetti-color': string
   '--ama-confetti-delay': string
   '--ama-confetti-duration': string
-  '--ama-confetti-end-x': string
-  '--ama-confetti-end-y': string
-  '--ama-confetti-mid-rotation': string
-  '--ama-confetti-origin-x': string
-  '--ama-confetti-origin-y': string
-  '--ama-confetti-rotation': string
+  '--ama-confetti-spin-x': string
+  '--ama-confetti-spin-z': string
+  '--ama-confetti-tilt': string
+  '--ama-confetti-x-from': string
+  '--ama-confetti-x-to': string
+  '--ama-confetti-y-apex': string
+  '--ama-confetti-y-fall': string
+  '--ama-confetti-y-from': string
 }
 
 type ConfettiPiece = {
-  apexX: string
-  apexY: string
   color: string
   delay: string
   duration: string
-  endX: string
-  endY: string
   key: string
-  midRotation: string
   origin: 'left' | 'right'
-  originX: string
-  originY: string
-  rotation: string
+  spinX: string
+  spinZ: string
+  tilt: string
+  xFrom: string
+  xTo: string
+  yApex: string
+  yFall: string
+  yFrom: string
 }
 
 const CONFETTI_COLORS = [
@@ -53,54 +53,63 @@ const CONFETTI_COLORS = [
   '#f1eee5',
 ] as const
 
-const BURST_PATHS = [
-  { apexX: 30, apexY: 64, endX: 38, endY: 43 },
-  { apexX: 36, apexY: 76, endX: 44, endY: 55 },
-  { apexX: 42, apexY: 58, endX: 51, endY: 35 },
-  { apexX: 46, apexY: 84, endX: 52, endY: 64 },
-  { apexX: 50, apexY: 68, endX: 58, endY: 44 },
-  { apexX: 54, apexY: 79, endX: 61, endY: 58 },
-  { apexX: 58, apexY: 60, endX: 65, endY: 37 },
-  { apexX: 62, apexY: 88, endX: 69, endY: 68 },
-  { apexX: 66, apexY: 72, endX: 73, endY: 50 },
-  { apexX: 70, apexY: 82, endX: 76, endY: 62 },
-  { apexX: 74, apexY: 64, endX: 81, endY: 42 },
-  { apexX: 78, apexY: 76, endX: 85, endY: 54 },
-] as const
+const PIECES_PER_BURST = 18
 
+// Ballistic decomposition: each piece is three nested layers so the physics
+// read true — a horizontal drive with slight drag (linear-ish), a vertical
+// rise/fall whose easings flip at the apex (decelerate up, accelerate down),
+// and a finite 3D tumble on the visible card. Variation is derived from the
+// index (no runtime randomness — SSR output stays stable).
 const CONFETTI = (['left', 'right'] as const).flatMap(
   (origin, originIndex): ConfettiPiece[] => {
     const direction = origin === 'left' ? 1 : -1
-    return BURST_PATHS.map((path, index) => {
-      const rotation = direction * (440 + ((index * 47) % 250))
+    return Array.from({ length: PIECES_PER_BURST }, (_, index) => {
+      const spread = ((index * 47 + originIndex * 31) % 100) / 100
+      const lift = ((index * 73 + originIndex * 17) % 100) / 100
+      const drop = ((index * 29 + originIndex * 53) % 100) / 100
+
+      const xFrom = origin === 'left' ? -4 : 104
+      const travel = 22 + spread * 48
+      const rise = 36 + lift * 44
 
       return {
-        apexX: `${origin === 'left' ? path.apexX : 100 - path.apexX}vw`,
-        apexY: `${100 - path.apexY}dvh`,
         color:
           CONFETTI_COLORS[
             (index + originIndex * 2) % CONFETTI_COLORS.length
           ]!,
-        delay: `${(index * 53 + originIndex * 29) % 260}ms`,
-        duration: `${2200 + ((index * 73 + originIndex * 41) % 520)}ms`,
-        endX: `${origin === 'left' ? path.endX : 100 - path.endX}vw`,
-        endY: `${100 - path.endY}dvh`,
+        delay: `${(index * 41 + originIndex * 23) % 420}ms`,
+        duration: `${2600 + ((index * 89 + originIndex * 37) % 900)}ms`,
         key: `${origin}-${index}`,
-        midRotation: `${Math.round(rotation * 0.58)}deg`,
         origin,
-        originX:
-          origin === 'left'
-            ? 'calc(env(safe-area-inset-left) - 1rem)'
-            : 'calc(100vw - env(safe-area-inset-right) + 1rem)',
-        originY:
-          'calc(100dvh - env(safe-area-inset-bottom) + 1rem)',
-        rotation: `${rotation}deg`,
+        spinX: `${360 + ((index * 97 + originIndex * 43) % 540)}deg`,
+        spinZ: `${direction * (540 + ((index * 67) % 360))}deg`,
+        tilt: `${(index * 23 + originIndex * 11) % 180}deg`,
+        xFrom: `${xFrom}vw`,
+        xTo: `${xFrom + direction * travel}vw`,
+        yApex: `${104 - rise}dvh`,
+        yFall: `${84 + drop * 24}dvh`,
+        yFrom: '104dvh',
       }
     })
   },
 )
 
-export function BookingSuccessStage({ children }: { children: React.ReactNode }) {
+/**
+ * The shared dark AMA stage: static gradient plate, WebGPU field once ready,
+ * and the centered content column, with the page's tokens flipped dark via
+ * `body:has(.ama-success-stage)`. The celebration extras (confetti, the
+ * confirmation seal) belong to BookingSuccessStage alone.
+ */
+export function AmaStage({
+  children,
+  align = 'center',
+  extras,
+}: {
+  children: React.ReactNode
+  /** `start` keeps form-like content left-aligned (the guest manage page). */
+  align?: 'center' | 'start'
+  extras?: React.ReactNode
+}) {
   const [shaderMounted, setShaderMounted] = useState(false)
   const [shaderReady, setShaderReady] = useState(false)
   const {
@@ -157,22 +166,40 @@ export function BookingSuccessStage({ children }: { children: React.ReactNode })
           />
         </span>
       ) : null}
-      <span className="ama-success-confetti" aria-hidden>
+      {extras}
+      <div
+        className={
+          align === 'start'
+            ? 'ama-success-stage-content ama-success-stage-content--start'
+            : 'ama-success-stage-content'
+        }
+      >
+        {children}
+      </div>
+    </section>
+  )
+}
+
+export function BookingSuccessStage({ children }: { children: React.ReactNode }) {
+  return (
+    <AmaStage
+      extras={
+        <span className="ama-success-confetti" aria-hidden>
         {CONFETTI.map(
           ({
-            apexX,
-            apexY,
             color,
             delay,
             duration,
-            endX,
-            endY,
             key,
-            midRotation,
             origin,
-            originX,
-            originY,
-            rotation,
+            spinX,
+            spinZ,
+            tilt,
+            xFrom,
+            xTo,
+            yApex,
+            yFall,
+            yFrom,
           }) => (
             <span
               key={key}
@@ -181,29 +208,33 @@ export function BookingSuccessStage({ children }: { children: React.ReactNode })
               data-ama-confetti-origin={origin}
               style={
                 {
-                  '--ama-confetti-apex-x': apexX,
-                  '--ama-confetti-apex-y': apexY,
                   '--ama-confetti-color': color,
                   '--ama-confetti-delay': delay,
                   '--ama-confetti-duration': duration,
-                  '--ama-confetti-end-x': endX,
-                  '--ama-confetti-end-y': endY,
-                  '--ama-confetti-mid-rotation': midRotation,
-                  '--ama-confetti-origin-x': originX,
-                  '--ama-confetti-origin-y': originY,
-                  '--ama-confetti-rotation': rotation,
+                  '--ama-confetti-spin-x': spinX,
+                  '--ama-confetti-spin-z': spinZ,
+                  '--ama-confetti-tilt': tilt,
+                  '--ama-confetti-x-from': xFrom,
+                  '--ama-confetti-x-to': xTo,
+                  '--ama-confetti-y-apex': yApex,
+                  '--ama-confetti-y-fall': yFall,
+                  '--ama-confetti-y-from': yFrom,
                 } as ConfettiStyle
               }
-            />
+            >
+              <span className="ama-success-confetti-fall">
+                <span className="ama-success-confetti-card" />
+              </span>
+            </span>
           ),
         )}
-      </span>
-      <div className="ama-success-stage-content">
-        <span className="ama-success-mark" aria-hidden>
-          ✓
         </span>
-        {children}
-      </div>
-    </section>
+      }
+    >
+      <span className="ama-success-mark" aria-hidden>
+        ✓
+      </span>
+      {children}
+    </AmaStage>
   )
 }

--- a/components/ama/manage-booking.test.tsx
+++ b/components/ama/manage-booking.test.tsx
@@ -142,7 +142,7 @@ describe('ManageBooking', () => {
     expect(screen.getAllByText('Google Meet').length).toBeGreaterThanOrEqual(1)
     expect(
       screen
-        .getByRole('link', { name: /meet\.google\.com/ })
+        .getByRole('link', { name: 'meet.google.com/abc-defg-hij' })
         .getAttribute('href'),
     ).toBe('https://meet.google.com/abc-defg-hij')
     expect(screen.getByText(/Confirmed/)).toBeTruthy()

--- a/components/ama/manage-booking.test.tsx
+++ b/components/ama/manage-booking.test.tsx
@@ -134,13 +134,16 @@ describe('ManageBooking', () => {
     expect(screen.queryByRole('button', { name: /Cancel booking/ })).toBeNull()
   })
 
-  it('renders the booking summary with zone label, provider, and meeting link', async () => {
+  it('renders the booking summary with provider and the meeting link in the plate', async () => {
     await renderManage()
 
-    expect(screen.getByText('America/New_York')).toBeTruthy()
+    // The zone label moved into a hover tooltip — never in the static DOM.
+    expect(screen.queryByText('America/New_York')).toBeNull()
     expect(screen.getAllByText('Google Meet').length).toBeGreaterThanOrEqual(1)
     expect(
-      screen.getByRole('link', { name: /打开会议链接|Open meeting link/ }).getAttribute('href'),
+      screen
+        .getByRole('link', { name: /meet\.google\.com/ })
+        .getAttribute('href'),
     ).toBe('https://meet.google.com/abc-defg-hij')
     expect(screen.getByText(/Confirmed/)).toBeTruthy()
   })

--- a/components/ama/manage-booking.tsx
+++ b/components/ama/manage-booking.tsx
@@ -3,9 +3,20 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { SlotPicker, type PublicSlot } from '~/components/ama/slot-picker'
+import { Barcode } from '~/components/barcode'
+import { Button } from '~/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '~/components/ui/dialog'
+import { Tooltip } from '~/components/ui/tooltip'
 import { T } from '~/lib/i18n'
 import { localize, useLocale } from '~/lib/locale-client'
-import { cn } from '~/lib/utils'
 
 type ManagedBooking = {
   status: string
@@ -64,11 +75,24 @@ const RESCHEDULE_NOTICES: Record<Exclude<RescheduleNotice, null>, { zh: string; 
   },
 }
 
-const primaryButtonClassName =
-  'inline-flex min-h-11 touch-manipulation items-center justify-center rounded-md bg-foreground px-5 text-sm font-medium text-background outline-none transition-transform duration-100 ease-[ease] active:scale-[0.97] disabled:pointer-events-none disabled:opacity-60 focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-reduce:transform-none motion-reduce:transition-none'
-
-const quietButtonClassName =
-  'inline-flex min-h-11 touch-manipulation items-center justify-center rounded-md px-4 text-sm text-muted-foreground outline-none transition-colors duration-150 hover:text-foreground focus-visible:ring-1 focus-visible:ring-foreground disabled:pointer-events-none disabled:opacity-60'
+/** The ornamental barcode label: the session's date in the guest's zone. */
+function sessionDateCode(iso: string, timeZone: string) {
+  const options: Intl.DateTimeFormatOptions = {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }
+  try {
+    return new Intl.DateTimeFormat('en-CA', options)
+      .format(new Date(iso))
+      .replaceAll('-', '')
+  } catch {
+    return new Intl.DateTimeFormat('en-CA', { ...options, timeZone: 'UTC' })
+      .format(new Date(iso))
+      .replaceAll('-', '')
+  }
+}
 
 function bookingTime(booking: ManagedBooking, timeZone: string) {
   const start = new Date(booking.startsAt)
@@ -288,35 +312,40 @@ export function ManageBooking({ token }: { token: string }) {
         </p>
       )}
 
-      <section
-        aria-label={localize(locale, '预订详情', 'Booking details')}
-        className="rounded-md px-4 py-5 shadow-[0_0_0_1px_var(--border)]"
-      >
-        <dl className="grid gap-4 text-sm">
-          <div className="grid gap-1">
-            <dt className="text-muted-foreground">
+      {/* The booking as a nameplate: the data is the session's own
+          specification, so it takes the boxed plate register the AMA page
+          established. Secondary notes ride inside the value cell; the
+          meeting link lives in the plate once it exists — the guest's copy
+          of the session's spec sheet. */}
+      <section aria-label={localize(locale, '预订详情', 'Booking details')}>
+        <dl className="spec-nameplate">
+          {/* The zone label is supplementary: hovering the time reveals it
+              as a tooltip. The printed time is already in the guest's zone. */}
+          <div>
+            <dt>
               <T zh="时间" en="Time" />
             </dt>
-            <dd className="font-medium tabular-nums">
-              {time && <T zh={time.zh} en={time.en} />}
+            <dd className="min-w-0 break-words">
+              <Tooltip content={booking.guestTimeZone}>
+                <span>{time && <T zh={time.zh} en={time.en} />}</span>
+              </Tooltip>
             </dd>
-            <dd className="text-[13px] text-muted-foreground">{booking.guestTimeZone}</dd>
           </div>
 
-          <div className="grid gap-1">
-            <dt className="text-muted-foreground">
+          <div>
+            <dt>
               <T zh="会议方式" en="Meeting" />
             </dt>
-            <dd className="font-medium">
+            <dd className="min-w-0 break-words">
               <T zh={providerLabel.zh} en={providerLabel.en} />
             </dd>
           </div>
 
-          <div className="grid gap-1">
-            <dt className="text-muted-foreground">
+          <div>
+            <dt>
               <T zh="状态" en="Status" />
             </dt>
-            <dd className="font-medium">
+            <dd className="min-w-0 break-words">
               {isCancelled ? (
                 <T zh="已取消" en="Cancelled" />
               ) : isFinalizing ? (
@@ -324,43 +353,45 @@ export function ManageBooking({ token }: { token: string }) {
               ) : (
                 <T zh="已确认" en="Confirmed" />
               )}
-            </dd>
-            {isFinalizing && (
-              <dd className="text-[13px] leading-5 text-muted-foreground">
-                <T
-                  zh="会议链接正在创建，准备好后会通过邮件送达。"
-                  en="The meeting link is being created and will arrive by email once ready."
-                />
-              </dd>
-            )}
-            {booking.refundStatus && booking.refundStatus !== 'none' && (
-              <dd className="text-[13px] leading-5 text-muted-foreground">
-                {booking.refundStatus === 'refunded' ? (
-                  <T zh="退款已完成。" en="Refund completed." />
-                ) : (
-                  // 'pending' and 'failed' both read as in-progress: a failed
-                  // automatic refund is retried or handled by hand, and the
-                  // guest never owes the difference.
+              {isFinalizing && (
+                <span className="block leading-5 text-muted-foreground">
                   <T
-                    zh="退款处理中，通常几个工作日内原路退回。"
-                    en="Refund in progress; it usually returns to your card within a few business days."
+                    zh="会议链接正在创建，准备好后会通过邮件送达。"
+                    en="The meeting link is being created and will arrive by email once ready."
                   />
-                )}
-              </dd>
-            )}
+                </span>
+              )}
+              {booking.refundStatus && booking.refundStatus !== 'none' && (
+                <span className="block leading-5 text-muted-foreground">
+                  {booking.refundStatus === 'refunded' ? (
+                    <T zh="退款已完成。" en="Refund completed." />
+                  ) : (
+                    // 'pending' and 'failed' both read as in-progress: a failed
+                    // automatic refund is retried or handled by hand, and the
+                    // guest never owes the difference.
+                    <T
+                      zh="退款处理中，通常几个工作日内原路退回。"
+                      en="Refund in progress; it usually returns to your card within a few business days."
+                    />
+                  )}
+                </span>
+              )}
+            </dd>
           </div>
 
           {booking.meetingUrl && !isCancelled && (
-            <div className="grid justify-items-start gap-1">
-              <dt className="sr-only">{localize(locale, '会议链接', 'Meeting link')}</dt>
-              <dd>
+            <div>
+              <dt>
+                <T zh="会议链接" en="Link" />
+              </dt>
+              <dd className="min-w-0 break-all">
                 <a
                   href={booking.meetingUrl}
                   target="_blank"
                   rel="noreferrer"
-                  className={primaryButtonClassName}
+                  className="underline decoration-current/35 underline-offset-2 outline-none transition-colors duration-150 hover:decoration-current focus-visible:rounded-sm focus-visible:ring-1 focus-visible:ring-current motion-reduce:transition-none"
                 >
-                  <T zh="打开会议链接" en="Open meeting link" />
+                  {booking.meetingUrl.replace(/^https?:\/\//, '')}
                 </a>
               </dd>
             </div>
@@ -382,23 +413,26 @@ export function ManageBooking({ token }: { token: string }) {
           {booking.canReschedule && (
             <div className="flex flex-col gap-4">
               {!rescheduleOpen ? (
-                <div>
-                  <button
-                    type="button"
+                <div className="flex justify-center">
+                  <Button
+                    variant="tertiary"
+                    size="lg"
                     aria-expanded={rescheduleOpen}
                     onClick={openReschedule}
-                    className={cn(
-                      quietButtonClassName,
-                      'px-4 shadow-[0_0_0_1px_var(--border)] hover:shadow-[0_0_0_1px_var(--foreground)]',
-                    )}
+                    expandHitArea
                   >
                     <T zh="改期" en="Reschedule" />
-                  </button>
+                  </Button>
                 </div>
               ) : (
-                <div className="flex flex-col gap-4">
-                  <h2 className="text-sm font-medium text-muted-foreground">
-                    <T zh="选择新时间" en="Pick a new time" />
+                <div className="flex flex-col gap-4 hairline-top pt-5">
+                  {/* The flow heading in the heading-ornament register:
+                      standalone hatch chip + tracked mono label. */}
+                  <h2 className="section-tag">
+                    <span className="section-tag-hatch" aria-hidden />
+                    <span className="section-tag-label">
+                      <T zh="选择新时间" en="Pick a new time" />
+                    </span>
                   </h2>
                   {slots === null && !slotsUnavailable && (
                     <div role="status" aria-live="polite">
@@ -439,30 +473,27 @@ export function ManageBooking({ token }: { token: string }) {
                     />
                   )}
                   <div className="flex flex-wrap items-center gap-3">
-                    <button
-                      type="button"
+                    <Button
+                      variant="primary"
+                      size="lg"
                       disabled={pending !== null || !selected}
+                      loading={pending === 'reschedule'}
                       onClick={() => void confirmReschedule()}
-                      className={primaryButtonClassName}
                     >
-                      {pending === 'reschedule' ? (
-                        <T zh="正在改期…" en="Rescheduling…" />
-                      ) : (
-                        <T zh="确认改期" en="Confirm new time" />
-                      )}
-                    </button>
-                    <button
-                      type="button"
+                      <T zh="确认改期" en="Confirm new time" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="lg"
                       disabled={pending !== null}
                       onClick={() => {
                         setRescheduleOpen(false)
                         setSelected(null)
                         setNotice(null)
                       }}
-                      className={quietButtonClassName}
                     >
                       <T zh="保持原时间" en="Keep the current time" />
-                    </button>
+                    </Button>
                   </div>
                 </div>
               )}
@@ -470,21 +501,34 @@ export function ManageBooking({ token }: { token: string }) {
           )}
 
           {booking.canCancel && (
-            <div className="flex flex-col gap-3">
-              {!confirmingCancel ? (
-                <div>
-                  <button
-                    type="button"
-                    disabled={pending !== null}
-                    onClick={() => setConfirmingCancel(true)}
-                    className={quietButtonClassName}
-                  >
-                    <T zh="取消预订" en="Cancel booking" />
-                  </button>
-                </div>
-              ) : (
-                <div className="flex flex-col gap-3 rounded-md px-4 py-4 shadow-[0_0_0_1px_var(--border)]">
-                  <p className="text-sm leading-6">
+            <>
+              {/* Hazard tape flanks the destructive doorway, centered like a
+                  document-foot action; the confirmation is a hazard-marked
+                  dialog on the surface ladder. */}
+              <div className="flex items-center justify-center gap-3">
+                <span className="ama-hazard-strip" aria-hidden />
+                <Button
+                  variant="ghost"
+                  size="lg"
+                  destructive
+                  disabled={pending !== null}
+                  onClick={() => setConfirmingCancel(true)}
+                  aria-haspopup="dialog"
+                  expandHitArea
+                >
+                  <T zh="取消预订" en="Cancel booking" />
+                </Button>
+                <span className="ama-hazard-strip" aria-hidden />
+              </div>
+
+              <Dialog open={confirmingCancel} onOpenChange={setConfirmingCancel}>
+                <DialogContent size="sm" className="ama-cancel-dialog">
+                  <DialogHeader className="pt-5">
+                    <DialogTitle>
+                      <T zh="取消预订" en="Cancel this booking" />
+                    </DialogTitle>
+                  </DialogHeader>
+                  <DialogDescription>
                     {booking.refundOnCancel ? (
                       <T
                         zh="确定取消吗？付款会自动全额退款，原路退回。"
@@ -496,34 +540,37 @@ export function ManageBooking({ token }: { token: string }) {
                         en="Cancel this booking? The session starts in less than 24 hours, so there is no automatic refund."
                       />
                     )}
-                  </p>
-                  <div className="flex flex-wrap items-center gap-3">
-                    <button
-                      type="button"
+                  </DialogDescription>
+                  {notice && (
+                    <p role="alert" className="mt-3 px-5 text-sm leading-6">
+                      <T
+                        zh={RESCHEDULE_NOTICES[notice].zh}
+                        en={RESCHEDULE_NOTICES[notice].en}
+                      />
+                    </p>
+                  )}
+                  <DialogFooter className="mt-4">
+                    <DialogClose size="lg" disabled={pending !== null}>
+                      <T zh="保留预订" en="Keep the booking" />
+                    </DialogClose>
+                    <Button
+                      variant="primary"
+                      size="lg"
+                      destructive
                       disabled={pending !== null}
+                      loading={pending === 'cancel'}
                       onClick={() => void confirmCancel()}
-                      className={primaryButtonClassName}
                     >
-                      {pending === 'cancel' ? (
-                        <T zh="正在取消…" en="Cancelling…" />
-                      ) : booking.refundOnCancel ? (
+                      {booking.refundOnCancel ? (
                         <T zh="取消并退款" en="Cancel and refund" />
                       ) : (
                         <T zh="仍然取消" en="Cancel anyway" />
                       )}
-                    </button>
-                    <button
-                      type="button"
-                      disabled={pending !== null}
-                      onClick={() => setConfirmingCancel(false)}
-                      className={quietButtonClassName}
-                    >
-                      <T zh="保留预订" en="Keep the booking" />
-                    </button>
-                  </div>
-                </div>
-              )}
-            </div>
+                    </Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
+            </>
           )}
         </section>
       )}
@@ -540,6 +587,12 @@ export function ManageBooking({ token }: { token: string }) {
           )}
         </p>
       )}
+
+      {/* Ornamental proof-sheet foot — the session date as its label. */}
+      <Barcode
+        code={`AMA-${sessionDateCode(booking.startsAt, booking.guestTimeZone)}`}
+        className="ama-success-barcode"
+      />
     </div>
   )
 }

--- a/components/ama/slot-picker.tsx
+++ b/components/ama/slot-picker.tsx
@@ -1,7 +1,13 @@
 'use client'
 
-import { useId, useMemo } from 'react'
+import { useMemo } from 'react'
 
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from '~/components/ui/select'
 import { T } from '~/lib/i18n'
 import { localize, useLocale } from '~/lib/locale-client'
 import { cn } from '~/lib/utils'
@@ -51,7 +57,6 @@ export function SlotPicker({
   disabled = false,
 }: SlotPickerProps) {
   const locale = useLocale()
-  const timeZoneSelectId = useId()
 
   const timeZones = useMemo(() => listTimeZones(timeZone), [timeZone])
 
@@ -131,22 +136,31 @@ export function SlotPicker({
   return (
     <div className="flex flex-col gap-6">
       <div className="grid gap-1.5 text-sm">
-        <label htmlFor={timeZoneSelectId} className="text-muted-foreground">
+        <span className="text-muted-foreground">
           <T zh="时区" en="Time zone" />
-        </label>
-        <select
-          id={timeZoneSelectId}
+        </span>
+        <Select
           value={timeZone}
+          onValueChange={onTimeZoneChange}
           disabled={disabled}
-          onChange={(event) => onTimeZoneChange(event.target.value)}
-          className="min-h-11 w-full touch-manipulation rounded-md bg-background px-3 text-base shadow-[0_0_0_1px_var(--border)] outline-none focus-visible:shadow-[0_0_0_1px_var(--foreground)]"
         >
-          {timeZones.map((zone) => (
-            <option key={zone} value={zone}>
-              {zone}
-            </option>
-          ))}
-        </select>
+          <SelectTrigger
+            aria-label={localize(locale, '时区', 'Time zone')}
+            className="w-full rounded-[2px] font-mono text-[13px]"
+          />
+          <SelectContent>
+            {timeZones.map((zone, index) => (
+              <SelectItem
+                key={zone}
+                value={zone}
+                index={index}
+                className="font-mono text-[13px]"
+              >
+                {zone}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
         <p className="text-[13px] text-muted-foreground">
           <T zh="以下时间均按你选择的时区显示。" en="All times are shown in your selected time zone." />
         </p>
@@ -155,7 +169,9 @@ export function SlotPicker({
       <div className="flex flex-col gap-5">
         {groups.map((group) => (
           <section key={group.key} aria-label={localize(locale, group.zhHeading, group.enHeading)}>
-            <h3 className="text-sm font-medium text-muted-foreground">
+            {/* Day headings take the plate-label register: machine chrome
+                over the mono time chips below. */}
+            <h3 className="font-mono text-[11px] uppercase tracking-[0.08em] text-muted-foreground">
               <T zh={group.zhHeading} en={group.enHeading} />
             </h3>
             <ul className="mt-2 grid grid-cols-3 gap-2 sm:grid-cols-4">
@@ -170,7 +186,7 @@ export function SlotPicker({
                       aria-label={localize(locale, slot.zhLabel, slot.enLabel)}
                       onClick={() => onSelect(slot.startsAt)}
                       className={cn(
-                        'min-h-11 w-full touch-manipulation rounded-md text-sm tabular-nums outline-none transition-colors duration-150',
+                        'min-h-11 w-full touch-manipulation rounded-[2px] font-mono text-[13px] tabular-nums outline-none transition-colors duration-150',
                         'focus-visible:ring-1 focus-visible:ring-[var(--focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-background',
                         isSelected
                           ? 'bg-foreground text-background shadow-[0_0_0_1px_var(--foreground)]'

--- a/components/pixel-cluster.tsx
+++ b/components/pixel-cluster.tsx
@@ -12,6 +12,12 @@ const VARIANTS = [
   ['b', '', 's', 'a'],
   ['a', 'b', 's', ''],
   ['', 'a', 'b', 's'],
+  // admin surfaces: Overview, AMA, Media, Photos, Booking detail
+  ['s', '', 'a', 'b'],
+  ['b', 's', 'a', ''],
+  ['', 'b', 's', 'a'],
+  ['a', '', 'b', 's'],
+  ['s', 'b', '', 'a'],
 ] as const
 
 export function PixelCluster({

--- a/components/section-tag.tsx
+++ b/components/section-tag.tsx
@@ -1,0 +1,27 @@
+import { cn } from '~/lib/utils'
+
+// The section-tag register from the public homepage h2s — index cell,
+// hazard-hatch chip, and uppercase mono label — as a shared component.
+// Rendered statically: no entrance class here; public callers that want
+// `.enter` keep their own inline markup.
+export function SectionTag({
+  index,
+  id,
+  className,
+  children,
+}: {
+  index: number
+  id?: string
+  className?: string
+  children: React.ReactNode
+}) {
+  return (
+    <h2 id={id} className={cn('section-tag', className)}>
+      <span className="section-tag-index" aria-hidden>
+        {String(index).padStart(2, '0')}
+      </span>
+      <span className="section-tag-hatch" aria-hidden />
+      <span className="section-tag-label">{children}</span>
+    </h2>
+  )
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -66,6 +66,14 @@ interface ButtonProps
    *  external open piece of UI (a popover, dropdown, etc.) so it reads as
    *  engaged while the menu is showing. */
   active?: boolean;
+  /** Destructive tone: primary becomes a filled destructive pill; the other
+   *  variants read destructive ink with a destructive-tinted hover. The focus
+   *  ring stays neutral — signal color never marks focus. */
+  destructive?: boolean;
+  /** Restore the 44px minimum hit target with a pseudo-element when the
+   *  visible pill is shorter (the .btn-cta::before recipe). Only for buttons
+   *  with ≥16px vertical clearance — never in dense stacked rows. */
+  expandHitArea?: boolean;
 }
 
 const bgVariants: Record<string, string> = {
@@ -82,6 +90,39 @@ const activeBgVariants: Record<string, string> = {
   ghost: "bg-active",
 };
 
+// Destructive tone. Filled primary mirrors the foreground recipe on
+// bg-destructive (label matches the existing bg-destructive/text-white
+// admin confirms); the quieter variants keep destructive ink over a
+// /10-alpha tinted hover.
+const destructiveRootVariants: Record<string, string> = {
+  primary: "text-white",
+  secondary: "text-destructive",
+  tertiary: "text-destructive",
+  ghost: "text-destructive hover:text-destructive",
+};
+
+const destructiveBgVariants: Record<string, string> = {
+  primary:
+    "bg-destructive group-hover:bg-destructive/90 group-active:bg-destructive/80",
+  secondary:
+    "bg-destructive/10 group-hover:bg-destructive/15 group-active:bg-destructive/20",
+  tertiary:
+    "bg-transparent group-hover:bg-destructive/10 group-active:bg-destructive/15",
+  ghost:
+    "bg-transparent group-hover:bg-destructive/10 group-active:bg-destructive/15",
+};
+
+const destructiveActiveBgVariants: Record<string, string> = {
+  primary: "bg-destructive/80",
+  secondary: "bg-destructive/20",
+  tertiary: "bg-destructive/15",
+  ghost: "bg-destructive/15",
+};
+
+// Vertical-only hit-target extension to 44px (mirrors .btn-cta::before).
+const expandHitAreaClasses =
+  "before:absolute before:inset-x-0 before:top-1/2 before:h-11 before:-translate-y-1/2 before:content-['']";
+
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
@@ -93,6 +134,8 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       leadingIcon: LeadingIcon,
       trailingIcon: TrailingIcon,
       active = false,
+      destructive = false,
+      expandHitArea = false,
       disabled,
       children,
       style,
@@ -127,8 +170,12 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           ? "h-4 w-4"
           : "h-3.5 w-3.5";
     const bgClass = active
-      ? activeBgVariants[variant ?? "primary"]
-      : bgVariants[variant ?? "primary"];
+      ? (destructive ? destructiveActiveBgVariants : activeBgVariants)[
+          variant ?? "primary"
+        ]
+      : (destructive ? destructiveBgVariants : bgVariants)[
+          variant ?? "primary"
+        ];
 
     const internals = (
       <>
@@ -209,6 +256,8 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         iconLeft: !isIconOnly && !!LeadingIcon,
         iconRight: !isIconOnly && !!TrailingIcon,
       }),
+      destructive && destructiveRootVariants[variant ?? "primary"],
+      expandHitArea && expandHitAreaClasses,
       className
     );
 

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import {
+  forwardRef,
+  type ComponentProps,
+  type ComponentPropsWithoutRef,
+  type CSSProperties,
+  type HTMLAttributes,
+  type ReactNode,
+} from "react";
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { Button, type ButtonProps } from "~/components/ui/button";
+import { ScrollAreaY } from "~/components/ui/scroll-area";
+import { Elevated } from "~/lib/elevated";
+import { useSurface } from "~/lib/surface-context";
+import { cn } from "~/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Dialog
+//
+// Built on Base UI's Dialog primitive, which owns focus trapping, dismissal
+// (outside press, Escape nesting), and deferred unmount driven by the CSS
+// transition on its data-[starting-style]/data-[ending-style] attributes —
+// no framer-motion, no actionsRef machinery. The popup rides the surface
+// ladder via Elevated (dialog convention: offset 4, shadow 4), and DialogBody
+// gives tall content a vertical scroll region with edge fades between the
+// fixed header and footer.
+// ---------------------------------------------------------------------------
+
+function Dialog(props: ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root {...props} />;
+}
+
+Dialog.displayName = "Dialog";
+
+function DialogTrigger(props: ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger {...props} />;
+}
+
+DialogTrigger.displayName = "DialogTrigger";
+
+// ---------------------------------------------------------------------------
+// DialogContent
+// ---------------------------------------------------------------------------
+
+interface DialogContentProps
+  extends ComponentPropsWithoutRef<typeof DialogPrimitive.Popup> {
+  size?: "sm" | "lg";
+}
+
+const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>(
+  ({ size = "lg", className, children, ...props }, ref) => (
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Backdrop className="fixed inset-0 z-[var(--z-card)] bg-background/70 backdrop-blur-[6px] transition-opacity duration-200 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 motion-reduce:transition-none" />
+      <DialogPrimitive.Popup
+        ref={ref}
+        render={<Elevated offset={4} shadowLevel={4} />}
+        className={cn(
+          // The blueprint sheet: the register's 2px corner and hairline
+          // frame (the printed-label chrome hover cards use), with ruled
+          // head/foot rows from DialogHeader/DialogFooter. The panel is
+          // translucent over a blurred backdrop — the sheet sits *on* the
+          // page rather than replacing it (dialog-glass keeps the ladder's
+          // surface color but drops its alpha). Flex column so DialogBody
+          // scrolls between them; exit runs at ~2/3 of the enter duration.
+          "dialog-glass fixed left-1/2 top-1/2 z-[var(--z-card)] flex max-h-[85dvh] -translate-x-1/2 -translate-y-1/2 flex-col rounded-[2px] border border-border outline-none transition-[opacity,transform] duration-200 ease-[var(--ease-swift)] data-[ending-style]:duration-[133ms] data-[ending-style]:scale-[0.97] data-[ending-style]:opacity-0 data-[starting-style]:scale-[0.97] data-[starting-style]:opacity-0 motion-reduce:transition-none",
+          size === "sm"
+            ? "w-[min(25rem,calc(100vw-2rem))]"
+            : "w-[min(34rem,calc(100vw-2rem))]",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </DialogPrimitive.Popup>
+    </DialogPrimitive.Portal>
+  )
+);
+
+DialogContent.displayName = "DialogContent";
+
+// ---------------------------------------------------------------------------
+// DialogHeader + DialogBody + DialogFooter
+// ---------------------------------------------------------------------------
+
+/** The ruled head row — a full-bleed hairline separates it from the body. */
+function DialogHeader({
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "flex shrink-0 items-baseline justify-between gap-4 border-b border-border px-5 pb-3 pt-4",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+DialogHeader.displayName = "DialogHeader";
+
+interface DialogBodyProps {
+  className?: string;
+  children: ReactNode;
+}
+
+/** The scrollable region between the fixed header and footer. */
+function DialogBody({ className, children }: DialogBodyProps) {
+  // Tint the edge fades with the dialog's own surface so continuation
+  // reads seamlessly (the substrate here is the Elevated popup's level).
+  const surface = Math.round(Math.max(1, Math.min(8, useSurface())));
+  return (
+    <ScrollAreaY
+      className="min-h-0 flex-1"
+      style={
+        { "--scroll-fade-surface": `var(--surface-${surface})` } as CSSProperties
+      }
+    >
+      <div className={cn("px-5 py-4", className)}>{children}</div>
+    </ScrollAreaY>
+  );
+}
+
+DialogBody.displayName = "DialogBody";
+
+/** The ruled foot row, mirroring the head. */
+function DialogFooter({
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "mt-auto flex shrink-0 flex-wrap items-center justify-end gap-2 border-t border-border px-5 py-3",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+DialogFooter.displayName = "DialogFooter";
+
+// ---------------------------------------------------------------------------
+// DialogTitle + DialogDescription + DialogClose
+// ---------------------------------------------------------------------------
+
+function DialogTitle({
+  className,
+  ...props
+}: ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      className={cn("text-sm font-medium", className)}
+      {...props}
+    />
+  );
+}
+
+DialogTitle.displayName = "DialogTitle";
+
+function DialogDescription({
+  className,
+  ...props
+}: ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      className={cn("px-5 pt-3 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+DialogDescription.displayName = "DialogDescription";
+
+/** Closes the dialog; renders the shared Button (ghost, sm) by default. */
+function DialogClose({
+  variant = "ghost",
+  size = "sm",
+  children,
+  ...props
+}: ButtonProps) {
+  return (
+    <DialogPrimitive.Close
+      render={
+        <Button variant={variant} size={size} {...props}>
+          {children}
+        </Button>
+      }
+    />
+  );
+}
+
+DialogClose.displayName = "DialogClose";
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogBody,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+};
+
+export type { DialogContentProps, DialogBodyProps };

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import {
+  forwardRef,
+  useId,
+  type InputHTMLAttributes,
+  type ReactNode,
+} from "react";
+import { cn } from "~/lib/utils";
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  /** Renders a wrapping label above the control (14px muted). */
+  label?: ReactNode;
+  /** 14px destructive text below the control, wired via aria-describedby. */
+  error?: ReactNode;
+  /** Destructive border treatment without an error message (e.g. the
+   *  type-PURGE confirmation input). Implied when `error` is set. */
+  destructive?: boolean;
+}
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      label,
+      error,
+      destructive = false,
+      className,
+      id,
+      "aria-describedby": ariaDescribedBy,
+      ...props
+    },
+    ref
+  ) => {
+    const autoId = useId();
+    const errorId = `${id ?? autoId}-error`;
+    const isDestructive = destructive || !!error;
+
+    const control = (
+      <input
+        ref={ref}
+        id={id}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={
+          error
+            ? [ariaDescribedBy, errorId].filter(Boolean).join(" ")
+            : ariaDescribedBy
+        }
+        className={cn(
+          // text-base (16px) keeps iOS Safari from zooming on focus; h-8 is
+          // the shared 32px control height (Button lg, subtle tabs, selects).
+          "block h-8 w-full rounded-lg border border-border bg-transparent px-2.5 text-base text-foreground outline-none",
+          "placeholder:text-muted-foreground",
+          "transition-colors duration-150 motion-reduce:transition-none",
+          "focus:border-foreground focus-visible:ring-1 focus-visible:ring-[color:var(--focus-ring)]",
+          "disabled:opacity-50",
+          isDestructive && "border-destructive focus:border-destructive",
+          className
+        )}
+        {...props}
+      />
+    );
+
+    if (!label && !error) return control;
+
+    const errorText = error ? (
+      <span id={errorId} className="text-sm text-destructive">
+        {error}
+      </span>
+    ) : null;
+
+    if (label) {
+      return (
+        <label className="grid gap-1.5 text-sm text-muted-foreground">
+          {label}
+          {control}
+          {errorText}
+        </label>
+      );
+    }
+
+    return (
+      <div className="grid gap-1.5">
+        {control}
+        {errorText}
+      </div>
+    );
+  }
+);
+
+Input.displayName = "Input";
+
+export { Input };
+export type { InputProps };

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -59,3 +59,61 @@ export function ScrollAreaX({
     </div>
   )
 }
+
+// Vertical sibling of ScrollAreaX: same mechanics, top/bottom edge fades.
+// The outer element is a flex column so a flexed parent (e.g. a dialog
+// body) sizes the viewport; standalone use sizes to content.
+export function ScrollAreaY({
+  className,
+  style,
+  children,
+}: {
+  className?: string
+  style?: React.CSSProperties
+  children: React.ReactNode
+}) {
+  const viewportRef = useRef<HTMLDivElement>(null)
+  const [edges, setEdges] = useState({ start: false, end: false })
+
+  useEffect(() => {
+    const viewport = viewportRef.current
+    if (!viewport) return
+
+    const update = () => {
+      const start = viewport.scrollTop > 1
+      const end =
+        viewport.scrollTop < viewport.scrollHeight - viewport.clientHeight - 1
+      setEdges((prev) =>
+        prev.start === start && prev.end === end ? prev : { start, end },
+      )
+    }
+
+    update()
+    viewport.addEventListener('scroll', update, { passive: true })
+    const observer = new ResizeObserver(update)
+    observer.observe(viewport)
+    for (const child of viewport.children) observer.observe(child)
+    return () => {
+      viewport.removeEventListener('scroll', update)
+      observer.disconnect()
+    }
+  }, [])
+
+  return (
+    <div className={cn('scroll-area-y', className)} style={style}>
+      <div ref={viewportRef} className="scroll-area-y-viewport">
+        {children}
+      </div>
+      <span
+        aria-hidden
+        className="scroll-area-y-fade scroll-area-y-fade-start"
+        data-visible={edges.start || undefined}
+      />
+      <span
+        aria-hidden
+        className="scroll-area-y-fade scroll-area-y-fade-end"
+        data-visible={edges.end || undefined}
+      />
+    </div>
+  )
+}

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -33,10 +33,22 @@ export function ScrollAreaX({
     update()
     viewport.addEventListener('scroll', update, { passive: true })
     const observer = new ResizeObserver(update)
+    const observeChildren = () => {
+      for (const child of viewport.children) observer.observe(child)
+    }
     observer.observe(viewport)
-    for (const child of viewport.children) observer.observe(child)
+    observeChildren()
+    // Children mounted later (a dialog body populating asynchronously)
+    // must re-arm measurement — re-observing an element is a no-op, and
+    // detached nodes drop out of the ResizeObserver on their own.
+    const mutations = new MutationObserver(() => {
+      observeChildren()
+      update()
+    })
+    mutations.observe(viewport, { childList: true })
     return () => {
       viewport.removeEventListener('scroll', update)
+      mutations.disconnect()
       observer.disconnect()
     }
   }, [])
@@ -91,10 +103,22 @@ export function ScrollAreaY({
     update()
     viewport.addEventListener('scroll', update, { passive: true })
     const observer = new ResizeObserver(update)
+    const observeChildren = () => {
+      for (const child of viewport.children) observer.observe(child)
+    }
     observer.observe(viewport)
-    for (const child of viewport.children) observer.observe(child)
+    observeChildren()
+    // Children mounted later (a dialog body populating asynchronously)
+    // must re-arm measurement — re-observing an element is a no-op, and
+    // detached nodes drop out of the ResizeObserver on their own.
+    const mutations = new MutationObserver(() => {
+      observeChildren()
+      update()
+    })
+    mutations.observe(viewport, { childList: true })
     return () => {
       viewport.removeEventListener('scroll', update)
+      mutations.disconnect()
       observer.disconnect()
     }
   }, [])

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -155,8 +155,8 @@ Select.displayName = "Select";
 
 const triggerVariants = cva(
   [
-    "group inline-flex items-center justify-between gap-2 outline-none cursor-pointer",
-    "min-h-11 min-w-24 px-2 text-[14px]",
+    "group relative inline-flex items-center justify-between gap-2 outline-none cursor-pointer",
+    "min-w-24 text-[14px]",
     "transition-[background-color,color,border-color,box-shadow] duration-150",
     "disabled:opacity-50 disabled:pointer-events-none",
     "focus-visible:ring-1 focus-visible:ring-[color:var(--focus-ring)]",
@@ -169,9 +169,16 @@ const triggerVariants = cva(
         borderless:
           "border border-transparent bg-transparent text-foreground hover:bg-hover",
       },
+      size: {
+        // Control-row height (matches Button lg / subtle tabs); the pseudo
+        // restores the 44px hit target without visible height.
+        md: "h-8 px-2.5 before:absolute before:inset-x-0 before:top-1/2 before:h-11 before:-translate-y-1/2 before:content-['']",
+        tall: "min-h-11 px-2",
+      },
     },
     defaultVariants: {
       variant: "bordered",
+      size: "md",
     },
   }
 );
@@ -186,7 +193,7 @@ interface SelectTriggerProps
 
 const SelectTrigger = forwardRef<HTMLButtonElement, SelectTriggerProps>(
   (
-    { className, variant, icon: Icon, placeholder = "Select…", error, ...props },
+    { className, variant, size, icon: Icon, placeholder = "Select…", error, ...props },
     ref
   ) => {
     const shape = useShape();
@@ -197,7 +204,7 @@ const SelectTrigger = forwardRef<HTMLButtonElement, SelectTriggerProps>(
           ref={ref}
           aria-invalid={!!error || undefined}
           className={cn(
-            triggerVariants({ variant }),
+            triggerVariants({ variant, size }),
             shape.input,
             error && "border-destructive/50 hover:border-destructive/50",
             className
@@ -485,7 +492,10 @@ const SelectItem = forwardRef<HTMLDivElement, SelectItemProps>(
             className={cn(
               // Fixed height (was py-2 around a 19.5px line box ≈ 35.5px) so
               // the text-box trim on the item text doesn't shrink the row.
-              `relative z-10 flex h-11 items-center gap-2 ${shape.item} px-2 text-[14px] cursor-pointer outline-none select-none`,
+              // shrink-0 is load-bearing: the popup is a flex column, so a
+              // long list (every IANA zone) would otherwise squash every
+              // row well under its 44px target.
+              `relative z-10 flex h-11 shrink-0 items-center gap-2 ${shape.item} px-2 text-[14px] cursor-pointer outline-none select-none`,
               isActive || isChecked
                 ? "text-foreground"
                 : "text-muted-foreground",

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -12,6 +12,8 @@ import { cn } from "~/lib/utils";
 interface SwitchProps {
   /** Renders a min-h-11 label row; the switch is labelled via aria-labelledby. */
   label?: ReactNode;
+  /** Accessible name for a switch without a visible label row. */
+  "aria-label"?: string;
   checked?: boolean;
   defaultChecked?: boolean;
   onCheckedChange?: (checked: boolean) => void;
@@ -22,6 +24,7 @@ interface SwitchProps {
 
 function Switch({
   label,
+  "aria-label": ariaLabel,
   checked,
   defaultChecked,
   onCheckedChange,
@@ -37,6 +40,7 @@ function Switch({
     <SwitchPrimitive.Root
       id={switchId}
       aria-labelledby={label ? labelId : undefined}
+      aria-label={label ? undefined : ariaLabel}
       checked={checked}
       defaultChecked={defaultChecked}
       onCheckedChange={onCheckedChange}

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useId, type ReactNode } from "react";
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch";
+import { cn } from "~/lib/utils";
+
+// CSS-only port of the fluid switch: Base UI owns the role="switch"
+// semantics, keyboard toggling, and the hidden form input (via `name`);
+// the thumb translates with a plain CSS transition on data-[checked] —
+// no framer-motion drag machinery.
+
+interface SwitchProps {
+  /** Renders a min-h-11 label row; the switch is labelled via aria-labelledby. */
+  label?: ReactNode;
+  checked?: boolean;
+  defaultChecked?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+  disabled?: boolean;
+  name?: string;
+  className?: string;
+}
+
+function Switch({
+  label,
+  checked,
+  defaultChecked,
+  onCheckedChange,
+  disabled = false,
+  name,
+  className,
+}: SwitchProps) {
+  const id = useId();
+  const labelId = `${id}-label`;
+  const switchId = `${id}-switch`;
+
+  const control = (
+    <SwitchPrimitive.Root
+      id={switchId}
+      aria-labelledby={label ? labelId : undefined}
+      checked={checked}
+      defaultChecked={defaultChecked}
+      onCheckedChange={onCheckedChange}
+      disabled={disabled}
+      name={name}
+      className={cn(
+        // 34x20 track; the thumb travels 2px -> 16px inside it.
+        "relative inline-flex h-5 w-[2.125rem] shrink-0 cursor-pointer items-center rounded-full outline-none",
+        "bg-border transition-colors duration-150 data-[checked]:bg-foreground motion-reduce:transition-none",
+        "focus-visible:ring-1 focus-visible:ring-[color:var(--focus-ring,#6B97FF)]",
+        "disabled:cursor-default disabled:opacity-50",
+        !label && className
+      )}
+    >
+      <SwitchPrimitive.Thumb className="block h-4 w-4 translate-x-0.5 rounded-full bg-background shadow-sm transition-transform duration-200 ease-[var(--ease-swift)] data-[checked]:translate-x-4 motion-reduce:transition-none" />
+    </SwitchPrimitive.Root>
+  );
+
+  if (!label) return control;
+
+  return (
+    <div
+      className={cn(
+        "flex min-h-11 items-center justify-between gap-3",
+        className
+      )}
+    >
+      <label id={labelId} htmlFor={switchId} className="text-sm">
+        {label}
+      </label>
+      {control}
+    </div>
+  );
+}
+
+Switch.displayName = "Switch";
+
+export { Switch };
+export type { SwitchProps };

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -19,7 +19,7 @@ import type { IconComponent } from "~/lib/icon-context";
 import { cn } from "~/lib/utils";
 import { useShape } from "~/lib/shape-context";
 import { useSurface } from "~/lib/surface-context";
-import { surfaceClasses } from "~/lib/surface-classes";
+import { SURFACE_BG, surfaceClasses } from "~/lib/surface-classes";
 import { useProximityHover } from "~/hooks/use-proximity-hover";
 
 /* ─────────────────────── Contexts ─────────────────────── */
@@ -32,11 +32,14 @@ interface TabsValueOrderContextValue {
 
 const TabsValueOrderContext = createContext<TabsValueOrderContextValue | null>(null);
 
+type TabsVariant = "segmented" | "subtle";
+
 interface TabsListContextValue {
   registerTab: (index: number, value: string, el: HTMLElement | null) => void;
   hoveredIndex: number | null;
   selectedValue: string | undefined;
   setOptimisticIdx: (index: number) => void;
+  variant: TabsVariant;
 }
 
 const TabsListContext = createContext<TabsListContextValue | null>(null);
@@ -147,10 +150,18 @@ Tabs.displayName = "Tabs";
 
 /* ─────────────────────── TabsList ─────────────────────── */
 
-type TabsListProps = ComponentPropsWithoutRef<typeof TabsPrimitive.List>;
+type TabsListProps = ComponentPropsWithoutRef<typeof TabsPrimitive.List> & {
+  /**
+   * `segmented` (default) is the filled 52px track with a lifted active pill.
+   * `subtle` drops the track for a 32px row of quiet chips — for dense chrome
+   * where the switch should not outweigh the content it filters. Items keep a
+   * 44px hit target through a pseudo-element.
+   */
+  variant?: TabsVariant;
+};
 
 const TabsList = forwardRef<HTMLDivElement, TabsListProps>(
-  ({ children, className, ...props }, ref) => {
+  ({ children, className, variant = "segmented", ...props }, ref) => {
     const containerRef = useRef<HTMLDivElement>(null);
     const isMouseInside = useRef(false);
     const shape = useShape();
@@ -159,6 +170,10 @@ const TabsList = forwardRef<HTMLDivElement, TabsListProps>(
     // On the page (substrate 1) this lands on surface 4 — matches the original design.
     // Inside a dialog (substrate 5) it lifts to surface 8 instead of staying at 4.
     const indicatorLevel = Math.min(substrate + 3, 8);
+    // Without the muted track underneath, the active chip only needs to clear
+    // the page by one step — and it carries no shadow, so the row stays flat.
+    const subtleIndicatorClass =
+      SURFACE_BG[Math.round(Math.max(1, Math.min(8, substrate + 1)))];
     const valueOrderCtx = useContext(TabsValueOrderContext);
     const [optimisticIdx, setOptimisticIdx] = useState<number | null>(null);
 
@@ -239,6 +254,7 @@ const TabsList = forwardRef<HTMLDivElement, TabsListProps>(
           hoveredIndex,
           selectedValue,
           setOptimisticIdx,
+          variant,
         }}
       >
         <TabsPrimitive.List
@@ -275,7 +291,8 @@ const TabsList = forwardRef<HTMLDivElement, TabsListProps>(
             setHoveredIndex(null);
           }}
           className={cn(
-            "relative inline-flex items-center gap-0.5 p-1 select-none bg-muted",
+            "relative inline-flex items-center select-none",
+            variant === "subtle" ? "gap-1" : "gap-0.5 p-1 bg-muted",
             shape.container,
             className
           )}
@@ -287,7 +304,9 @@ const TabsList = forwardRef<HTMLDivElement, TabsListProps>(
               data-tabs-indicator="selected"
               className={cn(
                 "absolute pointer-events-none",
-                surfaceClasses(indicatorLevel),
+                variant === "subtle"
+                  ? subtleIndicatorClass
+                  : surfaceClasses(indicatorLevel),
                 shape.bg
               )}
               style={{
@@ -356,7 +375,8 @@ interface TabItemProps
 const TabItem = forwardRef<HTMLButtonElement, TabItemProps>(
   ({ value, icon: Icon, label, _index = 0, className, ...props }, ref) => {
     const internalRef = useRef<HTMLButtonElement>(null);
-    const { registerTab, hoveredIndex, selectedValue, setOptimisticIdx } = useTabsList();
+    const { registerTab, hoveredIndex, selectedValue, setOptimisticIdx, variant } =
+      useTabsList();
 
     useEffect(() => {
       registerTab(_index, value, internalRef.current);
@@ -384,7 +404,12 @@ const TabItem = forwardRef<HTMLButtonElement, TabItemProps>(
         className={cn(
           // Fixed height (not py) so the text-box trim below doesn't shrink
           // the tab — browsers without text-box support render identically.
-          "relative z-10 flex h-11 min-w-11 items-center justify-center gap-1.5 px-2 cursor-pointer bg-transparent border-none outline-none",
+          "relative z-10 flex items-center justify-center gap-1.5 cursor-pointer bg-transparent border-none outline-none",
+          variant === "subtle"
+            ? // The chip is 32px; the pseudo restores the 44px hit target
+              // (the .btn-cta recipe) without adding visible height.
+              "h-8 min-w-8 px-2.5 before:absolute before:inset-x-0 before:top-1/2 before:h-11 before:-translate-y-1/2 before:content-['']"
+            : "h-11 min-w-11 px-2",
           className
         )}
         {...props}

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -529,19 +529,29 @@ typewriter/ascii textures, measuring ticks, registration marks. Rules:
 - **Nameplate** (`.spec-nameplate`): the boxed variant of the spec plate —
   label and value cells separated by hairline rules inside a hairline
   frame, like an equipment serial plate. Used where the data is a
-  product's own specification (the AMA session specs). Same mono
+  product's own specification: the AMA session specs, the guest manage
+  page's booking details, and the owner Booking detail's data sections
+  (schedule, guest, payment, meeting) — booking data is the session's
+  spec sheet. Unlike the unboxed plates, nameplate content is real data:
+  it stays selectable, and links keep working inside value cells. Same mono
   typography as the plate; labels uppercase at 11px, values tabular.
 - **Status ladder** (`.status-ladder`): journey steps as mono rows —
   two-digit index, label, and a 5px state cell at the row's end. Done is
   filled ink, pending is a hairline outline, and the current step carries
   the lit signal cell. Decorative reinforcement only (`aria-hidden`): the
   prose beside it always announces the same state. Lives on the AMA
-  confirmation, driven by the server's real hold state — a ladder must
-  never show state the page cannot prove.
+  confirmation's waiting and needs-reschedule states (the paid stage
+  carries the session nameplate instead) and on the admin Booking
+  detail's linear states, driven by the server's real state — a ladder
+  must never show state the page cannot prove.
 - **Certification stamp** (`.cert-stamp`): a hairline-bordered mono
   uppercase chip ("已确认 / Confirmed +") with the lit cell, for terminal
-  confirmed states. A stamp is applied once, at the end — never as a
-  badge on lists or previews.
+  states. A stamp is applied once, at the end — never as a badge on lists
+  or previews, and never on a transient state. The paid confirmation
+  presses a stamp in the heading-ornament (section-tag) composition —
+  boxed lit signal cell, hazard-hatch chip, tracked mono "已确认 +" — at
+  −3° over its session plate's top rule (`.ama-plate-stamp`), confirmed
+  state only; finalizing stays unstamped.
 - **Section tags** (`.section-tag`): section h2s on the homepage and the
   AMA page are set as index tags — a boxed two-digit number, a
   hazard-hatch chip (fine diagonal strokes in a bordered cell), and a
@@ -603,8 +613,10 @@ typewriter/ascii textures, measuring ticks, registration marks. Rules:
 - **Barcode** (`components/barcode.tsx`): a decorative label-graphic
   barcode whose bar widths derive deterministically from its code string
   (stable across SSR), with the human-readable code beneath. It scans as
-  ornament, not data (`aria-hidden`). One per surface, currently the
-  error proof sheets (`ERR-404-CALI-SO`, `ERR-500-CALI-SO`) at 38% ink.
+  ornament, not data (`aria-hidden`). One per surface: the error proof
+  sheets (`ERR-404-CALI-SO`, `ERR-500-CALI-SO`) at 38% ink, and the AMA
+  confirmation's proof-sheet foot (`AMA-<hold prefix>`) in the stage's
+  faded paper ink.
 - **Ghost folio numerals** (`.ghost-folio`): the writing index's year
   sections carry the year's last two digits as an oversized pixel-face
   numeral in `--ghost-ink`, top-right behind the rows — the folio-number
@@ -781,7 +793,16 @@ or shader initialization failure retain only the static traces.
 ## AMA confirmation
 
 The public confirmation route reserves its full celebration for a server-proven
-paid AMA Session whose Booking is `finalizing` or `confirmed`. Those two states
+paid AMA Session whose Booking is `finalizing` or `confirmed`. The guest manage
+page shares the same dark stage shell (`AmaStage`: the shader field, static
+plate, and page tokens flipped to the stage's paper-on-dark set, including a
+solid surface ramp so ladder-riding sheets stay dark in either page theme)
+with left-aligned form content, but the celebration extras — confetti and the
+confirmation seal — remain exclusive to the paid confirmation. On the manage
+page the destructive doorway is centered and flanked by hazard tape, and its
+confirmation is a dialog wearing a hazard band along the top edge; the
+reschedule flow opens under a hatch-chip heading with mono, square-cornered
+time chips. Those two states
 become one full-viewport dark stage using the Shaders **Undertones 8** preset
 (`bb1fda80-5ce2-4072-b528-9837f6e7aff7`) as its background: `Swirl` and
 `ChromaFlow`, refracted once through `FlutedGlass`, with the preset's restrained
@@ -792,9 +813,22 @@ without WebGPU. The field covers the full visual viewport behind the site
 chrome and confirmation copy; it is not framed as a card inside the content
 column.
 
-Two twelve-piece registration-color confetti bursts launch once from the lower
-left and lower right corners, arc inward across the viewport, and settle toward
-the center while a centered check mark arrives over the field. The pieces use
+Two eighteen-piece registration-color confetti bursts launch once from the
+lower left and lower right corners and arc inward across the viewport with
+real ballistics — a decaying horizontal drive, a rise that decelerates into
+the apex and a fall that accelerates out of it, and a finite 3D tumble that
+flashes each paper's thin edge — fading while still falling, never hanging in
+air. Meanwhile the confirmation seal arrives over the field: a square
+hairline plate on the register's 2px corner, calibration brackets outside it,
+hazard-hatch bands along its top and bottom edges behind the check, stamped at
+a settled −4° — an inspection stamp in the stage's paper ink. Beneath the
+copy, the booked session prints as a spec nameplate (time in the guest's zone,
+length, meeting provider) from server-sent facts only — the page never
+fabricates plate content — and the foot carries an ornamental barcode derived
+from the hold id, so every confirmation prints its own label. Everything on
+the stage reads in paper ink regardless of page theme. The journey ladder
+remains on the waiting and needs-reschedule states, where position in the
+journey is the message; the paid stage carries the plate instead. The pieces use
 only transform and opacity and never loop. Reduced motion keeps the static dark
 plate and check mark but omits both the shader and confetti.
 `needs_reschedule` is deliberately not celebratory: payment landed, but the
@@ -832,12 +866,46 @@ public analytics, social reads, and route view transitions. Its contract:
   when the Preferences panel opens; a remembered confirmation arms it
   instantly on later visits). Visitors never see owner chrome and public
   pages stay fully static.
-- **Quiet headers.** Admin pages open like public views: an h1 at 14px
-  medium muted ink with a tabular count line. Structure comes from
-  `hairline-top` separators and spacing, not from heavier type.
+- **Depth over stacking.** A surface that holds more than one job is a
+  menu, not a scroll: `/admin/ama` lists Bookings and Settings as catalog
+  rows (`components/admin-nav.tsx` `AdminMenu`/`AdminMenuRow`, the
+  Overview's dotted-leader grammar) with each row's own summary as its
+  value, and each job owns a page. Every subpage opens with an
+  `AdminBackLink` — a mono back mark naming its parent — above the header.
+  The dock still points at the menu; the Overview deep-links past it to
+  the page that answers the row.
+- **Print headers.** Admin pages open in the technical-print register: the
+  h1 is a `.page-eyebrow` mono mark with the pixel-cluster masthead pinned
+  top-right on the eyebrow line — exactly one per page, rendered statically
+  (admin markup never takes the public `.enter` classes). Each surface owns
+  a fixed cluster variant (Overview, AMA, Media, Photos, Booking detail),
+  so the prefetched static shell and the streamed page carry the same
+  stamp. The tabular count line keeps its place under the eyebrow;
+  structure still comes from `hairline-top` separators and spacing, not
+  heavier type. Multi-section pages set their h2s as `.section-tag` index
+  tags numbered in render order; h3s and entity titles (a guest's name)
+  stay plain 14px.
+- **Protocol state.** The Booking detail reinforces its lifecycle with the
+  `.status-ladder` (finalizing → confirmed → session held), driven only by
+  server-confirmed status; diverged states (needs reschedule, cancelled)
+  show no ladder — a ladder never shows state the page cannot prove. The
+  `.cert-stamp` is applied once, at the terminal held state, when the
+  ladder has no current step — so a page carries the masthead cell plus at
+  most one lit protocol cell, the sanctioned coexistence defined in Color.
+  Status dots stay round, amber for in-flight, red only for broken or
+  destructive; they never become signal cells.
+- **Prints under the pointer.** Admin photo tiles (curation prints, the
+  media contact sheet) develop `.calibration-corners` under fine-pointer
+  hover or focus, exactly as public tiles do; touch and reduced motion stay
+  static. Admin ornament is limited to the print, plate, and mark registers
+  — no rasters, instruments, or ghost art in daily-use chrome. Machine text
+  (ids, emails, event codes, capture data) is mono; counts stay
+  `tabular-nums`.
 - **Surfaces.** Inspectors and pickers are dialogs on the surface ladder
   (`Elevated` offset 4); popovers stay at offset 2. Never a native
-  `confirm()`/`prompt()`.
+  `confirm()`/`prompt()`. Dialogs wear the printed-label chrome the hover
+  cards established: the register's 2px corner, a hairline frame, and
+  ruled full-bleed head/foot rows (`components/ui/dialog.tsx`).
 - **Confirmation grammar.** Reversible-but-notable actions (archive,
   disconnect) use a two-step armed button that relaxes after ~4s.
   Irreversible actions (Purge) require the typed confirmation word inside

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -46,9 +46,13 @@ Current as of July 2026.
 - The admin was redesigned in July 2026 to share the public design language
   (warm paper, 37.5rem column, an owner dock; spec in
   `docs/design-language.md` § Owner admin). IA: `/admin` is a one-screen
-  overview, `/admin/ama` holds all AMA operations plus availability and
-  Google Calendar settings, `/admin/media` is the upload-to-archive library,
-  and `/admin/photos` is the Photo Selection curation room. The owner enters
+  overview, `/admin/ama` is a menu over `/admin/ama/bookings` (operations,
+  time requests, failed operations) and `/admin/ama/settings` (availability
+  windows, Google Calendar, open-time preview) — settings form POSTs
+  redirect back to `/admin/ama/settings` — `/admin/media` is the
+  upload-to-archive library, and `/admin/photos` is the Photo Selection
+  curation room. Surfaces holding more than one job become menus with
+  back-marked subpages rather than one stacked screen. The owner enters
   from the public dock's Preferences panel (owner-only row, or G then D),
   backed by a client probe to `GET /api/admin/session` so public pages stay
   static and Clerk stays off public routes.
@@ -189,6 +193,14 @@ The Vercel runtime receives only the CRUD-only `DATABASE_URL`. Never put
   configured, while manual labels remain available without it.
 - Design references are private. Public code and documentation use only the
   vocabulary in `docs/design-language.md`.
+- In development the photo-selection dev fixture masks an empty or failed
+  public read (production renders the empty state). The published-selection
+  cache is a `'use cache'` function invalidated by publish via
+  `revalidateTag(tag, { expire: 0 })`; a redeploy also rebuilds it fresh.
+  A failing read aborts Vercel builds loudly (`VERCEL_ENV` set) instead of
+  silently shipping an empty photos page; local builds with the usual
+  shaped-but-unreachable `DATABASE_URL` still pass and render the empty
+  state, with the failure logged.
 - Local builds validate the full server environment. Keep `.env.local`
   aligned with `.env.example`; blank provider placeholders are fine, but the
   always-required values (`ADMIN_EMAIL`, `AMA_ENCRYPTION_KEY`,

--- a/lib/ama/admin/ama-operations.test.tsx
+++ b/lib/ama/admin/ama-operations.test.tsx
@@ -26,18 +26,17 @@ function jsonResponse(body: unknown, status = 200) {
   return Response.json(body, { status })
 }
 
+// The route owns the page header now; the count line opens the component.
+function countLine(container: HTMLElement) {
+  return container.querySelector('p')!
+}
+
 function buttonWithText(container: HTMLElement, text: string) {
   const button = Array.from(container.querySelectorAll('button')).find((item) =>
     item.textContent?.includes(text),
   )
   if (!button) throw new Error(`No button containing "${text}"`)
   return button
-}
-
-const settings: AmaOperationsProps['settings'] = {
-  windows: [{ id: 1, isoWeekday: 1, startMinute: 540, endMinute: 720 }],
-  googleConnection: { status: 'disconnected', identity: null },
-  previewSlots: [],
 }
 
 const fixtures: AmaOperationsProps = {
@@ -109,7 +108,6 @@ const fixtures: AmaOperationsProps = {
       lastErrorCode: 'stripe_unavailable',
     },
   ],
-  settings,
 }
 
 const emptyFixtures: AmaOperationsProps = {
@@ -118,7 +116,6 @@ const emptyFixtures: AmaOperationsProps = {
   attention: [],
   timeRequests: [],
   failedOperations: [],
-  settings,
 }
 
 describe('AMA admin page', () => {
@@ -127,10 +124,10 @@ describe('AMA admin page', () => {
     const text = container.textContent!
 
     // Header counts: upcoming and everything needing a hand.
-    const countLine = container.querySelector('h1 + p')!
-    expect(countLine.textContent).toContain('1 ')
-    expect(countLine.textContent).toContain('3 ')
-    expect(countLine.className).toContain('tabular-nums')
+    const counts = countLine(container)
+    expect(counts.textContent).toContain('1 ')
+    expect(counts.textContent).toContain('3 ')
+    expect(counts.className).toContain('tabular-nums')
 
     // Attention comes first: the broken booking, the failed operation, and
     // the new Alternate Time Request.
@@ -156,23 +153,26 @@ describe('AMA admin page', () => {
     expect(text).not.toContain('Succeeded')
     expect(text).not.toContain('Running')
 
-    // Settings render at the bottom with the native form contract.
-    expect(text).toContain('Weekly Availability Windows')
+    // Settings moved to their own page under the AMA menu.
+    expect(text).not.toContain('Weekly Availability Windows')
     expect(
       container.querySelector('form[action="/api/admin/ama/availability"]'),
-    ).not.toBeNull()
-    expect(
-      container.querySelector('form[action="/api/admin/ama/google/connect"]'),
-    ).not.toBeNull()
+    ).toBeNull()
   })
 
   it('collapses past Bookings behind a toggle instead of the front page', () => {
     const { container } = render(<AmaOperations {...fixtures} />)
 
-    const details = container.querySelector('details')!
-    expect(details.open).toBe(false)
-    expect(details.textContent).toContain('Grace Hopper')
-    expect(details.querySelector('summary')?.textContent).toContain('1')
+    const toggle = container.querySelector(
+      'button[aria-controls="past-bookings"]',
+    )!
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    expect(toggle.textContent).toContain('1')
+    expect(container.textContent).not.toContain('Grace Hopper')
+
+    fireEvent.click(toggle)
+    expect(toggle.getAttribute('aria-expanded')).toBe('true')
+    expect(container.textContent).toContain('Grace Hopper')
   })
 
   it('shows one quiet all-clear line when nothing needs attention', () => {
@@ -202,7 +202,7 @@ describe('AMA admin page', () => {
       }),
     )
     expect(container.textContent).toContain('Marked as resolved.')
-    expect(container.querySelector('h1 + p')?.textContent).toContain('2 ')
+    expect(countLine(container).textContent).toContain('2 ')
   })
 
   it('retries a failed operation from the attention section', async () => {
@@ -229,7 +229,7 @@ describe('AMA admin page', () => {
         item.textContent?.includes('Retry'),
       ),
     ).toBe(false)
-    expect(container.querySelector('h1 + p')?.textContent).toContain('2 ')
+    expect(countLine(container).textContent).toContain('2 ')
   })
 
   it('requires an inline confirm before marking an operation resolved', async () => {

--- a/lib/ama/admin/ama-settings.test.tsx
+++ b/lib/ama/admin/ama-settings.test.tsx
@@ -51,20 +51,20 @@ function renderSettingsMarkup(
 }
 
 describe('AMA settings UI contract', () => {
-  it('keeps bilingual scheduling content and accessible form recovery in static HTML', () => {
+  it('keeps localized scheduling content and accessible form recovery in static HTML', () => {
     const html = renderSettingsMarkup('expired')
 
-    expect(html).toMatch(/<label[^>]+for="[^"]+-weekday-zh"[^>]+data-zh-block="true"/)
-    expect(html).toMatch(/<label[^>]+for="[^"]+-weekday-en"[^>]+data-en-block="true"/)
-    expect(html).toContain('<option value="1" selected="">星期一</option>')
-    expect(html).toContain('<option value="1" selected="">Monday</option>')
+    // The fluid Select posts through a hidden input; server locale is zh.
+    expect(html).toMatch(/<input[^>]+name="weekday"[^>]+value="1"/)
+    expect(html).toMatch(/<input[^>]+name="start"[^>]+value="09:00"/)
+    expect(html).toMatch(/<input[^>]+name="end"[^>]+value="12:00"/)
+    expect(html).toContain('星期一')
     expect(html).toContain('data-zh="true"')
     expect(html).toContain('data-en="true"')
     expect(html).toContain('Wed, Jul 15')
     expect(html).toContain('aria-describedby="availability-notice"')
     expect(html).toContain('id="availability-notice"')
     expect(html).toContain('min-h-11')
-    expect(html).toContain('motion-reduce:transition-none')
   })
 
   it('offers recovery and local disconnect for an unhealthy Calendar connection', () => {
@@ -96,7 +96,10 @@ describe('AMA settings UI contract', () => {
 
     const firstSubmit = fireEvent.submit(form)
     expect(firstSubmit).toBe(true)
-    expect(form.querySelector('button')?.textContent).toContain('Connecting')
+    // The pending state shows the Button spinner and locks the control.
+    const button = form.querySelector('button')!
+    expect(button.disabled).toBe(true)
+    expect(button.querySelector('svg')).not.toBeNull()
 
     const repeatSubmit = fireEvent.submit(form)
     expect(repeatSubmit).toBe(false)
@@ -139,30 +142,31 @@ describe('AMA settings UI contract', () => {
     fireEvent.submit(form)
     const confirmed = fireEvent.submit(form)
     expect(confirmed).toBe(true)
-    expect(button.textContent).toContain('Disconnecting')
+    expect(button.disabled).toBe(true)
+    expect(button.querySelector('svg')).not.toBeNull()
   })
 
-  it('preserves an edited weekday when the locale changes mid-form', () => {
-    const { container } = render(<AvailabilityWindowForm />)
-    const zhSelect = container.querySelector<HTMLSelectElement>('label[data-zh-block] select')!
-    const enSelect = container.querySelector<HTMLSelectElement>('label[data-en-block] select')!
+  it('keeps the posted weekday when the locale changes mid-form', () => {
+    // The single fluid Select posts one locale-independent `weekday` field,
+    // so a value chosen in one locale survives a mid-form locale swap.
+    const { container } = render(
+      <AvailabilityWindowForm
+        window={{ id: 1, isoWeekday: 5, startMinute: 540, endMinute: 720 }}
+      />,
+    )
+    const form = container.querySelector('form')!
+    const trigger = form.querySelector<HTMLButtonElement>('button[role="combobox"]')!
 
-    fireEvent.change(zhSelect, { target: { value: '5' } })
-    expect(zhSelect.value).toBe('5')
-    expect(enSelect.value).toBe('5')
+    expect(new FormData(form).get('weekday')).toBe('5')
+    expect(trigger.textContent).toContain('星期五')
 
     act(() => {
       document.documentElement.dataset.locale = 'en'
       window.dispatchEvent(new Event(LOCALE_CHANGE_EVENT))
     })
 
-    expect(enSelect.value).toBe('5')
-    expect(enSelect.options[4]?.text).toBe('Friday')
-    expect(zhSelect.options[4]?.text).toBe('星期五')
-    const formData = new FormData(container.querySelector('form')!)
-    expect(formData.get('weekdayZh')).toBe('5')
-    expect(formData.get('weekdayEn')).toBe('5')
-    expect(formData.get('weekdayOriginal')).toBe('1')
+    expect(trigger.textContent).toContain('Friday')
+    expect(new FormData(form).get('weekday')).toBe('5')
   })
 
   it('supports keyboard-style submission with a stable pending state', () => {
@@ -174,9 +178,13 @@ describe('AMA settings UI contract', () => {
 
     const save = container.querySelector<HTMLButtonElement>('button[value="create"]')!
     expect(save.disabled).toBe(true)
-    expect(save.textContent).toContain('Saving')
-    for (const select of container.querySelectorAll('select')) {
-      expect(select.disabled).toBe(true)
+    expect(save.querySelector('svg')).not.toBeNull()
+    const fields = container.querySelectorAll<HTMLInputElement>(
+      'input[name="weekday"], input[name="start"], input[name="end"]',
+    )
+    expect(fields.length).toBe(3)
+    for (const field of fields) {
+      expect(field.disabled).toBe(true)
     }
   })
 
@@ -220,6 +228,6 @@ describe('AMA settings UI contract', () => {
     fireEvent.click(remove)
     fireEvent.click(remove)
     expect(remove.disabled).toBe(true)
-    expect(remove.textContent).toContain('Deleting')
+    expect(remove.querySelector('svg')).not.toBeNull()
   })
 })

--- a/lib/ama/admin/booking-detail.test.tsx
+++ b/lib/ama/admin/booking-detail.test.tsx
@@ -177,10 +177,8 @@ describe('AMA booking detail', () => {
     expect(fetchMock).not.toHaveBeenCalled()
 
     // More than 24 hours out, the full-refund choice defaults to checked.
-    const checkbox = container.querySelector<HTMLInputElement>(
-      'input[type="checkbox"]',
-    )!
-    expect(checkbox.checked).toBe(true)
+    const refundSwitch = container.querySelector('[role="switch"]')!
+    expect(refundSwitch.getAttribute('aria-checked')).toBe('true')
 
     fireEvent.click(buttonWithText(container, 'Confirm cancellation'))
 

--- a/lib/ama/admin/http.test.ts
+++ b/lib/ama/admin/http.test.ts
@@ -188,7 +188,7 @@ describe('AMA admin HTTP contract', () => {
     for (const response of [createResponse, updateResponse, deleteResponse]) {
       expect(response.status).toBe(303)
       expect(response.headers.get('location')).toBe(
-        'https://cali.so/admin/ama?availability=saved',
+        'https://cali.so/admin/ama/settings?availability=saved',
       )
     }
   })
@@ -212,7 +212,7 @@ describe('AMA admin HTTP contract', () => {
     )
 
     expect(response.headers.get('location')).toBe(
-      'https://cali.so/admin/ama?availability=invalid',
+      'https://cali.so/admin/ama/settings?availability=invalid',
     )
     expect(f.mutations).toEqual([])
   })
@@ -241,7 +241,7 @@ describe('AMA admin HTTP contract', () => {
       ['create', { isoWeekday: 5, startMinute: 540, endMinute: 720 }],
     ])
     expect(response.headers.get('location')).toBe(
-      'https://cali.so/admin/ama?availability=saved',
+      'https://cali.so/admin/ama/settings?availability=saved',
     )
   })
 
@@ -289,7 +289,7 @@ describe('AMA admin HTTP contract', () => {
       ['complete', { state: 's', code: 'c', error: null }],
     ])
     expect(response.headers.get('location')).toBe(
-      'https://cali.so/admin/ama?calendar=connected',
+      'https://cali.so/admin/ama/settings?calendar=connected',
     )
   })
 
@@ -309,7 +309,7 @@ describe('AMA admin HTTP contract', () => {
     expect(f.googleEvents).toEqual([['disconnect']])
     expect(f.mutations).toEqual([])
     expect(response.headers.get('location')).toBe(
-      'https://cali.so/admin/ama?calendar=disconnected',
+      'https://cali.so/admin/ama/settings?calendar=disconnected',
     )
   })
 

--- a/lib/ama/admin/http.ts
+++ b/lib/ama/admin/http.ts
@@ -187,11 +187,11 @@ export function createAvailabilityMutationHandler(
       } else {
         const input = availabilityWindowFrom(formData)
         if (!input || (intent === 'update' && id === null)) {
-          return redirect(baseUrl, '/admin/ama?availability=invalid')
+          return redirect(baseUrl, '/admin/ama/settings?availability=invalid')
         }
         if (intent === 'create') await service.create(input)
         else if (intent === 'update') await service.update(id!, input)
-        else return redirect(baseUrl, '/admin/ama?availability=invalid')
+        else return redirect(baseUrl, '/admin/ama/settings?availability=invalid')
       }
 
       dependencies.security.recordPrivilegedAction(
@@ -199,9 +199,9 @@ export function createAvailabilityMutationHandler(
         'availability_mutation.succeeded',
         access.actorId,
       )
-      return redirect(baseUrl, '/admin/ama?availability=saved')
+      return redirect(baseUrl, '/admin/ama/settings?availability=saved')
     } catch {
-      return redirect(baseUrl, '/admin/ama?availability=failed')
+      return redirect(baseUrl, '/admin/ama/settings?availability=failed')
     }
   }
 }
@@ -227,7 +227,7 @@ export function createGoogleConnectHandler(
       )
       return redirect(baseUrl, providerUrl)
     } catch {
-      return redirect(baseUrl, '/admin/ama?calendar=unavailable')
+      return redirect(baseUrl, '/admin/ama/settings?calendar=unavailable')
     }
   }
 }
@@ -256,9 +256,9 @@ export function createGoogleCallbackHandler(
         'google_callback.completed',
         access.actorId,
       )
-      return redirect(baseUrl, `/admin/ama?calendar=${result}`)
+      return redirect(baseUrl, `/admin/ama/settings?calendar=${result}`)
     } catch {
-      return redirect(baseUrl, '/admin/ama?calendar=unavailable')
+      return redirect(baseUrl, '/admin/ama/settings?calendar=unavailable')
     }
   }
 }
@@ -282,9 +282,9 @@ export function createGoogleDisconnectHandler(
         'google_disconnect.succeeded',
         access.actorId,
       )
-      return redirect(baseUrl, '/admin/ama?calendar=disconnected')
+      return redirect(baseUrl, '/admin/ama/settings?calendar=disconnected')
     } catch {
-      return redirect(baseUrl, '/admin/ama?calendar=unavailable')
+      return redirect(baseUrl, '/admin/ama/settings?calendar=unavailable')
     }
   }
 }

--- a/lib/ama/booking/http.test.ts
+++ b/lib/ama/booking/http.test.ts
@@ -373,8 +373,18 @@ describe('hold state handler', () => {
     })
   })
 
-  it('reports a paid hold with its Booking status', async () => {
-    const f = stateFixture({ state: 'paid', bookingStatus: 'confirmed' })
+  it('reports a paid hold with its Booking status and session facts', async () => {
+    const startsAt = new Date('2026-08-01T02:00:00.000Z')
+    const endsAt = new Date('2026-08-01T03:00:00.000Z')
+    const f = stateFixture({
+      state: 'paid',
+      bookingStatus: 'confirmed',
+      startsAt,
+      endsAt,
+      meetingProvider: 'google-meet',
+      guestTimeZone: 'Asia/Taipei',
+      meetingUrl: 'https://meet.google.com/abc-defg-hij',
+    })
 
     const response = await f.handler(
       new Request('https://cali.so/api/ama/holds/x'),
@@ -382,7 +392,15 @@ describe('hold state handler', () => {
     )
 
     await expect(response.json()).resolves.toEqual({
-      hold: { state: 'paid', bookingStatus: 'confirmed' },
+      hold: {
+        state: 'paid',
+        bookingStatus: 'confirmed',
+        startsAt: startsAt.toISOString(),
+        endsAt: endsAt.toISOString(),
+        meetingProvider: 'google-meet',
+        guestTimeZone: 'Asia/Taipei',
+        meetingUrl: 'https://meet.google.com/abc-defg-hij',
+      },
     })
   })
 

--- a/lib/ama/booking/http.ts
+++ b/lib/ama/booking/http.ts
@@ -201,7 +201,15 @@ export function createHoldStateHandler({ service }: HoldStateDependencies) {
       }
       if (state.state === 'paid') {
         return json(200, {
-          hold: { state: 'paid', bookingStatus: state.bookingStatus },
+          hold: {
+            state: 'paid',
+            bookingStatus: state.bookingStatus,
+            startsAt: state.startsAt.toISOString(),
+            endsAt: state.endsAt.toISOString(),
+            meetingProvider: state.meetingProvider,
+            guestTimeZone: state.guestTimeZone,
+            meetingUrl: state.meetingUrl,
+          },
         })
       }
       return json(200, { hold: { state: state.state } })

--- a/lib/ama/booking/service.test.ts
+++ b/lib/ama/booking/service.test.ts
@@ -326,21 +326,34 @@ describe('Booking service getHoldState', () => {
     await f.service.createCheckout(f.holdId)
     await f.service.processWebhookEvent(completedEvent('cs_test_1'))
 
+    // Paid states carry the session facts the confirmation plate prints.
+    const booking = f.repo.bookings[0]
+    const sessionFacts = {
+      startsAt: booking.startsAt,
+      endsAt: booking.endsAt,
+      meetingProvider: booking.meetingProvider,
+      guestTimeZone: booking.guestTimeZone,
+      meetingUrl: booking.meetingUrl,
+    }
+
     await expect(f.service.getHoldState(f.holdId)).resolves.toEqual({
       state: 'paid',
       bookingStatus: 'finalizing',
+      ...sessionFacts,
     })
 
     f.repo.bookings[0].status = 'confirmed'
     await expect(f.service.getHoldState(f.holdId)).resolves.toEqual({
       state: 'paid',
       bookingStatus: 'confirmed',
+      ...sessionFacts,
     })
 
     f.repo.bookings[0].status = 'needs_reschedule'
     await expect(f.service.getHoldState(f.holdId)).resolves.toEqual({
       state: 'paid',
       bookingStatus: 'needs_reschedule',
+      ...sessionFacts,
     })
   })
 

--- a/lib/ama/booking/service.ts
+++ b/lib/ama/booking/service.ts
@@ -60,7 +60,19 @@ export type HoldStateResult =
     }
   | { state: 'expired' }
   | { state: 'processing' }
-  | { state: 'paid'; bookingStatus: 'finalizing' | 'confirmed' | 'needs_reschedule' }
+  | {
+      state: 'paid'
+      bookingStatus: 'finalizing' | 'confirmed' | 'needs_reschedule'
+      /** The confirmed session's facts — no guest identity, only what the
+       *  confirmation page prints on its plate. The meeting link rides along
+       *  once finalization has created it; possession of the hold id is the
+       *  same capability the checkout return already granted. */
+      startsAt: Date
+      endsAt: Date
+      meetingProvider: MeetingProviderName
+      guestTimeZone: string
+      meetingUrl: string | null
+    }
   | { state: 'cancelled' }
   | { state: 'unknown' }
 
@@ -273,7 +285,15 @@ export function createBookingService(dependencies: BookingServiceDependencies) {
         )
         if (booking) {
           if (booking.status === 'cancelled') return { state: 'cancelled' }
-          return { state: 'paid', bookingStatus: booking.status }
+          return {
+            state: 'paid',
+            bookingStatus: booking.status,
+            startsAt: booking.startsAt,
+            endsAt: booking.endsAt,
+            meetingProvider: booking.meetingProvider,
+            guestTimeZone: booking.guestTimeZone,
+            meetingUrl: booking.meetingUrl,
+          }
         }
       }
 

--- a/lib/media/admin/photo-selection-ui.test.tsx
+++ b/lib/media/admin/photo-selection-ui.test.tsx
@@ -13,6 +13,16 @@ vi.mock('next/navigation', () => ({
 import { PhotoCuration } from '../../../app/admin/(protected)/photos/PhotoCuration'
 import type { MediaAssetReviewRecord } from '../asset-review/service'
 
+// jsdom ships no ResizeObserver; the picker dialog's scrollable body
+// observes its viewport to drive the edge fades. Assigned directly (not
+// vi.stubGlobal) so afterEach's unstubAllGlobals leaves it in place.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver
+
 function asset(id: string, name: string): MediaAssetReviewRecord {
   return {
     id,

--- a/lib/media/admin/ui.test.tsx
+++ b/lib/media/admin/ui.test.tsx
@@ -7,6 +7,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MediaLibrary } from '../../../app/admin/(protected)/media/MediaLibrary'
 import type { MediaAssetReviewRecord } from '../asset-review/service'
 
+// jsdom ships no ResizeObserver; the inspector dialog's scrollable body
+// observes its viewport to drive the edge fades. Assigned directly (not
+// vi.stubGlobal) so afterEach's unstubAllGlobals leaves it in place.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver
+
 const activeAsset: MediaAssetReviewRecord = {
   id: '11111111-1111-4111-8111-111111111111',
   createdAt: new Date('2026-07-15T12:00:00.000Z'),
@@ -89,7 +99,8 @@ describe('Media archive UI contract', () => {
     expect(html).toContain('aria-haspopup="dialog"')
     // The selection mark shows what the photos page is using.
     expect(html).toContain('In use')
-    expect(html).toContain('min-h-11')
+    // Compact 32px controls restore their 44px hit target with a pseudo.
+    expect(html).toContain('before:h-11')
     expect(html).not.toMatch(/latitude|longitude|originals\//i)
   })
 

--- a/lib/media/photo-selection/server.test.ts
+++ b/lib/media/photo-selection/server.test.ts
@@ -5,8 +5,11 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('server-only', () => ({}))
+// The 'use cache' directive is inert under Vitest, so the function body
+// runs directly; cacheTag/cacheLife just need to be no-ops.
 vi.mock('next/cache', () => ({
-  unstable_cache: (callback: () => unknown) => callback,
+  cacheTag: () => undefined,
+  cacheLife: () => undefined,
 }))
 vi.mock('~/db', () => ({ getDatabase: vi.fn() }))
 vi.mock('./repository', () => ({
@@ -22,6 +25,7 @@ vi.mock('../storage/config', () => ({
 import { getPublishedPhotoSelection } from './server'
 
 afterEach(() => {
+  vi.unstubAllEnvs()
   vi.clearAllMocks()
 })
 
@@ -64,10 +68,45 @@ describe('Published Photo Selection server read', () => {
   })
 
   it('returns the empty public state when the database is unavailable', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
     mocks.getPublishedSelection.mockRejectedValueOnce(
       new Error('Database unavailable'),
     )
 
     await expect(getPublishedPhotoSelection()).resolves.toBeNull()
+    consoleError.mockRestore()
+  })
+
+  it('logs the swallowed error before rendering the empty state', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const failure = new Error('Database unavailable')
+    mocks.getPublishedSelection.mockRejectedValueOnce(failure)
+
+    await expect(getPublishedPhotoSelection()).resolves.toBeNull()
+    expect(consoleError).toHaveBeenCalledWith(
+      '[photo-selection] read failed; rendering empty state',
+      failure,
+    )
+    consoleError.mockRestore()
+  })
+
+  it('rethrows from the cached read on Vercel so a deploy fails loudly, while the caller still renders the empty state at runtime', async () => {
+    vi.stubEnv('VERCEL_ENV', 'production')
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const failure = new Error('Database unavailable')
+    mocks.getPublishedSelection.mockRejectedValueOnce(failure)
+
+    await expect(getPublishedPhotoSelection()).resolves.toBeNull()
+    expect(consoleError).toHaveBeenCalledWith(
+      '[photo-selection] public read failed; rendering empty state',
+      failure,
+    )
+    consoleError.mockRestore()
   })
 })

--- a/lib/media/photo-selection/server.ts
+++ b/lib/media/photo-selection/server.ts
@@ -1,6 +1,6 @@
 import 'server-only'
 
-import { unstable_cache } from 'next/cache'
+import { cacheLife, cacheTag } from 'next/cache'
 
 import { getDatabase } from '~/db'
 
@@ -49,20 +49,31 @@ function restoreSelectionDates(
   }
 }
 
-const readPublishedPhotoSelection = unstable_cache(
-  async () => {
+async function readPublishedPhotoSelection() {
+  'use cache'
+  cacheTag(PUBLIC_PHOTO_SELECTION_CACHE_TAG)
+  cacheLife('max')
+  try {
     const cdnBaseUrl = parseBunnyRenditionCdnEnv(process.env)
-    return createPublicPhotoSelectionRepository(
+    return await createPublicPhotoSelectionRepository(
       () => getDatabase(),
       cdnBaseUrl,
     ).getPublishedSelection()
-  },
-  ['published-photo-selection'],
-  {
-    tags: [PUBLIC_PHOTO_SELECTION_CACHE_TAG],
-    revalidate: false,
-  },
-)
+  } catch (error) {
+    // An error thrown inside the 'use cache' scope aborts a prerender even
+    // when the caller catches it. On Vercel that is deliberate: a deploy
+    // must fail loudly rather than silently ship an empty photos page. The
+    // documented local build (shaped but unreachable DATABASE_URL) renders
+    // the empty state instead. At runtime the rethrow lands in the caller's
+    // catch, so a request never 500s over this read.
+    if (process.env.VERCEL_ENV) throw error
+    console.error(
+      '[photo-selection] read failed; rendering empty state',
+      error,
+    )
+    return null
+  }
+}
 
 // Local development only: when no real selection exists (no database or
 // nothing published), fall back to generated test cards so the photos
@@ -78,7 +89,11 @@ export async function getPublishedPhotoSelection() {
     )
     if (selection && selection.items.length > 0) return selection
     return devFallback()
-  } catch {
+  } catch (error) {
+    console.error(
+      '[photo-selection] public read failed; rendering empty state',
+      error,
+    )
     return devFallback()
   }
 }

--- a/lib/media/photo-selection/server.ts
+++ b/lib/media/photo-selection/server.ts
@@ -49,6 +49,25 @@ function restoreSelectionDates(
   }
 }
 
+// Development renders the fixture cards when the read fails, so the full
+// error stack on every request is pure noise there — one compact warning
+// per process is enough. Everywhere else the error must stay loud.
+let warnedDevelopmentReadFailure = false
+
+function logReadFailure(scope: 'read' | 'public read', error: unknown) {
+  if (process.env.NODE_ENV === 'development') {
+    if (warnedDevelopmentReadFailure) return
+    warnedDevelopmentReadFailure = true
+    const summary =
+      error instanceof Error ? error.message.split('\n')[0] : String(error)
+    console.warn(
+      `[photo-selection] database unreachable in development; rendering dev fixtures (${summary})`,
+    )
+    return
+  }
+  console.error(`[photo-selection] ${scope} failed; rendering empty state`, error)
+}
+
 async function readPublishedPhotoSelection() {
   'use cache'
   cacheTag(PUBLIC_PHOTO_SELECTION_CACHE_TAG)
@@ -67,10 +86,7 @@ async function readPublishedPhotoSelection() {
     // the empty state instead. At runtime the rethrow lands in the caller's
     // catch, so a request never 500s over this read.
     if (process.env.VERCEL_ENV) throw error
-    console.error(
-      '[photo-selection] read failed; rendering empty state',
-      error,
-    )
+    logReadFailure('read', error)
     return null
   }
 }
@@ -90,10 +106,7 @@ export async function getPublishedPhotoSelection() {
     if (selection && selection.items.length > 0) return selection
     return devFallback()
   } catch (error) {
-    console.error(
-      '[photo-selection] public read failed; rendering empty state',
-      error,
-    )
+    logReadFailure('public read', error)
     return devFallback()
   }
 }


### PR DESCRIPTION
## What

One design pass bringing the owner admin and the AMA guest surfaces onto the public site's technical-print register and the shared fluid component set, plus the root cause fix for staging's empty `/photos` page.

### Admin
- **Print headers**: `page-eyebrow` h1s with fixed per-surface `PixelCluster` masthead variants (6–10), mirrored byte-for-byte in every PPR fallback for zero shift.
- **Depth-based IA**: `/admin/ama` is now a menu of catalog rows into `/admin/ama/bookings` and `/admin/ama/settings`; subpages carry a mono back mark (`components/admin-nav.tsx`).
- **Ornaments**: `SectionTag` h2s (01–04 on AMA), status ladder + cert stamp on Booking detail (linear states only), calibration corners on photo tiles, spec-plate capture data in the media inspector, nameplate tables for booking data, mono machine text, `zh-CN` date formatters (periods showed Traditional 週 before).
- **Shared controls**: every ad-hoc button/select/input/dialog replaced with the fluid set — `Button` gains additive `destructive` + `expandHitArea` (44px hit-target pseudo, applied only at isolated call sites); new `Dialog`, `Input`, `Switch`, `ScrollAreaY`, `SectionTag`; `Tabs` gains a `subtle` variant; `SelectTrigger` gains sizes. Field controls align on a 32px height.
- **Dialog chrome**: dialogs move to the printed-label register — 2px corner, hairline frame, ruled full-bleed head/foot rows — inherited by the photo picker and media inspector.

### AMA guest surfaces
- **Manage page** shares the confirmation's dark stage shell (`AmaStage`; confetti + seal stay exclusive to the paid celebration): nameplate booking card, tooltip timezone, meeting link in the plate, centered reschedule/cancel actions with hazard tape, blueprint cancel dialog, ornamental barcode foot, mono slot chips + fluid timezone Select.
- **Confirmation**: the seal is an inspection stamp (square plate, calibration brackets, hazard bands, settled −4°); the paid stage prints a session nameplate from **server-sent facts only** — the hold endpoint's paid state now includes times, provider, guest zone, and the meeting link once finalized (no guest identity; same possession-based capability as the checkout return). Section-tag-composed status stamp, hold-derived barcode, journey ladder retained on waiting states.
- **Confetti** rebuilt with real ballistics: three decomposed layers (horizontal drag, gravity easings flipping at the apex, finite 3D tumble), 18 pieces per burst, deterministic index-derived variation, never loops.

### Fix: staging showed 0 photos
`unstable_cache(revalidate: false)` baked a pre-publish empty selection into the static shell at build time **and it persists across deploys**; the publish route's `revalidateTag` write is fire-and-forget post-response, so one silent failure left it empty forever. The read is now `'use cache'` + `cacheTag` + `cacheLife('max')` (deployment-scoped keys), failing reads log, and an unreachable DB **aborts Vercel builds loudly** instead of silently shipping an empty photos page (local shaped-but-unreachable `DATABASE_URL` builds still pass). Admin copy clarified: all selected photos publish to `/photos`; the first three double as the homepage preview.

## Why

The admin and guest surfaces had drifted from the design language (ad-hoc buttons, quiet headers, generic cards), and the photos page bug made staging look broken. `docs/design-language.md` records all new contracts.

## Reviewer notes

- **Verification**: typecheck clean; unit 1074/1074, AMA 611/611, media-admin 43/43, deployment contracts 31/31; production build green with the PPR route table intact. Visual QA was done against a local fixture harness (not committed) covering every admin surface and both guest pages in both themes.
- **Merging this deploys production directly** (post-#206 automation). The build re-reads the published photo selection fresh — if the photos are published in the production Neon project they appear immediately; if the read fails, the build aborts loudly and the `[photo-selection]` log line names the cause. Staging (`dev`) can take this via the normal dev sync if a rehearsal is wanted first.
- **API change**: `GET /api/ama/holds/[holdId]` paid responses gain `startsAt`/`endsAt`/`meetingProvider`/`guestTimeZone`/`meetingUrl`. Contract tests updated.
- Known follow-ups (next iteration): timezone Select popup rows are too compact; dialog background should go translucent; extend the menu-and-back IA pattern to the remaining admin roots.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR brings the admin and AMA guest surfaces onto the design system's technical-print register, introduces six new shared fluid components (`Dialog`, `Input`, `Switch`, `ScrollAreaY`, `SectionTag`, plus `subtle` Tabs), and fixes the root cause of staging showing zero photos by replacing `unstable_cache(revalidate: false)` with `'use cache'` + `cacheLife('max')` and adding explicit build-time failure on Vercel.

- **Admin IA**: `/admin/ama` becomes a catalog menu; bookings and settings each move to their own subpages (`/admin/ama/bookings`, `/admin/ama/settings`) with a back-mark nav component; all redirect targets in `lib/ama/admin/http.ts` are updated accordingly.
- **API contract extension**: `GET /api/ama/holds/[holdId]` paid responses now include `startsAt`, `endsAt`, `meetingProvider`, `guestTimeZone`, and `meetingUrl` so the confirmation and manage-booking pages can print a session nameplate from server-sent facts only.
- **Photo selection fix**: `readPublishedPhotoSelection` now uses the `'use cache'` directive with `cacheLife('max')` for deployment-scoped key invalidation; on Vercel a DB failure during prerender rethrows to abort the build loudly rather than silently baking an empty page.

<h3>Confidence Score: 4/5</h3>

Safe to merge. The photo-selection cache fix is the highest-risk change and the logic is correct; the admin IA split is mechanical and all redirect targets were updated consistently.

All the logic changes are well-tested and the design-system work is cohesive. The two non-blocking issues (Switch missing accessible name when used unlabelled; ScrollAreaY ResizeObserver not tracking dynamically added children) do not affect the core booking or photos flows and are straightforward to fix in a follow-up.

components/ui/switch.tsx — the SwitchProps interface does not expose aria-label, so label-less uses are inaccessible to screen readers. components/ui/scroll-area.tsx — edge-fade state may lag on dialogs whose content populates after mount.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/media/photo-selection/server.ts | Replaces unstable_cache(revalidate:false) with 'use cache' + cacheLife('max'); on Vercel rethrows DB errors to abort the prerender (build fails loudly), while the outer caller catches at runtime and returns devFallback(). Logic is sound but the build-time abort behavior of 'use cache' cannot be exercised under Vitest — only the runtime path is unit-tested. |
| lib/ama/booking/service.ts | Extends HoldStateResult paid variant with startsAt, endsAt, meetingProvider, guestTimeZone, and meetingUrl from the booking record; service tests updated to assert all new fields. Clean. |
| lib/ama/booking/http.ts | Serialises the new session facts to ISO strings in the paid hold response; existing and new contract tests cover the shape. Clean. |
| lib/ama/admin/http.ts | Updates all redirect targets from /admin/ama to /admin/ama/settings after the IA split; all eight redirect paths are consistently updated. Clean. |
| components/ui/button.tsx | Adds destructive tone variants and expandHitArea (44px pseudo hit-target). Both correctly use the existing relative positioning in the button base class. Clean. |
| components/ui/dialog.tsx | New Dialog built on Base UI with Elevated surface ladder, DialogBody scroll region, and printed-label chrome. Clean implementation with correct focus management and deferred unmount via CSS transitions. |
| components/ui/input.tsx | New Input component with optional label, error state, and destructive border. Label nesting handles implicit association when no id is provided; aria-describedby uses a stable generated id for the error span. Clean. |
| components/ui/switch.tsx | New Switch component built on Base UI. When used without the label prop the control has no accessible name — the interface does not expose aria-label, so there is no way to label it externally either. |
| components/ui/scroll-area.tsx | Adds ScrollAreaY (vertical sibling of ScrollAreaX) with ResizeObserver-driven edge fades; observer only captures children present at mount, so dynamically added content requires a scroll event to update fade visibility. |
| components/ui/tabs.tsx | Adds subtle variant with 32px chips and 44px pseudo hit-targets; indicator uses a flat surface-bg instead of the lifted shadow pill. Context correctly propagates variant to TabItem. Clean. |
| components/ama/booking-confirmation.tsx | Extends paid confirmation state with session facts from the API; constructs SessionPlate only when all required fields are present; polling correctly stops on paid (terminal). Clean. |
| components/ama/manage-booking.tsx | Rewrites manage-booking onto the design system components (Dialog, Button destructive/expandHitArea, Tooltip); cancel and reschedule flows look correct with proper loading/error states. Clean. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser as "Browser (BookingConfirmation)"
    participant API as "GET /api/ama/holds/[holdId]"
    participant Service as "BookingService"
    participant DB as "Database"

    Browser->>API: "poll (holdId)"
    API->>Service: "getHoldState(holdId)"
    Service->>DB: "find booking by holdId"
    DB-->>Service: "BookingRecord (startsAt, endsAt, meetingProvider, guestTimeZone, meetingUrl)"
    Service-->>API: "state:paid + bookingStatus + session facts"
    API-->>Browser: "hold: { state:paid, bookingStatus, startsAt, endsAt, meetingProvider, guestTimeZone, meetingUrl }"
    Browser->>Browser: "build session object from server-sent facts"
    Browser->>Browser: "setState paid => isTerminal => stop polling"
    Browser->>Browser: "render SessionPlate (meetingUrl shown only when confirmed)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser as "Browser (BookingConfirmation)"
    participant API as "GET /api/ama/holds/[holdId]"
    participant Service as "BookingService"
    participant DB as "Database"

    Browser->>API: "poll (holdId)"
    API->>Service: "getHoldState(holdId)"
    Service->>DB: "find booking by holdId"
    DB-->>Service: "BookingRecord (startsAt, endsAt, meetingProvider, guestTimeZone, meetingUrl)"
    Service-->>API: "state:paid + bookingStatus + session facts"
    API-->>Browser: "hold: { state:paid, bookingStatus, startsAt, endsAt, meetingProvider, guestTimeZone, meetingUrl }"
    Browser->>Browser: "build session object from server-sent facts"
    Browser->>Browser: "setState paid => isTerminal => stop polling"
    Browser->>Browser: "render SessionPlate (meetingUrl shown only when confirmed)"
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acomponents%2Fui%2Fswitch.tsx%3A12-21%0A**Switch%20has%20no%20accessible%20name%20when%20%60label%60%20is%20omitted**%0A%0AWhen%20%60label%60%20is%20not%20provided%20the%20control%20renders%20with%20%60aria-labelledby%3D%7Bundefined%7D%60%20and%20no%20%60aria-label%60.%20Because%20%60SwitchProps%60%20does%20not%20extend%20%60HTMLAttributes%60%2C%20callers%20cannot%20pass%20%60aria-label%60%20externally%20either%2C%20so%20the%20toggle%20is%20completely%20unnamed%20for%20screen%20readers.%20Adding%20an%20%60aria-label%3F%3A%20string%60%20prop%20%28or%20spreading%20remaining%20props%20onto%20the%20root%29%20would%20let%20call%20sites%20provide%20a%20name%20without%20requiring%20a%20visible%20label.%0A%0A%23%23%23%20Issue%202%20of%203%0Acomponents%2Fui%2Fscroll-area.tsx%3A93-95%0A**ResizeObserver%20only%20captures%20children%20present%20at%20mount**%0A%0A%60for%20%28const%20child%20of%20viewport.children%29%20observer.observe%28child%29%60%20takes%20a%20snapshot%20of%20the%20DOM%20at%20the%20time%20the%20effect%20runs.%20Children%20added%20after%20mount%20%28e.g.%20when%20a%20dialog%20body%20is%20populated%20asynchronously%29%20will%20not%20be%20observed%2C%20so%20the%20edge-fade%20indicators%20may%20stay%20stale%20until%20the%20next%20scroll%20event%20fires.%20Replacing%20the%20per-child%20observations%20with%20a%20%60MutationObserver%60%20on%20the%20viewport%20%28observing%20%60childList%60%29%20and%20calling%20%60update%60%20from%20its%20callback%20would%20cover%20dynamic%20children%20without%20the%20need%20for%20per-child%20observers.%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Fmedia%2Fphoto-selection%2Fserver.ts%3A57-71%0A**Build-time%20abort%20is%20untestable%20under%20Vitest**%0A%0AThe%20%22deploy%20fails%20loudly%22%20guarantee%20rests%20on%20Next.js%20aborting%20the%20prerender%20when%20a%20%60'use%20cache'%60%20function%20throws%20%E2%80%94%20a%20behaviour%20that%20Vitest%20cannot%20exercise%20because%20the%20directive%20is%20mocked%20to%20a%20no-op.%20The%20third%20test%20%28%60rethrows%20from%20the%20cached%20read%20on%20Vercel%E2%80%A6%60%29%20verifies%20only%20the%20runtime%20re-throw%20path%20%28outer%20catch%20%E2%86%92%20%60devFallback%28%29%60%29%2C%20not%20the%20build-abort%20path.%20This%20means%20a%20future%20refactor%20that%20breaks%20the%20build-time%20contract%20would%20pass%20all%20unit%20tests%20silently.%20The%20code%20comment%20documents%20the%20gap%20honestly%2C%20so%20this%20is%20a%20known%20trade-off%20rather%20than%20a%20defect%3B%20worth%20keeping%20in%20mind%20for%20staging%20verification%20after%20deploy.%0A%0A&repo=calicastle%2Fcali.so&pr=208&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22calicastle%2Fcali.so%22%20on%20the%20existing%20branch%20%22claude%2Fadmin-ui-design-components-0b3615%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fadmin-ui-design-components-0b3615%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acomponents%2Fui%2Fswitch.tsx%3A12-21%0A**Switch%20has%20no%20accessible%20name%20when%20%60label%60%20is%20omitted**%0A%0AWhen%20%60label%60%20is%20not%20provided%20the%20control%20renders%20with%20%60aria-labelledby%3D%7Bundefined%7D%60%20and%20no%20%60aria-label%60.%20Because%20%60SwitchProps%60%20does%20not%20extend%20%60HTMLAttributes%60%2C%20callers%20cannot%20pass%20%60aria-label%60%20externally%20either%2C%20so%20the%20toggle%20is%20completely%20unnamed%20for%20screen%20readers.%20Adding%20an%20%60aria-label%3F%3A%20string%60%20prop%20%28or%20spreading%20remaining%20props%20onto%20the%20root%29%20would%20let%20call%20sites%20provide%20a%20name%20without%20requiring%20a%20visible%20label.%0A%0A%23%23%23%20Issue%202%20of%203%0Acomponents%2Fui%2Fscroll-area.tsx%3A93-95%0A**ResizeObserver%20only%20captures%20children%20present%20at%20mount**%0A%0A%60for%20%28const%20child%20of%20viewport.children%29%20observer.observe%28child%29%60%20takes%20a%20snapshot%20of%20the%20DOM%20at%20the%20time%20the%20effect%20runs.%20Children%20added%20after%20mount%20%28e.g.%20when%20a%20dialog%20body%20is%20populated%20asynchronously%29%20will%20not%20be%20observed%2C%20so%20the%20edge-fade%20indicators%20may%20stay%20stale%20until%20the%20next%20scroll%20event%20fires.%20Replacing%20the%20per-child%20observations%20with%20a%20%60MutationObserver%60%20on%20the%20viewport%20%28observing%20%60childList%60%29%20and%20calling%20%60update%60%20from%20its%20callback%20would%20cover%20dynamic%20children%20without%20the%20need%20for%20per-child%20observers.%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Fmedia%2Fphoto-selection%2Fserver.ts%3A57-71%0A**Build-time%20abort%20is%20untestable%20under%20Vitest**%0A%0AThe%20%22deploy%20fails%20loudly%22%20guarantee%20rests%20on%20Next.js%20aborting%20the%20prerender%20when%20a%20%60'use%20cache'%60%20function%20throws%20%E2%80%94%20a%20behaviour%20that%20Vitest%20cannot%20exercise%20because%20the%20directive%20is%20mocked%20to%20a%20no-op.%20The%20third%20test%20%28%60rethrows%20from%20the%20cached%20read%20on%20Vercel%E2%80%A6%60%29%20verifies%20only%20the%20runtime%20re-throw%20path%20%28outer%20catch%20%E2%86%92%20%60devFallback%28%29%60%29%2C%20not%20the%20build-abort%20path.%20This%20means%20a%20future%20refactor%20that%20breaks%20the%20build-time%20contract%20would%20pass%20all%20unit%20tests%20silently.%20The%20code%20comment%20documents%20the%20gap%20honestly%2C%20so%20this%20is%20a%20known%20trade-off%20rather%20than%20a%20defect%3B%20worth%20keeping%20in%20mind%20for%20staging%20verification%20after%20deploy.%0A%0A&repo=calicastle%2Fcali.so&pr=208&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
components/ui/switch.tsx:12-21
**Switch has no accessible name when `label` is omitted**

When `label` is not provided the control renders with `aria-labelledby={undefined}` and no `aria-label`. Because `SwitchProps` does not extend `HTMLAttributes`, callers cannot pass `aria-label` externally either, so the toggle is completely unnamed for screen readers. Adding an `aria-label?: string` prop (or spreading remaining props onto the root) would let call sites provide a name without requiring a visible label.

### Issue 2 of 3
components/ui/scroll-area.tsx:93-95
**ResizeObserver only captures children present at mount**

`for (const child of viewport.children) observer.observe(child)` takes a snapshot of the DOM at the time the effect runs. Children added after mount (e.g. when a dialog body is populated asynchronously) will not be observed, so the edge-fade indicators may stay stale until the next scroll event fires. Replacing the per-child observations with a `MutationObserver` on the viewport (observing `childList`) and calling `update` from its callback would cover dynamic children without the need for per-child observers.

### Issue 3 of 3
lib/media/photo-selection/server.ts:57-71
**Build-time abort is untestable under Vitest**

The "deploy fails loudly" guarantee rests on Next.js aborting the prerender when a `'use cache'` function throws — a behaviour that Vitest cannot exercise because the directive is mocked to a no-op. The third test (`rethrows from the cached read on Vercel…`) verifies only the runtime re-throw path (outer catch → `devFallback()`), not the build-abort path. This means a future refactor that breaks the build-time contract would pass all unit tests silently. The code comment documents the gap honestly, so this is a known trade-off rather than a defect; worth keeping in mind for staging verification after deploy.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(design): industrial ornament pass a..."](https://github.com/calicastle/cali.so/commit/b222bf6cccac7070ad0b1dd14730a8d1b379998b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45495689)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->
