### PR TITLE
Fix AMA availability and Calendar connection

### DIFF
--- a/app/admin/(protected)/ama/AvailabilityWindowForm.tsx
+++ b/app/admin/(protected)/ama/AvailabilityWindowForm.tsx
@@ -121,11 +121,12 @@ export function AvailabilityWindowForm({
           name="weekday"
           value={String(weekday)}
           onValueChange={(value) => setWeekday(Number(value))}
-          disabled={pending !== null}
+          readOnly={pending !== null}
         >
           <SelectTrigger
             aria-label={localize(locale, '星期', 'Day')}
             className="w-full"
+            disabled={pending !== null}
           />
           <SelectContent>
             {weekdays.map((option, index) => (
@@ -148,11 +149,12 @@ export function AvailabilityWindowForm({
         <Select
           name="start"
           defaultValue={formatMinute(availabilityWindow?.startMinute ?? 9 * 60)}
-          disabled={pending !== null}
+          readOnly={pending !== null}
         >
           <SelectTrigger
             aria-label={localize(locale, '开始时间', 'Start time')}
             className="w-full tabular-nums"
+            disabled={pending !== null}
           />
           <SelectContent>
             {startOptions.map((minute, index) => (
@@ -176,11 +178,12 @@ export function AvailabilityWindowForm({
         <Select
           name="end"
           defaultValue={formatMinute(availabilityWindow?.endMinute ?? 12 * 60)}
-          disabled={pending !== null}
+          readOnly={pending !== null}
         >
           <SelectTrigger
             aria-label={localize(locale, '结束时间', 'End time')}
             className="w-full tabular-nums"
+            disabled={pending !== null}
           />
           <SelectContent>
             {endOptions.map((minute, index) => (

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -13,6 +13,7 @@ import {
   useContext,
   type ComponentType,
   type ReactNode,
+  type ButtonHTMLAttributes,
   type HTMLAttributes,
 } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
@@ -70,6 +71,7 @@ interface SelectProps {
   defaultValue?: string;
   onValueChange?: (value: string) => void;
   disabled?: boolean;
+  readOnly?: boolean;
   name?: string;
   required?: boolean;
 }
@@ -107,6 +109,7 @@ function Select({
   defaultValue,
   onValueChange,
   disabled = false,
+  readOnly = false,
   name,
   required,
 }: SelectProps) {
@@ -140,6 +143,7 @@ function Select({
         onOpenChange={setOpen}
         items={items}
         disabled={disabled}
+        readOnly={readOnly}
         name={name}
         required={required}
         // Non-modal: the page keeps scrolling and the Positioner tracks the
@@ -189,7 +193,7 @@ const triggerVariants = cva(
 );
 
 interface SelectTriggerProps
-  extends Omit<HTMLAttributes<HTMLButtonElement>, "children">,
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children">,
     VariantProps<typeof triggerVariants> {
   icon?: SelectIcon;
   placeholder?: string;

--- a/lib/ama/admin/ama-settings.test.tsx
+++ b/lib/ama/admin/ama-settings.test.tsx
@@ -169,12 +169,18 @@ describe('AMA settings UI contract', () => {
     expect(new FormData(form).get('weekday')).toBe('5')
   })
 
-  it('supports keyboard-style submission with a stable pending state', () => {
+  it('keeps select values successful while a submission is pending', () => {
     const { container } = render(<AvailabilityWindowForm />)
     const form = container.querySelector('form')!
     form.addEventListener('submit', (event) => event.preventDefault())
 
     fireEvent.submit(form)
+
+    expect(Object.fromEntries(new FormData(form))).toMatchObject({
+      weekday: '1',
+      start: '09:00',
+      end: '12:00',
+    })
 
     const save = container.querySelector<HTMLButtonElement>('button[value="create"]')!
     expect(save.disabled).toBe(true)
@@ -184,7 +190,8 @@ describe('AMA settings UI contract', () => {
     )
     expect(fields.length).toBe(3)
     for (const field of fields) {
-      expect(field.disabled).toBe(true)
+      expect(field.disabled).toBe(false)
+      expect(field.readOnly).toBe(true)
     }
   })
 

--- a/lib/ama/google/client.test.ts
+++ b/lib/ama/google/client.test.ts
@@ -135,39 +135,6 @@ describe('Google Calendar provider', () => {
     ).rejects.toMatchObject({ code: 'denied_scope' })
   })
 
-  it('reads the connected identity from the primary Calendar resource', async () => {
-    const fetch = vi.fn(async () =>
-      Response.json({
-        id: 'owner@example.com',
-        summary: 'Cali Castle',
-        timeZone: 'Asia/Taipei',
-      }),
-    )
-    const client = createGoogleCalendarClient({
-      clientId: 'google-client-id',
-      clientSecret: 'google-client-secret',
-      fetch,
-      clock: { now: () => new Date('2026-07-14T04:00:00.000Z') },
-    })
-
-    const identity = await client.getPrimaryCalendarIdentity('access-token-value')
-
-    expect(identity).toEqual({
-      id: 'owner@example.com',
-      summary: 'Cali Castle',
-      timeZone: 'Asia/Taipei',
-    })
-    expect(fetch).toHaveBeenCalledWith(
-      'https://www.googleapis.com/calendar/v3/calendars/primary',
-      {
-        headers: {
-          Accept: 'application/json',
-          Authorization: 'Bearer access-token-value',
-        },
-      },
-    )
-  })
-
   it('refreshes an access token and computes its absolute expiry with the injected clock', async () => {
     const fetch = vi.fn(async () =>
       Response.json({ access_token: 'fresh-access-token', expires_in: 1800, token_type: 'Bearer' }),
@@ -384,22 +351,6 @@ describe('Google Calendar provider', () => {
     expect(String(error)).not.toContain('raw network detail')
   })
 
-  it('normalizes a Calendar API 401 as an expired or revoked connection', async () => {
-    const client = createGoogleCalendarClient({
-      clientId: 'google-client-id',
-      clientSecret: 'google-client-secret',
-      fetch: vi.fn(async () =>
-        Response.json({ error: { message: 'access-token-value is invalid' } }, { status: 401 }),
-      ),
-      clock: { now: () => new Date('2026-07-14T04:00:00.000Z') },
-    })
-
-    await expect(client.getPrimaryCalendarIdentity('access-token-value')).rejects.toMatchObject({
-      code: 'expired_or_revoked',
-      message: 'Google Calendar access expired or was revoked. Reconnect Google Calendar.',
-    })
-  })
-
   it('fails closed when Google returns a malformed token response', async () => {
     const client = createGoogleCalendarClient({
       clientId: 'google-client-id',
@@ -477,17 +428,4 @@ describe('Google Calendar provider', () => {
     expect(String(error)).not.toContain('raw-provider-outage-body')
   })
 
-  it('normalizes a structurally invalid Calendar response', async () => {
-    const client = createGoogleCalendarClient({
-      clientId: 'google-client-id',
-      clientSecret: 'google-client-secret',
-      fetch: vi.fn(async () => Response.json(null)),
-      clock: { now: () => new Date('2026-07-14T04:00:00.000Z') },
-    })
-
-    await expect(client.getPrimaryCalendarIdentity('access-token-value')).rejects.toMatchObject({
-      code: 'invalid_response',
-      message: 'Google Calendar returned an invalid response.',
-    })
-  })
 })

--- a/lib/ama/google/client.ts
+++ b/lib/ama/google/client.ts
@@ -54,12 +54,6 @@ type GoogleTokenResponse = {
   scope?: string
 }
 
-export type GoogleCalendarIdentity = {
-  id: string
-  summary: string
-  timeZone: string
-}
-
 export type GoogleBusyInterval = {
   start: string
   end: string
@@ -295,32 +289,6 @@ export function createGoogleCalendarClient(dependencies: GoogleCalendarClientDep
         expiresAt: new Date(
           dependencies.clock.now().getTime() + payload.expires_in * 1000,
         ),
-      }
-    },
-
-    async getPrimaryCalendarIdentity(accessToken: string): Promise<GoogleCalendarIdentity> {
-      const response = await request(`${GOOGLE_CALENDAR_API}/calendars/primary`, {
-        headers: {
-          Accept: 'application/json',
-          Authorization: `Bearer ${accessToken}`,
-        },
-      })
-      await assertCalendarResponse(response)
-      const payload = await readJson(response)
-      if (
-        !isRecord(payload) ||
-        typeof payload.id !== 'string' ||
-        !payload.id ||
-        typeof payload.summary !== 'string' ||
-        typeof payload.timeZone !== 'string' ||
-        !payload.timeZone
-      ) {
-        invalidResponse()
-      }
-      return {
-        id: payload.id,
-        summary: payload.summary,
-        timeZone: payload.timeZone,
       }
     },
 

--- a/lib/ama/google/service.test.ts
+++ b/lib/ama/google/service.test.ts
@@ -6,7 +6,6 @@ import { createSecretBox, type EncryptedSecretEnvelope } from '../secrets'
 import {
   GOOGLE_CALENDAR_SCOPES,
   GoogleCalendarError,
-  type GoogleCalendarIdentity,
 } from './client'
 import {
   createGoogleCalendarService,
@@ -97,14 +96,6 @@ function fixture() {
         expiresAt: new Date('2026-07-14T05:00:00.000Z'),
       }
     },
-    async getPrimaryCalendarIdentity(accessToken) {
-      calls.push(['identity', accessToken])
-      return {
-        id: 'owner@example.com',
-        summary: 'Cali Castle',
-        timeZone: 'Asia/Taipei',
-      } satisfies GoogleCalendarIdentity
-    },
     async refreshAccessToken(refreshToken) {
       calls.push(['refresh', refreshToken])
       return {
@@ -192,7 +183,7 @@ describe('Google Calendar connection service', () => {
     ])
   })
 
-  it('connects the primary calendar and stores only an encrypted refresh token', async () => {
+  it('connects with the granted event and free/busy scopes only', async () => {
     const f = fixture()
     await f.service.begin()
 
@@ -205,9 +196,9 @@ describe('Google Calendar connection service', () => {
     expect(result).toBe('connected')
     expect(f.connection).toMatchObject({
       status: 'connected',
-      calendarId: 'owner@example.com',
-      calendarEmail: 'owner@example.com',
-      calendarSummary: 'Cali Castle',
+      calendarId: 'primary',
+      calendarEmail: null,
+      calendarSummary: null,
       grantedScopes: [...GOOGLE_CALENDAR_SCOPES],
       lastErrorCode: null,
     })
@@ -220,6 +211,7 @@ describe('Google Calendar connection service', () => {
         redirectUri: new URL('https://cali.so/api/admin/ama/google/callback'),
       },
     ])
+    expect(f.calls).not.toContainEqual(['identity', 'access-token'])
   })
 
   it('rejects replayed OAuth state before exchanging another code', async () => {

--- a/lib/ama/google/service.ts
+++ b/lib/ama/google/service.ts
@@ -6,7 +6,6 @@ import type { EncryptedSecretEnvelope, createSecretBox } from '../secrets'
 import {
   GOOGLE_CALENDAR_SCOPES,
   GoogleCalendarError,
-  type GoogleCalendarIdentity,
 } from './client'
 
 const OAUTH_ATTEMPT_LIFETIME_MS = 10 * 60 * 1000
@@ -84,7 +83,6 @@ export interface GoogleCalendarProvider {
     refreshToken?: string
     expiresAt: Date
   }>
-  getPrimaryCalendarIdentity(accessToken: string): Promise<GoogleCalendarIdentity>
   refreshAccessToken(refreshToken: string): Promise<{
     accessToken?: string
     expiresAt: Date
@@ -114,10 +112,6 @@ export type GoogleConnectionResult =
   | 'expired'
   | 'revoked'
   | 'unavailable'
-
-function calendarEmail(identity: GoogleCalendarIdentity) {
-  return identity.id.includes('@') ? identity.id : null
-}
 
 function publicStatus(status: GoogleConnectionStatus | undefined): GoogleConnectionResult | 'disconnected' {
   if (!status || status === 'disconnected') return 'disconnected'
@@ -194,12 +188,11 @@ export function createGoogleCalendarService(dependencies: GoogleCalendarServiceD
         })
         if (!tokens.accessToken || !tokens.refreshToken) return 'unavailable'
 
-        const identity = await provider.getPrimaryCalendarIdentity(tokens.accessToken)
         await repository.saveConnection({
           status: 'connected',
-          calendarId: identity.id,
-          calendarEmail: calendarEmail(identity),
-          calendarSummary: identity.summary,
+          calendarId: 'primary',
+          calendarEmail: null,
+          calendarSummary: null,
           grantedScopes: [...GOOGLE_CALENDAR_SCOPES],
           refreshTokenEnvelope: secretBox.seal(
             tokens.refreshToken,


### PR DESCRIPTION
## Summary

- preserve Availability Window values while the native form submission is pending
- connect the primary Google Calendar without calling a metadata endpoint outside the granted scopes
- add regression coverage for both failures and remove the unused Calendar identity client surface

## Root cause

The availability selects became disabled during the submit event, before the browser serialized the form. Disabled controls were omitted, so every add request reached the server without a day or times.

The Google flow correctly requested event and free/busy access, but the callback then called `calendars.get`. Google does not allow that endpoint with either requested scope, so valid consent was incorrectly reported as missing permissions.

## Verification

- `pnpm typecheck`
- `pnpm test:ama` (608 tests and 7 migration checks)
- `pnpm test:unit` (1,106 tests)
- `git diff --check origin/dev...HEAD`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Two independent bugs are fixed: disabled selects were stripped from `FormData` before the server saw the availability window fields, and the OAuth callback called `GET /calendars/primary` — an endpoint outside the granted `calendar.events`/`calendar.freebusy` scopes — causing every valid consent to report as missing permissions.

- **Form fix**: `disabled` is moved from `<Select>` root (which marks the hidden input disabled) to `<SelectTrigger>` (visual lock only); `readOnly` on the root prevents the dropdown from opening while keeping the hidden input in `FormData`. `SelectTriggerProps` is updated to extend `ButtonHTMLAttributes` so the `disabled` prop type-checks correctly.
- **Google OAuth fix**: `getPrimaryCalendarIdentity` (and its `GoogleCalendarIdentity` type) is removed from both the client and the provider interface. The callback now writes `calendarId: 'primary'` with null email/summary and relies solely on the scope list returned by the token endpoint to detect denied permissions.
- **Tests**: regression tests for both failures are added; identity mock is removed from the service fixture; deleted client method tests are cleaned up.

<h3>Confidence Score: 4/5</h3>

Safe to merge — both fixes are narrowly scoped, backed by regression tests, and address root causes rather than symptoms.

Both changes are correct and well-tested. The only gap is that the connectedConnection test fixture still carries the old calendar identity fields, so the queryFreeBusy service path with calendarId: 'primary' (the only shape new connections will have) is not directly exercised. No production path is broken by this gap, but coverage of the actual post-fix state is incomplete.

lib/ama/google/service.test.ts — the connectedConnection fixture uses pre-fix calendarId/calendarEmail/calendarSummary values; worth updating to cover the queryFreeBusy path for calendarId: 'primary'.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/admin/(protected)/ama/AvailabilityWindowForm.tsx | Moves `disabled` from Select root to SelectTrigger and adds `readOnly` to Select root so hidden inputs remain in FormData during pending submission |
| components/ui/select.tsx | Adds `readOnly` prop to Select root and fixes SelectTriggerProps to extend ButtonHTMLAttributes so `disabled` is properly typed |
| lib/ama/google/client.ts | Removes getPrimaryCalendarIdentity and GoogleCalendarIdentity — the calendars.get endpoint is outside the calendar.events/freebusy scopes |
| lib/ama/google/service.ts | Drops getPrimaryCalendarIdentity from GoogleCalendarProvider interface; stores calendarId: 'primary' with null email/summary instead of fetching identity |
| lib/ama/google/service.test.ts | Removes identity mock from fixture and updates assertions; connectedConnection helper still uses old calendarId/calendarEmail/calendarSummary values, leaving queryFreeBusy untested for the new primary-alias path |
| lib/ama/google/client.test.ts | Removes tests for the deleted getPrimaryCalendarIdentity method; remaining coverage is unaffected |
| lib/ama/admin/ama-settings.test.tsx | Adds regression assertion that FormData contains weekday/start/end values during pending state, and verifies triggers are disabled but not excluded from form serialization |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant AvailabilityForm
    participant SelectRoot
    participant SelectTrigger
    participant GoogleOAuth
    participant TokenEndpoint
    participant CalendarAPI

    note over Browser,SelectTrigger: AMA Availability Form Fix
    Browser->>AvailabilityForm: submit
    AvailabilityForm->>SelectRoot: "readOnly=true (blocks open)"
    AvailabilityForm->>SelectTrigger: "disabled=true (visual lock)"
    note over SelectRoot: hidden input still enabled → included in FormData
    AvailabilityForm->>Browser: FormData includes weekday/start/end ✓

    note over GoogleOAuth,CalendarAPI: Google Calendar Connection Fix (before)
    GoogleOAuth->>TokenEndpoint: exchange code → tokens
    TokenEndpoint-->>GoogleOAuth: access_token + refresh_token
    GoogleOAuth->>CalendarAPI: GET /calendars/primary ❌ scope not granted
    CalendarAPI-->>GoogleOAuth: 403 insufficientPermissions
    GoogleOAuth-->>Browser: denied_scope (false positive)

    note over GoogleOAuth,CalendarAPI: Google Calendar Connection Fix (after)
    GoogleOAuth->>TokenEndpoint: exchange code → tokens
    TokenEndpoint-->>GoogleOAuth: access_token + refresh_token + scope
    GoogleOAuth->>GoogleOAuth: validate granted scopes ✓
    GoogleOAuth-->>Browser: "connected calendarId=primary"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant AvailabilityForm
    participant SelectRoot
    participant SelectTrigger
    participant GoogleOAuth
    participant TokenEndpoint
    participant CalendarAPI

    note over Browser,SelectTrigger: AMA Availability Form Fix
    Browser->>AvailabilityForm: submit
    AvailabilityForm->>SelectRoot: "readOnly=true (blocks open)"
    AvailabilityForm->>SelectTrigger: "disabled=true (visual lock)"
    note over SelectRoot: hidden input still enabled → included in FormData
    AvailabilityForm->>Browser: FormData includes weekday/start/end ✓

    note over GoogleOAuth,CalendarAPI: Google Calendar Connection Fix (before)
    GoogleOAuth->>TokenEndpoint: exchange code → tokens
    TokenEndpoint-->>GoogleOAuth: access_token + refresh_token
    GoogleOAuth->>CalendarAPI: GET /calendars/primary ❌ scope not granted
    CalendarAPI-->>GoogleOAuth: 403 insufficientPermissions
    GoogleOAuth-->>Browser: denied_scope (false positive)

    note over GoogleOAuth,CalendarAPI: Google Calendar Connection Fix (after)
    GoogleOAuth->>TokenEndpoint: exchange code → tokens
    TokenEndpoint-->>GoogleOAuth: access_token + refresh_token + scope
    GoogleOAuth->>GoogleOAuth: validate granted scopes ✓
    GoogleOAuth-->>Browser: "connected calendarId=primary"
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/ama/google/service.test.ts`, line 147-165 ([link](https://github.com/calicastle/cali.so/blob/df22e8617af2dda8ef0e0d811dffaf3dde147257/lib/ama/google/service.test.ts#L147-L165)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Test fixture doesn't reflect new connection shape**

   `connectedConnection` still stores `calendarId: 'owner@example.com'`, `calendarEmail: 'owner@example.com'`, and `calendarSummary: 'Cali Castle'`. Every post-PR connection stores `calendarId: 'primary'` with null email and summary instead. The `queryFreeBusy` tests therefore exercise a path (a pre-existing real email as `calendarId`) that production will never see again, leaving the actual `'primary'`-alias path untested through the service layer.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/ama/google/service.test.ts
   Line: 147-165

   Comment:
   **Test fixture doesn't reflect new connection shape**

   `connectedConnection` still stores `calendarId: 'owner@example.com'`, `calendarEmail: 'owner@example.com'`, and `calendarSummary: 'Cali Castle'`. Every post-PR connection stores `calendarId: 'primary'` with null email and summary instead. The `queryFreeBusy` tests therefore exercise a path (a pre-existing real email as `calendarId`) that production will never see again, leaving the actual `'primary'`-alias path untested through the service layer.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fama%2Fgoogle%2Fservice.test.ts%0ALine%3A%20147-165%0A%0AComment%3A%0A**Test%20fixture%20doesn't%20reflect%20new%20connection%20shape**%0A%0A%60connectedConnection%60%20still%20stores%20%60calendarId%3A%20'owner%40example.com'%60%2C%20%60calendarEmail%3A%20'owner%40example.com'%60%2C%20and%20%60calendarSummary%3A%20'Cali%20Castle'%60.%20Every%20post-PR%20connection%20stores%20%60calendarId%3A%20'primary'%60%20with%20null%20email%20and%20summary%20instead.%20The%20%60queryFreeBusy%60%20tests%20therefore%20exercise%20a%20path%20%28a%20pre-existing%20real%20email%20as%20%60calendarId%60%29%20that%20production%20will%20never%20see%20again%2C%20leaving%20the%20actual%20%60'primary'%60-alias%20path%20untested%20through%20the%20service%20layer.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=calicastle%2Fcali.so&pr=226&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22calicastle%2Fcali.so%22%20on%20the%20existing%20branch%20%22cali%2Ffix-ama-settings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cali%2Ffix-ama-settings%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fama%2Fgoogle%2Fservice.test.ts%0ALine%3A%20147-165%0A%0AComment%3A%0A**Test%20fixture%20doesn't%20reflect%20new%20connection%20shape**%0A%0A%60connectedConnection%60%20still%20stores%20%60calendarId%3A%20'owner%40example.com'%60%2C%20%60calendarEmail%3A%20'owner%40example.com'%60%2C%20and%20%60calendarSummary%3A%20'Cali%20Castle'%60.%20Every%20post-PR%20connection%20stores%20%60calendarId%3A%20'primary'%60%20with%20null%20email%20and%20summary%20instead.%20The%20%60queryFreeBusy%60%20tests%20therefore%20exercise%20a%20path%20%28a%20pre-existing%20real%20email%20as%20%60calendarId%60%29%20that%20production%20will%20never%20see%20again%2C%20leaving%20the%20actual%20%60'primary'%60-alias%20path%20untested%20through%20the%20service%20layer.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=calicastle%2Fcali.so&pr=226&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alib%2Fama%2Fgoogle%2Fservice.test.ts%3A147-165%0A**Test%20fixture%20doesn't%20reflect%20new%20connection%20shape**%0A%0A%60connectedConnection%60%20still%20stores%20%60calendarId%3A%20'owner%40example.com'%60%2C%20%60calendarEmail%3A%20'owner%40example.com'%60%2C%20and%20%60calendarSummary%3A%20'Cali%20Castle'%60.%20Every%20post-PR%20connection%20stores%20%60calendarId%3A%20'primary'%60%20with%20null%20email%20and%20summary%20instead.%20The%20%60queryFreeBusy%60%20tests%20therefore%20exercise%20a%20path%20%28a%20pre-existing%20real%20email%20as%20%60calendarId%60%29%20that%20production%20will%20never%20see%20again%2C%20leaving%20the%20actual%20%60'primary'%60-alias%20path%20untested%20through%20the%20service%20layer.%0A%0A&repo=calicastle%2Fcali.so&pr=226&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22calicastle%2Fcali.so%22%20on%20the%20existing%20branch%20%22cali%2Ffix-ama-settings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cali%2Ffix-ama-settings%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alib%2Fama%2Fgoogle%2Fservice.test.ts%3A147-165%0A**Test%20fixture%20doesn't%20reflect%20new%20connection%20shape**%0A%0A%60connectedConnection%60%20still%20stores%20%60calendarId%3A%20'owner%40example.com'%60%2C%20%60calendarEmail%3A%20'owner%40example.com'%60%2C%20and%20%60calendarSummary%3A%20'Cali%20Castle'%60.%20Every%20post-PR%20connection%20stores%20%60calendarId%3A%20'primary'%60%20with%20null%20email%20and%20summary%20instead.%20The%20%60queryFreeBusy%60%20tests%20therefore%20exercise%20a%20path%20%28a%20pre-existing%20real%20email%20as%20%60calendarId%60%29%20that%20production%20will%20never%20see%20again%2C%20leaving%20the%20actual%20%60'primary'%60-alias%20path%20untested%20through%20the%20service%20layer.%0A%0A&repo=calicastle%2Fcali.so&pr=226&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/ama/google/service.test.ts:147-165
**Test fixture doesn't reflect new connection shape**

`connectedConnection` still stores `calendarId: 'owner@example.com'`, `calendarEmail: 'owner@example.com'`, and `calendarSummary: 'Cali Castle'`. Every post-PR connection stores `calendarId: 'primary'` with null email and summary instead. The `queryFreeBusy` tests therefore exercise a path (a pre-existing real email as `calendarId`) that production will never see again, leaving the actual `'primary'`-alias path untested through the service layer.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ama): restore settings mutations"](https://github.com/calicastle/cali.so/commit/df22e8617af2dda8ef0e0d811dffaf3dde147257) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45574513)</sub>

<!-- /greptile_comment -->