### PR TITLE
Add locale suggestion banner

### DIFF
--- a/app/_components/site-document.tsx
+++ b/app/_components/site-document.tsx
@@ -7,6 +7,7 @@ import { Suspense } from 'react'
 import { AmbientBackground } from '~/components/ambient-background'
 import { Dock, DockFallback } from '~/components/dock'
 import { LocaleRestorer } from '~/components/locale-restorer'
+import { LocaleSuggestion } from '~/components/locale-suggestion'
 import { PreviewCardTimingProvider } from '~/components/preview-card-timing'
 import {
   RouteMotionController,
@@ -93,6 +94,9 @@ export async function SiteDocument({
         <ThemeProvider>
           <PreviewCardTimingProvider>
             <RouteMotionController />
+            <Suspense fallback={null}>
+              <LocaleSuggestion locale={locale} />
+            </Suspense>
             {restoreLocale && <LocaleRestorer />}
             <AmbientBackground />
             <div className="flex min-h-screen flex-col pb-20">

--- a/app/globals.css
+++ b/app/globals.css
@@ -4527,6 +4527,83 @@ a:focus-visible .external-label .external-mark {
   }
 }
 
+/* ── Locale suggestion: a fixed instrument strip ─────────────────── */
+
+.locale-suggestion-positioner {
+  position: fixed;
+  z-index: var(--z-toast);
+  top: calc(env(safe-area-inset-top) + 0.75rem);
+  left: 50%;
+  width: min(37.5rem, calc(100vw - 1.5rem));
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.locale-suggestion {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.5rem 1rem;
+  min-height: 3.5rem;
+  padding: 0.625rem 0.75rem;
+  border-radius: 2px;
+  outline: var(--border-hairline) solid var(--border);
+  outline-offset: calc(-1 * var(--border-hairline));
+  pointer-events: auto;
+  animation: locale-suggestion-enter 150ms var(--ease-swift) backwards;
+}
+
+.locale-suggestion-copy {
+  font-size: 0.875rem;
+  line-height: 1.5;
+  letter-spacing: -0.011em;
+}
+
+.locale-suggestion-actions {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.25rem;
+}
+
+.locale-suggestion-actions :is(a, button) {
+  font-size: 0.875rem;
+}
+
+@keyframes locale-suggestion-enter {
+  from {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 39.999rem) {
+  .locale-suggestion {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .locale-suggestion-actions {
+    justify-content: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .locale-suggestion,
+  .locale-suggestion :where(a, button, [aria-hidden]) {
+    animation: none;
+    transition: none;
+  }
+
+  .locale-suggestion :is(a, button):active > [aria-hidden] {
+    transform: none;
+  }
+}
+
 /* ── Bilingual chrome (lib/i18n.tsx) — CSS-swapped, no hydration ────
    Public routes render a single language per segment, so only the inline
    [data-zh]/[data-en] pair from <T> appears there. The block variant

--- a/app/site-document.test.tsx
+++ b/app/site-document.test.tsx
@@ -30,6 +30,11 @@ vi.mock('~/components/dock', () => ({
 vi.mock('~/components/locale-restorer', () => ({
   LocaleRestorer: () => null,
 }))
+vi.mock('~/components/locale-suggestion', () => ({
+  LocaleSuggestion: ({ locale }: { locale: 'zh' | 'en' }) => (
+    <span data-locale-suggestion={locale} />
+  ),
+}))
 vi.mock('~/components/preview-card-timing', () => ({
   PreviewCardTimingProvider: ({ children }: { children: React.ReactNode }) => (
     <div data-public-preview-cards="">{children}</div>
@@ -94,6 +99,7 @@ describe('SiteDocument analytics', () => {
       expect(html).toContain('data-public-footer')
       expect(html).toContain('data-public-route-transition')
       expect(html).toContain('data-public-preview-cards')
+      expect(html).toContain(`data-locale-suggestion="${locale}"`)
     }
   })
 
@@ -112,6 +118,7 @@ describe('SiteDocument analytics', () => {
     expect(html).not.toContain('data-public-route-motion')
     expect(html).not.toContain('data-public-route-transition')
     expect(html).not.toContain('data-public-preview-cards')
+    expect(html).not.toContain('data-locale-suggestion')
     expect(html).toContain('Owner admin')
     // The admin shares the warm working-paper palette (July 2026 decision)
     // while staying outside analytics and social reads.

--- a/components/locale-suggestion.test.tsx
+++ b/components/locale-suggestion.test.tsx
@@ -1,0 +1,144 @@
+/** @vitest-environment jsdom */
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const navigation = vi.hoisted(() => ({ pathname: '/ama' }))
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => navigation.pathname,
+  useSearchParams: () => new URLSearchParams(window.location.search),
+}))
+
+import { LocaleSuggestion } from './locale-suggestion'
+
+function setBrowserLanguages(languages: string[]) {
+  Object.defineProperty(window.navigator, 'languages', {
+    configurable: true,
+    value: languages,
+  })
+}
+
+describe('LocaleSuggestion', () => {
+  beforeEach(() => {
+    navigation.pathname = '/ama'
+    window.history.replaceState({}, '', '/ama')
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('offers English when the browser prefers English on a Chinese route', async () => {
+    setBrowserLanguages(['en-US', 'en'])
+
+    render(<LocaleSuggestion locale="zh" />)
+
+    expect(
+      (await screen.findByRole('region', { name: 'Language suggestion' }))
+        .textContent,
+    ).toContain('Would you prefer to view this page in English?')
+    expect(
+      screen.getByRole('link', { name: 'View in English' }).getAttribute('href'),
+    ).toBe('/en/ama')
+  })
+
+  it('prefers a saved site language over the browser language', async () => {
+    navigation.pathname = '/en/ama'
+    window.history.replaceState({}, '', '/en/ama')
+    window.localStorage.locale = 'zh'
+    setBrowserLanguages(['en-US'])
+
+    render(<LocaleSuggestion locale="en" />)
+
+    expect(
+      (await screen.findByRole('region', { name: '语言建议' })).textContent,
+    ).toContain('是否切换到中文浏览？')
+    expect(
+      screen.getByRole('link', { name: '切换到中文' }).getAttribute('href'),
+    ).toBe('/ama')
+  })
+
+  it('remembers the current language when the visitor chooses to stay', async () => {
+    setBrowserLanguages(['en-US'])
+    render(<LocaleSuggestion locale="zh" />)
+
+    fireEvent.click(await screen.findByRole('button', { name: '继续使用中文' }))
+
+    expect(window.localStorage.locale).toBe('zh')
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('region', { name: 'Language suggestion' }),
+      ).toBeNull()
+    })
+  })
+
+  it('preserves the URL and remembers the language when switching', async () => {
+    window.history.replaceState({}, '', '/ama?source=newsletter#details')
+    setBrowserLanguages(['en-GB'])
+    render(<LocaleSuggestion locale="zh" />)
+
+    const switchLink = await screen.findByRole('link', {
+      name: 'View in English',
+    })
+    switchLink.addEventListener('click', (event) => event.preventDefault())
+
+    expect(switchLink.getAttribute('href')).toBe(
+      '/en/ama?source=newsletter#details',
+    )
+    fireEvent.click(switchLink)
+    expect(window.localStorage.locale).toBe('en')
+  })
+
+  it('keeps the destination current after a hash-only navigation', async () => {
+    setBrowserLanguages(['en-US'])
+    render(<LocaleSuggestion locale="zh" />)
+
+    const switchLink = await screen.findByRole('link', {
+      name: 'View in English',
+    })
+    window.history.replaceState({}, '', '/ama#pricing')
+    fireEvent(window, new HashChangeEvent('hashchange'))
+
+    await waitFor(() => {
+      expect(switchLink.getAttribute('href')).toBe('/en/ama#pricing')
+    })
+  })
+
+  it('recognizes Chinese browser language variants', async () => {
+    navigation.pathname = '/en/projects'
+    window.history.replaceState({}, '', '/en/projects')
+    setBrowserLanguages(['zh-Hant-HK', 'en-US'])
+
+    render(<LocaleSuggestion locale="en" />)
+
+    expect(
+      (await screen.findByRole('region', { name: '语言建议' })).textContent,
+    ).toContain('是否切换到中文浏览？')
+  })
+
+  it('ignores unsupported browser languages', () => {
+    setBrowserLanguages(['ja-JP', 'fr-FR'])
+
+    render(<LocaleSuggestion locale="zh" />)
+
+    expect(screen.queryByRole('region')).toBeNull()
+  })
+
+  it('does not prompt when the saved preference matches the route', () => {
+    window.localStorage.locale = 'zh'
+    setBrowserLanguages(['en-US'])
+
+    render(<LocaleSuggestion locale="zh" />)
+
+    expect(screen.queryByRole('region')).toBeNull()
+  })
+})

--- a/components/locale-suggestion.test.tsx
+++ b/components/locale-suggestion.test.tsx
@@ -13,7 +13,6 @@ const navigation = vi.hoisted(() => ({ pathname: '/ama' }))
 
 vi.mock('next/navigation', () => ({
   usePathname: () => navigation.pathname,
-  useSearchParams: () => new URLSearchParams(window.location.search),
 }))
 
 import { LocaleSuggestion } from './locale-suggestion'
@@ -47,8 +46,8 @@ describe('LocaleSuggestion', () => {
         .textContent,
     ).toContain('Would you prefer to view this page in English?')
     expect(
-      screen.getByRole('link', { name: 'View in English' }).getAttribute('href'),
-    ).toBe('/en/ama')
+      screen.getByRole('button', { name: 'View in English' }),
+    ).not.toBeNull()
   })
 
   it('prefers a saved site language over the browser language', async () => {
@@ -63,8 +62,8 @@ describe('LocaleSuggestion', () => {
       (await screen.findByRole('region', { name: '语言建议' })).textContent,
     ).toContain('是否切换到中文浏览？')
     expect(
-      screen.getByRole('link', { name: '切换到中文' }).getAttribute('href'),
-    ).toBe('/ama')
+      screen.getByRole('button', { name: '切换到中文' }),
+    ).not.toBeNull()
   })
 
   it('remembers the current language when the visitor chooses to stay', async () => {
@@ -81,36 +80,16 @@ describe('LocaleSuggestion', () => {
     })
   })
 
