### PR TITLE
style(ama): soften conversation shader

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6142,13 +6142,13 @@ html[data-locale='en'] [data-en-block] {
 
 .ama-introduction-stage[data-shader-ready='true']
   .ama-conversation-shader-layer {
-  opacity: 0.1;
+  opacity: 0.06;
 }
 
 .dark
   .ama-introduction-stage[data-shader-ready='true']
   .ama-conversation-shader-layer {
-  opacity: 0.12;
+  opacity: 0.075;
 }
 
 .ama-introduction-content {


### PR DESCRIPTION
## Summary

- reduce the AMA introduction shader opacity in light and dark appearances
- keep the static fallback, shader motion, and lifecycle behavior unchanged

## Why

The conversation field was competing too strongly with the introduction content. Lowering the layer opacity keeps the shader present while making it a quieter ambient texture.

## Validation

- `pnpm exec vitest run components/ama/ama-introduction-stage.test.tsx`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces the opacity of the AMA conversation shader layer in both light and dark mode to make it a quieter ambient texture behind the introduction content.

- Light mode opacity lowered from `0.1` to `0.06` on `.ama-conversation-shader-layer` when `data-shader-ready='true'`.
- Dark mode opacity lowered from `0.12` to `0.075` under the same condition.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is two CSS opacity values reduced to soften the shader overlay, with no logic, layout, or accessibility implications.

Only two numeric CSS opacity values are touched. The static fallback, transition behavior, reduced-motion handling, and dark mode selectors are all left intact. There is nothing here that could break rendering or introduce regressions.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/globals.css | Two opacity values for `.ama-conversation-shader-layer` reduced (light: 0.1→0.06, dark: 0.12→0.075); no other behavior changed. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AMA Introduction Stage] --> B{data-shader-ready?}
    B -- false --> C[.ama-conversation-static visible
.ama-conversation-shader-layer opacity: 0]
    B -- true --> D{Dark mode?}
    D -- No --> E[.ama-conversation-shader-layer
opacity: 0.06 was 0.1]
    D -- Yes --> F[.ama-conversation-shader-layer
opacity: 0.075 was 0.12]
    E --> G[prefers-reduced-motion?]
    F --> G
    G -- Yes --> H[shader-layer hidden, static fallback
no transition]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[AMA Introduction Stage] --> B{data-shader-ready?}
    B -- false --> C[.ama-conversation-static visible
.ama-conversation-shader-layer opacity: 0]
    B -- true --> D{Dark mode?}
    D -- No --> E[.ama-conversation-shader-layer
opacity: 0.06 was 0.1]
    D -- Yes --> F[.ama-conversation-shader-layer
opacity: 0.075 was 0.12]
    E --> G[prefers-reduced-motion?]
    F --> G
    G -- Yes --> H[shader-layer hidden, static fallback
no transition]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["style(ama): soften conversation shader"](https://github.com/calicastle/cali.so/commit/8c48d8d604741a06967c5bb5fd83cb6170af6b4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45582980)</sub>

<!-- /greptile_comment -->