### PR TITLE
Sync Production release fixes back into dev

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -13,16 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  migration-review:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    environment: production-migration-review
-    steps:
-      - name: Confirm Production migration review
-        run: echo "Production migration review approved."
-
   deploy:
-    needs: migration-review
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     environment: production
@@ -53,7 +44,9 @@ jobs:
       - name: Run database migrations
         env:
           MIGRATION_DATABASE_URL: ${{ secrets.MIGRATION_DATABASE_URL }}
-        run: pnpm db:migrate
+        run: |
+          : "${MIGRATION_DATABASE_URL:?Production MIGRATION_DATABASE_URL is not configured}"
+          pnpm db:migrate
 
       - name: Deploy Vercel Production
         env:
@@ -62,6 +55,9 @@ jobs:
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
+          : "${VERCEL_ORG_ID:?Production VERCEL_ORG_ID is not configured}"
+          : "${VERCEL_PROJECT_ID:?Production VERCEL_PROJECT_ID is not configured}"
+          : "${VERCEL_TOKEN:?Production VERCEL_TOKEN is not configured}"
           deployment_url="$(
             pnpm dlx vercel@56.3.1 deploy --prod \
               --yes \

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # cali.so
 
-Source for [Cali Castle's personal site](https://cali.so). The ground-up
-rewrite is the v3 release. The 2024 site remains the historical v2 release,
-Git `dev` is the long-lived Staging and integration branch, and `main` is
-Production.
+Source for [Cali Castle's personal site](https://cali.so). The ground-up v3
+source release reached `main` on July 20, 2026. The 2024 site remains the
+historical v2 release, Git `dev` is the protected long-lived Staging and
+integration branch, and `main` is Production.
 
 This repository documents and builds cali.so itself. It is not maintained as a
 general-purpose blog template.
@@ -19,17 +19,19 @@ general-purpose blog template.
   snapshots
 - An always-available owner admin for Media and AMA operations, protected by
   Clerk authentication, exact owner metadata, origin checks, and rate limits;
-  public AMA transactions remain disabled for the v3 production launch
+  provider-backed AMA capabilities follow complete credential pairs and fail
+  closed when their pair is absent
 - A Bunny-backed Media Library with owner review and curation in admin; its
   active Published Photo Selection powers `/photos` and the homepage preview
   while private Originals remain server-only
 - CSP, same-origin mutation checks, rate limits, fail-closed provider controls,
   security automation, and isolated Staging, Preview, and Production credentials
 
-The public route and launch contract is tracked in
-[issue #98](https://github.com/CaliCastle/cali.so/issues/98). Merging the
-finished release into `main` is the production cutover, not an ordinary
-integration step.
+The public route and launch contract is preserved in closed
+[issue #98](https://github.com/CaliCastle/cali.so/issues/98) and the
+[cutover record](docs/v3-cutover-readiness.md). PR
+[#195](https://github.com/CaliCastle/cali.so/pull/195) promoted v3 to `main`;
+future releases continue through reviewed `dev` to `main` pull requests.
 
 ## Local development
 
@@ -44,8 +46,8 @@ cp .env.example .env.local
 pnpm dev
 ```
 
-`.env.example` documents the runtime variables and fail-closed capability
-switches. The application database credential must be a CRUD-only runtime
+`.env.example` documents the runtime variables and fail-closed provider
+boundaries. The application database credential must be a CRUD-only runtime
 role. Supply `MIGRATION_DATABASE_URL` only to an explicit migration command;
 do not store it in `.env.local` or Vercel.
 
@@ -93,9 +95,10 @@ pnpm audit:prod
 - `dev` automatically migrates and deploys persistent Staging. Internal feature
   branches receive persistent Neon `preview/<git-branch>` children of Staging;
   fork pull requests receive code-only CI.
-- Production uses a separate Neon project. Two sequential protected GitHub
-  environments approve the migration review and database access before GitHub
-  deploys the exact `main` commit.
+- Production uses a separate Neon project and a `main`-only GitHub environment
+  for its migration and deployment credentials. After required pull-request
+  checks pass and a commit reaches `main`, GitHub automatically migrates and
+  deploys that exact commit.
 - Next.js preview versions stay pinned exactly and require explicit review,
   a lockfile update, and the complete validation suite.
 - Staging and Previews use a separate non-production Neon project and disposable
@@ -111,9 +114,9 @@ pnpm audit:prod
 - Owner admin remains available in every environment and relies on
   Clerk authentication plus the server-checked
   `publicMetadata.siteOwner = "yes"` marker rather than an environment switch.
-  Public AMA mutations, payments, booking finalization, Google, and Tencent
-  remain disabled in Production until their later product and security gates
-  are complete.
+  Public AMA mutations are enabled by default. Payments, booking finalization,
+  Google, and Tencent turn on only when their complete Production credential
+  pairs are configured and otherwise fail closed with 503.
 - The public photo surfaces depend on migrations `0005` through `0008`, the
   private Originals and public Renditions boundary, and an active Published
   Photo Selection. The retired static photo fallback is not part of v3.
@@ -141,8 +144,8 @@ not describe v3.
 
 ## Release history
 
-- **v3.0** (in development): ground-up, repository-owned rewrite described by
-  issue #98
+- **v3.0** (July 20, 2026): ground-up, repository-owned source release promoted
+  through PR #195 and described by issue #98
 - **v2.0** (2024-03-13): legacy Sanity and Next.js 14 site
 - **v1.1** (2024-03-10): migrated the legacy database from PlanetScale to Neon
 

--- a/docs/adr/0010-github-controlled-neon-deployments.md
+++ b/docs/adr/0010-github-controlled-neon-deployments.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Accepted. This supersedes the integration-branch naming portion of ADR-0005.
+Accepted, amended 2026-07-20. This supersedes the integration-branch naming
+portion of ADR-0005.
 
 Git `dev` is the long-lived Staging branch, backed by a persistent `staging`
 branch in the non-production Neon project. Internal feature branches receive
@@ -11,8 +12,10 @@ separate Production Neon project. GitHub Actions creates or reuses the database
 branch, runs migrations, then deploys the exact commit, while Vercel Git
 deployments stay disabled so code cannot race its schema. Migration credentials
 exist only in scoped GitHub deployment steps, Vercel receives CRUD-only runtime
-URLs, and Production requires two sequential protected-environment approvals
-plus a fail-closed expand-only migration check. This custom control plane is
-more involved than Neon's managed
+URLs, and Production retains a fail-closed expand-only migration check.
+Production runs automatically when a reviewed commit reaches `main`: branch
+protection and required pull-request checks are the human approval boundary,
+while a `main`-only GitHub environment scopes the migration and deployment
+secrets. This custom control plane is more involved than Neon's managed
 Vercel integration, but it preserves a non-production Staging parent and keeps
 DDL credentials out of application builds and runtimes.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -6,14 +6,22 @@ Current as of July 2026.
 
 - The ground-up rewrite is **v3**. The site released in 2024 remains the
   historical v2.
+- v3.0 reached `main` on July 20, 2026 through
+  [PR #195](https://github.com/CaliCastle/cali.so/pull/195), at merge commit
+  `4f071ab`. `dev` was restored at that same commit after GitHub's automatic
+  branch cleanup and is protected against deletion and force pushes.
+- The first protected Production run
+  [#29696010332](https://github.com/CaliCastle/cali.so/actions/runs/29696010332)
+  received an empty migration credential and stopped before database access or
+  Vercel deployment. The hotfix provisions split Production roles and makes
+  the replacement run automatic when its reviewed commit reaches `main`.
 - Git **`dev`** is the long-lived Staging and integration branch. `main` drives
   Production; a reviewed `dev` to `main` pull request is the release path.
-- Release scope and evidence are tracked by
-  [#98](https://github.com/CaliCastle/cali.so/issues/98). Do not merge to
-  `main` until its complete dependency chain and final proof are green.
-- Release slices #99 through #106 are merged into `v2`. Final cutover proof is
-  tracked by #107; those `v2` references are historical evidence from before
-  the branch became `dev`.
+- Release scope and evidence are preserved in closed issues
+  [#98](https://github.com/CaliCastle/cali.so/issues/98) and
+  [#107](https://github.com/CaliCastle/cali.so/issues/107), plus
+  `docs/v3-cutover-readiness.md`. References there to Git `v2` are historical
+  evidence from before the integration branch became `dev`.
 
 ## Current architecture
 
@@ -85,8 +93,8 @@ Current as of July 2026.
 - GitHub Actions owns deployment ordering. `dev` migrates the persistent Neon
   `staging` branch before deploying Vercel Staging. Internal feature branches
   use persistent `preview/<git-branch>` children of Staging. Production lives
-  in a separate Neon project and waits for two sequential protected-environment
-  approvals before database access.
+  in a separate Neon project; every commit reaching `main` automatically uses
+  the `main`-only Production environment to migrate before deploying.
 - Security baseline controls from PR #97 remain mandatory: CSP and security
   headers, same-origin mutation policy, rate limits, kill switches,
   privacy-safe audit events, isolated credentials, and security automation.
@@ -102,7 +110,7 @@ Current as of July 2026.
   and regeneration remain available in the inspector). Location Label
   suggestions follow their provider credential.
 
-## Launch gates
+## Release gates
 
 1. Preserve every legacy public URL through native content, a static archive,
    or an intentional permanent replacement. Drive verification from one

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -10,11 +10,12 @@ Current as of July 2026.
   [PR #195](https://github.com/CaliCastle/cali.so/pull/195), at merge commit
   `4f071ab`. `dev` was restored at that same commit after GitHub's automatic
   branch cleanup and is protected against deletion and force pushes.
-- The first protected Production run
-  [#29696010332](https://github.com/CaliCastle/cali.so/actions/runs/29696010332)
-  received an empty migration credential and stopped before database access or
-  Vercel deployment. The hotfix provisions split Production roles and makes
-  the replacement run automatic when its reviewed commit reaches `main`.
+- [PR #206](https://github.com/CaliCastle/cali.so/pull/206) completed the
+  Production hotfix at merge commit `d891463`. Attempt 3 of
+  [Deploy Production run #29707454879](https://github.com/CaliCastle/cali.so/actions/runs/29707454879)
+  passed the expand-only check, applied migrations with the dedicated
+  `cali_migrator` role, and deployed that exact commit automatically. The live
+  public and signed-out admin boundaries pass at `https://cali.so`.
 - Git **`dev`** is the long-lived Staging and integration branch. `main` drives
   Production; a reviewed `dev` to `main` pull request is the release path.
 - Release scope and evidence are preserved in closed issues

--- a/docs/security/baseline.md
+++ b/docs/security/baseline.md
@@ -8,7 +8,7 @@ an attacker can read the implementation.
 
 | Environment | Data and integrations | Secret policy |
 | --- | --- | --- |
-| Production | Production-only accounts and durable data | Available only after two sequential protected-environment approvals |
+| Production | Production-only accounts and durable data | `main`-only GitHub environment; automatic after required pull-request checks and merge |
 | Staging | Persistent non-production baseline and test accounts | Staging-scoped credentials; never production credentials |
 | Preview | Disposable child of Staging for one internal Git branch | Preview-scoped runtime credentials; never production credentials |
 | Local and CI | Local emulators, fixtures, or dedicated test accounts | Developer-local or CI-scoped credentials with the minimum privilege |
@@ -17,8 +17,9 @@ an attacker can read the implementation.
   accounts wherever the provider supports it. Never encode secrets in source,
   build output, client bundles, logs, issue text, or workflow files.
 - Scope Vercel environment variables explicitly. A production secret must not
-  be exposed to Preview or Development. Protect the production deployment and
-  require an audited approval path for exceptional access.
+  be exposed to Preview or Development. Restrict Production credentials to the
+  `main`-only GitHub environment; pull-request checks and branch protection are
+  the human approval boundary before the automatic deployment.
 - Forks and untrusted pull requests receive no sensitive credentials. Workflows
   triggered by pull requests must not use `pull_request_target` to execute
   contributor-controlled code.

--- a/docs/security/verification.md
+++ b/docs/security/verification.md
@@ -1,6 +1,6 @@
 # Security verification
 
-Last checked: 2026-07-16. This note separates repository evidence from hosted
+Last checked: 2026-07-20. This note separates repository evidence from hosted
 settings. Do not paste credentials, scan findings, or exploit details here;
 use GitHub private vulnerability reporting.
 
@@ -52,22 +52,19 @@ must remain private.
 
 ## GitHub
 
-Repository API checks on 2026-07-16 verified:
+Repository API checks refreshed on 2026-07-20 verified:
 
 - [x] Private vulnerability reporting, secret scanning, push protection, and
   Dependabot security updates are enabled.
 - [x] Default Actions workflow permissions are read-only and workflows cannot
   approve pull requests.
 - [x] Actions must be pinned to a full commit SHA.
-- [x] The historical `v2` ruleset requires pull requests, blocks force pushes
-  and branch deletion, and limits the audited emergency bypass to repository
-  administrators. It requires no approving review while the project has one
-  maintainer.
-- [x] The historical `v2` ruleset requires the successful GitHub Actions checks named
+- [x] The `dev` and `main` rulesets require pull requests, block force pushes
+  and branch deletion, and require the successful GitHub Actions checks named
   `Quality` and `CodeQL`.
-- [ ] Rename the hosted `v2` branch and its ruleset target to `dev`, then verify
-  the same PR, deletion, force-push, and required-check protections.
-- [ ] Require `Quality` and `CodeQL` on `main` branch protection.
+- [x] Neither protected branch has a bypass actor. Branch protection and
+  required checks are the human approval boundary before automatic Production
+  deployment.
 - [x] CodeQL default setup is disabled so the committed advanced workflow is
   the single analysis source.
 - [ ] Non-provider secret patterns and validity checks are unavailable in the
@@ -75,23 +72,23 @@ Repository API checks on 2026-07-16 verified:
   change.
 - [x] Fork pull requests cannot receive Vercel secrets, and the GitHub Actions
   workflow uses committed non-secret fixtures instead of repository secrets.
-- [ ] Configure `preview`, `staging`, no-secret
-  `production-migration-review`, and protected `production` GitHub environments
-  with the variables, secrets, branch restrictions, and required Production
-  reviewers documented in the cutover runbook.
+- [x] Configure `preview`, `staging`, and `production` GitHub environments with
+  the variables, secrets, and branch restrictions documented in the cutover
+  runbook. Production runs automatically after required checks pass and a
+  reviewed commit reaches `main`; it has no deployment reviewer.
 
 ## Vercel
 
-Project API checks on 2026-07-16 verified:
+Project API checks refreshed on 2026-07-20 verified:
 
 - [x] `cali-so` is accessible in the `Cali` Pro workspace. Its production
   branch remains `main`, and Git fork protection is enabled.
 - [x] Production and Preview have distinct database variables. Preview uses a
   disposable Neon branch and a pooled CRUD-only runtime role; migrations use a
   separate direct credential that is absent from Vercel.
-- [ ] Rename the persistent non-production Neon branch to `staging`, configure
-  the custom Vercel Staging environment, and verify feature branches receive
-  isolated `preview/<git-branch>` children.
+- [x] The persistent non-production Neon branch is `staging`, the custom Vercel
+  Staging environment is configured, and feature branches receive isolated
+  `preview/<git-branch>` children.
 - [x] Committed Vercel configuration disables Git deployments; hosted proof
   requires a GitHub-controlled Staging and Preview deployment after setup.
 - [x] The former AMA capability switches are absent. Owner admin remains
@@ -119,10 +116,14 @@ Project API checks on 2026-07-16 verified:
   payload-free Preview query confirmed runtime-log access. The Pro workspace
   has Observability Plus enabled for this project, so Vercel's documented
   runtime-log retention is 30 days with a maximum 14-day query window.
-- [ ] At cutover, replace the legacy Production database variable with the
-  verified Neon runtime role and verify its grants under issue #107. Production
-  database inspection still requires two fresh explicit confirmations.
+- [x] Production uses separate `cali_migrator` and `cali_runtime` identities.
+  GitHub stores the direct migration credential only in its `main`-restricted
+  Production environment; Vercel stores only the pooled CRUD runtime URL. The
+  runtime role cannot create schema, and the migration role cannot manage roles
+  or databases.
+- [ ] Confirm the automatic Production workflow applies migrations `0001`
+  through `0012`, deploys the exact `main` commit, and passes smoke checks.
 
 Clerk provider configuration and owner recovery remain tracked by issue #93.
-Production provider values remain a cutover concern until v3 replaces the
-historical site on `main`.
+Production provider values remain a post-merge deployment and verification
+concern until the automatic Production workflow and smoke checks complete.

--- a/docs/security/verification.md
+++ b/docs/security/verification.md
@@ -121,9 +121,14 @@ Project API checks refreshed on 2026-07-20 verified:
   Production environment; Vercel stores only the pooled CRUD runtime URL. The
   runtime role cannot create schema, and the migration role cannot manage roles
   or databases.
-- [ ] Confirm the automatic Production workflow applies migrations `0001`
-  through `0012`, deploys the exact `main` commit, and passes smoke checks.
+- [x] Attempt 3 of
+  [Deploy Production run #29707454879](https://github.com/CaliCastle/cali.so/actions/runs/29707454879)
+  passed the expand-only policy, applied migrations `0001` through `0012`, and
+  deployed the exact `main@d891463` commit automatically. Post-deploy checks
+  verified the public security boundary, all 13 hosted browser cases, and a
+  signed-out `401` from `/api/admin/media/assets` rather than a server error.
 
 Clerk provider configuration and owner recovery remain tracked by issue #93.
-Production provider values remain a post-merge deployment and verification
-concern until the automatic Production workflow and smoke checks complete.
+Signed-in owner operations and end-to-end checks for each configured external
+provider remain separate operational follow-ups; they are not deployment
+workflow blockers.

--- a/docs/v3-cutover-ops-runbook.md
+++ b/docs/v3-cutover-ops-runbook.md
@@ -1,9 +1,11 @@
 # v3 cutover ops runbook
 
 Maintainer-operated commands for the hosted blockers in
-`docs/v3-cutover-readiness.md`. Every step here changes production-adjacent
-state and is intentionally left to a human operator. Nothing in this file
-contains a secret; commands that need one prompt for it interactively.
+`docs/v3-cutover-readiness.md`. Manual commands here change
+production-adjacent state and remain operator-controlled; the committed
+Production workflow itself runs automatically after a reviewed commit reaches
+`main`. Nothing in this file contains a secret; commands that need one prompt
+for it interactively.
 
 ## Vercel CLI scope
 
@@ -50,8 +52,7 @@ Neon project.
 | --- | --- | --- | --- |
 | `preview` | `NEON_PROJECT_ID`, `NEON_MIGRATION_ROLE`, `NEON_RUNTIME_ROLE`, `NEON_DATABASE`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` | project-scoped `NEON_API_KEY`, `VERCEL_TOKEN` | Internal branches only; exclude `dev` and `main` |
 | `staging` | Same non-production variables | Same non-production secrets | `dev` only; no approval |
-| `production-migration-review` | None | None | `main` only; required reviewer |
-| `production` | `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` | `MIGRATION_DATABASE_URL`, `VERCEL_TOKEN` | `main` only; required reviewer |
+| `production` | `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` | `MIGRATION_DATABASE_URL`, `VERCEL_TOKEN` | `main` only; no deployment reviewer |
 
 The committed `vercel.json` disables Vercel Git deployments. Do not re-enable
 them in the dashboard: GitHub must create or select the Neon branch, migrate it,
@@ -208,16 +209,15 @@ results in the readiness report:
 
 ## 6. Production database and migrations
 
-Gated by two fresh explicit confirmations immediately before access. Verify
-the separate Production Neon project, CRUD-only runtime role, and migration-role
-default privileges for both existing and future tables and sequences. A merge
-to `main` then starts `Deploy Production`. The no-secret
-`production-migration-review` environment records the first approval. Only
-after it succeeds can the separately protected `production` environment expose
-the migration credential and record the second approval.
+Direct operator access remains gated by two fresh explicit confirmations.
+Verify the separate Production Neon project, CRUD-only runtime role, and
+migration-role default privileges for both existing and future tables and
+sequences. A reviewed commit reaching `main` starts `Deploy Production`
+automatically. The `main`-only `production` environment exposes the migration
+credential to that workflow without an additional deployment review.
 
 The workflow hash-locks the immutable legacy baseline `0000` and reviewed v3
-migrations `0001` through `0011`, rejecting any modification or deletion.
+migrations `0001` through `0012`, rejecting any modification or deletion.
 Migration `0000` stays outside the v3 Drizzle journal and is not rerun. Future
 migrations fail closed unless every SQL
 statement is an explicitly allowed expand operation: create a new table, type,
@@ -226,10 +226,11 @@ non-null column with a statically proven non-null default; validate a named
 constraint; or set a statically proven non-null column default. New constraints,
 including `NOT VALID` constraints, affect new writes and therefore require an
 explicitly reviewed digest exception. Dynamic blocks, unknown default
-expressions, and every unrecognized statement are rejected. After both
-approvals and that check, the workflow applies pending migrations with the
-GitHub-only credential and deploys the exact commit. Do not approve either
-environment until the migration diff and rollback anchor have been reviewed.
+expressions, and every unrecognized statement are rejected. After the
+credential guards and expand-only check, the workflow applies pending
+migrations with the GitHub-only credential and deploys the exact commit.
+Review the migration diff and rollback anchor in the pull request before
+merging to `main`.
 
 ## 7. Rollback anchor
 

--- a/docs/v3-cutover-ops-runbook.md
+++ b/docs/v3-cutover-ops-runbook.md
@@ -7,6 +7,12 @@ Production workflow itself runs automatically after a reviewed commit reaches
 `main`. Nothing in this file contains a secret; commands that need one prompt
 for it interactively.
 
+The v3.0 Production deployment completed on July 20, 2026. Attempt 3 of
+[Deploy Production run #29707454879](https://github.com/CaliCastle/cali.so/actions/runs/29707454879)
+applied migrations and deployed `main@d891463` without a manual approval step.
+Treat the provisioning commands below as a rebuild and rotation reference, not
+as a statement that Production is still unconfigured.
+
 ## Vercel CLI scope
 
 The team slug `cali` collides with the personal account, so slug-based scope
@@ -128,10 +134,11 @@ JSON
 
 ## 4. Provision the Production environment
 
-Production currently satisfies none of the v3 contract in `.env.example`.
-Each `env add` prompts for its value; generate fresh secrets rather than
-copying Preview's, and never add `MIGRATION_DATABASE_URL` to any Vercel
-environment.
+Production satisfied this contract for the v3.0 deployment on July 20, 2026.
+Before rebuilding or rotating it, inventory the live environment and change
+only the intended values. Each `env add` prompts for its value; generate fresh
+secrets rather than copying Preview's, and never add
+`MIGRATION_DATABASE_URL` to any Vercel environment.
 
 ```bash
 add() { npx vercel env add "$1" production $SCOPE; }
@@ -148,10 +155,10 @@ add NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 add CLERK_SECRET_KEY
 add CRON_SECRET              # openssl rand -hex 32
 
-# Server-only key material — generate per environment, never reuse Preview's.
-add AMA_ENCRYPTION_KEY       # openssl rand -hex 32
-add RATE_LIMIT_HASH_KEY      # openssl rand -hex 32
-add MEDIA_ENCRYPTION_KEY     # openssl rand -hex 32
+# Server-only key material — 32 decoded bytes of base64 per environment.
+add AMA_ENCRYPTION_KEY       # openssl rand -base64 32
+add RATE_LIMIT_HASH_KEY      # openssl rand -base64 32
+add MEDIA_ENCRYPTION_KEY     # openssl rand -base64 32
 
 # Rate limits (values from .env.example defaults unless tuned).
 add ADMIN_MUTATION_RATE_LIMIT_MAX_REQUESTS

--- a/docs/v3-cutover-readiness.md
+++ b/docs/v3-cutover-readiness.md
@@ -15,12 +15,21 @@ Quality, and CodeQL.
 The first Deploy Production run
 [#29696010332](https://github.com/CaliCastle/cali.so/actions/runs/29696010332)
 passed its no-secret review but received an empty `MIGRATION_DATABASE_URL`, so
-Drizzle stopped before connecting and Vercel deployment was skipped. The
-follow-up hotfix configures dedicated Production migration and CRUD-only runtime
-roles, makes each `main` push migrate and deploy automatically, and keeps the
-credentials isolated to their GitHub and Vercel consumers. Its merge triggers
-the replacement Production run; this record does not claim success until that
-run and its smoke checks pass.
+Drizzle stopped before connecting and Vercel deployment was skipped.
+[PR #206](https://github.com/CaliCastle/cali.so/pull/206) then added dedicated
+Production migration and CRUD-only runtime roles, made each `main` push migrate
+and deploy automatically, and kept each credential isolated to its GitHub or
+Vercel consumer.
+
+PR #206 merged as `d891463`. Attempt 3 of
+[Deploy Production run #29707454879](https://github.com/CaliCastle/cali.so/actions/runs/29707454879)
+passed the expand-only check, applied migrations `0001` through `0012`, and
+deployed that exact commit to
+`https://cali-nnstyrz6o-cali.vercel.app`. The exact deployment and
+`https://cali.so` return 200. The post-deploy security-boundary verifier and all
+13 hosted browser cases pass against Production; the signed-out Media API now
+returns 401 instead of the pre-fix 500. Automated Production deployment and
+public smoke proof are complete.
 
 ## Pre-cutover verdict (historical)
 
@@ -63,7 +72,7 @@ Production deployment status.
 | Repository validation | PASS (LOCAL AND FEATURE PREVIEW) / AWAITING QUALITY AND STAGING | The new `pnpm test:browser` production-build gate passes 19 Chromium behavior cases plus six WebKit smoke executions locally. Feature Preview run [29671775136](https://github.com/CaliCastle/cali.so/actions/runs/29671775136) passed all 13 read-only `@hosted` cases against `https://cali-lonkhb5df-cali.vercel.app` for `2336124`. `Quality` and the Staging deployment remain pending. |
 | Public browser behavior | PASS | Local and Staging review covered desktop and mobile, both locales, light and dark appearance, reduced motion, keyboard navigation, metadata, overflow, feeds, generated social images, and Instant Navigation. |
 | Owner admin boundary | PASS (Staging signed-out path) / AWAITING OWNER AND PRODUCTION PROOF | A clean browser navigation to Staging `/admin` completes Clerk's development-instance handshake and reaches the isolated sign-in UI. The complete remote security-boundary verifier passes. Signed-in owner reads and mutations still require authorized operator access and the database gate below; confirm the Production Clerk keys and owner metadata at cutover. |
-| Complete diff Standards review | PARTIAL / AWAITING RE-REVIEW | PR #189 landed the credential-driven AMA and owner-auth decisions plus keyboard-instant Preview-card, lightbox, and article-map behavior. The browser gate now verifies those motion paths. Issues #184 through #186 remain open because their PR merged to `dev`, not the default branch; the layer-scale finding and judgement-level `app/globals.css` disposition still need a recorded resolution before the refreshed review can pass. |
+| Complete diff Standards review | PARTIAL / AWAITING RE-REVIEW | PR #189 landed the credential-driven AMA and owner-auth decisions plus keyboard-instant Preview-card, lightbox, and article-map behavior. The browser gate now verifies those motion paths. At this snapshot, issues #184 through #186 remained open because their PR had merged to `dev`, not the default branch; the layer-scale finding and judgement-level `app/globals.css` disposition still needed a recorded resolution before the refreshed review could pass. |
 | Complete diff Spec review | PARTIAL / AWAITING RE-REVIEW | No scope creep was found, and the missing automated browser-test command plus automated feature Preview evidence are now implemented. Analytics dashboard proof remains absent, and Domain evidence was overstated. The Clerk redirect-shape verifier intentionally stops at the first 307, but the separate clean-browser matrix completed the development handshake and rendered Clerk sign-in. |
 | Production-like Staging | PASS (public and signed-out boundaries) | `https://beta.cali.so` serves `dev@8802607`. The complete public route, link, discovery, legacy-URL, security-boundary, and manual browser matrix passed. Signed-in owner operations and provider-backed workflows remain separate gates. |
 | Issue #107 feature Preview evidence | PASS (AUTOMATED MATRIX) / AWAITING MANUAL HOSTED EVIDENCE | The exact feature Preview for `2336124` passed the 13-case hosted matrix across both locales, appearance and viewport profiles, reduced motion, metadata, feeds, social images, Instant Navigation, public Analytics inclusion, and the signed-out admin boundary. Fresh Analytics dashboard proof and signed-in owner evidence remain separate manual gates. |
@@ -204,8 +213,8 @@ Final review artifacts after the accessibility corrections:
   paths. The Playwright production-build gate now verifies zero card and cell
   motion on keyboard Preview-card focus, synchronous lightbox open and Escape
   focus restoration, instant article-map toggles, and zero running Web
-  Animations under reduced motion. Issues #184 through #186 remain open because
-  their PR merged to `dev` rather than the default branch.
+  Animations under reduced motion. Issues #184 through #186 shipped on `main`
+  through PR #189 and were closed during the release-record cleanup.
 - Earlier design-contract findings around selection weight, contrast, scroll
   reveals, and chrome typography are closed. The final review newly found that
   the implementation uses local and page-level numeric stacking values beyond
@@ -258,18 +267,17 @@ configuration, and an active Published Photo Selection. Git remains
 authoritative for writing and ordinary site content, but not for the curated
 photo wall.
 
-Before accepting a successful Production deployment, an authorized operator
-must:
+For the v3.0 deployment, the authorized operator confirmed the Production
+runtime role has only the required CRUD grants, confirmed Vercel has no
+migration credential, and isolated the direct migration credential in the
+`main`-restricted GitHub Production environment. Run #29707454879 applied the
+complete additive migration history before deploying the exact commit. Public
+site, discovery, URL, link, security-boundary, and signed-out admin checks pass
+against Production.
 
-1. confirm the production runtime role has only the required CRUD grants;
-2. confirm Vercel has no migration credential;
-3. apply the separately approved pending Media migrations with the migration
-   role, preserving the additive migration history;
-4. verify private Originals, public Renditions, and the active Published Photo
-   Selection against the production Bunny and Neon boundary;
-5. verify each configured AMA provider uses a complete Production-only
-   credential pair; and
-6. smoke-test the public site and every configured AMA provider workflow.
+Signed-in owner verification, the private Originals and public Renditions
+storage contract, the active Published Photo Selection, and complete
+end-to-end exercises for each configured AMA provider remain operator checks.
 
 Production database or sensitive cloud-data inspection requires two fresh,
 explicit confirmations immediately before access.
@@ -290,36 +298,29 @@ remain in place during application rollback; destructive down migrations are
 not part of the procedure. Record the known-good deployment identifier and an
 operator before accepting a Production deployment.
 
-## Unverified or deferred at merge
+## Post-release follow-ups
 
 Maintainer-operated commands for the hosted actions below are collected in
 `docs/v3-cutover-ops-runbook.md`.
 
-1. Refresh the complete-diff Standards and Spec reviews, record the disposition
-   of issues #184 through #186 now that their implementation is on `main`, and
-   reconcile the implementation with the documented closed layer scale. The
+1. Refresh the complete-diff Standards and Spec reviews and reconcile the
+   implementation with the documented closed layer scale. Issues #184 through
+   #186 are shipped and closed. The
    judgement-level `app/globals.css` divergent-change finding may remain a
    follow-up only if the maintainer records that disposition.
-2. Review and accept the recorded automated Feature Preview evidence for
-   `2336124`, then use that exact deployment for the remaining Analytics
-   dashboard and other manual hosted evidence.
+2. Confirm fresh Chinese and English Production pageviews are visible in the
+   existing `cali-so` Analytics dashboard.
 3. With two fresh confirmations, verify Staging migrations `0010` and `0011`,
    Media and AMA tables, and the runtime role's CRUD-only grants. Then sign in
    as the marked owner and prove one non-destructive read plus the required
    mutation boundaries. Until then, treat signed-in Staging admin operations as
    unvalidated.
-4. Verify the configured Production migration role, CRUD-only runtime role,
-   required secrets, rate limits, intended AMA provider credential pairs, and
-   complete Bunny and media configuration against the deployed application.
-5. In the Vercel dashboard, verify logs, drains, retention, firewall rules,
+4. In the Vercel dashboard, verify logs, drains, retention, firewall rules,
    the production-branch mapping, and the certificate.
-6. Verify the automatic Production workflow applies the reviewed migration
-   baseline before deploying the exact `main` commit. Direct operator database
-   inspection still requires two fresh confirmations.
-7. Verify the production Bunny and Neon Media boundary, run the protected live
+5. Verify the Production Bunny and Neon Media boundary, run the protected live
    storage contract, and publish the intended two-photo Published Photo
    Selection through the owner admin.
-8. Confirm fresh Chinese and English pageviews from the recorded Feature
-    Preview are visible in the existing `cali-so` Analytics dashboard.
-9. Confirm the rollback procedure against the recorded known-good deployment.
-10. Complete the automatic Production deployment and post-deploy smoke tests.
+6. Sign in as the marked Production owner and exercise each configured AMA
+   provider workflow without exposing customer or credential data.
+7. Confirm the rollback procedure against the now-recorded Production
+   deployment.

--- a/docs/v3-cutover-readiness.md
+++ b/docs/v3-cutover-readiness.md
@@ -1,31 +1,35 @@
-# v3 cutover readiness
+# v3 cutover record
 
-Last checked: 2026-07-19.
+Finalized: 2026-07-20.
 
-The controlled deployment architecture is active: `dev` is the integration
-branch, `staging` is the persistent non-production database branch, and the
-GitHub environments are configured for Preview, Staging, migration review, and
-Production. `main` remains the Production branch and has not been merged or
-deployed as part of this ticket.
+## Final outcome
 
-## Verdict
+The v3.0 source cutover reached `main` through
+[PR #195](https://github.com/CaliCastle/cali.so/pull/195) at merge commit
+`4f071ab` on July 20, 2026. The final `dev` commit passed Staging, Quality, and
+CodeQL before merge. GitHub's automatic head-branch cleanup removed `dev`; the
+branch was restored at the same commit. Active `dev` and `main` rulesets now
+block deletion, force pushes, and direct bypass while requiring pull requests,
+Quality, and CodeQL.
 
-**NOT READY.** `dev` is green under the complete local release suite and the
-current Staging deployment at `https://beta.cali.so` passed its migration,
-public-site, security-boundary, link, URL-contract, and browser checks. The
-decisive blocker is still Production provisioning: the last authorized audit
-found that its runtime contract, including the database and media provider
-configuration, was not ready for v3. Required checks on `main`, Staging runtime
-grant and signed-in owner verification, Production database and provider proof,
-Vercel dashboard checks, Analytics ingestion proof, and rollback proof remain
-open. PR #189 resolved the motion implementations, but the complete-diff
-Standards and Spec reviews still need to be refreshed; the documented layer
-finding remains. Automated Feature Preview evidence now passes, while manual
-hosted and Analytics evidence remains open.
+The first Deploy Production run
+[#29696010332](https://github.com/CaliCastle/cali.so/actions/runs/29696010332)
+passed its no-secret review but received an empty `MIGRATION_DATABASE_URL`, so
+Drizzle stopped before connecting and Vercel deployment was skipped. The
+follow-up hotfix configures dedicated Production migration and CRUD-only runtime
+roles, makes each `main` push migrate and deploy automatically, and keeps the
+credentials isolated to their GitHub and Vercel consumers. Its merge triggers
+the replacement Production run; this record does not claim success until that
+run and its smoke checks pass.
 
-Unknown hosted state is not counted as passed. This report does not authorize
-merging to `main`, changing production settings, accessing production data, or
-running production migrations.
+## Pre-cutover verdict (historical)
+
+At the last pre-merge audit, the verdict was **NOT READY**. `dev` was green
+under the complete local release suite, and the audited Staging deployment at
+`https://beta.cali.so` passed its migration, public-site, security-boundary,
+link, URL-contract, and browser checks. Production provisioning, signed-in
+owner verification, dashboard checks, Analytics ingestion, and rollback proof
+remained open at that snapshot. Unknown hosted state was not counted as passed.
 
 ## Audit baseline
 
@@ -48,7 +52,10 @@ owner admin manages the catalog and curation workflow, and the public homepage
 and `/photos` now consume the active Published Photo Selection from Bunny
 Renditions. The retired static photo fallback has been removed.
 
-## Gate summary
+## Pre-cutover gate summary (historical)
+
+The table below preserves the July 19 evidence and must not be read as current
+Production deployment status.
 
 | Gate | Status | Evidence or blocker |
 | --- | --- | --- |
@@ -62,8 +69,8 @@ Renditions. The retired static photo fallback has been removed.
 | Issue #107 feature Preview evidence | PASS (AUTOMATED MATRIX) / AWAITING MANUAL HOSTED EVIDENCE | The exact feature Preview for `2336124` passed the 13-case hosted matrix across both locales, appearance and viewport profiles, reduced motion, metadata, feeds, social images, Instant Navigation, public Analytics inclusion, and the signed-out admin boundary. Fresh Analytics dashboard proof and signed-in owner evidence remain separate manual gates. |
 | Vercel Web Analytics | AWAITING DASHBOARD CONFIRMATION | Chinese and English Feature Preview and Staging routes load the first-party Insights client; the signed-out owner-admin boundary excludes it. Confirm fresh Chinese and English pageviews from the recorded Feature Preview in the existing `cali-so` Analytics dashboard. |
 | GitHub security settings | PASS | Secret scanning, push protection, Dependabot security updates, read-only Actions defaults, and full-SHA action policy are enabled. |
-| Required GitHub checks | PARTIAL | The `dev` ruleset requires `Quality` and `CodeQL`; `main` branch protection still requires neither. The maintainer-operated command is in `docs/v3-cutover-ops-runbook.md`. |
-| Deployment environments | PASS | GitHub has Preview, Staging, `production-migration-review`, and Production environments with the intended branch policies; the last two require maintainer review. |
+| Required GitHub checks | PARTIAL | At this snapshot, the `dev` ruleset required `Quality` and `CodeQL` while `main` protection required neither. Both branches are protected now. |
+| Deployment environments | PASS | At this snapshot, GitHub had Preview, Staging, `production-migration-review`, and Production environments, with the last two requiring maintainer review. The release decision was later amended to one automatic, `main`-only Production environment. |
 | Current Vercel project settings | PASS | Project inspection succeeds with the explicit team scope. The earlier `Not authorized` was a CLI quirk: the team slug `cali` resolves to the personal account, so commands must pass the team ID as `--scope` (see the runbook). |
 | Production capability posture | PASS (superseded July 2026) | The former `AMA_*_ENABLED` switches are removed by maintainer decision: AMA capabilities are enabled by default, and each provider capability follows its credential pair, failing closed with 503 while the pair is absent. Owner admin has no capability switch. |
 | Staging and Production secret isolation | PARTIAL / AWAITING DATABASE CONFIRMATION | Staging uses its isolated Clerk instance and has no Redis fallback. The successful Staging workflow reported that all migrations were applied, but table state and the runtime role's CRUD-only grants were not inspected. If migration `0010` or its grants are missing, rate-limited admin mutations fail closed with 503 while public reads remain available. Two fresh confirmations are required before remote database inspection. |
@@ -244,12 +251,15 @@ Migrations `0001` through `0004` are additive AMA foundations. Migrations
 publication revisions, durable Purge progress, and the Catalog State rename.
 Migration `0010` adds durable Preview rate-limit windows without storing raw
 request keys. Migration `0011` adds the paid AMA booking tables, constraints,
-and indexes. Their checked-in snapshots and migration tests pass. The v3 public
-photo surfaces require the Media migrations, production Bunny configuration,
-and an active Published Photo Selection. Git remains authoritative for writing
-and ordinary site content, but not for the curated photo wall.
+and indexes. Migration `0012` expands published Rendition profiles without a
+table rewrite. Their checked-in snapshots and migration tests pass. The v3
+public photo surfaces require the Media migrations, production Bunny
+configuration, and an active Published Photo Selection. Git remains
+authoritative for writing and ordinary site content, but not for the curated
+photo wall.
 
-Before cutover, an authorized operator must:
+Before accepting a successful Production deployment, an authorized operator
+must:
 
 1. confirm the production runtime role has only the required CRUD grants;
 2. confirm Vercel has no migration credential;
@@ -266,27 +276,27 @@ explicit confirmations immediately before access.
 
 ## Domain and rollback expectations
 
-The intended cutover is a reviewed pull request from `dev` into `main`.
-`Deploy Production` must wait for the no-secret migration-review approval and
-then the separately protected Production approval, migrate the separate
-Production Neon project, and deploy that exact commit. Vercel
-must retain `cali.so` and `www.cali.so` on the same project. No manual DNS move
-is expected, but current project ownership, aliases, certificate, and
-environment scopes must be verified first.
+The release flow is a reviewed pull request from `dev` into `main`. Every commit
+reaching `main` automatically runs credential guards, the expand-only
+migration check, Production migrations, and the exact Vercel deployment in that
+order. The `main`-only Production environment scopes credentials without an
+additional deployment reviewer. Vercel must retain `cali.so` and `www.cali.so`
+on the same project. No manual DNS move is expected, but current project
+ownership, aliases, certificate, and environment scopes must be verified.
 
 Rollback must prefer promoting the last known-good Vercel production deployment
-or reverting the cutover merge. The eleven additive database migrations should
+or reverting the cutover merge. The twelve additive database migrations should
 remain in place during application rollback; destructive down migrations are
 not part of the procedure. Record the known-good deployment identifier and an
-operator before cutover.
+operator before accepting a Production deployment.
 
-## Remaining manual actions
+## Unverified or deferred at merge
 
 Maintainer-operated commands for the hosted actions below are collected in
 `docs/v3-cutover-ops-runbook.md`.
 
 1. Refresh the complete-diff Standards and Spec reviews, record the disposition
-   of issues #184 through #186 now that their implementation is in `dev`, and
+   of issues #184 through #186 now that their implementation is on `main`, and
    reconcile the implementation with the documented closed layer scale. The
    judgement-level `app/globals.css` divergent-change finding may remain a
    follow-up only if the maintainer records that disposition.
@@ -298,25 +308,18 @@ Maintainer-operated commands for the hosted actions below are collected in
    as the marked owner and prove one non-destructive read plus the required
    mutation boundaries. Until then, treat signed-in Staging admin operations as
    unvalidated.
-4. Provision the Production environment for the v3 contract: replace the
-   legacy `DATABASE_URL` with the CRUD-only Neon runtime role and add the
-   missing secrets, rate limits, intended AMA provider credential pairs, and
-   complete Bunny and media configuration.
-5. Add required `Quality` and `CodeQL` checks to protected `main`; `dev` already
-   requires both.
-6. In the Vercel dashboard, verify logs, drains, retention, firewall rules,
+4. Verify the configured Production migration role, CRUD-only runtime role,
+   required secrets, rate limits, intended AMA provider credential pairs, and
+   complete Bunny and media configuration against the deployed application.
+5. In the Vercel dashboard, verify logs, drains, retention, firewall rules,
    the production-branch mapping, and the certificate.
-7. With two fresh confirmations, verify Production runtime grants and the
-   reviewed initial migration baseline. Configure and approve the no-secret
-   `production-migration-review` environment first, then approve the protected
-   `production` environment only after confirming the workflow will migrate
-   before deploy.
-8. Verify the production Bunny and Neon Media boundary, run the protected live
+6. Verify the automatic Production workflow applies the reviewed migration
+   baseline before deploying the exact `main` commit. Direct operator database
+   inspection still requires two fresh confirmations.
+7. Verify the production Bunny and Neon Media boundary, run the protected live
    storage contract, and publish the intended two-photo Published Photo
    Selection through the owner admin.
-9. Confirm fresh Chinese and English pageviews from the recorded Feature
+8. Confirm fresh Chinese and English pageviews from the recorded Feature
     Preview are visible in the existing `cali-so` Analytics dashboard.
-10. Confirm the rollback procedure against the recorded known-good deployment.
-11. Only after every blocker above is passed, merge `dev` to `main`, approve
-    both Production deployment gates in order, and complete the cutover smoke
-    tests.
+9. Confirm the rollback procedure against the recorded known-good deployment.
+10. Complete the automatic Production deployment and post-deploy smoke tests.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cali.so",
-  "version": "3.0.0-dev",
+  "version": "3.0.0",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "packageManager": "pnpm@10.12.1",

--- a/scripts/deployment-workflows.test.mjs
+++ b/scripts/deployment-workflows.test.mjs
@@ -118,16 +118,13 @@ test('dev continuously migrates and deploys the persistent Staging environment',
   )
 })
 
-test('main uses protected Production credentials and deploys only after migration', async () => {
+test('main automatically deploys with protected Production credentials after migration', async () => {
   const config = await workflow('deploy-production')
   assert.deepEqual(config.on.push.branches, ['main'])
-
-  const review = config.jobs['migration-review']
-  assert.equal(review.environment, 'production-migration-review')
-  assert.equal(review.env, undefined)
+  assert.equal(config.jobs['migration-review'], undefined)
 
   const job = config.jobs.deploy
-  assert.equal(job.needs, 'migration-review')
+  assert.equal(job.needs, undefined)
   assert.equal(job.environment, 'production')
   assert.equal(job.env, undefined)
   assertOrdered(
@@ -154,9 +151,15 @@ test('main uses protected Production credentials and deploys only after migratio
     migrate.env.MIGRATION_DATABASE_URL,
     '${{ secrets.MIGRATION_DATABASE_URL }}',
   )
+  assert.match(migrate.run, /\$\{MIGRATION_DATABASE_URL:\?/)
+  assert.match(migrate.run, /pnpm db:migrate/)
+  assert.equal(migrate.env.VERCEL_TOKEN, undefined)
   const deploy = job.steps.find(
     (step) => step.name === 'Deploy Vercel Production',
   )
+  for (const name of ['VERCEL_ORG_ID', 'VERCEL_PROJECT_ID', 'VERCEL_TOKEN']) {
+    assert.match(deploy.run, new RegExp(`\\$\\{${name}:\\?`))
+  }
   assert.match(deploy.run, /vercel@56\.3\.1 deploy --prod/)
   assert.match(
     deploy.run,

--- a/scripts/verify-production-security-boundary.mjs
+++ b/scripts/verify-production-security-boundary.mjs
@@ -291,7 +291,19 @@ async function verifyPublicAmaApiBoundary(baseUrl) {
     const outcome = outcomes.find(({ status }) => response.status === status)
     assert.ok(outcome, `${path} boundary status ${response.status}`)
     if (outcome.error) {
-      assert.deepEqual(JSON.parse(responseBody), { error: outcome.error })
+      let parsedBody
+      try {
+        parsedBody = JSON.parse(responseBody)
+      } catch {
+        assert.fail(
+          `${path} response body is not JSON: ${responseBody.slice(0, 200)}`,
+        )
+      }
+      assert.deepEqual(
+        parsedBody,
+        { error: outcome.error },
+        `${path} boundary body`,
+      )
     }
     assert.equal(response.headers.get('cache-control'), 'no-store')
     assert.equal(response.headers.get('set-cookie'), null)

--- a/scripts/verify-production-security-boundary.mjs
+++ b/scripts/verify-production-security-boundary.mjs
@@ -236,32 +236,63 @@ async function verifyPublicAmaApiBoundary(baseUrl) {
   }
   const holdId = '00000000-0000-4000-8000-000000000000'
   // Public mutations are enabled by default: empty submissions stop at
-  // validation, while routes whose provider (Stripe, Resend) is not
-  // configured in this environment keep failing closed with 503.
+  // validation. Provider-backed routes have two exact safe outcomes: a
+  // configured provider rejects the synthetic resource or signature, while
+  // an unconfigured provider fails closed with 503.
   const requests = [
-    { path: '/api/ama/holds', body: '{}', status: 400 },
-    { path: `/api/ama/holds/${holdId}/checkout`, body: '{}', status: 503 },
-    { path: '/api/ama/stripe/webhook', body: '{}', status: 503 },
-    { path: '/api/ama/alternate-time-requests', body: '{}', status: 400 },
+    {
+      path: '/api/ama/holds',
+      requestBody: '{}',
+      outcomes: [{ status: 400 }],
+    },
+    {
+      path: `/api/ama/holds/${holdId}/checkout`,
+      requestBody: '{}',
+      outcomes: [
+        { status: 404, error: 'not_found' },
+        { status: 503 },
+      ],
+    },
+    {
+      path: '/api/ama/stripe/webhook',
+      requestBody: '{}',
+      outcomes: [
+        { status: 400, error: 'invalid_signature' },
+        { status: 503 },
+      ],
+    },
+    {
+      path: '/api/ama/alternate-time-requests',
+      requestBody: '{}',
+      outcomes: [{ status: 400 }],
+    },
     {
       path: '/api/ama/manage/security-boundary-token/cancel',
-      body: '{}',
-      status: 503,
+      requestBody: '{}',
+      outcomes: [{ status: 503 }],
     },
     {
       path: '/api/ama/manage/security-boundary-token/reschedule',
-      body: '{}',
-      status: 503,
+      requestBody: '{}',
+      outcomes: [{ status: 503 }],
     },
   ]
 
-  for (const { path, body, status } of requests) {
-    const { response } = await fetchBoundary(baseUrl, path, {
-      method: 'POST',
-      headers: sameOriginHeaders,
-      body,
-    })
-    assert.equal(response.status, status, `${path} boundary status`)
+  for (const { path, requestBody, outcomes } of requests) {
+    const { response, body: responseBody } = await fetchBoundary(
+      baseUrl,
+      path,
+      {
+        method: 'POST',
+        headers: sameOriginHeaders,
+        body: requestBody,
+      },
+    )
+    const outcome = outcomes.find(({ status }) => response.status === status)
+    assert.ok(outcome, `${path} boundary status ${response.status}`)
+    if (outcome.error) {
+      assert.deepEqual(JSON.parse(responseBody), { error: outcome.error })
+    }
     assert.equal(response.headers.get('cache-control'), 'no-store')
     assert.equal(response.headers.get('set-cookie'), null)
   }

--- a/tests/browser/admin-boundary.spec.ts
+++ b/tests/browser/admin-boundary.spec.ts
@@ -29,7 +29,13 @@ test('@hosted signed-out admin navigation stops at the authentication boundary',
   expect(responseBody).not.toContain('/_vercel/insights/script.js')
 
   if (response.status() === 404) {
-    expect(headers['x-clerk-auth-reason']).toBe('protect-rewrite, dev-browser-missing')
+    // Clerk reports the same fail-closed rewrite with an environment-specific
+    // signed-out reason: Preview lacks the development browser token, while
+    // Production lacks both a session token and UAT.
+    expect([
+      'protect-rewrite, dev-browser-missing',
+      'protect-rewrite, session-token-and-uat-missing',
+    ]).toContain(headers['x-clerk-auth-reason'])
     return
   }
 


### PR DESCRIPTION
## Summary

- sync the automatic Production deployment hotfix from `main` back into `dev`
- carry the final v3 release evidence and hosted verification corrections into the integration branch
- make `dev` the current base for the pending dependency updates

## Included

- PR #206 and its dedicated Production migration/runtime credential boundary
- PR #207 and the successful v3 Production deployment record
- the final Greptile diagnostic follow-up

## Verification

- `main` is five commits ahead of `dev` and zero commits behind
- Deploy Production run #29708437226 passed for `main@9c2c255`
- the source commits passed Quality, CodeQL, Preview, Production deployment, and hosted smoke verification
