### PR TITLE
Fix upload chunk rate-limit validation

### DIFF
--- a/lib/media/admin/http.test.ts
+++ b/lib/media/admin/http.test.ts
@@ -872,6 +872,45 @@ describe('Media admin HTTP contract', () => {
     })
   })
 
+  it.each([
+    '/api/admin/media/upload-intents/upload_01/original',
+    '/api/admin/media/upload-intents/upload_01/original?chunk=invalid',
+    '/api/admin/media/upload-intents/upload_01/original?chunk=1',
+  ])('rejects an invalid chunk index before rate limiting: %s', async (path) => {
+    const f = fixture(false)
+    const limit = vi.fn(async () => ({ success: true }))
+    const handler = createMediaOriginalUploadHandler({
+      authenticator: f.authenticator,
+      security: f.security,
+      baseUrl: new URL('https://cali.so'),
+      ingestionRepository: {
+        async claimUploadIntentTransfer() {
+          return {
+            originalKey: 'originals/upload_01.jpg',
+            contentType: 'image/jpeg',
+            byteSize: 1,
+            checksumSha256: '0'.repeat(64),
+          }
+        },
+      },
+      storage: {
+        async inspectOriginalChunk() {
+          throw new Error('an invalid chunk must not reach storage')
+        },
+        async storeOriginalChunk() {
+          throw new Error('an invalid chunk must not reach storage')
+        },
+      },
+      uploadChunkRateLimiter: { retryAfterSeconds: 60, limit },
+    })
+
+    const response = await handler(request(path, { method: 'PUT' }), 'upload_01')
+
+    expect(response.status).toBe(422)
+    await expect(response.json()).resolves.toEqual({ error: 'invalid_request' })
+    expect(limit).not.toHaveBeenCalled()
+  })
+
   it('rate limits repeated chunks per Upload Intent without touching storage', async () => {
     const f = fixture(false)
     const bytes = 'private image bytes'

--- a/lib/media/admin/http.ts
+++ b/lib/media/admin/http.ts
@@ -16,6 +16,7 @@ import { MediaGeocodingError } from '../geocoding/service'
 import { MediaPurgeError } from '../purge/service'
 import { MediaReconciliationError } from '../reconciliation/service'
 import { PhotoSelectionError } from '../photo-selection/service'
+import { originalUploadChunkCount } from '../storage/transfer'
 import { storeOriginalChunkFromSameOriginRequest } from '../storage/upload'
 
 type Authenticator = {
@@ -635,6 +636,17 @@ export function createMediaOriginalUploadHandler(
       return json(503, { error: 'dependency_unavailable' })
     }
     if (!intent) return json(404, { error: 'not_found' })
+    const chunk = new URL(request.url).searchParams.get('chunk')
+    const chunkIndex = chunk !== null && /^\d+$/.test(chunk)
+      ? Number(chunk)
+      : Number.NaN
+    if (
+      !Number.isSafeInteger(chunkIndex) ||
+      chunkIndex < 0 ||
+      chunkIndex >= originalUploadChunkCount(intent.byteSize)
+    ) {
+      return json(422, { error: 'invalid_request' })
+    }
     let rateLimit
     try {
       rateLimit = await dependencies.uploadChunkRateLimiter.limit(
@@ -654,10 +666,6 @@ export function createMediaOriginalUploadHandler(
         ),
       })
     }
-    const chunk = new URL(request.url).searchParams.get('chunk')
-    const chunkIndex = chunk !== null && /^\d+$/.test(chunk)
-      ? Number(chunk)
-      : Number.NaN
     return storeOriginalChunkFromSameOriginRequest({
       request,
       canonicalBaseUrl: dependencies.baseUrl,


### PR DESCRIPTION
## Summary

- validate upload chunk indices before consuming per-intent rate-limit quota
- reject missing, non-integer, and out-of-range indices with 422
- cover the rate-limiter ordering with focused HTTP contract tests

## Verification

- `pnpm exec vitest run lib/media/admin/http.test.ts`
- `pnpm typecheck`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the ordering of chunk-index validation relative to the per-intent rate-limit check in the media upload handler. Previously, an invalid or missing `chunk` query parameter would still consume a rate-limit token before the request was rejected; now the 422 is returned first.

- The chunk-parsing and validation block is moved from after the rate-limit call to immediately after the upload-intent is claimed, so malformed requests never touch the `uploadChunkRateLimiter`.
- A new parameterised `it.each` test covers missing, non-integer, and out-of-range chunk indices, asserting both 422 status and that the rate-limiter mock is never invoked.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a pure reordering of existing logic with no new state mutations or altered semantics.

The validation block is moved verbatim; no logic was changed, only its position relative to the rate-limiter call. The new test directly exercises all three rejection cases and asserts the rate-limiter mock is never reached, giving good coverage of the intended contract. The imported `originalUploadChunkCount` function is simple and well-tested elsewhere.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/media/admin/http.ts | Chunk-index validation block relocated from after the rate-limiter to before it; logic is identical to the removed block, imports `originalUploadChunkCount` for the range check. |
| lib/media/admin/http.test.ts | Adds a focused `it.each` contract test covering missing, non-integer, and out-of-range chunk indices, asserting 422 response and that the rate-limiter is not called. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Handler as Upload Handler
    participant Repo as IngestionRepository
    participant RL as RateLimiter
    participant Storage

    Client->>Handler: "PUT /upload-intents/:id/original?chunk=N"
    Handler->>Handler: authenticate()
    Handler->>Repo: claimUploadIntentTransfer()
    Repo-->>Handler: intent (byteSize, key, …)

    alt chunk missing / non-integer / out-of-range
        Handler-->>Client: 422 invalid_request
        note over RL: never called
    else valid chunk index
        Handler->>RL: limit(uploadIntentId)
        alt rate limit exceeded
            RL-->>Handler: "{ success: false }"
            Handler-->>Client: 429 rate_limited
        else within limit
            RL-->>Handler: "{ success: true }"
            Handler->>Storage: storeOriginalChunk(chunkIndex)
            Storage-->>Handler: ok
            Handler-->>Client: 2xx
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Handler as Upload Handler
    participant Repo as IngestionRepository
    participant RL as RateLimiter
    participant Storage

    Client->>Handler: "PUT /upload-intents/:id/original?chunk=N"
    Handler->>Handler: authenticate()
    Handler->>Repo: claimUploadIntentTransfer()
    Repo-->>Handler: intent (byteSize, key, …)

    alt chunk missing / non-integer / out-of-range
        Handler-->>Client: 422 invalid_request
        note over RL: never called
    else valid chunk index
        Handler->>RL: limit(uploadIntentId)
        alt rate limit exceeded
            RL-->>Handler: "{ success: false }"
            Handler-->>Client: 429 rate_limited
        else within limit
            RL-->>Handler: "{ success: true }"
            Handler->>Storage: storeOriginalChunk(chunkIndex)
            Storage-->>Handler: ok
            Handler-->>Client: 2xx
        end
    end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(media): validate chunks before limit..."](https://github.com/calicastle/cali.so/commit/7cc217892219b4f6d51f90103b53f506582311e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45556131)</sub>

<!-- /greptile_comment -->