-  it('preserves the URL and remembers the language when switching', async () => {
+  it('remembers the language when switching', async () => {
     window.history.replaceState({}, '', '/ama?source=newsletter#details')
     setBrowserLanguages(['en-GB'])
     render(<LocaleSuggestion locale="zh" />)
 
-    const switchLink = await screen.findByRole('link', {
+    const switchButton = await screen.findByRole('button', {
       name: 'View in English',
     })
-    switchLink.addEventListener('click', (event) => event.preventDefault())
-
-    expect(switchLink.getAttribute('href')).toBe(
-      '/en/ama?source=newsletter#details',
-    )
-    fireEvent.click(switchLink)
+    fireEvent.click(switchButton)
     expect(window.localStorage.locale).toBe('en')
-  })
-
-  it('keeps the destination current after a hash-only navigation', async () => {
-    setBrowserLanguages(['en-US'])
-    render(<LocaleSuggestion locale="zh" />)
-
-    const switchLink = await screen.findByRole('link', {
-      name: 'View in English',
-    })
-    window.history.replaceState({}, '', '/ama#pricing')
-    fireEvent(window, new HashChangeEvent('hashchange'))
-
-    await waitFor(() => {
-      expect(switchLink.getAttribute('href')).toBe('/en/ama#pricing')
-    })
   })
 
   it('recognizes Chinese browser language variants', async () => {
@@ -140,5 +119,25 @@ describe('LocaleSuggestion', () => {
     render(<LocaleSuggestion locale="zh" />)
 
     expect(screen.queryByRole('region')).toBeNull()
+  })
+
+  it('ignores cross-tab storage changes for unrelated keys', async () => {
+    setBrowserLanguages(['ja-JP'])
+    render(<LocaleSuggestion locale="zh" />)
+    window.localStorage.locale = 'en'
+
+    fireEvent(
+      window,
+      new StorageEvent('storage', { key: 'theme', newValue: 'dark' }),
+    )
+    expect(screen.queryByRole('region')).toBeNull()
+
+    fireEvent(
+      window,
+      new StorageEvent('storage', { key: 'locale', newValue: 'en' }),
+    )
+    expect(
+      await screen.findByRole('region', { name: 'Language suggestion' }),
+    ).not.toBeNull()
   })
 })

--- a/components/locale-suggestion.tsx
+++ b/components/locale-suggestion.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { usePathname, useSearchParams } from 'next/navigation'
+import { useEffect, useState } from 'react'
+
+import { Button } from '~/components/ui/button'
+import { Elevated } from '~/lib/elevated'
+import { localePath, type Locale } from '~/lib/locale-route'
+
+const SUGGESTION_COPY = {
+  zh: {
+    regionLabel: '语言建议',
+    message: '是否切换到中文浏览？',
+    switchLabel: '切换到中文',
+    stayLabel: 'Continue in English',
+    language: 'zh-CN',
+    stayLanguage: 'en',
+  },
+  en: {
+    regionLabel: 'Language suggestion',
+    message: 'Would you prefer to view this page in English?',
+    switchLabel: 'View in English',
+    stayLabel: '继续使用中文',
+    language: 'en',
+    stayLanguage: 'zh-CN',
+  },
+} as const satisfies Record<
+  Locale,
+  {
+    regionLabel: string
+    message: string
+    switchLabel: string
+    stayLabel: string
+    language: string
+    stayLanguage: string
+  }
+>
+
+function supportedLocale(language: string): Locale | null {
+  const base = language.trim().toLowerCase().split('-')[0]
+  return base === 'zh' || base === 'en' ? base : null
+}
+
+function savedLocale(): Locale | null {
+  try {
+    return supportedLocale(localStorage.locale ?? '')
+  } catch {
+    return null
+  }
+}
+
+function rememberLocale(locale: Locale) {
+  try {
+    localStorage.locale = locale
+  } catch {
+    /* Private browsing can make storage unavailable. */
+  }
+}
+
+export function LocaleSuggestion({ locale }: { locale: Locale }) {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const [suggestedLocale, setSuggestedLocale] = useState<Locale | null>(null)
+  const [hash, setHash] = useState('')
+
+  useEffect(() => {
+    const resolveSuggestion = () => {
+      const languages = navigator.languages.length
+        ? navigator.languages
+        : [navigator.language]
+      const preferred =
+        savedLocale() ??
+        languages
+          .map(supportedLocale)
+          .find((candidate): candidate is Locale => candidate !== null)
+      setSuggestedLocale(preferred && preferred !== locale ? preferred : null)
+    }
+
+    resolveSuggestion()
+    window.addEventListener('storage', resolveSuggestion)
+    return () => window.removeEventListener('storage', resolveSuggestion)
+  }, [locale])
+
+  useEffect(() => {
+    const updateHash = () => setHash(window.location.hash)
+    updateHash()
+    window.addEventListener('hashchange', updateHash)
+    return () => window.removeEventListener('hashchange', updateHash)
+  }, [])
+
+  if (!suggestedLocale) return null
+
+  const copy = SUGGESTION_COPY[suggestedLocale]
+  // useSearchParams keeps this render current, while location.search retains
+  // the browser's exact escaping and parameter order for the full navigation.
+  const search = searchParams.toString() ? window.location.search : ''
+  const currentPath = `${pathname}${search}${hash}`
+  const stay = () => {
+    rememberLocale(locale)
+    setSuggestedLocale(null)
+  }
+
+  return (
+    <div className="locale-suggestion-positioner">
+      <Elevated
+        offset={2}
+        shadowLevel={3}
+        role="region"
+        aria-label={copy.regionLabel}
+        aria-live="polite"
+        aria-atomic="true"
+        lang={copy.language}
+        data-locale-suggestion={suggestedLocale}
+        className="locale-suggestion"
+      >
+        <p className="locale-suggestion-copy">{copy.message}</p>
+        <div className="locale-suggestion-actions">
+          <Button asChild size="lg" expandHitArea>
+            <a
+              href={localePath(suggestedLocale, currentPath)}
+              onClick={() => rememberLocale(suggestedLocale)}
+            >
+              {copy.switchLabel}
+            </a>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="lg"
+            expandHitArea
+            lang={copy.stayLanguage}
+            onClick={stay}
+          >
+            {copy.stayLabel}
+          </Button>
+        </div>
+      </Elevated>
+    </div>
+  )
+}

--- a/components/locale-suggestion.tsx
+++ b/components/locale-suggestion.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { usePathname, useSearchParams } from 'next/navigation'
+import { usePathname } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
 import { Button } from '~/components/ui/button'
@@ -59,9 +59,7 @@ function rememberLocale(locale: Locale) {
 
 export function LocaleSuggestion({ locale }: { locale: Locale }) {
   const pathname = usePathname()
-  const searchParams = useSearchParams()
   const [suggestedLocale, setSuggestedLocale] = useState<Locale | null>(null)
-  const [hash, setHash] = useState('')
 
   useEffect(() => {
     const resolveSuggestion = () => {
@@ -77,24 +75,22 @@ export function LocaleSuggestion({ locale }: { locale: Locale }) {
     }
 
     resolveSuggestion()
-    window.addEventListener('storage', resolveSuggestion)
-    return () => window.removeEventListener('storage', resolveSuggestion)
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === 'locale' || event.key === null) resolveSuggestion()
+    }
+    window.addEventListener('storage', onStorage)
+    return () => window.removeEventListener('storage', onStorage)
   }, [locale])
-
-  useEffect(() => {
-    const updateHash = () => setHash(window.location.hash)
-    updateHash()
-    window.addEventListener('hashchange', updateHash)
-    return () => window.removeEventListener('hashchange', updateHash)
-  }, [])
 
   if (!suggestedLocale) return null
 
   const copy = SUGGESTION_COPY[suggestedLocale]
-  // useSearchParams keeps this render current, while location.search retains
-  // the browser's exact escaping and parameter order for the full navigation.
-  const search = searchParams.toString() ? window.location.search : ''
-  const currentPath = `${pathname}${search}${hash}`
+  const switchLocale = () => {
+    rememberLocale(suggestedLocale)
+    // Assigning only pathname keeps the browser-owned query and fragment while
+    // localePath validates that the destination remains a local route.
+    window.location.pathname = localePath(suggestedLocale, pathname)
+  }
   const stay = () => {
     rememberLocale(locale)
     setSuggestedLocale(null)
@@ -115,13 +111,13 @@ export function LocaleSuggestion({ locale }: { locale: Locale }) {
       >
         <p className="locale-suggestion-copy">{copy.message}</p>
         <div className="locale-suggestion-actions">
-          <Button asChild size="lg" expandHitArea>
-            <a
-              href={localePath(suggestedLocale, currentPath)}
-              onClick={() => rememberLocale(suggestedLocale)}
-            >
-              {copy.switchLabel}
-            </a>
+          <Button
+            type="button"
+            size="lg"
+            expandHitArea
+            onClick={switchLocale}
+          >
+            {copy.switchLabel}
           </Button>
           <Button
             type="button"

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -714,6 +714,18 @@ restoration. Locale-sensitive attributes derive from the route so accessible
 names never mix languages, and server metadata, canonical links, feeds, and OG
 images share the same route identity.
 
+On a public route, a saved site preference takes priority; without one, the
+first supported language in `navigator.languages` becomes the preference. If
+that resolved preference differs from the explicit route, one fixed top-center
+instrument strip offers the equivalent route. The suggestion speaks in the
+offered language, preserves the path, query, and fragment, and requires an
+explicit choice: switch, or stay in the current language. Either choice becomes
+the saved site preference; unsupported browser languages produce no prompt.
+The strip uses the surface ladder, 2px print-register corner, compact chrome
+type, existing button hierarchy, and `--z-toast`. It never redirects
+automatically, never shifts layout or steals focus, and disables its brief
+transform-and-opacity entrance under reduced motion.
+
 Each post keeps its Chinese source in `index.mdx` and a complete English
 translation in `index.en.mdx`. The matching route renders only that source and
 its document minimap; English heading IDs retain their `en-` prefix for stable


### PR DESCRIPTION
## Summary

- suggest the matching Chinese or English route from the saved site preference, then the browser language
- preserve the current path, query, and fragment while remembering switch and stay choices
- add a fixed industrial-language prompt with responsive, dark-mode, reduced-motion, and accessibility behavior
- document the locale suggestion contract and cover it with focused integration tests

## Validation

- `pnpm typecheck`
- `pnpm test:unit` (1,117 tests)
- `pnpm test:localization` (148 checks)
- `pnpm build` with the repository's CI fixture environment
- desktop and mobile browser visual checks
- standards and specification review

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a fixed top-center locale-suggestion banner that detects the visitor's preferred language (saved site preference first, then `navigator.languages`) and offers to switch to the matching route when the current locale doesn't align.

- **`components/locale-suggestion.tsx`** — new `'use client'` component that resolves a suggestion on mount, listens for `'locale'`-keyed storage events for cross-tab sync, and exposes switch/stay actions that both persist the choice to `localStorage` before acting.
- **`app/_components/site-document.tsx`** — mounts `<LocaleSuggestion>` inside a `Suspense` boundary on the public code path only; the admin path is correctly excluded.
- **`app/globals.css`** — adds the positioner, grid layout, entrance animation, responsive breakpoint, and `prefers-reduced-motion` overrides for the strip.
- **`components/locale-suggestion.test.tsx`** — integration tests covering browser-language detection, saved-preference priority, Chinese variant recognition, stay/switch persistence, and cross-tab storage filtering.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the banner is client-only, never redirects automatically, writes only to localStorage, and is absent from the admin path.

All changed paths are additive and self-contained: the client component owns its own state and cleanup, the storage listener is scoped to the locale key, and the CSS uses isolated class names with proper reduced-motion and responsive overrides. No server data paths, database writes, or auth boundaries are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| components/locale-suggestion.tsx | New client component that reads navigator.languages and localStorage to resolve a locale suggestion, renders a fixed banner, and handles switch/stay interactions; logic is correct and side effects are properly cleaned up. |
| components/locale-suggestion.test.tsx | Integration tests covering the full suggestion lifecycle — browser-lang detection, saved-preference priority, stay/switch persistence, Chinese variant recognition, and cross-tab storage filtering. |
| app/_components/site-document.tsx | Mounts LocaleSuggestion inside a Suspense boundary on the public code path only; admin path is correctly excluded. |
| app/globals.css | Adds fixed positioner, grid layout, entrance animation, responsive breakpoint, and prefers-reduced-motion overrides for the suggestion strip. |
| app/site-document.test.tsx | Extends existing SiteDocument tests: verifies the mock LocaleSuggestion renders on public routes and is absent on the admin path. |
| docs/design-language.md | Documents the locale suggestion contract: priority order, path preservation, explicit-choice requirement, surface/z-index values, and reduced-motion behaviour. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Component mounts\nuseEffect runs] --> B[Read navigator.languages]
    B --> C{savedLocale\nin localStorage?}
    C -- yes --> D[preferred = savedLocale]
    C -- no --> E[preferred = first supported\nbrowser language]
    D --> F{preferred !== current locale?}
    E --> F
    F -- no --> G[No banner shown]
    F -- yes --> H[setSuggestedLocale\nBanner renders]
    H --> I{User action}
    I -- Switch --> J[rememberLocale suggestedLocale\nwindow.location.pathname = localePath]
    I -- Stay --> K[rememberLocale currentLocale\nsetSuggestedLocale null\nBanner dismissed]
    L[StorageEvent key === locale] --> A
    M[locale prop changes] --> A
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Component mounts\nuseEffect runs] --> B[Read navigator.languages]
    B --> C{savedLocale\nin localStorage?}
    C -- yes --> D[preferred = savedLocale]
    C -- no --> E[preferred = first supported\nbrowser language]
    D --> F{preferred !== current locale?}
    E --> F
    F -- no --> G[No banner shown]
    F -- yes --> H[setSuggestedLocale\nBanner renders]
    H --> I{User action}
    I -- Switch --> J[rememberLocale suggestedLocale\nwindow.location.pathname = localePath]
    I -- Stay --> K[rememberLocale currentLocale\nsetSuggestedLocale null\nBanner dismissed]
    L[StorageEvent key === locale] --> A
    M[locale prop changes] --> A
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix: address locale suggestion reviews"](https://github.com/calicastle/cali.so/commit/6b7d9ad5a762662a6f6f288af0e7e4e012d32cb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45575759)</sub>

<!-- /greptile_comment -->