### PR TITLE
Route Dependabot updates through dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
       day: monday
@@ -16,6 +17,7 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
       day: monday


### PR DESCRIPTION
## Summary

- target npm Dependabot updates at `dev`
- target GitHub Actions Dependabot updates at `dev`
- keep automated dependency changes inside the Staging-first release path

## Why

The existing configuration followed the default branch, so PRs #201 through #205 targeted Production directly and were validated against the pre-hotfix release commit. Dependency updates should integrate through protected `dev`, then reach `main` through the normal reviewed promotion.

## Verification

- parsed `.github/dependabot.yml` with the repository's `yaml` package
- asserted both update blocks resolve `target-branch: dev`
- `git diff --check`
