### PR TITLE
Refresh repository plans and operational docs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,8 +3,9 @@
 ## Supported versions
 
 Security fixes are applied to the version deployed at
-[cali.so](https://cali.so). Pre-release v3 work is supported only while it is
-on an active repository branch.
+[cali.so](https://cali.so). The current v3 release is supported on `main`;
+unreleased integration work is supported while it remains on active `dev` or
+pull-request branches.
 
 ## Report a vulnerability privately
 

--- a/docs/adr/0005-next-16-3-preview-with-ship-gates.md
+++ b/docs/adr/0005-next-16-3-preview-with-ship-gates.md
@@ -1,15 +1,21 @@
-# Build on an exact reviewed Next.js 16.3 preview; cutover remains gated
+# Ship on an exact reviewed Next.js 16.3 preview
 
-v3 is developed on the historically named `v2` integration branch. It may
-ship on an exact reviewed Next.js 16.3 preview instead of waiting for a stable
-release, but floating preview or canary ranges are prohibited.
+## Status
+
+Accepted as the v3.0 release decision. The historical `v2` integration-branch
+name is superseded by ADR-0010, and the production cutover completed on July
+20, 2026. The exact-pin and preview-update gates remain in force.
+
+v3 was developed on the historically named `v2` integration branch and shipped
+on an exact reviewed Next.js 16.3 preview instead of waiting for a stable
+release. Floating preview or canary ranges remain prohibited.
 
 Every preview update requires explicit review, an exact package and lockfile
 change, a known-advisory check, and the complete validation suite. The agreed
 release pin is `16.3.0-preview.6`, adopted in the Cache Components baseline
 issue rather than as an incidental documentation update.
 
-Production cutover is gated on both:
+Production cutover was gated on both:
 
 1. completing the full issue #91 rollout: Cache Components, route-by-route
    Instant Navigations, and Partial Prefetching;

--- a/docs/asset-sources.md
+++ b/docs/asset-sources.md
@@ -44,6 +44,6 @@ are promotional artwork from Apple Music, publishers, authors, or retailers.
 | Hustle Harder, Hustle Smarter | [HarperCollins](https://www.harpercollins.com/products/hustle-harder-hustle-smarter-curtis-50-cent-jackson) |
 | Build | [HarperCollins](https://www.harpercollins.com/products/build-tony-fadell) |
 | Sword of Destiny | [Orbit / Hachette](https://www.hachettebookgroup.com/titles/andrzej-sapkowski/sword-of-destiny/9780316389716/) |
-| Universal Principles of UX | [Quarto](https://cloud.firebrandtech.com/api/v2/image/111/9780760378045/CoverArtHigh/XL) |
+| Universal Principles of UX | [Quarto](https://www.quarto.com/books/9780760378045/universal-principles-of-ux) |
 | Steal Like an Artist | [Workman / Hachette](https://workman.com/titles/austin-kleon/steal-like-an-artist/9780761169253/) |
 | Show Your Work! | [Workman / Hachette](https://workman.com/titles/austin-kleon/show-your-work/9780761178972/) |

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -94,16 +94,18 @@ Current as of July 2026.
   fail closed with 503 while they are not.
   `docs/ama-booking-operations.md` is the environment and operations
   reference.
-- Rate limits use Upstash only in Production. Preview persists its limits in
-  the isolated Neon database, while Local and CI use process-local limits.
+- Rate limits use Upstash only in Production. Staging and Preview persist their
+  limits in isolated Neon databases, while Local and CI use process-local
+  limits.
 - GitHub Actions owns deployment ordering. `dev` migrates the persistent Neon
   `staging` branch before deploying Vercel Staging. Internal feature branches
   use persistent `preview/<git-branch>` children of Staging. Production lives
   in a separate Neon project; every commit reaching `main` automatically uses
   the `main`-only Production environment to migrate before deploying.
 - Security baseline controls from PR #97 remain mandatory: CSP and security
-  headers, same-origin mutation policy, rate limits, kill switches,
-  privacy-safe audit events, isolated credentials, and security automation.
+  headers, same-origin mutation policy, rate limits, credential-driven
+  fail-closed provider controls, privacy-safe audit events, isolated
+  credentials, and security automation.
 - Playwright is the browser release gate. Quality runs the complete production-
   build Chromium suite plus a WebKit smoke matrix, while Preview and Staging
   rerun the read-only hosted subset against the exact deployment URL.
@@ -121,7 +123,8 @@ Current as of July 2026.
   Text when none exists yet (upload-to-archive needs no review step; edits
   and regeneration remain available in the inspector). Location Label
   suggestions follow their provider credential.
-  Before deploying ADR-0013, set `BUNNY_MEDIA_ZONE`,
+  Before promoting the one-zone Media contract to Production, set
+  `BUNNY_MEDIA_ZONE`,
   `BUNNY_MEDIA_PASSWORD`, and `BUNNY_MEDIA_CDN_URL` from the existing
   Rendition zone, then add the two protected-path Edge Rules. Remove the old
   Original and Rendition variable names only after the new contract verifies.
@@ -133,8 +136,8 @@ Current as of July 2026.
 1. Preserve every legacy public URL through native content, a static archive,
    or an intentional permanent replacement. Drive verification from one
    checked-in manifest, not spot checks.
-2. Complete all three issue #91 stages: Cache Components baseline,
-   route-by-route Instant Navigations, then Partial Prefetching.
+2. Preserve the completed issue #91 baseline: Cache Components,
+   route-by-route Instant Navigations, and Partial Prefetching.
 3. Keep owner admin authenticated and reachable, and keep AMA capabilities
    whose provider credentials are absent failing closed with 503.
 4. Validate from a frozen-lockfile install: types, all tests, migrations,
@@ -233,17 +236,21 @@ The Vercel runtime receives only the CRUD-only `DATABASE_URL`. Never put
   always-required values (`ADMIN_EMAIL`, `AMA_ENCRYPTION_KEY`,
   `RATE_LIMIT_HASH_KEY`, `SITE_URL`, Bunny media) must be present.
 
-## Post-launch work
+## Current work queue
 
-- #93's passkey-first high-impact boundary was retired in July 2026
-  (maintainer decision): the owner admin has no step-up verification, and
-  passkeys remain only as the Clerk sign-in method. Hosted setup, session
-  revocation, and credential rotation stay documented in
-  `docs/security/clerk-admin-operations.md`. The public AMA product slices
-  (#82 through #87) are implemented and enabled by default; going live end
-  to end only needs the provider credential pairs and hosted checks in
-  `docs/ama-booking-operations.md`.
-- Revisit Bunny S3 preview constraints and provider capabilities before
-  expanding the Media Library beyond the curated photo workflow.
-- Re-enable private capabilities only after their provider, retention,
-  incident-response, and hosted-control checks are complete.
+GitHub Issues is the canonical planning surface. Refresh every issue's live
+assumptions immediately before implementation.
+
+1. #176 consolidates duplicated test infrastructure and CI ownership.
+2. #180 adds the committed Site Profile. #181 depends on it and makes the
+   Operator Stack optional per site without adding an environment kill switch.
+3. #182 depends on #180 and #181 and documents the supported fork workflow.
+4. #183 makes route-motion state explicit and fail-closed.
+5. #89, #94, and #95 remain needs-triage follow-ups for public accounts,
+   privacy, and incident-response operations.
+
+The retired #93 passkey boundary remains documented in
+`docs/security/clerk-admin-operations.md`. Revisit Bunny S3 preview constraints
+before expanding Media beyond curated photos, and configure private provider
+capabilities only after their retention, incident-response, and hosted-control
+checks are complete.

--- a/docs/media/ai-provider-policy.md
+++ b/docs/media/ai-provider-policy.md
@@ -16,7 +16,7 @@ generative editing.
 - Both model identifiers are server configuration and can be replaced without
   changing the application service.
 - This routing preserves model-level fallback but not provider-level outage
-  isolation; that tradeoff is accepted for the owner-only Staging feature.
+  isolation; that tradeoff is accepted for this owner-only Media capability.
 
 ## Data boundary
 

--- a/docs/media/bunny-live-release-gate.md
+++ b/docs/media/bunny-live-release-gate.md
@@ -25,3 +25,25 @@ same-origin browser upload protection, checks Rendition cache headers, then
 purges every object in a `finally` cleanup. Never point this environment at a
 production zone. A successful run is the release evidence for the Bunny S3
 preview, path protection, delivery, and permanent-deletion contract.
+
+## Public delivery checks
+
+After the storage contract passes, verify the exact deployed commit without
+using private provider or database output as evidence:
+
+1. Load `/photos`, `/en/photos`, and the homepage in both locales. They must use
+   one active Published Photo Selection with no static fallback.
+2. Confirm rendered media URLs use the configured Bunny CDN hostname, return
+   `image/jpeg`, and select responsive 640, 1024, 1600, and 2560 Renditions. An
+   expanded photo must use the largest available Rendition rather than enlarging
+   its tile source.
+3. Confirm HTML and public responses contain no Original or transfer-chunk key,
+   checksum, exact Capture Location, encrypted location, raw metadata, Alt Text
+   Suggestion, provider response, or private error.
+4. Check natural aspect ratios, Focal Point crops, keyboard and touch metadata,
+   reduced motion, and localized Alt Text.
+
+A failed Publish must leave the previous Published Photo Selection active.
+Interrupted ingestion must remain recoverable through reconciliation or the
+owner Resume processing action. Production database or cloud verification still
+requires two fresh explicit confirmations.

--- a/docs/media/photo-release-cutover.md
+++ b/docs/media/photo-release-cutover.md
@@ -1,8 +1,11 @@
-# Issue #96 photo release cutover
+# Historical issue #96 photo release cutover
 
-This cutover uses the owner Media Library and Photo Selection workflows. Do not
-merge the final local-photo cleanup until every delivery check below passes in
-the target environment.
+Status: completed in July 2026. This file preserves the two-photo migration
+inputs and the release boundary that removed the static fallback. It is not a
+current operating procedure. Current uploads use `/admin/media`, curation and
+publication use `/admin/photos`, and the active contract lives in
+`lib/media/CONTEXT.md`. Current storage and public-delivery release checks live
+in `docs/media/bunny-live-release-gate.md`.
 
 ## Fixed inputs
 
@@ -11,48 +14,27 @@ the target environment.
 | 1 | `IMG_7560.HEIC` | `88a49da230bb852105ed25e9135cd076d2d515810767a57f79839c6933fe4f49` |
 | 2 | `IMG_20250508_003134_Original.JPG` | `1825bebd811ee2ff341932b96967bd13a0102e1aec90a699af981eaec8991c51` |
 
-The files currently live in `~/Downloads`. The admin persists an unfinished
-upload's idempotency key by checksum until processing succeeds, so selecting
-the same Original after a browser or request interruption resumes the same
-Upload Intent instead of registering another asset.
+These were the fixed Originals used for the cutover. Their former local
+`~/Downloads` location was temporary and is not part of the repository or the
+current recovery contract.
 
-## Import and review
+## Completed outcome
 
-1. Confirm the deployment uses the intended non-production or production Neon
-   database and matching Bunny zones. Production database or cloud changes
-   require two explicit confirmations.
-2. Sign in to `/admin/media`, select both Originals together, and wait until
-   both Media Assets are Ready for review. Do not upload the prepared JPEGs as
-   Originals.
-3. Confirm all 640, 1024, 1600, and 2560 Renditions are progressive sRGB
-   JPEGs at quality 90 with 4:4:4 chroma and that their embedded metadata is
-   stripped. Confirm each Original remains readable only through the
-   authenticated server boundary.
-4. Review orientation, capture date, camera details, editable Location Labels,
-   and Focal Points. Generate or edit both Alt Text languages, then explicitly
-   approve the pair for each Media Asset.
-5. In `/admin/media#publish`, add only these two assets in the table order
-   above and verify the homepage preview. Publish once; a retry must use the
-   same idempotency key and Published Photo Selection revision.
+- Issue #96 is closed and its Media Library, ingestion, curation, and public
+  Photo Selection paths shipped.
+- `lib/photos.ts` and `public/images/photos/photo-{1..6}` were removed. Public
+  pages have no static photo fallback.
+- `/admin/media` owns upload-to-archive and asset editing. A first Alt Text
+  Suggestion auto-applies when approved Alt Text is absent; regeneration never
+  overwrites approved text.
+- `/admin/photos` owns Draft Photo Selection curation and publication.
+- New processing produces 640, 1024, 1600, and 2560 progressive sRGB JPEG
+  Renditions. Only Renditions are publicly deliverable.
 
-## Public delivery gate
+## Historical boundary
 
-1. Load `/photos` and the homepage in both locales. They must report two photos
-   from one Published Photo Selection revision with no static fallback.
-2. Verify each rendered URL uses the configured Bunny CDN hostname, returns
-   `image/jpeg`, and selects a responsive Rendition. Confirm all four profile
-   URLs deliver successfully before testing an expanded photo, and confirm the
-   lightbox requests the 2560 profile rather than enlarging its tile source.
-3. Confirm source HTML and public responses contain no Original key or URL,
-   checksum, exact coordinates, encrypted Capture Location, raw metadata, AI
-   suggestion, provider response, or private error.
-4. Check natural aspect ratios, Focal Point crops, keyboard and touch metadata,
-   reduced motion, and localized Alt Text.
-5. Record the successful Bunny live contract run and these read checks in the
-   release evidence. Only then merge the final cleanup that removes
-   `lib/photos.ts` and `public/images/photos/photo-{1..6}`.
-
-If any step fails, leave the prior deployment and local assets untouched. A
-failed Publish keeps the previous Published Photo Selection active, and an
-interrupted ingestion is recovered by the reconciliation job or the owner's
-Resume processing action.
+The cutover established that Originals, transfer chunks, checksums, exact
+Capture Locations, Alt Text Suggestions, provider payloads, and private errors
+do not enter public responses. It also established that a failed Publish keeps
+the previous Published Photo Selection active and interrupted ingestion remains
+recoverable. The current release gate preserves those guarantees.

--- a/docs/security/verification.md
+++ b/docs/security/verification.md
@@ -100,14 +100,19 @@ Project API checks refreshed on 2026-07-20 verified:
   remain fail closed.
 - [ ] Configure an isolated Preview Resend credential pair only when hosted AMA
   finalization and transactional email testing is required.
-- [ ] Apply migration `0010` to the Preview Neon branch and grant its runtime
-  role CRUD-only access to `rate_limit_windows`. This remote database check
-  requires two fresh confirmations. Preview unconditionally selects the
-  database limiter and has no Redis fallback; if the table or grants are
-  missing, protected admin mutations fail closed with 503.
+- [x] Internal Preview deployment run
+  [#29719376370](https://github.com/CaliCastle/cali.so/actions/runs/29719376370)
+  applied the reviewed migrations successfully before deploying its exact
+  commit. Preview workflows now apply all migrations automatically.
+- [ ] Verify the exact active Preview runtime role has CRUD-only access to
+  `rate_limit_windows`. This remote database check requires two fresh
+  confirmations. Preview unconditionally selects the database limiter and has
+  no Redis fallback; if the table or grants are missing, protected admin
+  mutations fail closed with 503.
 - [x] Every `KV_*`, `REDIS_URL`, and `UPSTASH_*` variable is absent from
   Preview. Redis is Production-only. The Preview runtime is configured to use
-  isolated Neon, but its migration and grants are not yet counted as verified.
+  isolated Neon. Automated migration ordering is verified; live runtime grants
+  are not yet counted as verified.
 - [ ] Remove the obsolete `Admin Security` challenge for the removed
   `POST /api/admin/auth/request` route.
 - [x] The dead `AMA_ADMIN_ENABLED` Preview variable is absent; the owner admin
@@ -128,7 +133,8 @@ Project API checks refreshed on 2026-07-20 verified:
   verified the public security boundary, all 13 hosted browser cases, and a
   signed-out `401` from `/api/admin/media/assets` rather than a server error.
 
-Clerk provider configuration and owner recovery remain tracked by issue #93.
-Signed-in owner operations and end-to-end checks for each configured external
-provider remain separate operational follow-ups; they are not deployment
-workflow blockers.
+Issue #93 is closed. Current Clerk provider configuration, owner recovery,
+session revocation, and credential rotation are documented in
+`docs/security/clerk-admin-operations.md`. Signed-in owner operations and
+end-to-end checks for each configured external provider remain separate
+operational follow-ups; they are not deployment workflow blockers.

--- a/docs/v3-cutover-ops-runbook.md
+++ b/docs/v3-cutover-ops-runbook.md
@@ -78,23 +78,26 @@ from the isolated `target/` working directory.
 
 ## 2. Require Quality and CodeQL on both branches
 
-The `dev` ruleset (`18920686`) already requires `Quality` and `CodeQL`
-alongside its deletion, non-fast-forward, and pull-request rules. Do not append
-a duplicate required-check rule.
+Both branches use active repository rulesets as the canonical protection
+source:
 
-Protect `main` as well (PUT replaces the whole protection object; force pushes
-and deletions stay disabled by default):
+- `dev`: ruleset `18920686`, `Protect dev integration`;
+- `main`: ruleset `19171463`, `Protect production`.
+
+Each ruleset requires pull requests, `Quality`, and `CodeQL`, and blocks branch
+deletion and non-fast-forward updates. Verify the live rulesets read-only:
 
 ```bash
-gh api -X PUT repos/CaliCastle/cali.so/branches/main/protection --input - <<'JSON'
-{
-  "required_status_checks": { "strict": false, "contexts": ["Quality", "CodeQL"] },
-  "enforce_admins": false,
-  "required_pull_request_reviews": null,
-  "restrictions": null
-}
-JSON
+gh api repos/CaliCastle/cali.so/rulesets/18920686 \
+  --jq '{name, enforcement, conditions, rules}'
+gh api repos/CaliCastle/cali.so/rulesets/19171463 \
+  --jq '{name, enforcement, conditions, rules}'
 ```
+
+Do not add legacy branch-protection settings on top of these rulesets or append
+duplicate required-check rules. Recreating or changing either ruleset is shared
+repository state and requires fresh confirmation plus a full before/after
+review of its conditions, bypass actors, and rules.
 
 ## 3. Isolate Staging, Preview, and Production credentials
 
@@ -110,15 +113,17 @@ JSON
   Redis store: Staging and Preview rate limits use their isolated Neon
   branches.
 
-- The first successful Staging workflow applies migrations `0010` and `0011`
-  with the separately scoped GitHub migration role before deployment. Verify
-  the Staging runtime role has only required CRUD access to
-  `rate_limit_windows` and the AMA booking tables; it must not own tables or
-  receive DDL privileges.
+- Staging and internal Preview workflows apply every reviewed migration in
+  `db/migrations/` with the separately scoped GitHub migration role before
+  deployment.
+  Verify the Staging runtime role has only required CRUD access to
+  `rate_limit_windows`, the AMA booking tables, and current Media tables; it
+  must not own tables or receive DDL privileges.
   Staging and Preview have no Redis fallback: if the table or grants are missing,
   rate-limited admin mutations fail closed with 503. Because the Redis
-  variables are already absent, do not count mutation checks as passed
-  until this migration and grant verification succeeds.
+  variables are already absent, a successful migration workflow proves
+  ordering but not the live runtime grants. Do not count mutation checks as
+  passed until the exact deployment and grant verification succeed.
 
 - Keep the non-production Clerk keys isolated to Preview and Staging. Never
   copy the Production Clerk secret into either environment.

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,21 +1,26 @@
-# Animation plans
+# Archived animation plans
+
+Plans 001 through 003 are completed implementation records. New work is tracked
+in GitHub Issues, which is the repository's canonical planning surface.
 
 | # | Plan | Severity | Status |
 | --- | --- | --- | --- |
 | 001 | [Let the desktop TOC finish closing](001-desktop-toc-close.md) | MEDIUM | DONE |
 | 002 | [Limit route motion to pointer-opened posts](002-limit-route-motion-to-post-pointers.md) | HIGH | DONE |
 | 003 | [Keep global chrome fixed during post transitions](003-keep-global-chrome-fixed.md) | MEDIUM | DONE |
-| 004 | [Prove route motion accessibility in the browser](004-prove-route-motion-accessibility.md) | MEDIUM | DONE |
+| 004 | Prove route motion accessibility in the browser | MEDIUM | RETIRED |
 
 ## Recommended execution order
 
 Plan 001 is complete.
 
-Plans 002 through 004 were completed in this order:
+Plans 002 and 003 were completed in this order:
 
 1. **002** establishes the input-modality contract: only primary pointer/touch
    post navigation may animate.
 2. **003** depends on 002 and moves the settled route focus treatment from the
    document root to route content while keeping global chrome fixed.
-3. **004** depends on 002 and 003. It adds real-browser proof for positive
-   pointer motion, keyboard navigation, reduced motion, and fixed chrome.
+
+Plan 004 and its original Playwright suite were removed in `932d321`. The
+current browser release gate was introduced separately in PR #193 and lives in
+`tests/browser/`; it is not the deleted plan 004 suite.


### PR DESCRIPTION
## Summary

- mark completed cutover and animation plans as historical records
- align security, Media, migration, and branch-protection guidance with the current v3 architecture
- add current public Media delivery checks and replace the broken Quarto source link
- refresh the handoff work queue and hosted verification evidence
- update canonical issue plans #176 and #180 through #183 in place with current ADR numbers, environment contracts, source references, and CI baselines

## Why

Release and planning documents had accumulated conflicting pre-cutover instructions. Some paths referenced retired admin surfaces, two-zone Bunny variables, outdated test counts, or legacy branch protection that could misdirect future maintenance work.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm test:unit` (119 files, 1,109 tests)
- `pnpm test:deployment` (31 tests)
- Markdown local-link, command, ADR-reference, and stale-pattern audits
- live GitHub ruleset verification for `dev` and `main`
- independent Standards and Spec reviews

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This documentation-only PR converts pre-cutover operating procedures into historical records and aligns planning/ops docs with the current v3 post-launch architecture. No application code, tests, or configuration files are changed.

- Marks ADR-0005, the animation plans README, and the #96 photo release cutover as completed historical artifacts; redirects readers to active surfaces (`bunny-live-release-gate.md`, `tests/browser/`, GitHub Issues).
- Replaces the legacy `PUT /branches/main/protection` branch-protection API call in the cutover runbook with read-only ruleset verification commands for the two active rulesets (18920686 / 19171463), and fixes a broken Quarto source link in `docs/asset-sources.md`.
- Promotes tracking of future work to GitHub Issues (#176, #180–#183, #89, #94, #95) and adds a new public delivery verification checklist to `docs/media/bunny-live-release-gate.md`.

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no application code, tests, or configuration touched; safe to merge.

Every changed file is a Markdown document. The most impactful operational change — swapping the legacy PUT /branches/main/protection API call for read-only gh api …/rulesets/… verification commands — accurately reflects the repository's active ruleset setup and removes a command that would have overwritten rulesets with a less capable legacy protection object. The Quarto URL fix replaces a broken image-API endpoint with a stable book-page URL. All historical documents are clearly labeled as such and redirect readers to their current replacements. No open logic, security boundary, or data-handling questions were introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/v3-cutover-ops-runbook.md | Replaced the deprecated legacy `PUT /branches/main/protection` call with read-only `gh api …/rulesets/{id}` verification commands; migration status language updated to reflect automated workflows. |
| docs/security/verification.md | Marks Preview migration run as completed (with linked Actions evidence), splits the former combined todo into a completed migration item and a still-open grant verification item, and closes out issue #93. |
| docs/handoff.md | Post-launch work section replaced with a numbered GitHub Issues work queue; rate-limit and security-baseline descriptions updated to match current Staging/Preview environment contract. |
| docs/media/bunny-live-release-gate.md | New 'Public delivery checks' section added with four numbered verification steps covering URL correctness, rendition selection, privacy boundary, and accessibility. |
| docs/media/photo-release-cutover.md | Converted from an active procedure document into a historical record; step-by-step instructions removed and replaced with a completed-outcome summary and historical boundary statement. |
| docs/adr/0005-next-16-3-preview-with-ship-gates.md | ADR reworded from future-tense gates to a historical record of the v3.0 decision, referencing ADR-0010 superseding the integration-branch name and noting the completed Production cutover. |
| plans/README.md | Renamed to 'Archived animation plans'; plan 004 link removed (file deleted in 932d321) and status changed to RETIRED; explicit note added pointing to the replacement suite in tests/browser/. |
| docs/asset-sources.md | Broken Quarto image-API URL replaced with the canonical book landing page URL. |
| SECURITY.md | Supported-versions statement updated to reflect that v3 now lives on main with integration work on dev and PR branches. |
| docs/media/ai-provider-policy.md | Single wording fix: 'owner-only Staging feature' → 'owner-only Media capability' to reflect the current scope of the AI provider tradeoff. |

<sub>Reviews (1): Last reviewed commit: ["docs: refresh repository plans"](https://github.com/calicastle/cali.so/commit/81ca7c2bad870b2fae145b1799dba388001dd91a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45563056)</sub>

<!-- /greptile_comment -->