### PR TITLE
Overhaul Media upload, archive, and purge workflows

### DIFF
--- a/app/admin/(protected)/media/MediaLibrary.tsx
+++ b/app/admin/(protected)/media/MediaLibrary.tsx
@@ -5,22 +5,31 @@ import {
   useMemo,
   useRef,
   useState,
-  type ChangeEvent,
-  type DragEvent,
   type KeyboardEvent,
   type MouseEvent,
 } from 'react'
+
+import {
+  TransferDialog,
+  type QueueItem,
+  type TransferDiscardTarget,
+} from './TransferDialog'
 
 import { PixelCluster } from '~/components/pixel-cluster'
 import { Button } from '~/components/ui/button'
 import {
   Dialog,
   DialogBody,
+  DialogClose,
   DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
   DialogTitle,
 } from '~/components/ui/dialog'
 import { Input } from '~/components/ui/input'
 import { TabItem, Tabs, TabsList } from '~/components/ui/tabs'
+import { adminResponseJson } from '~/lib/admin/client-response'
 import { T } from '~/lib/i18n'
 import { localize, useLocale } from '~/lib/locale-client'
 import { isMediaAssetEligible } from '~/lib/media/asset-review/eligibility'
@@ -30,20 +39,10 @@ import {
   MAX_ORIGINAL_UPLOAD_CHUNK_BYTES,
   originalUploadChunkCount,
 } from '~/lib/media/storage/transfer'
+import { uploadChunkWithRetry } from '~/lib/media/transfer/client'
+import type { TransferJob } from '~/lib/media/transfer/service'
 
 type LibraryView = 'active' | 'archived'
-type QueueStatus = 'hashing' | 'uploading' | 'processing' | 'ready' | 'failed'
-
-type QueueItem = {
-  id: string
-  file: File
-  idempotencyKey?: string
-  uploadIntentId?: string
-  checksumSha256?: string
-  uploadedChunkCount?: number
-  status: QueueStatus
-  error?: string
-}
 
 const acceptedTypes = new Set([
   'image/heic',
@@ -107,14 +106,6 @@ function clearDurableUploadIdempotencyKey(input: {
   }
 }
 
-async function responseJson(response: Response) {
-  const body = (await response.json()) as Record<string, unknown>
-  if (!response.ok) {
-    throw new Error(typeof body.error === 'string' ? body.error : 'request_failed')
-  }
-  return body
-}
-
 function assetName(asset: MediaAssetReviewRecord) {
   return (
     asset.locationLabelEn ||
@@ -132,17 +123,6 @@ function assetNameIsIdFallback(asset: MediaAssetReviewRecord) {
     asset.altTextEn ||
     asset.altTextZhHans
   )
-}
-
-const queueErrorCopy: Record<string, { zh: string; en: string }> = {
-  invalid_file: {
-    zh: '不支持的类型，或超过 50 MiB',
-    en: 'Unsupported type, or over 50 MiB',
-  },
-  upload_failed: { zh: '传输中断', en: 'Transfer interrupted' },
-  processing_failed: { zh: '处理失败', en: 'Processing failed' },
-  rate_limited: { zh: '操作太频繁，稍后重试', en: 'Rate limited — wait a moment' },
-  request_failed: { zh: '请求失败', en: 'Request failed' },
 }
 
 function processingLabel(asset: MediaAssetReviewRecord) {
@@ -179,123 +159,14 @@ function statusTone(asset: MediaAssetReviewRecord): 'busy' | 'attention' | null 
   return null
 }
 
-function DropZone({
-  items,
-  onFiles,
-  onRetry,
-}: {
-  items: QueueItem[]
-  onFiles(files: File[]): void
-  onRetry(item: QueueItem): void
-}) {
-  const inputRef = useRef<HTMLInputElement>(null)
-  const [dragging, setDragging] = useState(false)
-
-  function drop(event: DragEvent<HTMLDivElement>) {
-    event.preventDefault()
-    setDragging(false)
-    onFiles(Array.from(event.dataTransfer.files))
-  }
-
-  return (
-    <div
-      onDragEnter={(event) => {
-        event.preventDefault()
-        setDragging(true)
-      }}
-      onDragOver={(event) => event.preventDefault()}
-      onDragLeave={() => setDragging(false)}
-      onDrop={drop}
-      className={`mt-6 rounded-lg border border-dashed px-5 py-4 transition-colors duration-150 ${
-        dragging ? 'border-foreground bg-surface-1' : 'border-border'
-      }`}
-    >
-      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3">
-        <div>
-          <p className="text-sm font-medium">
-            <T zh="拖入或选择照片" en="Drop or choose photos" />
-          </p>
-          <p className="mt-0.5 text-sm text-muted-foreground">
-            JPEG · PNG · HEIC · ≤ 50 MiB
-          </p>
-        </div>
-        <Button
-          type="button"
-          variant="primary"
-          size="md"
-          expandHitArea
-          onClick={() => inputRef.current?.click()}
-        >
-          <T zh="选择文件" en="Choose files" />
-        </Button>
-        <input
-          ref={inputRef}
-          type="file"
-          multiple
-          accept=".heic,.heif,.jpg,.jpeg,.png,image/heic,image/heif,image/jpeg,image/png"
-          className="sr-only"
-          onChange={(event: ChangeEvent<HTMLInputElement>) => {
-            onFiles(Array.from(event.target.files ?? []))
-            event.target.value = ''
-          }}
-        />
-      </div>
-
-      {items.length > 0 && (
-        <ol aria-live="polite" className="mt-4 hairline-top">
-          {items.map((item) => {
-            const cause = item.error
-              ? queueErrorCopy[item.error] ?? queueErrorCopy.request_failed!
-              : null
-            return (
-              <li
-                key={item.id}
-                className="flex min-h-11 items-center justify-between gap-4 py-1.5 text-sm"
-              >
-                <div className="min-w-0">
-                  <p className="truncate">{item.file.name}</p>
-                  <p className="text-sm text-muted-foreground">
-                    {item.status === 'hashing' && <T zh="正在校验" en="Checking" />}
-                    {item.status === 'uploading' && <T zh="正在上传" en="Uploading" />}
-                    {item.status === 'processing' && <T zh="正在处理" en="Processing" />}
-                    {item.status === 'ready' && <T zh="已入档" en="In the archive" />}
-                    {item.status === 'failed' && cause && (
-                      <T zh={cause.zh} en={cause.en} />
-                    )}
-                  </p>
-                </div>
-                {item.status === 'failed' ? (
-                  // Dense stacked rows — the row's own min-h-11 is the tap
-                  // target, so no expandHitArea here.
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="shrink-0"
-                    onClick={() => onRetry(item)}
-                  >
-                    <T zh="重试" en="Retry" />
-                  </Button>
-                ) : (
-                  <span className="shrink-0 text-sm tabular-nums text-muted-foreground">
-                    {(item.file.size / 1024 / 1024).toFixed(1)} MiB
-                  </span>
-                )}
-              </li>
-            )
-          })}
-        </ol>
-      )}
-    </div>
-  )
-}
-
 function Inspector({
   asset,
+  onArchiveUndo,
   onUpdated,
   onClose,
 }: {
   asset: MediaAssetReviewRecord
+  onArchiveUndo(asset: MediaAssetReviewRecord, operationId: string): void
   onUpdated(asset: MediaAssetReviewRecord | null): void
   onClose(): void
 }) {
@@ -311,24 +182,12 @@ function Inspector({
   const [focalPoint, setFocalPoint] = useState(asset.focalPoint)
   const [pending, setPending] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
-  const [archiveArmed, setArchiveArmed] = useState(false)
-  const [purgeArmed, setPurgeArmed] = useState(false)
-  const [purgeText, setPurgeText] = useState('')
+  const [purgeOpen, setPurgeOpen] = useState(false)
   const noticeRef = useRef<HTMLParagraphElement>(null)
-  const archiveTimerRef = useRef<number | null>(null)
 
   useEffect(() => {
     if (notice) noticeRef.current?.focus()
   }, [notice])
-
-  useEffect(
-    () => () => {
-      if (archiveTimerRef.current !== null) {
-        window.clearTimeout(archiveTimerRef.current)
-      }
-    },
-    [],
-  )
 
   async function mutate(body: Record<string, unknown>) {
     const response = await fetch(`/api/admin/media/assets/${asset.id}`, {
@@ -336,7 +195,7 @@ function Inspector({
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(body),
     })
-    return responseJson(response)
+    return adminResponseJson(response)
   }
 
   // One save: display metadata and Alt Text go out together; untouched
@@ -402,7 +261,7 @@ function Inspector({
       const response = await fetch(`/api/admin/media/assets/${asset.id}/alt-text`, {
         method: 'POST',
       })
-      const body = await responseJson(response)
+      const body = await adminResponseJson(response)
       const suggestion = body.suggestion as { zhHans: string; en: string }
       setAltZh(suggestion.zhHans)
       setAltEn(suggestion.en)
@@ -427,7 +286,7 @@ function Inspector({
         `/api/admin/media/assets/${asset.id}/location-label`,
         { method: 'POST' },
       )
-      const body = await responseJson(response)
+      const body = await adminResponseJson(response)
       const suggestion = body.suggestion as { zhHans?: string; en?: string }
       if (suggestion.zhHans) setLocationZh(suggestion.zhHans)
       if (suggestion.en) setLocationEn(suggestion.en)
@@ -471,7 +330,7 @@ function Inspector({
       const response = await fetch(`/api/admin/media/assets/${asset.id}/resume`, {
         method: 'POST',
       })
-      const body = await responseJson(response)
+      const body = await adminResponseJson(response)
       onUpdated(body.asset as MediaAssetReviewRecord)
       setNotice(
         localize(
@@ -493,28 +352,16 @@ function Inspector({
     }
   }
 
-  function requestArchive() {
-    if (!archiveArmed) {
-      setArchiveArmed(true)
-      if (archiveTimerRef.current !== null) {
-        window.clearTimeout(archiveTimerRef.current)
-      }
-      archiveTimerRef.current = window.setTimeout(
-        () => setArchiveArmed(false),
-        4000,
-      )
-      return
-    }
-    setArchiveArmed(false)
-    void changeCatalogState('archive')
-  }
-
   async function changeCatalogState(intent: 'archive' | 'restore') {
     setPending(intent)
     setNotice(null)
     try {
       const body = await mutate({ intent })
-      onUpdated(body.asset as MediaAssetReviewRecord)
+      const updated = body.asset as MediaAssetReviewRecord
+      onUpdated(updated)
+      if (intent === 'archive' && typeof body.undoOperationId === 'string') {
+        onArchiveUndo(updated, body.undoOperationId)
+      }
       setNotice(
         intent === 'archive'
           ? localize(locale, '已归档。', 'Archived.')
@@ -524,8 +371,8 @@ function Inspector({
       setNotice(
         localize(
           locale,
-          '这个素材仍在照片选集中，或暂时无法更新。',
-          'This asset is still in a Photo Selection or could not be updated.',
+          '暂时无法更新，请重试。',
+          'Could not update this Media Asset. Try again.',
         ),
       )
     } finally {
@@ -534,16 +381,16 @@ function Inspector({
   }
 
   async function purge() {
-    if (purgeText !== 'PURGE') return
     setPending('purge')
     setNotice(null)
     try {
       const response = await fetch(`/api/admin/media/assets/${asset.id}/purge`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ confirmation: purgeText }),
+        body: JSON.stringify({ confirmation: 'PURGE' }),
       })
-      await responseJson(response)
+      await adminResponseJson(response)
+      setPurgeOpen(false)
       onUpdated(null)
       onClose()
     } catch {
@@ -787,15 +634,10 @@ function Inspector({
               type="button"
               variant="ghost"
               size="sm"
-              destructive={archiveArmed}
               disabled={pending !== null}
-              onClick={requestArchive}
+              onClick={() => void changeCatalogState('archive')}
             >
-              {archiveArmed ? (
-                <T zh="确认归档？" en="Confirm archive?" />
-              ) : (
-                <T zh="归档" en="Archive" />
-              )}
+              <T zh="归档" en="Archive" />
             </Button>
           )}
           {asset.catalogState === 'archived' && (
@@ -817,7 +659,7 @@ function Inspector({
               size="sm"
               destructive
               disabled={pending !== null}
-              onClick={() => setPurgeArmed((current) => !current)}
+              onClick={() => setPurgeOpen(true)}
             >
               {asset.catalogState === 'purging' ? (
                 <T zh="重试清除" en="Retry Purge" />
@@ -842,38 +684,6 @@ function Inspector({
         )}
       </div>
 
-      {purgeArmed && (
-        <div className="mt-4 grid gap-3 rounded-md bg-surface-1 p-4">
-          <p className="text-sm leading-5">
-            <T
-              zh="永久清除不可撤销：原片、成品和目录记录都会删除。输入 PURGE 确认。"
-              en="Purge cannot be undone: the Original, Renditions, and catalog record are removed. Type PURGE to confirm."
-            />
-          </p>
-          <div className="flex flex-wrap items-center gap-2">
-            <Input
-              destructive
-              value={purgeText}
-              onChange={(event) => setPurgeText(event.target.value)}
-              placeholder="PURGE"
-              aria-label={localize(locale, '输入 PURGE 确认', 'Type PURGE to confirm')}
-              className="w-32"
-            />
-            <Button
-              type="button"
-              variant="primary"
-              size="md"
-              destructive
-              loading={pending === 'purge'}
-              disabled={pending !== null || purgeText !== 'PURGE'}
-              onClick={() => void purge()}
-            >
-              <T zh="确认清除" en="Confirm purge" />
-            </Button>
-          </div>
-        </div>
-      )}
-
       {asset.catalogState !== 'active' && (
         <p className="mt-3 text-sm leading-5 text-muted-foreground">
           <T
@@ -882,6 +692,43 @@ function Inspector({
           />
         </p>
       )}
+
+      <Dialog open={purgeOpen} onOpenChange={setPurgeOpen}>
+        <DialogContent size="sm" className="h-64">
+          <DialogHeader>
+            <DialogTitle>
+              <T zh="永久清除素材" en="Purge Media Asset" />
+            </DialogTitle>
+            <DialogClose disabled={pending === 'purge'}>
+              <T zh="取消" en="Cancel" />
+            </DialogClose>
+          </DialogHeader>
+          <DialogDescription>
+            <T
+              zh="原片、成品和目录记录会永久删除。如果它仍在照片选集中，系统会只撤下这一张，不会发布其他草稿更改。"
+              en="The Original, Renditions, and catalog record will be permanently removed. If selected, only this photo is withdrawn; unrelated Draft changes stay unpublished."
+            />
+          </DialogDescription>
+          <DialogBody>
+            <p className="text-sm leading-6 text-muted-foreground">
+              <T zh="此操作无法撤销。" en="This action cannot be undone." />
+            </p>
+          </DialogBody>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="primary"
+              size="md"
+              destructive
+              loading={pending === 'purge'}
+              disabled={pending !== null}
+              onClick={() => void purge()}
+            >
+              <T zh="永久清除" en="Purge" />
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   )
 }
@@ -893,24 +740,43 @@ function Inspector({
 export function MediaLibrary({
   initialActive,
   initialArchived,
+  initialTransfers,
   selectionIds,
 }: {
   initialActive: MediaAssetReviewRecord[]
   initialArchived: MediaAssetReviewRecord[]
+  initialTransfers: TransferJob[]
   selectionIds: string[]
 }) {
   const locale = useLocale()
   const [active, setActive] = useState(initialActive)
   const [archived, setArchived] = useState(initialArchived)
+  const [transfers, setTransfers] = useState(initialTransfers)
   const [view, setView] = useState<LibraryView>('active')
   const [queue, setQueue] = useState<QueueItem[]>([])
+  const [transferOpen, setTransferOpen] = useState(false)
   const [search, setSearch] = useState('')
   const [openId, setOpenId] = useState<string | null>(null)
+  const [archiveUndo, setArchiveUndo] = useState<{
+    assetId: string
+    operationId: string
+  } | null>(null)
+  const [discardTarget, setDiscardTarget] =
+    useState<TransferDiscardTarget | null>(null)
+  const [pendingTransferId, setPendingTransferId] = useState<string | null>(null)
+  const [transferNotices, setTransferNotices] = useState<Record<string, string>>(
+    {},
+  )
   const queueTimersRef = useRef<number[]>([])
+  const cancelingTransferIdsRef = useRef(new Set<string>())
+  const archiveUndoTimerRef = useRef<number | null>(null)
 
   useEffect(
     () => () => {
       for (const timer of queueTimersRef.current) window.clearTimeout(timer)
+      if (archiveUndoTimerRef.current !== null) {
+        window.clearTimeout(archiveUndoTimerRef.current)
+      }
     },
     [],
   )
@@ -937,6 +803,15 @@ export function MediaLibrary({
     )
   }, [assets, search])
   const open = assets.find((asset) => asset.id === openId) ?? null
+  const visibleTransfers = useMemo(
+    () =>
+      transfers.filter(
+        (job) =>
+          !queue.some((item) => item.uploadIntentId === job.uploadIntentId),
+      ),
+    [queue, transfers],
+  )
+  const transferCount = queue.length + visibleTransfers.length
 
   function patchQueue(id: string, patch: Partial<QueueItem>) {
     setQueue((current) =>
@@ -969,17 +844,190 @@ export function MediaLibrary({
     })
   }
 
+  function offerArchiveUndo(assetId: string, operationId: string) {
+    setArchiveUndo({ assetId, operationId })
+    if (archiveUndoTimerRef.current !== null) {
+      window.clearTimeout(archiveUndoTimerRef.current)
+    }
+    archiveUndoTimerRef.current = window.setTimeout(
+      () => setArchiveUndo(null),
+      10_000,
+    )
+  }
+
+  async function undoArchive() {
+    if (!archiveUndo) return
+    const pendingUndo = archiveUndo
+    setArchiveUndo(null)
+    try {
+      const response = await fetch(
+        `/api/admin/media/assets/${pendingUndo.assetId}`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            intent: 'undo_archive',
+            operationId: pendingUndo.operationId,
+          }),
+        },
+      )
+      const body = await adminResponseJson(response)
+      mergeAsset(body.asset as MediaAssetReviewRecord)
+      setView('active')
+    } catch {
+      await reloadAssets().catch(() => undefined)
+    }
+  }
+
   async function reloadAssets() {
     const [activeResponse, archivedResponse] = await Promise.all([
       fetch('/api/admin/media/assets?view=active', { cache: 'no-store' }),
       fetch('/api/admin/media/assets?view=archived', { cache: 'no-store' }),
     ])
     const [activeBody, archivedBody] = await Promise.all([
-      responseJson(activeResponse),
-      responseJson(archivedResponse),
+      adminResponseJson(activeResponse),
+      adminResponseJson(archivedResponse),
     ])
     setActive(activeBody.assets as MediaAssetReviewRecord[])
     setArchived(archivedBody.assets as MediaAssetReviewRecord[])
+  }
+
+  async function reloadTransfers() {
+    const response = await fetch('/api/admin/media/upload-intents', {
+      cache: 'no-store',
+    })
+    const body = await adminResponseJson(response)
+    if (!Array.isArray(body.transfers)) throw new Error('invalid_response')
+    setTransfers(body.transfers as TransferJob[])
+  }
+
+  function setTransferNotice(uploadIntentId: string, notice: string | null) {
+    setTransferNotices((current) => {
+      const next = { ...current }
+      if (notice === null) delete next[uploadIntentId]
+      else next[uploadIntentId] = notice
+      return next
+    })
+  }
+
+  async function retryPersistedFile(job: TransferJob, file: File) {
+    setPendingTransferId(job.uploadIntentId)
+    setTransferNotice(job.uploadIntentId, null)
+    const contentType = fileContentType(file)
+    if (contentType !== job.contentType || file.size !== job.byteSize) {
+      setTransferNotice(
+        job.uploadIntentId,
+        localize(
+          locale,
+          '请选择同一张原片（类型和大小必须一致）。',
+          'Choose the same Original; its type and size must match.',
+        ),
+      )
+      setPendingTransferId(null)
+      return
+    }
+    try {
+      const sha256 = await checksum(file)
+      if (sha256 !== job.checksumSha256) {
+        setTransferNotice(
+          job.uploadIntentId,
+          localize(
+            locale,
+            '这不是原来的文件，请重新选择。',
+            'This is not the original file. Choose it again.',
+          ),
+        )
+        return
+      }
+      const item: QueueItem = {
+        id: crypto.randomUUID(),
+        file,
+        uploadIntentId: job.uploadIntentId,
+        checksumSha256: sha256,
+        status: 'uploading',
+      }
+      setQueue((current) => [item, ...current])
+      void upload(item)
+    } catch {
+      setTransferNotice(
+        job.uploadIntentId,
+        localize(locale, '无法读取这个文件。', 'This file could not be read.'),
+      )
+    } finally {
+      setPendingTransferId(null)
+    }
+  }
+
+  async function retryPersistedProcessing(job: TransferJob) {
+    if (!job.mediaAssetId) return
+    setPendingTransferId(job.uploadIntentId)
+    setTransferNotice(job.uploadIntentId, null)
+    try {
+      const response = await fetch(
+        `/api/admin/media/assets/${job.mediaAssetId}/resume`,
+        { method: 'POST' },
+      )
+      await adminResponseJson(response)
+      await Promise.all([reloadAssets(), reloadTransfers()])
+      setView('active')
+    } catch {
+      setTransferNotice(
+        job.uploadIntentId,
+        localize(
+          locale,
+          '暂时无法恢复处理，请稍后重试。',
+          'Processing could not resume yet. Try again later.',
+        ),
+      )
+      await reloadTransfers().catch(() => undefined)
+    } finally {
+      setPendingTransferId(null)
+    }
+  }
+
+  async function discardTransfer() {
+    if (!discardTarget) return
+    const target = discardTarget
+    cancelingTransferIdsRef.current.add(target.uploadIntentId)
+    let discarded = false
+    setPendingTransferId(target.uploadIntentId)
+    setTransferNotice(target.uploadIntentId, null)
+    try {
+      const response = await fetch(
+        `/api/admin/media/upload-intents/${target.uploadIntentId}`,
+        { method: 'DELETE' },
+      )
+      await adminResponseJson(response)
+      discarded = true
+      setQueue((current) =>
+        current.filter(
+          (item) => item.uploadIntentId !== target.uploadIntentId,
+        ),
+      )
+      setTransfers((current) =>
+        current.filter(
+          (job) => job.uploadIntentId !== target.uploadIntentId,
+        ),
+      )
+      setDiscardTarget(null)
+      await Promise.all([reloadAssets(), reloadTransfers()])
+    } catch {
+      setTransferNotice(
+        target.uploadIntentId,
+        localize(
+          locale,
+          '丢弃未完成。已确认的步骤会保留，可以安全重试。',
+          'Discard is incomplete. Confirmed progress is saved and safe to retry.',
+        ),
+      )
+      setDiscardTarget(null)
+      await reloadTransfers().catch(() => undefined)
+    } finally {
+      if (!discarded) {
+        cancelingTransferIdsRef.current.delete(target.uploadIntentId)
+      }
+      setPendingTransferId(null)
+    }
   }
 
   async function upload(item: QueueItem) {
@@ -1010,7 +1058,7 @@ export function MediaLibrary({
             checksumSha256: sha256,
           }),
         })
-        const intentBody = await responseJson(intentResponse)
+        const intentBody = await adminResponseJson(intentResponse)
         uploadIntentId = (intentBody.uploadIntent as { id: string }).id
         patchQueue(item.id, {
           checksumSha256: sha256,
@@ -1029,6 +1077,7 @@ export function MediaLibrary({
       const chunkCount = originalUploadChunkCount(item.file.size)
       let uploadedChunkCount = item.uploadedChunkCount ?? 0
       let restartedAfterConflict = false
+      let replacedMissingIntent = false
       while (uploadedChunkCount < chunkCount) {
         patchQueue(item.id, { status: 'uploading' })
         const start = uploadedChunkCount * MAX_ORIGINAL_UPLOAD_CHUNK_BYTES
@@ -1037,7 +1086,7 @@ export function MediaLibrary({
           Math.min(start + MAX_ORIGINAL_UPLOAD_CHUNK_BYTES, item.file.size),
         )
         const chunkChecksumSha256 = await checksum(chunk)
-        const uploadResponse = await fetch(
+        const uploadResponse = await uploadChunkWithRetry(
           `/api/admin/media/upload-intents/${uploadIntentId}/original?chunk=${uploadedChunkCount}`,
           {
             method: 'PUT',
@@ -1048,13 +1097,67 @@ export function MediaLibrary({
             body: chunk,
           },
         )
+        if (cancelingTransferIdsRef.current.has(uploadIntentId)) {
+          throw new Error('upload_failed')
+        }
         if (!uploadResponse.ok) {
+          // Chunk responses use an empty 204 body on success, so they cannot
+          // all flow through adminResponseJson. Failures still must use the
+          // shared handler to re-enter Clerk after an expired session.
+          if (uploadResponse.status === 401) {
+            await adminResponseJson(uploadResponse)
+          }
+          if (uploadResponse.status === 404 && !replacedMissingIntent) {
+            replacedMissingIntent = true
+            // The stale reservation may still own partial chunks. Discard is
+            // idempotent and closes the server-side transfer before a fresh
+            // intent starts; a completed/ready replay simply rejects it.
+            await fetch(
+              `/api/admin/media/upload-intents/${uploadIntentId}`,
+              { method: 'DELETE' },
+            ).catch(() => undefined)
+            clearDurableUploadIdempotencyKey({
+              checksumSha256: sha256,
+              byteSize: item.file.size,
+              contentType,
+            })
+            idempotencyKey = durableUploadIdempotencyKey({
+              checksumSha256: sha256,
+              byteSize: item.file.size,
+              contentType,
+            })
+            const replacementResponse = await fetch(
+              '/api/admin/media/upload-intents',
+              {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({
+                  idempotencyKey,
+                  contentType,
+                  byteSize: item.file.size,
+                  checksumSha256: sha256,
+                }),
+              },
+            )
+            const replacementBody = await adminResponseJson(replacementResponse)
+            uploadIntentId = (
+              replacementBody.uploadIntent as { id: string }
+            ).id
+            uploadedChunkCount = 0
+            patchQueue(item.id, {
+              idempotencyKey,
+              uploadIntentId,
+              uploadedChunkCount: 0,
+            })
+            continue
+          }
           if (uploadResponse.status === 409 && !restartedAfterConflict) {
             restartedAfterConflict = true
             uploadedChunkCount = 0
             patchQueue(item.id, { uploadedChunkCount: 0 })
             continue
           }
+          await adminResponseJson(uploadResponse)
           throw new Error('upload_failed')
         }
         uploadedChunkCount += 1
@@ -1062,13 +1165,16 @@ export function MediaLibrary({
       }
 
       patchQueue(item.id, { uploadIntentId, status: 'processing' })
+      if (cancelingTransferIdsRef.current.has(uploadIntentId)) {
+        throw new Error('upload_failed')
+      }
       const completionResponse = await fetch(
         `/api/admin/media/upload-intents/${uploadIntentId}/complete`,
         { method: 'POST' },
       )
       let completionBody
       try {
-        completionBody = await responseJson(completionResponse)
+        completionBody = await adminResponseJson(completionResponse)
       } catch (error) {
         if (error instanceof Error && error.message === 'original_mismatch') {
           patchQueue(item.id, { uploadedChunkCount: 0 })
@@ -1079,6 +1185,7 @@ export function MediaLibrary({
         id: string
         processingState: string
       }
+      patchQueue(item.id, { mediaAssetId: mediaAsset.id })
       if (mediaAsset.processingState !== 'ready') throw new Error('processing_failed')
       patchQueue(item.id, { status: 'ready' })
       scheduleQueueClear(item.id)
@@ -1088,6 +1195,9 @@ export function MediaLibrary({
         contentType,
       })
       try {
+        setTransfers((current) =>
+          current.filter((job) => job.uploadIntentId !== uploadIntentId),
+        )
         await reloadAssets()
         setView('active')
       } catch {
@@ -1100,7 +1210,7 @@ export function MediaLibrary({
           `/api/admin/media/assets/${mediaAsset.id}/alt-text`,
           { method: 'POST' },
         )
-        const altTextBody = await responseJson(altTextResponse)
+        const altTextBody = await adminResponseJson(altTextResponse)
         if (altTextBody.asset) {
           mergeAsset(altTextBody.asset as MediaAssetReviewRecord)
         }
@@ -1113,6 +1223,7 @@ export function MediaLibrary({
         status: 'failed',
         error: error instanceof Error ? error.message : 'request_failed',
       })
+      await reloadTransfers().catch(() => undefined)
     }
   }
 
@@ -1136,29 +1247,38 @@ export function MediaLibrary({
         </h1>
         <PixelCluster variant={8} className="shrink-0" />
       </div>
-      <p className="mt-1 text-sm tabular-nums text-muted-foreground">
-        {active.length} <T zh="张使用中" en="active" />
-        {archived.length > 0 && (
-          <>
-            {' · '}
-            {archived.length} <T zh="张已归档" en="archived" />
-          </>
-        )}
-      </p>
+      <div className="mt-1 flex h-10 items-center justify-between gap-4">
+        <p className="text-sm tabular-nums text-muted-foreground">
+          {active.length} <T zh="张素材" en="in Library" />
+          {archived.length > 0 && (
+            <>
+              {' · '}
+              {archived.length} <T zh="张已归档" en="archived" />
+            </>
+          )}
+        </p>
+        <Button
+          type="button"
+          variant="primary"
+          size="lg"
+          expandHitArea
+          active={transferOpen}
+          onClick={() => setTransferOpen(true)}
+        >
+          <T zh="传输" en="Transfers" />
+          {transferCount > 0 && (
+            <span className="min-w-3 text-center tabular-nums">{transferCount}</span>
+          )}
+        </Button>
+      </div>
 
-      <DropZone
-        items={queue}
-        onFiles={addFiles}
-        onRetry={(item) => void upload(item)}
-      />
-
-      <div className="mt-6 flex flex-wrap items-center justify-between gap-3">
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
         <Tabs value={view} onValueChange={(value) => setView(value as LibraryView)}>
           <TabsList
             variant="subtle"
             aria-label={localize(locale, '媒体视图', 'Media view')}
           >
-            <TabItem value="active" label={localize(locale, '使用中', 'Active')} />
+            <TabItem value="active" label={localize(locale, '素材库', 'Library')} />
             <TabItem
               value="archived"
               label={localize(locale, '已归档', 'Archived')}
@@ -1178,13 +1298,14 @@ export function MediaLibrary({
         </label>
       </div>
 
-      {visibleAssets.length === 0 ? (
-        <p className="mt-6 hairline-top py-10 text-sm leading-6 text-muted-foreground">
+      <div className="min-h-[25rem]">
+        {visibleAssets.length === 0 ? (
+          <p className="mt-6 hairline-top py-10 text-sm leading-6 text-muted-foreground">
           {assets.length === 0 ? (
             view === 'active' ? (
               <T
-                zh="档案还是空的——把照片拖进上面的框里就好。"
-                en="The archive is empty — drop photos into the tray above."
+                zh="素材库还是空的——从传输开始。"
+                en="The Library is empty — start a Transfer."
               />
             ) : (
               <T zh="没有已归档的素材。" en="Nothing is archived." />
@@ -1192,9 +1313,9 @@ export function MediaLibrary({
           ) : (
             <T zh="没有匹配的素材。" en="No matches." />
           )}
-        </p>
-      ) : (
-        <ul className="mt-4 grid grid-cols-3 gap-2">
+          </p>
+        ) : (
+          <ul className="mt-4 grid grid-cols-3 gap-2">
           {visibleAssets.map((asset) => {
             const tone = statusTone(asset)
             const inSelection = selectionIds.includes(asset.id)
@@ -1248,17 +1369,19 @@ export function MediaLibrary({
               </li>
             )
           })}
-        </ul>
-      )}
+          </ul>
+        )}
 
-      {view === 'active' && active.some((asset) => !isMediaAssetEligible(asset)) && (
-        <p className="mt-4 text-sm leading-5 text-muted-foreground">
-          <T
-            zh="带黄点的素材还不能发布——处理中，或缺少替代文本（打开后保存即可）；红点表示需要打开检查一下。"
-            en="Amber dots are not publishable yet — still processing, or missing Alt Text (open and save to fix); red dots want a look inside."
-          />
-        </p>
-      )}
+        {view === 'active' &&
+          active.some((asset) => !isMediaAssetEligible(asset)) && (
+            <p className="mt-4 text-sm leading-5 text-muted-foreground">
+              <T
+                zh="带黄点的素材还不能发布——处理中，或缺少替代文本（打开后保存即可）；红点表示需要打开检查一下。"
+                en="Amber dots are not publishable yet — still processing, or missing Alt Text (open and save to fix); red dots want a look inside."
+              />
+            </p>
+          )}
+      </div>
 
       <Dialog
         open={open !== null}
@@ -1266,12 +1389,18 @@ export function MediaLibrary({
           if (!next) setOpenId(null)
         }}
       >
-        <DialogContent size="lg">
+        <DialogContent
+          size="lg"
+          className="h-[min(46rem,calc(100dvh-2rem))]"
+        >
           <DialogBody>
             {open && (
               <Inspector
                 key={open.id}
                 asset={open}
+                onArchiveUndo={(asset, operationId) => {
+                  offerArchiveUndo(asset.id, operationId)
+                }}
                 onUpdated={(asset) => mergeAsset(asset, openId ?? undefined)}
                 onClose={() => setOpenId(null)}
               />
@@ -1279,6 +1408,42 @@ export function MediaLibrary({
           </DialogBody>
         </DialogContent>
       </Dialog>
+
+      <TransferDialog
+        open={transferOpen}
+        onOpenChange={setTransferOpen}
+        queue={queue}
+        transfers={visibleTransfers}
+        notices={transferNotices}
+        pendingTransferId={pendingTransferId}
+        discardTarget={discardTarget}
+        onFiles={addFiles}
+        onDismissQueueItem={(item) => {
+          setQueue((current) =>
+            current.filter((candidate) => candidate.id !== item.id),
+          )
+        }}
+        onRetryQueueItem={(item) => void upload(item)}
+        onChooseFile={(target, file) => void retryPersistedFile(target, file)}
+        onRetryProcessing={(target) => void retryPersistedProcessing(target)}
+        onRequestDiscard={setDiscardTarget}
+        onCloseDiscard={() => setDiscardTarget(null)}
+        onConfirmDiscard={() => void discardTransfer()}
+      />
+
+      {archiveUndo && (
+        <div
+          role="status"
+          className="fixed bottom-24 left-1/2 z-[var(--z-toast)] flex min-h-11 w-[min(24rem,calc(100vw-2rem))] -translate-x-1/2 items-center justify-between gap-3 rounded-[2px] bg-foreground px-4 py-2 text-background shadow-[var(--shadow-medium)]"
+        >
+          <span className="text-sm">
+            <T zh="已归档并从照片选集撤下。" en="Archived and withdrawn from Photo Selection." />
+          </span>
+          <Button type="button" variant="secondary" size="sm" onClick={() => void undoArchive()}>
+            <T zh="撤销" en="Undo" />
+          </Button>
+        </div>
+      )}
     </div>
   )
 }

--- a/app/admin/(protected)/media/TransferDialog.tsx
+++ b/app/admin/(protected)/media/TransferDialog.tsx
@@ -1,0 +1,488 @@
+'use client'
+
+import {
+  useRef,
+  useState,
+  type ChangeEvent,
+  type DragEvent,
+} from 'react'
+
+import { Button } from '~/components/ui/button'
+import {
+  Dialog,
+  DialogBody,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '~/components/ui/dialog'
+import { T } from '~/lib/i18n'
+import type { TransferJob } from '~/lib/media/transfer/service'
+
+export type QueueStatus =
+  | 'hashing'
+  | 'uploading'
+  | 'processing'
+  | 'ready'
+  | 'failed'
+
+export type QueueItem = {
+  id: string
+  file: File
+  idempotencyKey?: string
+  uploadIntentId?: string
+  mediaAssetId?: string
+  checksumSha256?: string
+  uploadedChunkCount?: number
+  status: QueueStatus
+  error?: string
+}
+
+export type TransferDiscardTarget = {
+  uploadIntentId: string
+  label: string
+}
+
+const queueErrorCopy: Record<string, { zh: string; en: string }> = {
+  invalid_file: {
+    zh: '不支持的类型，或超过 50 MiB',
+    en: 'Unsupported type, or over 50 MiB',
+  },
+  upload_failed: { zh: '传输中断', en: 'Transfer interrupted' },
+  processing_failed: { zh: '处理失败', en: 'Processing failed' },
+  original_mismatch: { zh: '原片校验失败', en: 'Original verification failed' },
+  rate_limited: { zh: '操作太频繁，稍后重试', en: 'Rate limited — wait a moment' },
+  request_failed: { zh: '请求失败', en: 'Request failed' },
+}
+
+function DropZone({
+  items,
+  onFiles,
+  onDiscard,
+  onDismiss,
+  onRetry,
+}: {
+  items: QueueItem[]
+  onFiles(files: File[]): void
+  onDiscard(item: QueueItem): void
+  onDismiss(item: QueueItem): void
+  onRetry(item: QueueItem): void
+}) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [dragging, setDragging] = useState(false)
+
+  function drop(event: DragEvent<HTMLDivElement>) {
+    event.preventDefault()
+    setDragging(false)
+    onFiles(Array.from(event.dataTransfer.files))
+  }
+
+  return (
+    <div
+      onDragEnter={(event) => {
+        event.preventDefault()
+        setDragging(true)
+      }}
+      onDragOver={(event) => event.preventDefault()}
+      onDragLeave={() => setDragging(false)}
+      onDrop={drop}
+      className={`rounded-lg border border-dashed px-5 py-4 transition-colors duration-150 ${
+        dragging ? 'border-foreground bg-surface-1' : 'border-border'
+      }`}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3">
+        <div>
+          <p className="text-sm font-medium">
+            <T zh="拖入或选择照片" en="Drop or choose photos" />
+          </p>
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            JPEG · PNG · HEIC · ≤ 50 MiB
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="primary"
+          size="md"
+          expandHitArea
+          onClick={() => inputRef.current?.click()}
+        >
+          <T zh="选择文件" en="Choose files" />
+        </Button>
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          accept=".heic,.heif,.jpg,.jpeg,.png,image/heic,image/heif,image/jpeg,image/png"
+          className="sr-only"
+          onChange={(event: ChangeEvent<HTMLInputElement>) => {
+            onFiles(Array.from(event.target.files ?? []))
+            event.target.value = ''
+          }}
+        />
+      </div>
+
+      {items.length > 0 && (
+        <ol aria-live="polite" className="mt-4 hairline-top">
+          {items.map((item) => {
+            const cause = item.error
+              ? queueErrorCopy[item.error] ?? queueErrorCopy.request_failed!
+              : null
+            return (
+              <li
+                key={item.id}
+                className="flex min-h-11 items-center justify-between gap-4 py-1.5 text-sm"
+              >
+                <div className="min-w-0">
+                  <p className="truncate">{item.file.name}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {item.status === 'hashing' && <T zh="正在校验" en="Checking" />}
+                    {item.status === 'uploading' && <T zh="正在上传" en="Uploading" />}
+                    {item.status === 'processing' && <T zh="正在处理" en="Processing" />}
+                    {item.status === 'ready' && <T zh="已入档" en="In the archive" />}
+                    {item.status === 'failed' && cause && (
+                      <T zh={cause.zh} en={cause.en} />
+                    )}
+                  </p>
+                </div>
+                {item.status === 'failed' ? (
+                  <div className="flex shrink-0 items-center gap-1">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onRetry(item)}
+                    >
+                      <T zh="重试" en="Retry" />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      destructive={item.uploadIntentId !== undefined}
+                      onClick={() =>
+                        item.uploadIntentId ? onDiscard(item) : onDismiss(item)
+                      }
+                    >
+                      {item.uploadIntentId ? (
+                        <T zh="丢弃" en="Discard" />
+                      ) : (
+                        <T zh="移除" en="Dismiss" />
+                      )}
+                    </Button>
+                  </div>
+                ) : item.status === 'processing' && item.uploadIntentId ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    destructive
+                    onClick={() => onDiscard(item)}
+                  >
+                    <T zh="丢弃" en="Discard" />
+                  </Button>
+                ) : (
+                  <span className="shrink-0 text-sm tabular-nums text-muted-foreground">
+                    {(item.file.size / 1024 / 1024).toFixed(1)} MiB
+                  </span>
+                )}
+              </li>
+            )
+          })}
+        </ol>
+      )}
+    </div>
+  )
+}
+
+function transferFileLabel(job: TransferJob) {
+  const kind =
+    {
+      'image/heic': 'HEIC',
+      'image/heif': 'HEIF',
+      'image/jpeg': 'JPEG',
+      'image/png': 'PNG',
+    }[job.contentType] ?? 'Image'
+  return `${kind} · ${(job.byteSize / 1024 / 1024).toFixed(1)} MiB`
+}
+
+function transferStateCopy(job: TransferJob) {
+  if (job.stage === 'awaiting_file') {
+    return { zh: '等待重新选择原片', en: 'Choose the Original again to resume' }
+  }
+  if (job.stage === 'processing') return { zh: '正在处理', en: 'Processing' }
+  if (job.stage === 'discarding') {
+    return { zh: '丢弃未完成，可以安全重试', en: 'Discard incomplete; safe to retry' }
+  }
+  if (job.processingErrorCode === 'image_unsupported_format') {
+    return {
+      zh: '无法解码此格式；可导出为 JPEG 或 PNG 后重试',
+      en: 'This encoding could not be decoded; export as JPEG or PNG and retry',
+    }
+  }
+  if (job.processingErrorCode === 'capture_location_invalid') {
+    return {
+      zh: '拍摄位置元数据无效；可移除元数据后重试',
+      en: 'Capture Location metadata is invalid; remove it and retry',
+    }
+  }
+  if (job.processingErrorCode === 'storage_not_found') {
+    return {
+      zh: '找不到原片；请丢弃后重新传输',
+      en: 'The Original is missing; discard this job and transfer it again',
+    }
+  }
+  if (
+    job.processingErrorCode === 'dependency_unavailable' ||
+    job.processingErrorCode?.startsWith('storage_')
+  ) {
+    return {
+      zh: '存储服务暂时不可用，可以安全重试',
+      en: 'Storage is temporarily unavailable; it is safe to retry',
+    }
+  }
+  return { zh: '处理失败，可以重试', en: 'Processing failed; retry available' }
+}
+
+function PersistedTransferRow({
+  job,
+  notice,
+  pending,
+  onChooseFile,
+  onDiscard,
+  onRetryProcessing,
+}: {
+  job: TransferJob
+  notice?: string
+  pending: boolean
+  onChooseFile(job: TransferJob, file: File): void
+  onDiscard(job: TransferJob): void
+  onRetryProcessing(job: TransferJob): void
+}) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const state = transferStateCopy(job)
+
+  return (
+    <li className="flex min-h-14 items-center justify-between gap-4 py-1.5 text-sm">
+      <div className="min-w-0">
+        <p className="truncate font-mono text-[12px]">{transferFileLabel(job)}</p>
+        <p className="text-sm text-muted-foreground">
+          {notice ?? <T zh={state.zh} en={state.en} />}
+        </p>
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        {job.stage === 'awaiting_file' && (
+          <>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              loading={pending}
+              disabled={pending}
+              onClick={() => inputRef.current?.click()}
+            >
+              <T zh="选择原片" en="Choose Original" />
+            </Button>
+            <input
+              ref={inputRef}
+              type="file"
+              accept=".heic,.heif,.jpg,.jpeg,.png,image/heic,image/heif,image/jpeg,image/png"
+              className="sr-only"
+              onChange={(event) => {
+                const file = event.target.files?.[0]
+                if (file) onChooseFile(job, file)
+                event.target.value = ''
+              }}
+            />
+          </>
+        )}
+        {(job.stage === 'failed' || job.stage === 'processing') && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            loading={pending}
+            disabled={pending}
+            onClick={() => onRetryProcessing(job)}
+          >
+            <T zh="重试" en="Retry" />
+          </Button>
+        )}
+        {job.stage === 'discarding' && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            destructive
+            loading={pending}
+            disabled={pending}
+            onClick={() => onDiscard(job)}
+          >
+            <T zh="重试丢弃" en="Retry Discard" />
+          </Button>
+        )}
+        {(
+          job.stage === 'awaiting_file' ||
+          job.stage === 'processing' ||
+          job.stage === 'failed'
+        ) && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            destructive
+            disabled={pending}
+            onClick={() => onDiscard(job)}
+          >
+            <T zh="丢弃" en="Discard" />
+          </Button>
+        )}
+      </div>
+    </li>
+  )
+}
+
+export function TransferDialog({
+  open,
+  onOpenChange,
+  queue,
+  transfers,
+  notices,
+  pendingTransferId,
+  discardTarget,
+  onFiles,
+  onDismissQueueItem,
+  onRetryQueueItem,
+  onChooseFile,
+  onRetryProcessing,
+  onRequestDiscard,
+  onCloseDiscard,
+  onConfirmDiscard,
+}: {
+  open: boolean
+  onOpenChange(open: boolean): void
+  queue: QueueItem[]
+  transfers: TransferJob[]
+  notices: Record<string, string>
+  pendingTransferId: string | null
+  discardTarget: TransferDiscardTarget | null
+  onFiles(files: File[]): void
+  onDismissQueueItem(item: QueueItem): void
+  onRetryQueueItem(item: QueueItem): void
+  onChooseFile(job: TransferJob, file: File): void
+  onRetryProcessing(job: TransferJob): void
+  onRequestDiscard(target: TransferDiscardTarget): void
+  onCloseDiscard(): void
+  onConfirmDiscard(): void
+}) {
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent
+          size="lg"
+          className="h-[min(38rem,calc(100dvh-2rem))]"
+        >
+          <DialogHeader>
+            <DialogTitle>
+              <T zh="传输" en="Transfers" />
+            </DialogTitle>
+            <DialogClose>
+              <T zh="关闭" en="Close" />
+            </DialogClose>
+          </DialogHeader>
+          <DialogDescription>
+            <T
+              zh="关闭窗口不会停止当前传输。JPEG、PNG、HEIC，最大 50 MiB。"
+              en="Closing this dialog does not stop active jobs. JPEG, PNG, or HEIC up to 50 MiB."
+            />
+          </DialogDescription>
+          <DialogBody>
+            <DropZone
+              items={queue}
+              onFiles={onFiles}
+              onDiscard={(item) => {
+                if (!item.uploadIntentId) return
+                onRequestDiscard({
+                  uploadIntentId: item.uploadIntentId,
+                  label: item.file.name,
+                })
+              }}
+              onDismiss={onDismissQueueItem}
+              onRetry={onRetryQueueItem}
+            />
+            {transfers.length > 0 && (
+              <section className="mt-5">
+                <h3 className="text-sm font-medium">
+                  <T zh="未完成" en="Incomplete" />
+                </h3>
+                <ol aria-live="polite" className="mt-2 divide-y divide-border">
+                  {transfers.map((job) => (
+                    <PersistedTransferRow
+                      key={job.uploadIntentId}
+                      job={job}
+                      notice={notices[job.uploadIntentId]}
+                      pending={pendingTransferId === job.uploadIntentId}
+                      onChooseFile={onChooseFile}
+                      onDiscard={(target) =>
+                        onRequestDiscard({
+                          uploadIntentId: target.uploadIntentId,
+                          label: transferFileLabel(target),
+                        })
+                      }
+                      onRetryProcessing={onRetryProcessing}
+                    />
+                  ))}
+                </ol>
+              </section>
+            )}
+          </DialogBody>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={discardTarget !== null}
+        onOpenChange={(next) => {
+          if (!next && pendingTransferId === null) onCloseDiscard()
+        }}
+      >
+        <DialogContent size="sm" className="h-64">
+          <DialogHeader>
+            <DialogTitle>
+              <T zh="丢弃传输" en="Discard Transfer" />
+            </DialogTitle>
+            <DialogClose disabled={pendingTransferId !== null}>
+              <T zh="取消" en="Cancel" />
+            </DialogClose>
+          </DialogHeader>
+          <DialogDescription>
+            <T
+              zh="未完成的原片、分块和处理记录会永久删除。"
+              en={
+                'The incomplete Original, chunks, and processing record will be permanently removed.'
+              }
+            />
+          </DialogDescription>
+          <DialogBody>
+            <p className="truncate text-sm text-muted-foreground">
+              {discardTarget?.label}
+            </p>
+          </DialogBody>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="primary"
+              size="md"
+              destructive
+              loading={pendingTransferId !== null}
+              disabled={pendingTransferId !== null}
+              onClick={onConfirmDiscard}
+            >
+              <T zh="永久丢弃" en="Discard Permanently" />
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/app/admin/(protected)/media/page.tsx
+++ b/app/admin/(protected)/media/page.tsx
@@ -25,49 +25,46 @@ function MediaFallback() {
         </h1>
         <PixelCluster variant={8} className="shrink-0" />
       </div>
-      <p className="mt-1 text-sm tabular-nums text-muted-foreground">…</p>
-      <div className="mt-6 rounded-lg border border-dashed border-border px-5 py-4">
-        <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3">
-          <div>
-            <p className="text-sm font-medium">
-              <T zh="拖入或选择照片" en="Drop or choose photos" />
-            </p>
-            <p className="mt-0.5 text-sm text-muted-foreground">
-              JPEG · PNG · HEIC · ≤ 50 MiB
-            </p>
-          </div>
-          <span className="inline-flex h-7 items-center rounded-full bg-surface-1 px-3 text-[12px] text-muted-foreground">
-            <T zh="选择文件" en="Choose files" />
-          </span>
-        </div>
+      <div className="mt-1 flex h-10 items-center justify-between gap-4">
+        <p className="text-sm tabular-nums text-muted-foreground">…</p>
+        <span className="inline-flex h-8 items-center rounded-full bg-surface-1 px-3.5 text-[12px] text-muted-foreground">
+          <T zh="传输" en="Transfers" />
+        </span>
       </div>
-      {/* The subtle Tabs row is 32px tall (h-8 chips, no track). */}
-      <div className="mt-6 flex min-h-8 items-center" />
-      <ul className="mt-4 grid grid-cols-3 gap-2">
-        {Array.from({ length: 6 }, (_, index) => (
-          <li
-            key={index}
-            aria-hidden
-            className="aspect-square rounded-[2px] bg-surface-1"
-          />
-        ))}
-      </ul>
+      {/* The final controls occupy this exact 32px command row. */}
+      <div className="mt-4 flex min-h-8 items-center justify-between gap-3">
+        <span className="h-8 w-32 rounded-full bg-surface-1" />
+        <span className="h-8 w-40 rounded-sm bg-surface-1" />
+      </div>
+      <div className="min-h-[25rem]">
+        <ul className="mt-4 grid grid-cols-3 gap-2">
+          {Array.from({ length: 6 }, (_, index) => (
+            <li
+              key={index}
+              aria-hidden
+              className="aspect-square rounded-[2px] bg-surface-1"
+            />
+          ))}
+        </ul>
+      </div>
     </div>
   )
 }
 
 async function MediaLoader() {
   const owner = await requireOwnerPage('/admin/media')
-  const { getDraft, listAssets } = getMediaAdminPageServices()
-  const [active, archived, draft] = await Promise.all([
+  const { getDraft, listAssets, listTransfers } = getMediaAdminPageServices()
+  const [active, archived, draft, transfers] = await Promise.all([
     listAssets({ ownerUserId: owner.id, view: 'active' }),
     listAssets({ ownerUserId: owner.id, view: 'archived' }),
     getDraft(owner.id),
+    listTransfers(owner.id),
   ])
   return (
     <MediaLibrary
       initialActive={active}
       initialArchived={archived}
+      initialTransfers={transfers}
       selectionIds={draft.mediaAssetIds}
     />
   )

--- a/app/admin/(protected)/photos/PhotoCuration.tsx
+++ b/app/admin/(protected)/photos/PhotoCuration.tsx
@@ -18,9 +18,11 @@ import {
   DialogClose,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '~/components/ui/dialog'
+import { adminResponseJson } from '~/lib/admin/client-response'
 import { T } from '~/lib/i18n'
 import { localize, useLocale } from '~/lib/locale-client'
 import {
@@ -34,14 +36,6 @@ import { tiltFromSlug } from '~/lib/polaroid'
 const SAVE_DEBOUNCE_MS = 600
 
 type SaveState = 'idle' | 'saving' | 'saved' | 'error' | 'conflict'
-
-async function responseJson(response: Response) {
-  const body = (await response.json()) as Record<string, unknown>
-  if (!response.ok) {
-    throw new Error(typeof body.error === 'string' ? body.error : 'request_failed')
-  }
-  return body
-}
 
 function assetName(asset: MediaAssetReviewRecord) {
   return (
@@ -173,7 +167,7 @@ export function PhotoCuration({
             mediaAssetIds: orderRef.current,
           }),
         })
-        const body = await responseJson(response)
+        const body = await adminResponseJson(response)
         const draft = body.draft as DraftPhotoSelection
         revisionRef.current = draft.revision
         publishKeyRef.current = null
@@ -269,7 +263,7 @@ export function PhotoCuration({
           idempotencyKey,
         }),
       })
-      await responseJson(response)
+      await adminResponseJson(response)
       publishKeyRef.current = null
       setConfirming(false)
       setNotice(
@@ -331,15 +325,15 @@ export function PhotoCuration({
         </h1>
         <PixelCluster variant={9} className="shrink-0" />
       </div>
-      <div className="mt-1 flex min-h-8 flex-wrap items-center justify-between gap-x-4 gap-y-2">
-        <p className="text-sm tabular-nums text-muted-foreground">
+      <div className="mt-1 flex h-12 items-center justify-between gap-4">
+        <p className="min-w-0 text-sm leading-5 tabular-nums text-muted-foreground">
           {order.length}{' '}
           <T
             zh="张照片 · 前三张兼作首页预览"
             en="photos · first three double as the homepage preview"
           />
         </p>
-        <div className="flex items-center gap-3">
+        <div className="flex shrink-0 items-center gap-3">
           <span aria-live="polite" className="text-sm text-muted-foreground">
             {saveState === 'saving' && <T zh="保存中…" en="Saving…" />}
             {saveState === 'saved' && <T zh="草稿已保存" en="Draft saved" />}
@@ -357,15 +351,16 @@ export function PhotoCuration({
             disabled={
               busy || conflict || saveState === 'error' || ineligibleIds.length > 0
             }
-            onClick={() => setConfirming((current) => !current)}
+            onClick={() => setConfirming(true)}
           >
             <T zh="发布" en="Publish" />
           </Button>
         </div>
       </div>
 
-      {conflict && (
-        <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-md bg-surface-1 px-4 py-3">
+      <div className="mt-4 h-20 overflow-y-auto rounded-md bg-surface-1 px-3 py-2">
+        {conflict ? (
+          <div className="flex min-h-16 flex-wrap items-center justify-between gap-3">
           <p className="text-sm leading-5">
             <T
               zh="草稿已在其他页面更改。"
@@ -375,90 +370,25 @@ export function PhotoCuration({
           <Button variant="secondary" size="sm" onClick={() => router.refresh()}>
             <T zh="重新载入草稿" en="Reload draft" />
           </Button>
-        </div>
-      )}
-
-      {confirming && !conflict && (
-        <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-md bg-surface-1 px-4 py-3">
-          <p className="text-sm leading-6">
-            {order.length === 0 ? (
-              <T
-                zh="发布空选集会清空照片页和首页预览。"
-                en="Publishing an empty selection clears the photos page and homepage previews."
-              />
-            ) : (
-              <>
-                {order.length} <T zh="张照片" en="photos" />
-                {added > 0 && (
-                  <>
-                    {' · '}
-                    <T zh={`新增 ${added}`} en={`${added} added`} />
-                  </>
-                )}
-                {removed > 0 && (
-                  <>
-                    {' · '}
-                    <T zh={`移除 ${removed}`} en={`${removed} removed`} />
-                  </>
-                )}
-                {reordered && (
-                  <>
-                    {' · '}
-                    <T zh="顺序有变" en="order changed" />
-                  </>
-                )}
-                {added === 0 && removed === 0 && !reordered && (
-                  <>
-                    {' · '}
-                    <T zh="与线上一致" en="matches what is live" />
-                  </>
-                )}
-              </>
-            )}
-          </p>
-          <div className="flex items-center gap-1">
-            <Button
-              variant="ghost"
-              size="sm"
-              disabled={busy}
-              onClick={() => setConfirming(false)}
-            >
-              <T zh="取消" en="Cancel" />
-            </Button>
-            <Button
-              variant="primary"
-              size="sm"
-              loading={publishing}
-              onClick={() => void publish()}
-            >
-              <T zh="确认发布" en="Confirm publish" />
-            </Button>
           </div>
-        </div>
-      )}
-
-      {notice && (
-        <p
-          ref={noticeRef}
-          role="status"
-          tabIndex={-1}
-          className="mt-4 rounded-md bg-surface-1 px-4 py-3 text-sm leading-6 outline-none"
-        >
-          {notice}
-        </p>
-      )}
-
-      {ineligibleIds.length > 0 && (
-        <p role="alert" className="mt-4 border-l-2 border-destructive pl-4 text-sm leading-6">
-          <T
-            zh="选集中有照片不再符合发布条件（虚化显示）。移除它，或到媒体页完成处理。"
-            en="A photo in the selection is no longer eligible (shown dimmed). Remove it, or repair it in Media."
-          />
-        </p>
-      )}
-
-      {selectedId && selectedIndex >= 0 && (
-        <div className="mt-4 flex min-h-11 flex-wrap items-center gap-1 rounded-md bg-surface-1 px-3 py-1.5">
+        ) : ineligibleIds.length > 0 ? (
+          <p role="alert" className="flex min-h-16 items-center border-l-2 border-destructive pl-4 text-sm leading-6">
+            <T
+              zh="选集中有照片不再符合发布条件（虚化显示）。移除它，或到媒体页完成处理。"
+              en="A photo in the selection is no longer eligible (shown dimmed). Remove it, or repair it in Media."
+            />
+          </p>
+        ) : notice ? (
+          <p
+            ref={noticeRef}
+            role="status"
+            tabIndex={-1}
+            className="flex min-h-16 items-center text-sm leading-6 outline-none"
+          >
+            {notice}
+          </p>
+        ) : selectedId && selectedIndex >= 0 ? (
+          <div className="flex min-h-16 flex-wrap items-center gap-1">
           <span className="px-2 text-sm tabular-nums text-muted-foreground">
             {String(selectedIndex + 1).padStart(2, '0')} / {order.length}
           </span>
@@ -507,19 +437,28 @@ export function PhotoCuration({
           >
             ✕
           </Button>
-        </div>
-      )}
+          </div>
+        ) : (
+          <p className="flex min-h-16 items-center text-sm leading-5 text-muted-foreground">
+            <T
+              zh="选择照片可移动或移除；拖动可直接排序。"
+              en="Select a photo to move or remove it; drag to reorder directly."
+            />
+          </p>
+        )}
+      </div>
 
-      {order.length === 0 ? (
-        <p className="mt-6 hairline-top py-10 text-sm leading-6 text-muted-foreground">
+      <div className="min-h-[30rem]">
+        {order.length === 0 ? (
+          <p className="mt-6 hairline-top py-10 text-sm leading-6 text-muted-foreground">
           <T
             zh="选集是空的。从档案里挑几张照片开始吧。"
             en="The selection is empty. Pick a few photos from the archive to begin."
           />
-        </p>
-      ) : null}
+          </p>
+        ) : null}
 
-      <ul className="mt-6 grid grid-cols-3 gap-x-4 gap-y-6">
+        <ul className="mt-4 grid grid-cols-3 gap-x-4 gap-y-6">
         {order.map((id, index) => {
           const asset = assetById.get(id)
           const ineligible = !asset || !isMediaAssetEligible(asset)
@@ -582,10 +521,82 @@ export function PhotoCuration({
             </span>
           </button>
         </li>
-      </ul>
+        </ul>
+      </div>
+
+      <Dialog open={confirming} onOpenChange={setConfirming}>
+        <DialogContent size="sm" className="h-64">
+          <DialogHeader>
+            <DialogTitle>
+              <T zh="发布照片选集" en="Publish Photo Selection" />
+            </DialogTitle>
+            <DialogClose disabled={publishing}>
+              <T zh="取消" en="Cancel" />
+            </DialogClose>
+          </DialogHeader>
+          <DialogDescription>
+            <T
+              zh="发布会替换照片页和首页预览中的当前选集。"
+              en="Publishing replaces the current selection on Photos and the homepage preview."
+            />
+          </DialogDescription>
+          <DialogBody>
+            <p className="text-sm leading-6 tabular-nums">
+              {order.length === 0 ? (
+                <T
+                  zh="发布空选集会清空照片页和首页预览。"
+                  en="Publishing an empty selection clears the photos page and homepage previews."
+                />
+              ) : (
+                <>
+                  {order.length} <T zh="张照片" en="photos" />
+                  {added > 0 && (
+                    <>
+                      {' · '}
+                      <T zh={`新增 ${added}`} en={`${added} added`} />
+                    </>
+                  )}
+                  {removed > 0 && (
+                    <>
+                      {' · '}
+                      <T zh={`移除 ${removed}`} en={`${removed} removed`} />
+                    </>
+                  )}
+                  {reordered && (
+                    <>
+                      {' · '}
+                      <T zh="顺序有变" en="order changed" />
+                    </>
+                  )}
+                  {added === 0 && removed === 0 && !reordered && (
+                    <>
+                      {' · '}
+                      <T zh="与线上一致" en="matches what is live" />
+                    </>
+                  )}
+                </>
+              )}
+            </p>
+          </DialogBody>
+          <DialogFooter>
+            <Button
+              variant="primary"
+              size="md"
+              loading={publishing}
+              disabled={publishing}
+              onClick={() => void publish()}
+            >
+              <T zh="发布" en="Publish" />
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={pickerOpen} onOpenChange={setPickerOpen}>
-        <DialogContent size="lg">
+        <DialogContent
+          size="lg"
+          className="h-[min(38rem,calc(100dvh-2rem))]"
+        >
           <DialogHeader>
             <DialogTitle>
               <T zh="从档案添加" en="Add from the archive" />
@@ -594,8 +605,9 @@ export function PhotoCuration({
               <T zh="完成" en="Done" />
             </DialogClose>
           </DialogHeader>
+          <DialogBody>
           {candidates.length === 0 ? (
-            <p className="mt-4 text-sm leading-6 text-muted-foreground">
+            <p className="text-sm leading-6 text-muted-foreground">
               <T
                 zh="档案里的照片都已经在选集里了。"
                 en="Every archive photo is already in the selection."
@@ -603,10 +615,9 @@ export function PhotoCuration({
             </p>
           ) : (
             <>
-              <DialogDescription>
+              <p className="mb-4 text-sm text-muted-foreground">
                 <T zh="点一下即可加入选集末尾。" en="Tap a photo to append it to the selection." />
-              </DialogDescription>
-              <DialogBody className="mt-4">
+              </p>
                 <ul className="grid grid-cols-3 gap-2">
                   {candidates.map((asset) => {
                     const reason = ineligibilityReason(asset)
@@ -663,9 +674,9 @@ export function PhotoCuration({
                     />
                   </p>
                 )}
-              </DialogBody>
             </>
           )}
+          </DialogBody>
         </DialogContent>
       </Dialog>
     </div>

--- a/app/admin/(protected)/photos/page.tsx
+++ b/app/admin/(protected)/photos/page.tsx
@@ -26,18 +26,22 @@ function PhotosFallback() {
         </h1>
         <PixelCluster variant={9} className="shrink-0" />
       </div>
-      <div className="mt-1 flex min-h-8 flex-wrap items-center justify-between gap-x-4 gap-y-2">
+      <div className="mt-1 flex h-12 items-center justify-between gap-4">
         <p className="text-sm tabular-nums text-muted-foreground">…</p>
+        <span className="h-8 w-20 rounded-full bg-surface-1" />
       </div>
-      <ul className="mt-6 grid grid-cols-3 gap-x-4 gap-y-6">
-        {Array.from({ length: 6 }, (_, index) => (
-          <li
-            key={index}
-            aria-hidden
-            className="aspect-[0.86] rounded-[3px] bg-surface-1"
-          />
-        ))}
-      </ul>
+      <div className="mt-4 h-20 rounded-md bg-surface-1" />
+      <div className="min-h-[30rem]">
+        <ul className="mt-4 grid grid-cols-3 gap-x-4 gap-y-6">
+          {Array.from({ length: 6 }, (_, index) => (
+            <li
+              key={index}
+              aria-hidden
+              className="aspect-[0.86] rounded-[3px] bg-surface-1"
+            />
+          ))}
+        </ul>
+      </div>
     </div>
   )
 }

--- a/app/api/admin/media/upload-intents/[uploadIntentId]/route.ts
+++ b/app/api/admin/media/upload-intents/[uploadIntentId]/route.ts
@@ -1,0 +1,18 @@
+import { createMediaTransferDiscardHandler } from '~/lib/media/admin/http'
+import {
+  getMediaAdminServices,
+  ownerRequestAuthenticator,
+} from '~/lib/media/admin/server'
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ uploadIntentId: string }> },
+) {
+  const { uploadIntentId } = await params
+  const { security, transfer } = getMediaAdminServices()
+  return createMediaTransferDiscardHandler({
+    authenticator: ownerRequestAuthenticator,
+    security,
+    transfer,
+  })(request, uploadIntentId)
+}

--- a/app/api/admin/media/upload-intents/route.ts
+++ b/app/api/admin/media/upload-intents/route.ts
@@ -1,4 +1,7 @@
-import { createMediaUploadIntentHandler } from '~/lib/media/admin/http'
+import {
+  createMediaTransferListHandler,
+  createMediaUploadIntentHandler,
+} from '~/lib/media/admin/http'
 import {
   getMediaAdminServices,
   ownerRequestAuthenticator,
@@ -10,5 +13,14 @@ export async function POST(request: Request) {
     authenticator: ownerRequestAuthenticator,
     ingestion,
     security,
+  })(request)
+}
+
+export async function GET(request: Request) {
+  const { security, transfer } = getMediaAdminServices()
+  return createMediaTransferListHandler({
+    authenticator: ownerRequestAuthenticator,
+    security,
+    transfer,
   })(request)
 }

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -13,8 +13,8 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: ReactNode;
   /** 14px destructive text below the control, wired via aria-describedby. */
   error?: ReactNode;
-  /** Destructive border treatment without an error message (e.g. the
-   *  type-PURGE confirmation input). Implied when `error` is set. */
+  /** Destructive border treatment without an error message. Implied when
+   *  `error` is set. */
   destructive?: boolean;
 }
 

--- a/db/migrations/0013_brief_yellowjacket.sql
+++ b/db/migrations/0013_brief_yellowjacket.sql
@@ -1,0 +1,33 @@
+CREATE TABLE "media_asset_archive_operations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"owner_user_id" varchar(255) NOT NULL,
+	"media_asset_id" uuid NOT NULL,
+	"draft_id" uuid,
+	"draft_revision_before" integer,
+	"draft_revision_after" integer,
+	"draft_position" integer,
+	"published_selection_before" uuid,
+	"published_selection_after" uuid,
+	"archived_at" timestamp with time zone NOT NULL,
+	"undo_expires_at" timestamp with time zone NOT NULL,
+	"undone_at" timestamp with time zone,
+	CONSTRAINT "media_asset_archive_operations_owner_check" CHECK (length(btrim("media_asset_archive_operations"."owner_user_id")) > 0),
+	CONSTRAINT "media_asset_archive_operations_draft_check" CHECK (num_nonnulls("media_asset_archive_operations"."draft_id", "media_asset_archive_operations"."draft_revision_before", "media_asset_archive_operations"."draft_revision_after", "media_asset_archive_operations"."draft_position") IN (0, 4)),
+	CONSTRAINT "media_asset_archive_operations_publication_check" CHECK (num_nonnulls("media_asset_archive_operations"."published_selection_before", "media_asset_archive_operations"."published_selection_after") IN (0, 2)),
+	CONSTRAINT "media_asset_archive_operations_expiry_check" CHECK ("media_asset_archive_operations"."undo_expires_at" > "media_asset_archive_operations"."archived_at" AND ("media_asset_archive_operations"."undone_at" IS NULL OR "media_asset_archive_operations"."undone_at" >= "media_asset_archive_operations"."archived_at"))
+);
+--> statement-breakpoint
+ALTER TABLE "media_published_photo_selections" DROP CONSTRAINT "media_published_photo_selections_revision_check";--> statement-breakpoint
+DROP INDEX "media_published_photo_selections_draft_revision_uidx";--> statement-breakpoint
+ALTER TABLE "media_published_photo_selections" ALTER COLUMN "draft_revision" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "media_published_photo_selections" ADD COLUMN "publication_kind" varchar(16) DEFAULT 'draft' NOT NULL;--> statement-breakpoint
+ALTER TABLE "media_upload_intents" ADD COLUMN "discard_started_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "media_asset_archive_operations" ADD CONSTRAINT "media_asset_archive_operations_media_asset_id_media_assets_id_fk" FOREIGN KEY ("media_asset_id") REFERENCES "public"."media_assets"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "media_asset_archive_operations" ADD CONSTRAINT "media_asset_archive_operations_draft_id_media_photo_selection_drafts_id_fk" FOREIGN KEY ("draft_id") REFERENCES "public"."media_photo_selection_drafts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "media_asset_archive_operations" ADD CONSTRAINT "media_asset_archive_operations_published_selection_before_media_published_photo_selections_id_fk" FOREIGN KEY ("published_selection_before") REFERENCES "public"."media_published_photo_selections"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "media_asset_archive_operations" ADD CONSTRAINT "media_asset_archive_operations_published_selection_after_media_published_photo_selections_id_fk" FOREIGN KEY ("published_selection_after") REFERENCES "public"."media_published_photo_selections"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "media_asset_archive_operations_owner_idx" ON "media_asset_archive_operations" USING btree ("owner_user_id","media_asset_id","undo_expires_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "media_published_photo_selections_draft_revision_uidx" ON "media_published_photo_selections" USING btree ("owner_user_id","draft_revision") WHERE "media_published_photo_selections"."publication_kind" = 'draft';--> statement-breakpoint
+ALTER TABLE "media_published_photo_selections" ADD CONSTRAINT "media_published_photo_selections_kind_check" CHECK ("media_published_photo_selections"."publication_kind" IN ('draft', 'withdrawal'));--> statement-breakpoint
+ALTER TABLE "media_published_photo_selections" ADD CONSTRAINT "media_published_photo_selections_revision_check" CHECK (("media_published_photo_selections"."publication_kind" = 'draft' AND "media_published_photo_selections"."draft_revision" >= 0) OR ("media_published_photo_selections"."publication_kind" = 'withdrawal' AND "media_published_photo_selections"."draft_revision" IS NULL));--> statement-breakpoint
+ALTER TABLE "media_upload_intents" ADD CONSTRAINT "media_upload_intents_discard_check" CHECK ("media_upload_intents"."discard_started_at" IS NULL OR ("media_upload_intents"."completed_at" IS NULL AND "media_upload_intents"."discard_started_at" >= "media_upload_intents"."created_at"));

--- a/db/migrations/meta/0013_snapshot.json
+++ b/db/migrations/meta/0013_snapshot.json
@@ -1,0 +1,3583 @@
+{
+  "id": "cf095551-ac65-41d8-87fe-dc405d63aba0",
+  "prevId": "4242c828-f65d-43c5-a3e4-378fc721ead8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ama_admin_sessions": {
+      "name": "ama_admin_sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_admin_sessions_expires_at_idx": {
+          "name": "ama_admin_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ama_alternate_time_requests": {
+      "name": "ama_alternate_time_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "guest_name": {
+          "name": "guest_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guest_email": {
+          "name": "guest_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guest_time_zone": {
+          "name": "guest_time_zone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_windows": {
+          "name": "preferred_windows",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ama_alternate_time_requests_status_idx": {
+          "name": "ama_alternate_time_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_alternate_time_requests_guest_check": {
+          "name": "ama_alternate_time_requests_guest_check",
+          "value": "length(btrim(\"ama_alternate_time_requests\".\"guest_name\")) > 0 AND length(btrim(\"ama_alternate_time_requests\".\"guest_email\")) > 0"
+        },
+        "ama_alternate_time_requests_locale_check": {
+          "name": "ama_alternate_time_requests_locale_check",
+          "value": "\"ama_alternate_time_requests\".\"locale\" IN ('zh', 'en')"
+        },
+        "ama_alternate_time_requests_windows_check": {
+          "name": "ama_alternate_time_requests_windows_check",
+          "value": "length(btrim(\"ama_alternate_time_requests\".\"preferred_windows\")) > 0 AND char_length(\"ama_alternate_time_requests\".\"preferred_windows\") <= 1000"
+        },
+        "ama_alternate_time_requests_note_check": {
+          "name": "ama_alternate_time_requests_note_check",
+          "value": "\"ama_alternate_time_requests\".\"note\" IS NULL OR char_length(\"ama_alternate_time_requests\".\"note\") <= 1000"
+        },
+        "ama_alternate_time_requests_status_check": {
+          "name": "ama_alternate_time_requests_status_check",
+          "value": "\"ama_alternate_time_requests\".\"status\" IN ('new', 'resolved', 'dismissed')"
+        },
+        "ama_alternate_time_requests_resolution_check": {
+          "name": "ama_alternate_time_requests_resolution_check",
+          "value": "(\"ama_alternate_time_requests\".\"status\" = 'new') = (\"ama_alternate_time_requests\".\"resolved_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_auth_tokens": {
+      "name": "ama_auth_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_auth_tokens_expires_at_idx": {
+          "name": "ama_auth_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ama_availability_windows": {
+      "name": "ama_availability_windows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "iso_weekday": {
+          "name": "iso_weekday",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_minute": {
+          "name": "start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_minute": {
+          "name": "end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_availability_windows_order_idx": {
+          "name": "ama_availability_windows_order_idx",
+          "columns": [
+            {
+              "expression": "iso_weekday",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_minute",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_minute",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_availability_windows_iso_weekday_check": {
+          "name": "ama_availability_windows_iso_weekday_check",
+          "value": "\"ama_availability_windows\".\"iso_weekday\" BETWEEN 1 AND 7"
+        },
+        "ama_availability_windows_start_minute_check": {
+          "name": "ama_availability_windows_start_minute_check",
+          "value": "\"ama_availability_windows\".\"start_minute\" BETWEEN 0 AND 1439"
+        },
+        "ama_availability_windows_end_minute_check": {
+          "name": "ama_availability_windows_end_minute_check",
+          "value": "\"ama_availability_windows\".\"end_minute\" BETWEEN 1 AND 1440"
+        },
+        "ama_availability_windows_same_day_check": {
+          "name": "ama_availability_windows_same_day_check",
+          "value": "\"ama_availability_windows\".\"start_minute\" < \"ama_availability_windows\".\"end_minute\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_booking_events": {
+      "name": "ama_booking_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(48)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "ama_booking_events_booking_idx": {
+          "name": "ama_booking_events_booking_idx",
+          "columns": [
+            {
+              "expression": "booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ama_booking_events_booking_id_ama_bookings_id_fk": {
+          "name": "ama_booking_events_booking_id_ama_bookings_id_fk",
+          "tableFrom": "ama_booking_events",
+          "tableTo": "ama_bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_booking_events_event_check": {
+          "name": "ama_booking_events_event_check",
+          "value": "length(btrim(\"ama_booking_events\".\"event\")) > 0"
+        },
+        "ama_booking_events_actor_check": {
+          "name": "ama_booking_events_actor_check",
+          "value": "\"ama_booking_events\".\"actor\" IN ('guest', 'owner', 'system', 'provider')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_booking_intents": {
+      "name": "ama_booking_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "hold_claim_id": {
+          "name": "hold_claim_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guest_name": {
+          "name": "guest_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guest_email": {
+          "name": "guest_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guest_time_zone": {
+          "name": "guest_time_zone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief_text": {
+          "name": "brief_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief_urls": {
+          "name": "brief_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "meeting_provider": {
+          "name": "meeting_provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_booking_intents_hold_claim_uidx": {
+          "name": "ama_booking_intents_hold_claim_uidx",
+          "columns": [
+            {
+              "expression": "hold_claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ama_booking_intents_checkout_session_uidx": {
+          "name": "ama_booking_intents_checkout_session_uidx",
+          "columns": [
+            {
+              "expression": "stripe_checkout_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ama_booking_intents_hold_claim_id_ama_slot_claims_id_fk": {
+          "name": "ama_booking_intents_hold_claim_id_ama_slot_claims_id_fk",
+          "tableFrom": "ama_booking_intents",
+          "tableTo": "ama_slot_claims",
+          "columnsFrom": [
+            "hold_claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_booking_intents_guest_check": {
+          "name": "ama_booking_intents_guest_check",
+          "value": "length(btrim(\"ama_booking_intents\".\"guest_name\")) > 0 AND length(btrim(\"ama_booking_intents\".\"guest_email\")) > 0"
+        },
+        "ama_booking_intents_locale_check": {
+          "name": "ama_booking_intents_locale_check",
+          "value": "\"ama_booking_intents\".\"locale\" IN ('zh', 'en')"
+        },
+        "ama_booking_intents_time_zone_check": {
+          "name": "ama_booking_intents_time_zone_check",
+          "value": "length(btrim(\"ama_booking_intents\".\"guest_time_zone\")) > 0"
+        },
+        "ama_booking_intents_topics_check": {
+          "name": "ama_booking_intents_topics_check",
+          "value": "jsonb_typeof(\"ama_booking_intents\".\"topics\") = 'array' AND jsonb_array_length(\"ama_booking_intents\".\"topics\") BETWEEN 1 AND 8"
+        },
+        "ama_booking_intents_brief_check": {
+          "name": "ama_booking_intents_brief_check",
+          "value": "length(btrim(\"ama_booking_intents\".\"brief_text\")) > 0 AND char_length(\"ama_booking_intents\".\"brief_text\") <= 2000"
+        },
+        "ama_booking_intents_brief_urls_check": {
+          "name": "ama_booking_intents_brief_urls_check",
+          "value": "jsonb_typeof(\"ama_booking_intents\".\"brief_urls\") = 'array' AND jsonb_array_length(\"ama_booking_intents\".\"brief_urls\") <= 5"
+        },
+        "ama_booking_intents_provider_check": {
+          "name": "ama_booking_intents_provider_check",
+          "value": "\"ama_booking_intents\".\"meeting_provider\" IN ('google-meet', 'tencent-meeting')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_bookings": {
+      "name": "ama_bookings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finalizing'"
+        },
+        "guest_name": {
+          "name": "guest_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guest_email": {
+          "name": "guest_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guest_time_zone": {
+          "name": "guest_time_zone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief_text": {
+          "name": "brief_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brief_urls": {
+          "name": "brief_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brief_purged_at": {
+          "name": "brief_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_provider": {
+          "name": "meeting_provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_total": {
+          "name": "amount_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refund_status": {
+          "name": "refund_status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "stripe_refund_id": {
+          "name": "stripe_refund_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refund_reason": {
+          "name": "refund_reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by": {
+          "name": "cancelled_by",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_url": {
+          "name": "meeting_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_calendar_event_id": {
+          "name": "google_calendar_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tencent_meeting_id": {
+          "name": "tencent_meeting_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_created_at": {
+          "name": "meeting_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manage_token_hash": {
+          "name": "manage_token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manage_token_issued_at": {
+          "name": "manage_token_issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manage_token_revoked_at": {
+          "name": "manage_token_revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_bookings_intent_uidx": {
+          "name": "ama_bookings_intent_uidx",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ama_bookings_checkout_session_uidx": {
+          "name": "ama_bookings_checkout_session_uidx",
+          "columns": [
+            {
+              "expression": "stripe_checkout_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ama_bookings_manage_token_uidx": {
+          "name": "ama_bookings_manage_token_uidx",
+          "columns": [
+            {
+              "expression": "manage_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ama_bookings_schedule_idx": {
+          "name": "ama_bookings_schedule_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ama_bookings_claim_idx": {
+          "name": "ama_bookings_claim_idx",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ama_bookings_intent_id_ama_booking_intents_id_fk": {
+          "name": "ama_bookings_intent_id_ama_booking_intents_id_fk",
+          "tableFrom": "ama_bookings",
+          "tableTo": "ama_booking_intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "ama_bookings_claim_id_ama_slot_claims_id_fk": {
+          "name": "ama_bookings_claim_id_ama_slot_claims_id_fk",
+          "tableFrom": "ama_bookings",
+          "tableTo": "ama_slot_claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_bookings_status_check": {
+          "name": "ama_bookings_status_check",
+          "value": "\"ama_bookings\".\"status\" IN ('finalizing', 'confirmed', 'needs_reschedule', 'cancelled')"
+        },
+        "ama_bookings_locale_check": {
+          "name": "ama_bookings_locale_check",
+          "value": "\"ama_bookings\".\"locale\" IN ('zh', 'en')"
+        },
+        "ama_bookings_provider_check": {
+          "name": "ama_bookings_provider_check",
+          "value": "\"ama_bookings\".\"meeting_provider\" IN ('google-meet', 'tencent-meeting')"
+        },
+        "ama_bookings_interval_check": {
+          "name": "ama_bookings_interval_check",
+          "value": "\"ama_bookings\".\"starts_at\" < \"ama_bookings\".\"ends_at\""
+        },
+        "ama_bookings_claim_presence_check": {
+          "name": "ama_bookings_claim_presence_check",
+          "value": "\"ama_bookings\".\"status\" IN ('needs_reschedule', 'cancelled') OR \"ama_bookings\".\"claim_id\" IS NOT NULL"
+        },
+        "ama_bookings_refund_status_check": {
+          "name": "ama_bookings_refund_status_check",
+          "value": "\"ama_bookings\".\"refund_status\" IN ('none', 'pending', 'refunded', 'failed')"
+        },
+        "ama_bookings_refund_reason_check": {
+          "name": "ama_bookings_refund_reason_check",
+          "value": "\"ama_bookings\".\"refund_reason\" IS NULL OR \"ama_bookings\".\"refund_reason\" IN ('guest_cancellation', 'owner_cancellation', 'owner_exception')"
+        },
+        "ama_bookings_cancellation_check": {
+          "name": "ama_bookings_cancellation_check",
+          "value": "(\"ama_bookings\".\"status\" = 'cancelled') = (\"ama_bookings\".\"cancelled_at\" IS NOT NULL AND \"ama_bookings\".\"cancelled_by\" IS NOT NULL)"
+        },
+        "ama_bookings_cancelled_by_check": {
+          "name": "ama_bookings_cancelled_by_check",
+          "value": "\"ama_bookings\".\"cancelled_by\" IS NULL OR \"ama_bookings\".\"cancelled_by\" IN ('guest', 'owner')"
+        },
+        "ama_bookings_brief_purge_check": {
+          "name": "ama_bookings_brief_purge_check",
+          "value": "(\"ama_bookings\".\"brief_purged_at\" IS NULL AND \"ama_bookings\".\"brief_text\" IS NOT NULL AND \"ama_bookings\".\"brief_urls\" IS NOT NULL) OR (\"ama_bookings\".\"brief_purged_at\" IS NOT NULL AND \"ama_bookings\".\"brief_text\" IS NULL AND \"ama_bookings\".\"brief_urls\" IS NULL)"
+        },
+        "ama_bookings_manage_token_check": {
+          "name": "ama_bookings_manage_token_check",
+          "value": "(\"ama_bookings\".\"manage_token_hash\" IS NULL) = (\"ama_bookings\".\"manage_token_issued_at\" IS NULL)"
+        },
+        "ama_bookings_amount_check": {
+          "name": "ama_bookings_amount_check",
+          "value": "\"ama_bookings\".\"amount_total\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_durable_operations": {
+      "name": "ama_durable_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(48)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_durable_operations_dedupe_uidx": {
+          "name": "ama_durable_operations_dedupe_uidx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ama_durable_operations_due_idx": {
+          "name": "ama_durable_operations_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ama_durable_operations_booking_idx": {
+          "name": "ama_durable_operations_booking_idx",
+          "columns": [
+            {
+              "expression": "booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ama_durable_operations_booking_id_ama_bookings_id_fk": {
+          "name": "ama_durable_operations_booking_id_ama_bookings_id_fk",
+          "tableFrom": "ama_durable_operations",
+          "tableTo": "ama_bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_durable_operations_kind_check": {
+          "name": "ama_durable_operations_kind_check",
+          "value": "length(btrim(\"ama_durable_operations\".\"kind\")) > 0"
+        },
+        "ama_durable_operations_status_check": {
+          "name": "ama_durable_operations_status_check",
+          "value": "\"ama_durable_operations\".\"status\" IN ('pending', 'running', 'succeeded', 'failed', 'cancelled', 'resolved')"
+        },
+        "ama_durable_operations_attempts_check": {
+          "name": "ama_durable_operations_attempts_check",
+          "value": "\"ama_durable_operations\".\"attempt_count\" >= 0 AND \"ama_durable_operations\".\"max_attempts\" > 0"
+        },
+        "ama_durable_operations_lease_check": {
+          "name": "ama_durable_operations_lease_check",
+          "value": "num_nonnulls(\"ama_durable_operations\".\"lease_token\", \"ama_durable_operations\".\"lease_expires_at\") IN (0, 2)"
+        },
+        "ama_durable_operations_completion_check": {
+          "name": "ama_durable_operations_completion_check",
+          "value": "(\"ama_durable_operations\".\"status\" IN ('succeeded', 'failed', 'cancelled', 'resolved')) = (\"ama_durable_operations\".\"completed_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_google_calendar_connections": {
+      "name": "ama_google_calendar_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_email": {
+          "name": "calendar_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_summary": {
+          "name": "calendar_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_scopes": {
+          "name": "granted_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "refresh_token_envelope": {
+          "name": "refresh_token_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_google_calendar_connections_singleton_check": {
+          "name": "ama_google_calendar_connections_singleton_check",
+          "value": "\"ama_google_calendar_connections\".\"id\" = 1"
+        },
+        "ama_google_calendar_connections_status_check": {
+          "name": "ama_google_calendar_connections_status_check",
+          "value": "\"ama_google_calendar_connections\".\"status\" IN ('disconnected', 'connected', 'expired', 'revoked', 'denied_scope', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_google_oauth_attempts": {
+      "name": "ama_google_oauth_attempts",
+      "schema": "",
+      "columns": {
+        "state_hash": {
+          "name": "state_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email": {
+          "name": "owner_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pkce_verifier_envelope": {
+          "name": "pkce_verifier_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_google_oauth_attempts_expires_at_idx": {
+          "name": "ama_google_oauth_attempts_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ama_provider_events": {
+      "name": "ama_provider_events",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ama_provider_events_provider_event_id_pk": {
+          "name": "ama_provider_events_provider_event_id_pk",
+          "columns": [
+            "provider",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_provider_events_provider_check": {
+          "name": "ama_provider_events_provider_check",
+          "value": "\"ama_provider_events\".\"provider\" = 'stripe'"
+        },
+        "ama_provider_events_identity_check": {
+          "name": "ama_provider_events_identity_check",
+          "value": "length(btrim(\"ama_provider_events\".\"event_id\")) > 0 AND length(btrim(\"ama_provider_events\".\"event_type\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ama_slot_claims": {
+      "name": "ama_slot_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_during": {
+          "name": "blocked_during",
+          "type": "tstzrange",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_reason": {
+          "name": "release_reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ama_slot_claims_active_idx": {
+          "name": "ama_slot_claims_active_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ama_slot_claims_expiry_idx": {
+          "name": "ama_slot_claims_expiry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ama_slot_claims_kind_check": {
+          "name": "ama_slot_claims_kind_check",
+          "value": "\"ama_slot_claims\".\"kind\" IN ('hold', 'booking')"
+        },
+        "ama_slot_claims_status_check": {
+          "name": "ama_slot_claims_status_check",
+          "value": "\"ama_slot_claims\".\"status\" IN ('active', 'released')"
+        },
+        "ama_slot_claims_interval_check": {
+          "name": "ama_slot_claims_interval_check",
+          "value": "\"ama_slot_claims\".\"starts_at\" < \"ama_slot_claims\".\"ends_at\""
+        },
+        "ama_slot_claims_blocked_during_check": {
+          "name": "ama_slot_claims_blocked_during_check",
+          "value": "\"ama_slot_claims\".\"blocked_during\" = tstzrange(\"ama_slot_claims\".\"starts_at\" - interval '15 minutes', \"ama_slot_claims\".\"ends_at\" + interval '15 minutes', '[)')"
+        },
+        "ama_slot_claims_hold_expiry_check": {
+          "name": "ama_slot_claims_hold_expiry_check",
+          "value": "(\"ama_slot_claims\".\"kind\" = 'hold') = (\"ama_slot_claims\".\"expires_at\" IS NOT NULL)"
+        },
+        "ama_slot_claims_release_check": {
+          "name": "ama_slot_claims_release_check",
+          "value": "(\"ama_slot_claims\".\"status\" = 'active' AND \"ama_slot_claims\".\"released_at\" IS NULL AND \"ama_slot_claims\".\"release_reason\" IS NULL) OR (\"ama_slot_claims\".\"status\" = 'released' AND \"ama_slot_claims\".\"released_at\" IS NOT NULL AND \"ama_slot_claims\".\"release_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_active_photo_publication": {
+      "name": "media_active_photo_publication",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "published_selection_id": {
+          "name": "published_selection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_active_photo_publication_selection_uidx": {
+          "name": "media_active_photo_publication_selection_uidx",
+          "columns": [
+            {
+              "expression": "published_selection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_active_photo_publication_published_selection_id_media_published_photo_selections_id_fk": {
+          "name": "media_active_photo_publication_published_selection_id_media_published_photo_selections_id_fk",
+          "tableFrom": "media_active_photo_publication",
+          "tableTo": "media_published_photo_selections",
+          "columnsFrom": [
+            "published_selection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_active_photo_publication_singleton_check": {
+          "name": "media_active_photo_publication_singleton_check",
+          "value": "\"media_active_photo_publication\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_asset_archive_operations": {
+      "name": "media_asset_archive_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_revision_before": {
+          "name": "draft_revision_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_revision_after": {
+          "name": "draft_revision_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_position": {
+          "name": "draft_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_selection_before": {
+          "name": "published_selection_before",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_selection_after": {
+          "name": "published_selection_after",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "undo_expires_at": {
+          "name": "undo_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "undone_at": {
+          "name": "undone_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "media_asset_archive_operations_owner_idx": {
+          "name": "media_asset_archive_operations_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "undo_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_asset_archive_operations_media_asset_id_media_assets_id_fk": {
+          "name": "media_asset_archive_operations_media_asset_id_media_assets_id_fk",
+          "tableFrom": "media_asset_archive_operations",
+          "tableTo": "media_assets",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_asset_archive_operations_draft_id_media_photo_selection_drafts_id_fk": {
+          "name": "media_asset_archive_operations_draft_id_media_photo_selection_drafts_id_fk",
+          "tableFrom": "media_asset_archive_operations",
+          "tableTo": "media_photo_selection_drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_asset_archive_operations_published_selection_before_media_published_photo_selections_id_fk": {
+          "name": "media_asset_archive_operations_published_selection_before_media_published_photo_selections_id_fk",
+          "tableFrom": "media_asset_archive_operations",
+          "tableTo": "media_published_photo_selections",
+          "columnsFrom": [
+            "published_selection_before"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "media_asset_archive_operations_published_selection_after_media_published_photo_selections_id_fk": {
+          "name": "media_asset_archive_operations_published_selection_after_media_published_photo_selections_id_fk",
+          "tableFrom": "media_asset_archive_operations",
+          "tableTo": "media_published_photo_selections",
+          "columnsFrom": [
+            "published_selection_after"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_asset_archive_operations_owner_check": {
+          "name": "media_asset_archive_operations_owner_check",
+          "value": "length(btrim(\"media_asset_archive_operations\".\"owner_user_id\")) > 0"
+        },
+        "media_asset_archive_operations_draft_check": {
+          "name": "media_asset_archive_operations_draft_check",
+          "value": "num_nonnulls(\"media_asset_archive_operations\".\"draft_id\", \"media_asset_archive_operations\".\"draft_revision_before\", \"media_asset_archive_operations\".\"draft_revision_after\", \"media_asset_archive_operations\".\"draft_position\") IN (0, 4)"
+        },
+        "media_asset_archive_operations_publication_check": {
+          "name": "media_asset_archive_operations_publication_check",
+          "value": "num_nonnulls(\"media_asset_archive_operations\".\"published_selection_before\", \"media_asset_archive_operations\".\"published_selection_after\") IN (0, 2)"
+        },
+        "media_asset_archive_operations_expiry_check": {
+          "name": "media_asset_archive_operations_expiry_check",
+          "value": "\"media_asset_archive_operations\".\"undo_expires_at\" > \"media_asset_archive_operations\".\"archived_at\" AND (\"media_asset_archive_operations\".\"undone_at\" IS NULL OR \"media_asset_archive_operations\".\"undone_at\" >= \"media_asset_archive_operations\".\"archived_at\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_asset_purge_jobs": {
+      "name": "media_asset_purge_jobs",
+      "schema": "",
+      "columns": {
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_deleted_at": {
+          "name": "original_deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "media_asset_purge_jobs_owner_idx": {
+          "name": "media_asset_purge_jobs_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_asset_purge_jobs_owner_check": {
+          "name": "media_asset_purge_jobs_owner_check",
+          "value": "length(btrim(\"media_asset_purge_jobs\".\"owner_user_id\")) > 0"
+        },
+        "media_asset_purge_jobs_claim_check": {
+          "name": "media_asset_purge_jobs_claim_check",
+          "value": "num_nonnulls(\"media_asset_purge_jobs\".\"claim_token\", \"media_asset_purge_jobs\".\"claim_expires_at\") IN (0, 2)"
+        },
+        "media_asset_purge_jobs_error_check": {
+          "name": "media_asset_purge_jobs_error_check",
+          "value": "\"media_asset_purge_jobs\".\"last_error_code\" IS NULL OR length(btrim(\"media_asset_purge_jobs\".\"last_error_code\")) > 0"
+        },
+        "media_asset_purge_jobs_completion_check": {
+          "name": "media_asset_purge_jobs_completion_check",
+          "value": "(\"media_asset_purge_jobs\".\"completed_at\" IS NULL AND \"media_asset_purge_jobs\".\"original_key\" IS NOT NULL) OR (\"media_asset_purge_jobs\".\"completed_at\" IS NOT NULL AND \"media_asset_purge_jobs\".\"original_key\" IS NULL AND \"media_asset_purge_jobs\".\"original_deleted_at\" IS NOT NULL AND \"media_asset_purge_jobs\".\"claim_token\" IS NULL AND \"media_asset_purge_jobs\".\"claim_expires_at\" IS NULL AND \"media_asset_purge_jobs\".\"last_error_code\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_asset_purge_renditions": {
+      "name": "media_asset_purge_renditions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_deleted_at": {
+          "name": "object_deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cdn_purged_at": {
+          "name": "cdn_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "media_asset_purge_renditions_object_uidx": {
+          "name": "media_asset_purge_renditions_object_uidx",
+          "columns": [
+            {
+              "expression": "media_asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_asset_purge_renditions_media_asset_id_media_asset_purge_jobs_media_asset_id_fk": {
+          "name": "media_asset_purge_renditions_media_asset_id_media_asset_purge_jobs_media_asset_id_fk",
+          "tableFrom": "media_asset_purge_renditions",
+          "tableTo": "media_asset_purge_jobs",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "media_asset_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_asset_purge_renditions_object_key_check": {
+          "name": "media_asset_purge_renditions_object_key_check",
+          "value": "length(btrim(\"media_asset_purge_renditions\".\"object_key\")) > 0"
+        },
+        "media_asset_purge_renditions_progress_check": {
+          "name": "media_asset_purge_renditions_progress_check",
+          "value": "\"media_asset_purge_renditions\".\"cdn_purged_at\" IS NULL OR \"media_asset_purge_renditions\".\"object_deleted_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_assets": {
+      "name": "media_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "upload_intent_id": {
+          "name": "upload_intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'image'"
+        },
+        "catalog_state": {
+          "name": "catalog_state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "processing_state": {
+          "name": "processing_state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upload_initiated'"
+        },
+        "processing_error_code": {
+          "name": "processing_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_content_type": {
+          "name": "original_content_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_byte_size": {
+          "name": "original_byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_checksum_sha256": {
+          "name": "original_checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera_make": {
+          "name": "camera_make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera_model": {
+          "name": "camera_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lens": {
+          "name": "lens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_length_millimeters": {
+          "name": "focal_length_millimeters",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aperture": {
+          "name": "aperture",
+          "type": "numeric(6, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutter_speed_seconds": {
+          "name": "shutter_speed_seconds",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iso": {
+          "name": "iso",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_point_x": {
+          "name": "focal_point_x",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_point_y": {
+          "name": "focal_point_y",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_location_envelope": {
+          "name": "capture_location_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_label_zh_hans": {
+          "name": "location_label_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_label_en": {
+          "name": "location_label_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_suggestion_zh_hans": {
+          "name": "alt_text_suggestion_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_suggestion_en": {
+          "name": "alt_text_suggestion_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_suggestion_model": {
+          "name": "alt_text_suggestion_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_suggested_at": {
+          "name": "alt_text_suggested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_zh_hans": {
+          "name": "alt_text_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_en": {
+          "name": "alt_text_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_approved_at": {
+          "name": "alt_text_approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purge_started_at": {
+          "name": "purge_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_assets_upload_intent_uidx": {
+          "name": "media_assets_upload_intent_uidx",
+          "columns": [
+            {
+              "expression": "upload_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_assets_original_key_uidx": {
+          "name": "media_assets_original_key_uidx",
+          "columns": [
+            {
+              "expression": "original_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_assets_library_idx": {
+          "name": "media_assets_library_idx",
+          "columns": [
+            {
+              "expression": "catalog_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processing_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_assets_upload_intent_id_media_upload_intents_id_fk": {
+          "name": "media_assets_upload_intent_id_media_upload_intents_id_fk",
+          "tableFrom": "media_assets",
+          "tableTo": "media_upload_intents",
+          "columnsFrom": [
+            "upload_intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_assets_kind_check": {
+          "name": "media_assets_kind_check",
+          "value": "\"media_assets\".\"kind\" = 'image'"
+        },
+        "media_assets_catalog_state_check": {
+          "name": "media_assets_catalog_state_check",
+          "value": "\"media_assets\".\"catalog_state\" IN ('active', 'archived', 'purging')"
+        },
+        "media_assets_processing_state_check": {
+          "name": "media_assets_processing_state_check",
+          "value": "\"media_assets\".\"processing_state\" IN ('upload_initiated', 'original_verified', 'processing', 'ready', 'retryable_failure', 'repair_required')"
+        },
+        "media_assets_processing_error_check": {
+          "name": "media_assets_processing_error_check",
+          "value": "(\"media_assets\".\"processing_state\" IN ('retryable_failure', 'repair_required')) = (\"media_assets\".\"processing_error_code\" IS NOT NULL AND length(btrim(\"media_assets\".\"processing_error_code\")) > 0)"
+        },
+        "media_assets_original_key_check": {
+          "name": "media_assets_original_key_check",
+          "value": "length(btrim(\"media_assets\".\"original_key\")) > 0"
+        },
+        "media_assets_original_content_type_check": {
+          "name": "media_assets_original_content_type_check",
+          "value": "\"media_assets\".\"original_content_type\" IN ('image/jpeg', 'image/png', 'image/heic', 'image/heif')"
+        },
+        "media_assets_original_byte_size_check": {
+          "name": "media_assets_original_byte_size_check",
+          "value": "\"media_assets\".\"original_byte_size\" BETWEEN 1 AND 52428800"
+        },
+        "media_assets_original_checksum_check": {
+          "name": "media_assets_original_checksum_check",
+          "value": "\"media_assets\".\"original_checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "media_assets_dimensions_check": {
+          "name": "media_assets_dimensions_check",
+          "value": "num_nonnulls(\"media_assets\".\"width\", \"media_assets\".\"height\") IN (0, 2) AND (\"media_assets\".\"width\" IS NULL OR (\"media_assets\".\"width\" > 0 AND \"media_assets\".\"height\" > 0 AND (\"media_assets\".\"width\"::bigint * \"media_assets\".\"height\"::bigint) <= 100000000))"
+        },
+        "media_assets_focal_point_check": {
+          "name": "media_assets_focal_point_check",
+          "value": "num_nonnulls(\"media_assets\".\"focal_point_x\", \"media_assets\".\"focal_point_y\") IN (0, 2) AND (\"media_assets\".\"focal_point_x\" IS NULL OR (\"media_assets\".\"focal_point_x\" BETWEEN 0 AND 1 AND \"media_assets\".\"focal_point_y\" BETWEEN 0 AND 1))"
+        },
+        "media_assets_camera_values_check": {
+          "name": "media_assets_camera_values_check",
+          "value": "(\"media_assets\".\"focal_length_millimeters\" IS NULL OR \"media_assets\".\"focal_length_millimeters\" > 0) AND (\"media_assets\".\"aperture\" IS NULL OR \"media_assets\".\"aperture\" > 0) AND (\"media_assets\".\"shutter_speed_seconds\" IS NULL OR \"media_assets\".\"shutter_speed_seconds\" > 0) AND (\"media_assets\".\"iso\" IS NULL OR \"media_assets\".\"iso\" > 0)"
+        },
+        "media_assets_alt_suggestion_check": {
+          "name": "media_assets_alt_suggestion_check",
+          "value": "num_nonnulls(\"media_assets\".\"alt_text_suggestion_zh_hans\", \"media_assets\".\"alt_text_suggestion_en\", \"media_assets\".\"alt_text_suggestion_model\", \"media_assets\".\"alt_text_suggested_at\") IN (0, 4) AND (\"media_assets\".\"alt_text_suggestion_zh_hans\" IS NULL OR (length(btrim(\"media_assets\".\"alt_text_suggestion_zh_hans\")) > 0 AND length(btrim(\"media_assets\".\"alt_text_suggestion_en\")) > 0 AND length(btrim(\"media_assets\".\"alt_text_suggestion_model\")) > 0))"
+        },
+        "media_assets_alt_text_check": {
+          "name": "media_assets_alt_text_check",
+          "value": "num_nonnulls(\"media_assets\".\"alt_text_zh_hans\", \"media_assets\".\"alt_text_en\", \"media_assets\".\"alt_text_approved_at\") IN (0, 3) AND (\"media_assets\".\"alt_text_zh_hans\" IS NULL OR (length(btrim(\"media_assets\".\"alt_text_zh_hans\")) > 0 AND length(btrim(\"media_assets\".\"alt_text_en\")) > 0))"
+        },
+        "media_assets_archive_check": {
+          "name": "media_assets_archive_check",
+          "value": "(\"media_assets\".\"catalog_state\" = 'active' AND \"media_assets\".\"archived_at\" IS NULL AND \"media_assets\".\"purge_started_at\" IS NULL) OR (\"media_assets\".\"catalog_state\" = 'archived' AND \"media_assets\".\"archived_at\" IS NOT NULL AND \"media_assets\".\"purge_started_at\" IS NULL) OR (\"media_assets\".\"catalog_state\" = 'purging' AND \"media_assets\".\"archived_at\" IS NOT NULL AND \"media_assets\".\"purge_started_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_photo_selection_draft_entries": {
+      "name": "media_photo_selection_draft_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_photo_selection_draft_entries_asset_uidx": {
+          "name": "media_photo_selection_draft_entries_asset_uidx",
+          "columns": [
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_photo_selection_draft_entries_position_uidx": {
+          "name": "media_photo_selection_draft_entries_position_uidx",
+          "columns": [
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_photo_selection_draft_entries_draft_id_media_photo_selection_drafts_id_fk": {
+          "name": "media_photo_selection_draft_entries_draft_id_media_photo_selection_drafts_id_fk",
+          "tableFrom": "media_photo_selection_draft_entries",
+          "tableTo": "media_photo_selection_drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_photo_selection_draft_entries_media_asset_id_media_assets_id_fk": {
+          "name": "media_photo_selection_draft_entries_media_asset_id_media_assets_id_fk",
+          "tableFrom": "media_photo_selection_draft_entries",
+          "tableTo": "media_assets",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_photo_selection_draft_entries_position_check": {
+          "name": "media_photo_selection_draft_entries_position_check",
+          "value": "\"media_photo_selection_draft_entries\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_photo_selection_drafts": {
+      "name": "media_photo_selection_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_photo_selection_drafts_owner_uidx": {
+          "name": "media_photo_selection_drafts_owner_uidx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_photo_selection_drafts_owner_check": {
+          "name": "media_photo_selection_drafts_owner_check",
+          "value": "length(btrim(\"media_photo_selection_drafts\".\"owner_user_id\")) > 0"
+        },
+        "media_photo_selection_drafts_revision_check": {
+          "name": "media_photo_selection_drafts_revision_check",
+          "value": "\"media_photo_selection_drafts\".\"revision\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_published_photo_selection_entries": {
+      "name": "media_published_photo_selection_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "published_selection_id": {
+          "name": "published_selection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_media_asset_id": {
+          "name": "source_media_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "focal_point_x": {
+          "name": "focal_point_x",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_point_y": {
+          "name": "focal_point_y",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text_zh_hans": {
+          "name": "alt_text_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt_text_en": {
+          "name": "alt_text_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_label_zh_hans": {
+          "name": "location_label_zh_hans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_label_en": {
+          "name": "location_label_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera_make": {
+          "name": "camera_make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera_model": {
+          "name": "camera_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lens": {
+          "name": "lens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_length_millimeters": {
+          "name": "focal_length_millimeters",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aperture": {
+          "name": "aperture",
+          "type": "numeric(6, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutter_speed_seconds": {
+          "name": "shutter_speed_seconds",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iso": {
+          "name": "iso",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_published_photo_selection_entries_asset_uidx": {
+          "name": "media_published_photo_selection_entries_asset_uidx",
+          "columns": [
+            {
+              "expression": "published_selection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_media_asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_published_photo_selection_entries_position_uidx": {
+          "name": "media_published_photo_selection_entries_position_uidx",
+          "columns": [
+            {
+              "expression": "published_selection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_published_photo_selection_entries_published_selection_id_media_published_photo_selections_id_fk": {
+          "name": "media_published_photo_selection_entries_published_selection_id_media_published_photo_selections_id_fk",
+          "tableFrom": "media_published_photo_selection_entries",
+          "tableTo": "media_published_photo_selections",
+          "columnsFrom": [
+            "published_selection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_published_photo_selection_entries_position_check": {
+          "name": "media_published_photo_selection_entries_position_check",
+          "value": "\"media_published_photo_selection_entries\".\"position\" >= 0"
+        },
+        "media_published_photo_selection_entries_dimensions_check": {
+          "name": "media_published_photo_selection_entries_dimensions_check",
+          "value": "\"media_published_photo_selection_entries\".\"width\" > 0 AND \"media_published_photo_selection_entries\".\"height\" > 0 AND (\"media_published_photo_selection_entries\".\"width\"::bigint * \"media_published_photo_selection_entries\".\"height\"::bigint) <= 100000000"
+        },
+        "media_published_photo_selection_entries_focal_point_check": {
+          "name": "media_published_photo_selection_entries_focal_point_check",
+          "value": "num_nonnulls(\"media_published_photo_selection_entries\".\"focal_point_x\", \"media_published_photo_selection_entries\".\"focal_point_y\") IN (0, 2) AND (\"media_published_photo_selection_entries\".\"focal_point_x\" IS NULL OR (\"media_published_photo_selection_entries\".\"focal_point_x\" BETWEEN 0 AND 1 AND \"media_published_photo_selection_entries\".\"focal_point_y\" BETWEEN 0 AND 1))"
+        },
+        "media_published_photo_selection_entries_alt_text_check": {
+          "name": "media_published_photo_selection_entries_alt_text_check",
+          "value": "length(btrim(\"media_published_photo_selection_entries\".\"alt_text_zh_hans\")) > 0 AND length(btrim(\"media_published_photo_selection_entries\".\"alt_text_en\")) > 0"
+        },
+        "media_published_photo_selection_entries_camera_values_check": {
+          "name": "media_published_photo_selection_entries_camera_values_check",
+          "value": "(\"media_published_photo_selection_entries\".\"focal_length_millimeters\" IS NULL OR \"media_published_photo_selection_entries\".\"focal_length_millimeters\" > 0) AND (\"media_published_photo_selection_entries\".\"aperture\" IS NULL OR \"media_published_photo_selection_entries\".\"aperture\" > 0) AND (\"media_published_photo_selection_entries\".\"shutter_speed_seconds\" IS NULL OR \"media_published_photo_selection_entries\".\"shutter_speed_seconds\" > 0) AND (\"media_published_photo_selection_entries\".\"iso\" IS NULL OR \"media_published_photo_selection_entries\".\"iso\" > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_published_photo_selection_renditions": {
+      "name": "media_published_photo_selection_renditions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "published_entry_id": {
+          "name": "published_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_width": {
+          "name": "profile_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_published_photo_selection_renditions_profile_uidx": {
+          "name": "media_published_photo_selection_renditions_profile_uidx",
+          "columns": [
+            {
+              "expression": "published_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_width",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_published_photo_selection_renditions_published_entry_id_media_published_photo_selection_entries_id_fk": {
+          "name": "media_published_photo_selection_renditions_published_entry_id_media_published_photo_selection_entries_id_fk",
+          "tableFrom": "media_published_photo_selection_renditions",
+          "tableTo": "media_published_photo_selection_entries",
+          "columnsFrom": [
+            "published_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_published_photo_selection_renditions_profile_check": {
+          "name": "media_published_photo_selection_renditions_profile_check",
+          "value": "\"media_published_photo_selection_renditions\".\"profile_width\" IN (640, 1024, 1600, 2560)"
+        },
+        "media_published_photo_selection_renditions_object_key_check": {
+          "name": "media_published_photo_selection_renditions_object_key_check",
+          "value": "length(btrim(\"media_published_photo_selection_renditions\".\"object_key\")) > 0"
+        },
+        "media_published_photo_selection_renditions_dimensions_check": {
+          "name": "media_published_photo_selection_renditions_dimensions_check",
+          "value": "\"media_published_photo_selection_renditions\".\"width\" BETWEEN 1 AND \"media_published_photo_selection_renditions\".\"profile_width\" AND \"media_published_photo_selection_renditions\".\"height\" > 0 AND (\"media_published_photo_selection_renditions\".\"width\"::bigint * \"media_published_photo_selection_renditions\".\"height\"::bigint) <= 100000000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_published_photo_selections": {
+      "name": "media_published_photo_selections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_kind": {
+          "name": "publication_kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "draft_revision": {
+          "name": "draft_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_count": {
+          "name": "item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "media_published_photo_selections_idempotency_uidx": {
+          "name": "media_published_photo_selections_idempotency_uidx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_published_photo_selections_draft_revision_uidx": {
+          "name": "media_published_photo_selections_draft_revision_uidx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "draft_revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"media_published_photo_selections\".\"publication_kind\" = 'draft'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_published_photo_selections_identity_check": {
+          "name": "media_published_photo_selections_identity_check",
+          "value": "length(btrim(\"media_published_photo_selections\".\"owner_user_id\")) > 0 AND length(btrim(\"media_published_photo_selections\".\"idempotency_key\")) > 0"
+        },
+        "media_published_photo_selections_kind_check": {
+          "name": "media_published_photo_selections_kind_check",
+          "value": "\"media_published_photo_selections\".\"publication_kind\" IN ('draft', 'withdrawal')"
+        },
+        "media_published_photo_selections_revision_check": {
+          "name": "media_published_photo_selections_revision_check",
+          "value": "(\"media_published_photo_selections\".\"publication_kind\" = 'draft' AND \"media_published_photo_selections\".\"draft_revision\" >= 0) OR (\"media_published_photo_selections\".\"publication_kind\" = 'withdrawal' AND \"media_published_photo_selections\".\"draft_revision\" IS NULL)"
+        },
+        "media_published_photo_selections_item_count_check": {
+          "name": "media_published_photo_selections_item_count_check",
+          "value": "\"media_published_photo_selections\".\"item_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_renditions": {
+      "name": "media_renditions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_width": {
+          "name": "profile_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum_sha256": {
+          "name": "checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'image/jpeg'"
+        },
+        "color_space": {
+          "name": "color_space",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'srgb'"
+        },
+        "progressive": {
+          "name": "progressive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata_stripped": {
+          "name": "metadata_stripped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_renditions_asset_profile_uidx": {
+          "name": "media_renditions_asset_profile_uidx",
+          "columns": [
+            {
+              "expression": "media_asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_width",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_renditions_object_key_uidx": {
+          "name": "media_renditions_object_key_uidx",
+          "columns": [
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_renditions_media_asset_id_media_assets_id_fk": {
+          "name": "media_renditions_media_asset_id_media_assets_id_fk",
+          "tableFrom": "media_renditions",
+          "tableTo": "media_assets",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_renditions_object_key_check": {
+          "name": "media_renditions_object_key_check",
+          "value": "length(btrim(\"media_renditions\".\"object_key\")) > 0"
+        },
+        "media_renditions_profile_check": {
+          "name": "media_renditions_profile_check",
+          "value": "\"media_renditions\".\"profile_width\" IN (640, 1024, 1600, 2560)"
+        },
+        "media_renditions_checksum_check": {
+          "name": "media_renditions_checksum_check",
+          "value": "\"media_renditions\".\"checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "media_renditions_dimensions_check": {
+          "name": "media_renditions_dimensions_check",
+          "value": "\"media_renditions\".\"width\" BETWEEN 1 AND \"media_renditions\".\"profile_width\" AND \"media_renditions\".\"height\" > 0 AND (\"media_renditions\".\"width\"::bigint * \"media_renditions\".\"height\"::bigint) <= 100000000"
+        },
+        "media_renditions_byte_size_check": {
+          "name": "media_renditions_byte_size_check",
+          "value": "\"media_renditions\".\"byte_size\" > 0"
+        },
+        "media_renditions_content_type_check": {
+          "name": "media_renditions_content_type_check",
+          "value": "\"media_renditions\".\"content_type\" = 'image/jpeg'"
+        },
+        "media_renditions_color_space_check": {
+          "name": "media_renditions_color_space_check",
+          "value": "\"media_renditions\".\"color_space\" = 'srgb'"
+        },
+        "media_renditions_progressive_check": {
+          "name": "media_renditions_progressive_check",
+          "value": "\"media_renditions\".\"progressive\" = true"
+        },
+        "media_renditions_metadata_stripped_check": {
+          "name": "media_renditions_metadata_stripped_check",
+          "value": "\"media_renditions\".\"metadata_stripped\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_upload_intents": {
+      "name": "media_upload_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum_sha256": {
+          "name": "checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discard_started_at": {
+          "name": "discard_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_upload_intents_owner_idempotency_uidx": {
+          "name": "media_upload_intents_owner_idempotency_uidx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_upload_intents_original_key_uidx": {
+          "name": "media_upload_intents_original_key_uidx",
+          "columns": [
+            {
+              "expression": "original_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_upload_intents_expiry_idx": {
+          "name": "media_upload_intents_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_upload_intents_identity_check": {
+          "name": "media_upload_intents_identity_check",
+          "value": "length(btrim(\"media_upload_intents\".\"owner_user_id\")) > 0 AND length(btrim(\"media_upload_intents\".\"idempotency_key\")) > 0"
+        },
+        "media_upload_intents_original_key_check": {
+          "name": "media_upload_intents_original_key_check",
+          "value": "length(btrim(\"media_upload_intents\".\"original_key\")) > 0"
+        },
+        "media_upload_intents_content_type_check": {
+          "name": "media_upload_intents_content_type_check",
+          "value": "\"media_upload_intents\".\"content_type\" IN ('image/jpeg', 'image/png', 'image/heic', 'image/heif')"
+        },
+        "media_upload_intents_byte_size_check": {
+          "name": "media_upload_intents_byte_size_check",
+          "value": "\"media_upload_intents\".\"byte_size\" BETWEEN 1 AND 52428800"
+        },
+        "media_upload_intents_checksum_check": {
+          "name": "media_upload_intents_checksum_check",
+          "value": "\"media_upload_intents\".\"checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "media_upload_intents_expiry_check": {
+          "name": "media_upload_intents_expiry_check",
+          "value": "\"media_upload_intents\".\"expires_at\" > \"media_upload_intents\".\"created_at\""
+        },
+        "media_upload_intents_completion_check": {
+          "name": "media_upload_intents_completion_check",
+          "value": "\"media_upload_intents\".\"completed_at\" IS NULL OR \"media_upload_intents\".\"completed_at\" >= \"media_upload_intents\".\"created_at\""
+        },
+        "media_upload_intents_discard_check": {
+          "name": "media_upload_intents_discard_check",
+          "value": "\"media_upload_intents\".\"discard_started_at\" IS NULL OR (\"media_upload_intents\".\"completed_at\" IS NULL AND \"media_upload_intents\".\"discard_started_at\" >= \"media_upload_intents\".\"created_at\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.newsletters": {
+      "name": "newsletters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_windows": {
+      "name": "rate_limit_windows",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_times": {
+          "name": "request_times",
+          "type": "timestamp with time zone[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_expires_at": {
+          "name": "window_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_windows_expiry_idx": {
+          "name": "rate_limit_windows_expiry_idx",
+          "columns": [
+            {
+              "expression": "window_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_windows_scope_key_hash_pk": {
+          "name": "rate_limit_windows_scope_key_hash_pk",
+          "columns": [
+            "scope",
+            "key_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "rate_limit_windows_request_times_check": {
+          "name": "rate_limit_windows_request_times_check",
+          "value": "cardinality(\"rate_limit_windows\".\"request_times\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subscribers": {
+      "name": "subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1784425491213,
       "tag": "0012_high_fidelity_photo_renditions",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1784538814471,
+      "tag": "0013_brief_yellowjacket",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -162,6 +162,7 @@ export const mediaUploadIntents = pgTable(
     checksumSha256: varchar('checksum_sha256', { length: 64 }).notNull(),
     expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
     completedAt: timestamp('completed_at', { withTimezone: true }),
+    discardStartedAt: timestamp('discard_started_at', { withTimezone: true }),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
   },
@@ -199,6 +200,10 @@ export const mediaUploadIntents = pgTable(
     check(
       'media_upload_intents_completion_check',
       sql`${table.completedAt} IS NULL OR ${table.completedAt} >= ${table.createdAt}`,
+    ),
+    check(
+      'media_upload_intents_discard_check',
+      sql`${table.discardStartedAt} IS NULL OR (${table.completedAt} IS NULL AND ${table.discardStartedAt} >= ${table.createdAt})`,
     ),
   ],
 )
@@ -511,7 +516,11 @@ export const mediaPublishedPhotoSelections = pgTable(
     id: uuid('id').defaultRandom().primaryKey(),
     ownerUserId: varchar('owner_user_id', { length: 255 }).notNull(),
     idempotencyKey: varchar('idempotency_key', { length: 128 }).notNull(),
-    draftRevision: integer('draft_revision').notNull(),
+    publicationKind: varchar('publication_kind', { length: 16 })
+      .$type<'draft' | 'withdrawal'>()
+      .default('draft')
+      .notNull(),
+    draftRevision: integer('draft_revision'),
     itemCount: integer('item_count').notNull(),
     publishedAt: timestamp('published_at', { withTimezone: true }).notNull(),
   },
@@ -523,18 +532,73 @@ export const mediaPublishedPhotoSelections = pgTable(
     uniqueIndex('media_published_photo_selections_draft_revision_uidx').on(
       table.ownerUserId,
       table.draftRevision,
-    ),
+    ).where(sql`${table.publicationKind} = 'draft'`),
     check(
       'media_published_photo_selections_identity_check',
       sql`length(btrim(${table.ownerUserId})) > 0 AND length(btrim(${table.idempotencyKey})) > 0`,
     ),
     check(
+      'media_published_photo_selections_kind_check',
+      sql`${table.publicationKind} IN ('draft', 'withdrawal')`,
+    ),
+    check(
       'media_published_photo_selections_revision_check',
-      sql`${table.draftRevision} >= 0`,
+      sql`(${table.publicationKind} = 'draft' AND ${table.draftRevision} >= 0) OR (${table.publicationKind} = 'withdrawal' AND ${table.draftRevision} IS NULL)`,
     ),
     check(
       'media_published_photo_selections_item_count_check',
       sql`${table.itemCount} >= 0`,
+    ),
+  ],
+)
+
+export const mediaAssetArchiveOperations = pgTable(
+  'media_asset_archive_operations',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    ownerUserId: varchar('owner_user_id', { length: 255 }).notNull(),
+    mediaAssetId: uuid('media_asset_id')
+      .notNull()
+      .references(() => mediaAssets.id, { onDelete: 'cascade' }),
+    draftId: uuid('draft_id').references(() => mediaPhotoSelectionDrafts.id, {
+      onDelete: 'cascade',
+    }),
+    draftRevisionBefore: integer('draft_revision_before'),
+    draftRevisionAfter: integer('draft_revision_after'),
+    draftPosition: integer('draft_position'),
+    publishedSelectionBefore: uuid('published_selection_before').references(
+      () => mediaPublishedPhotoSelections.id,
+      { onDelete: 'restrict' },
+    ),
+    publishedSelectionAfter: uuid('published_selection_after').references(
+      () => mediaPublishedPhotoSelections.id,
+      { onDelete: 'restrict' },
+    ),
+    archivedAt: timestamp('archived_at', { withTimezone: true }).notNull(),
+    undoExpiresAt: timestamp('undo_expires_at', { withTimezone: true }).notNull(),
+    undoneAt: timestamp('undone_at', { withTimezone: true }),
+  },
+  (table) => [
+    index('media_asset_archive_operations_owner_idx').on(
+      table.ownerUserId,
+      table.mediaAssetId,
+      table.undoExpiresAt,
+    ),
+    check(
+      'media_asset_archive_operations_owner_check',
+      sql`length(btrim(${table.ownerUserId})) > 0`,
+    ),
+    check(
+      'media_asset_archive_operations_draft_check',
+      sql`num_nonnulls(${table.draftId}, ${table.draftRevisionBefore}, ${table.draftRevisionAfter}, ${table.draftPosition}) IN (0, 4)`,
+    ),
+    check(
+      'media_asset_archive_operations_publication_check',
+      sql`num_nonnulls(${table.publishedSelectionBefore}, ${table.publishedSelectionAfter}) IN (0, 2)`,
+    ),
+    check(
+      'media_asset_archive_operations_expiry_check',
+      sql`${table.undoExpiresAt} > ${table.archivedAt} AND (${table.undoneAt} IS NULL OR ${table.undoneAt} >= ${table.archivedAt})`,
     ),
   ],
 )

--- a/docs/adr/0007-bunny-backed-media-library.md
+++ b/docs/adr/0007-bunny-backed-media-library.md
@@ -30,13 +30,18 @@ External storage and database writes cannot share a transaction. Registration,
 repair, and Purge therefore persist idempotent operation progress before each
 side effect and resume from the last confirmed step. A Media Asset becomes
 ready only after its Original and complete required Rendition manifest are
-verified. Purge deletes the catalog record last.
+verified. Incomplete work remains an owner-visible Transfer Job across dialog
+dismissal and reload, with Retry and permanent Discard; it does not enter the
+Library or Archived views. Purge and Transfer Job Discard delete the catalog
+record last.
 
 Public pages consume one allowlisted projection of the current Published Photo
 Selection. That snapshot captures the public Rendition references, order,
 Focal Points, Alt Text, and Display Metadata. Editing a Media Asset or Draft
 Photo Selection cannot change public output until Publish atomically advances
-the active snapshot.
+the active snapshot. Archive and Purge are the narrow exception: each creates
+an immutable withdrawal publication from the active snapshot with only the
+target Media Asset removed. Unrelated Draft edits remain unpublished.
 
 Owner-authenticated admin pages manage the catalog and its public selections.
 Git remains the source of truth for MDX and ordinary site content, so adopting
@@ -44,10 +49,13 @@ the Media Library does not turn Bunny or Neon into a general-purpose CMS.
 
 ## Consequences
 
-- Archive is a reversible catalog state, not access revocation. It is blocked
-  while a Media Asset belongs to a Draft or Published Photo Selection.
+- Archive is a reversible catalog state, not access revocation. It withdraws
+  the target from Draft and Published Photo Selections. Immediate Undo restores
+  the prior membership and order only while the affected revisions remain
+  unchanged; a later Restore returns the Media Asset to the Library only.
 - Purge is explicit, irreversible, resumable, and must clear every known Bunny
-  CDN URL before it reports success. Replication is not a backup from Purge.
+  CDN URL before it reports success. It uses the same surgical selection
+  withdrawal as Archive. Replication is not a backup from Purge.
 - Raw embedded metadata is not stored in Neon or copied into Renditions. Public
   projections cannot contain Capture Location, Original references, provider
   payloads, or operation details.
@@ -62,4 +70,18 @@ the Media Library does not turn Bunny or Neon into a general-purpose CMS.
   full Original in the private zone before processing. Reconciliation claims
   stale Upload Intents after a 15-minute activity lease before removing
   abandoned chunks so cleanup cannot race an active transfer.
+- Transfer Job Discard first closes its Upload Intent. A chunk request that was
+  already in flight rechecks the intent after storage commits and removes its
+  own chunk if Discard won, preventing orphaned transfer objects.
+- Chunk retries honor `Retry-After` for rate limits and transient provider
+  failures. Any owner API 401 performs a full protected-page navigation so an
+  expired Clerk session returns through sign-in instead of becoming a generic
+  transfer failure.
+- Processing persists each deterministic Rendition manifest before its Bunny
+  write. A per-asset processing lock serializes those writes with Discard and
+  Purge, so Purge either sees the committed object key or cancellation wins
+  before the storage write begins.
+- Draft Save, Publish, Archive, Archive Undo, and Purge take one owner-scoped
+  selection lock before locking Media Assets. This preserves one lock order
+  across catalog and publication mutations.
 - Git-owned writing and non-photo assets remain outside this context.

--- a/docs/adr/0012-owner-admin-without-step-up.md
+++ b/docs/adr/0012-owner-admin-without-step-up.md
@@ -15,8 +15,9 @@ The single-owner personal-site workflow did not justify repeated verification
 prompts after an already authenticated owner session. The remaining controls
 stay mandatory: same-origin mutation guards, per-actor rate limits,
 privileged-action audit events, the admin CSP, and least-privileged provider and
-database credentials. Media Asset Purge also requires the literal `PURGE`
-confirmation validated by the server.
+database credentials. Media Asset Purge remains an explicit irreversible action
+behind one fixed confirmation dialog with one destructive button; it adds no
+typed phrase or second owner prompt.
 
 Passkeys remain the recommended Clerk sign-in method and the owner should keep
 two independently recoverable passkeys. Session revocation, owner-metadata

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -917,12 +917,26 @@ public analytics, social reads, and route view transitions. Its contract:
   (`Elevated` offset 4); popovers stay at offset 2. Never a native
   `confirm()`/`prompt()`. Dialogs wear the printed-label chrome the hover
   cards established: the register's 2px corner, a hairline frame, and
-  ruled full-bleed head/foot rows (`components/ui/dialog.tsx`).
-- **Confirmation grammar.** Reversible-but-notable actions (archive,
-  disconnect) use a two-step armed button that relaxes after ~4s.
-  Irreversible actions (Purge) require the typed confirmation word inside
-  the dialog; the server validates the same literal. Publishing shows an
-  inline summary of what changes before one confirm.
+  ruled full-bleed head/foot rows (`components/ui/dialog.tsx`). Transient
+  workflows use fixed viewport-bounded geometry; async state scrolls inside
+  the body and never resizes the page or the open sheet.
+- **Media workflow.** Transfers, the Media inspector, Transfer Discard, Purge,
+  the Photo Selection picker, and Publish are fixed-geometry dialogs. Transfer
+  Jobs persist when the dialog closes and after reload. Incomplete work stays
+  in Transfers with Retry and Discard, including while processing, and never
+  appears as an empty Media Asset in Library or Archived. Chunk rate limits
+  keep the row in place, follow the server's retry delay, and preserve the
+  same fixed dialog geometry.
+- **Confirmation grammar.** Archive is one action followed by a ten-second Undo
+  toast. Purge and Transfer Discard each use one fixed confirmation dialog with
+  one destructive confirmation button and no typed phrase. Publishing uses one
+  fixed dialog that summarizes the pending membership and order change before
+  one confirm. Other reversible-but-notable admin actions may retain their
+  two-step armed control where their own workflow specifies it.
+- **Reserved commands.** Photo Selection permanently reserves its command
+  region for selection controls, conflicts, eligibility, and publication
+  feedback. Loading shells reserve the same header, command, and grid geometry,
+  so selecting, publishing, and streaming owner data do not move the prints.
 - **No entrance animations** — the admin is daily-use chrome (frequency
   principle). Status is a quiet dot: amber for in-flight, red only for
   broken or destructive. Numbers are always `tabular-nums`.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -55,8 +55,8 @@ Current as of July 2026.
   `publicMetadata.siteOwner = "yes"` authorization marker. Origin checks, rate
   limits, audit events, and the strict admin CSP remain in force. Passkey
   step-up (reverification) was removed entirely in July 2026 (maintainer
-  decision) — see `docs/security/clerk-admin-operations.md`; the typed PURGE
-  confirmation for Media purge is still validated server-side.
+  decision) — see `docs/security/clerk-admin-operations.md`. Media Purge uses
+  one fixed confirmation dialog with no typed phrase.
 - The admin was redesigned in July 2026 to share the public design language
   (warm paper, 37.5rem column, an owner dock; spec in
   `docs/design-language.md` § Owner admin). IA: `/admin` is a one-screen
@@ -118,6 +118,13 @@ Current as of July 2026.
   and lease-claimed reconciliation removes abandoned chunks without racing an
   active transfer. `/photos` and homepage previews consume
   the active Published Photo Selection from Bunny Renditions. Media
+  Transfer Jobs persist across dialog dismissal and reload; Retry and Discard
+  stay in Transfers, including during processing, while only ready Media
+  Assets appear in Library or Archived. Rendition writes serialize with
+  Discard/Purge and persist their cleanup manifest before storage. Archive and
+  Purge surgically withdraw the target from Draft and
+  Published Photo Selections without publishing unrelated Draft edits. Archive
+  offers immediate Undo when the affected revisions remain unchanged.
   capabilities have no runtime feature switches: Alt Text Suggestions are on
   by default and, since July 2026, auto-apply as the approved bilingual Alt
   Text when none exists yet (upload-to-archive needs no review step; edits

--- a/docs/security/clerk-admin-operations.md
+++ b/docs/security/clerk-admin-operations.md
@@ -52,8 +52,9 @@ decision in July 2026: on a single-owner personal site the repeated prompts
 gated daily flows without a matching threat. Owner authorization is now
 exclusively the server-side `siteOwner` check, still wrapped in same-origin
 mutation guards, per-actor rate limits, privileged-action audit events, and
-the strict admin CSP. Media Asset Purge additionally requires the literal
-typed `PURGE` confirmation, validated server-side.
+the strict admin CSP. Media Asset Purge uses one explicit fixed dialog with a
+single destructive confirmation button; there is no typed phrase or second
+owner prompt.
 
 Alongside it, the admin's per-request nonce CSP was retired when admin
 routes adopted prerendered instant-navigation shells (nonces require

--- a/lib/admin/client-response.test.ts
+++ b/lib/admin/client-response.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { reloadLocation } from '~/lib/navigation'
+
+import { adminResponseJson } from './client-response'
+
+vi.mock('~/lib/navigation', () => ({ reloadLocation: vi.fn() }))
+
+describe('admin client responses', () => {
+  beforeEach(() => {
+    vi.mocked(reloadLocation).mockClear()
+  })
+
+  it('re-enters authentication after an expired owner session', async () => {
+    await expect(
+      adminResponseJson(
+        Response.json({ error: 'unauthorized' }, { status: 401 }),
+      ),
+    ).rejects.toThrow('unauthorized')
+
+    expect(reloadLocation).toHaveBeenCalledOnce()
+  })
+
+  it('returns successful JSON without navigating', async () => {
+    await expect(
+      adminResponseJson(Response.json({ ok: true })),
+    ).resolves.toEqual({ ok: true })
+    expect(reloadLocation).not.toHaveBeenCalled()
+  })
+
+  it('re-enters authentication before parsing a non-JSON 401', async () => {
+    await expect(
+      adminResponseJson(new Response(null, { status: 401 })),
+    ).rejects.toThrow('request_failed')
+    expect(reloadLocation).toHaveBeenCalledOnce()
+  })
+})

--- a/lib/admin/client-response.ts
+++ b/lib/admin/client-response.ts
@@ -1,0 +1,19 @@
+import { reloadLocation } from '~/lib/navigation'
+
+export async function adminResponseJson(response: Response) {
+  if (!response.ok && response.status === 401) {
+    // A full navigation re-enters the protected admin page boundary, which
+    // redirects an expired Clerk session back through sign-in. Do this before
+    // parsing because an upstream authentication boundary may return an empty
+    // or non-JSON response.
+    reloadLocation()
+  }
+  const body = (await response.json().catch(() => ({}))) as Record<
+    string,
+    unknown
+  >
+  if (!response.ok) {
+    throw new Error(typeof body.error === 'string' ? body.error : 'request_failed')
+  }
+  return body
+}

--- a/lib/ama/security/service.ts
+++ b/lib/ama/security/service.ts
@@ -32,6 +32,7 @@ export type PrivilegedAuditEvent =
   | 'media_photo_selection.draft_saved'
   | 'media_photo_selection.published'
   | 'media_upload.completed'
+  | 'media_upload.discarded'
   | 'media_upload.intent_created'
 
 export type AmaFeatureFlags = {

--- a/lib/media/CONTEXT.md
+++ b/lib/media/CONTEXT.md
@@ -16,8 +16,18 @@ the selections that publish them across the personal site.
 
 **Media Asset**:
 A reusable file registered in the Media Library, together with its owned
-metadata and storage references.
+metadata and storage references. Only a ready Media Asset appears in Library
+or Archived; an incomplete attempt remains a Transfer Job.
 _Avoid_: Upload, file record
+
+**Transfer Job**:
+The owner-visible attempt to move one chosen Original through transfer,
+verification, and processing into Archive. A failed Transfer Job remains in the
+transfer queue for Retry or permanent Discard. An in-flight processing job can
+also be permanently Discarded; processing and Purge serialize on that Media
+Asset so no late Rendition can escape cleanup. Transfer Jobs do not appear as
+empty Archived Media Assets.
+_Avoid_: Empty Media Asset, failed archive item
 
 **Original**:
 The protected, full-quality source object from which public versions are made.
@@ -84,14 +94,25 @@ Original verification, Rendition processing, readiness, retryable failure, and
 repair required. It is separate from Catalog State.
 _Avoid_: Lifecycle, upload status
 
+Every processing write records its deterministic Rendition manifest before
+the Bunny side effect. Processing, Discard, and Purge use the same per-asset
+lock; Photo Selection mutations use one owner-scoped lock before Media Asset
+locks. These orders are part of the persistence contract, not UI behavior.
+
 **Archived Media Asset**:
 A Media Asset hidden from normal library views and unavailable to new Photo
-Selections while its files and metadata remain recoverable.
+Selections while its files and metadata remain recoverable. Archive withdraws
+the Media Asset from Draft and Published Photo Selections; immediate Undo may
+restore the exact prior membership and order while those selection revisions
+remain unchanged. A later Restore returns the Media Asset to the Library only.
 _Avoid_: Deleted asset, trashed file
 
 **Purge**:
 The irreversible removal of a Media Asset, including its Original, Renditions,
-and catalog record.
+and catalog record. If the Media Asset belongs to a Draft or Published Photo
+Selection, Purge first withdraws that asset from both. Withdrawing from the
+Published Photo Selection advances only that publication; unrelated Draft
+changes remain unpublished.
 _Avoid_: Delete, remove
 
 **Photo Selection**:
@@ -108,5 +129,6 @@ _Avoid_: Working gallery, unpublished photos
 The immutable snapshot shown on the photos page and in homepage previews. It
 captures membership, order, public Rendition references, Focal Points, Alt
 Text, and Display Metadata, and changes only when the owner publishes a Draft
-Photo Selection.
+Photo Selection, or when Archive or Purge withdraws one Media Asset without
+publishing unrelated Draft changes.
 _Avoid_: Live gallery, active photos

--- a/lib/media/admin/http.test.ts
+++ b/lib/media/admin/http.test.ts
@@ -16,6 +16,8 @@ import {
   createMediaOriginalUploadHandler,
   createMediaPurgeHandler,
   createMediaResumeHandler,
+  createMediaTransferDiscardHandler,
+  createMediaTransferListHandler,
   createMediaUploadCompletionHandler,
   createMediaUploadIntentHandler,
   createPhotoSelectionDraftHandler,
@@ -189,6 +191,10 @@ describe('Media admin HTTP contract', () => {
           f.calls.push(input)
           return input
         },
+        async undoArchive(input) {
+          f.calls.push(input)
+          return input
+        },
         async restore(input) {
           f.calls.push(input)
           return input
@@ -233,6 +239,10 @@ describe('Media admin HTTP contract', () => {
             f.calls.push(input)
             return input
           },
+          async undoArchive(input) {
+            f.calls.push(input)
+            return input
+          },
           async restore(input) {
             f.calls.push(input)
             return input
@@ -269,6 +279,10 @@ describe('Media admin HTTP contract', () => {
           return input
         },
         async archive(input) {
+          f.calls.push(input)
+          return input
+        },
+        async undoArchive(input) {
           f.calls.push(input)
           return input
         },
@@ -314,6 +328,58 @@ describe('Media admin HTTP contract', () => {
     expect(response.status).toBe(503)
     expect(body).toBe('{"error":"dependency_unavailable"}')
     expect(body).not.toContain('password')
+  })
+
+  it('returns an Archive Undo capability through the owner boundary', async () => {
+    const f = fixture()
+    const operationId = '22222222-2222-4222-8222-222222222222'
+    const handler = createMediaAssetActionHandler({
+      authenticator: f.authenticator,
+      security: f.security,
+      review: {
+        async updateDisplayMetadata() {
+          throw new Error('not used')
+        },
+        async approveAltText() {
+          throw new Error('not used')
+        },
+        async archive(input) {
+          f.calls.push(input)
+          return { asset: { id: mediaAssetId, catalogState: 'archived' }, operationId, undoOperationId: operationId }
+        },
+        async undoArchive(input) {
+          f.calls.push(input)
+          return { asset: { id: mediaAssetId, catalogState: 'active' } }
+        },
+        async restore() {
+          throw new Error('not used')
+        },
+      },
+    })
+
+    const archived = await handler(
+      request(`/api/admin/media/assets/${mediaAssetId}`, {
+        body: JSON.stringify({ intent: 'archive' }),
+      }),
+      mediaAssetId,
+    )
+    await expect(archived.json()).resolves.toMatchObject({
+      asset: { catalogState: 'archived' },
+      undoOperationId: operationId,
+    })
+    const undone = await handler(
+      request(`/api/admin/media/assets/${mediaAssetId}`, {
+        body: JSON.stringify({ intent: 'undo_archive', operationId }),
+      }),
+      mediaAssetId,
+    )
+    await expect(undone.json()).resolves.toMatchObject({
+      asset: { catalogState: 'active' },
+    })
+    expect(f.calls).toEqual([
+      { ownerUserId: 'owner_01', mediaAssetId },
+      { ownerUserId: 'owner_01', mediaAssetId, operationId },
+    ])
   })
 
   it('creates typed Upload Intents and records the privileged action', async () => {
@@ -793,6 +859,7 @@ describe('Media admin HTTP contract', () => {
         },
       },
       storage: {
+        async deleteOriginalChunk() {},
         async inspectOriginalChunk() {
           throw new Error('a missing intent must not reach storage')
         },
@@ -821,6 +888,58 @@ describe('Media admin HTTP contract', () => {
     ])
   })
 
+  it('lists durable Transfer Jobs through a no-store owner read', async () => {
+    const f = fixture()
+    const handler = createMediaTransferListHandler({
+      authenticator: f.authenticator,
+      security: f.security,
+      transfer: {
+        async list(ownerUserId) {
+          f.calls.push(ownerUserId)
+          return [{ uploadIntentId: 'upload_01', stage: 'failed' }]
+        },
+      },
+    })
+
+    const response = await handler(
+      request('/api/admin/media/upload-intents'),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    await expect(response.json()).resolves.toEqual({
+      transfers: [{ uploadIntentId: 'upload_01', stage: 'failed' }],
+    })
+    expect(f.calls).toEqual(['owner_01'])
+  })
+
+  it('discards one owner Transfer Job through the mutation boundary', async () => {
+    const f = fixture()
+    const handler = createMediaTransferDiscardHandler({
+      authenticator: f.authenticator,
+      security: f.security,
+      transfer: {
+        async discard(input) {
+          f.calls.push(input)
+          return { status: 'discarded' }
+        },
+      },
+    })
+
+    const response = await handler(
+      request(`/api/admin/media/upload-intents/${mediaAssetId}`, {
+        method: 'DELETE',
+      }),
+      mediaAssetId,
+    )
+
+    expect(response.status).toBe(200)
+    expect(f.calls).toEqual([
+      { ownerUserId: 'owner_01', uploadIntentId: mediaAssetId },
+    ])
+    expect(f.auditEvents.at(-1)?.event).toBe('media_upload.discarded')
+  })
+
   it('stores an authorized Original chunk below the platform body limit', async () => {
     // A 50 MiB Original needs 13 bounded requests, so chunks must not consume
     // the generic owner mutation budget that protects semantic actions.
@@ -844,6 +963,7 @@ describe('Media admin HTTP contract', () => {
         },
       },
       storage: {
+        async deleteOriginalChunk() {},
         async inspectOriginalChunk() {
           return null
         },
@@ -872,6 +992,58 @@ describe('Media admin HTTP contract', () => {
     })
   })
 
+  it('removes a chunk when Discard wins after the initial transfer claim', async () => {
+    const f = fixture(false)
+    const bytes = 'private image bytes'
+    const checksumSha256 = createHash('sha256').update(bytes).digest('hex')
+    const intent = {
+      originalKey: 'originals/upload_01.jpg',
+      contentType: 'image/jpeg',
+      byteSize: bytes.length,
+      checksumSha256,
+    }
+    const claimUploadIntentTransfer = vi
+      .fn()
+      .mockResolvedValueOnce(intent)
+      .mockResolvedValueOnce(null)
+    const deleteOriginalChunk = vi.fn(async () => {})
+    const handler = createMediaOriginalUploadHandler({
+      authenticator: f.authenticator,
+      security: f.security,
+      baseUrl: new URL('https://cali.so'),
+      ingestionRepository: { claimUploadIntentTransfer },
+      storage: {
+        deleteOriginalChunk,
+        async inspectOriginalChunk() {
+          return null
+        },
+        async storeOriginalChunk() {},
+      },
+      uploadChunkRateLimiter: {
+        retryAfterSeconds: 60,
+        async limit() {
+          return { success: true }
+        },
+      },
+    })
+
+    const response = await handler(
+      request('/api/admin/media/upload-intents/upload_01/original?chunk=0', {
+        method: 'PUT',
+        body: bytes,
+        contentType: 'application/octet-stream',
+        headers: { 'x-media-chunk-sha256': checksumSha256 },
+      }),
+      'upload_01',
+    )
+
+    expect(response.status).toBe(404)
+    expect(deleteOriginalChunk).toHaveBeenCalledWith(
+      'originals/upload_01.jpg',
+      0,
+    )
+  })
+
   it.each([
     '/api/admin/media/upload-intents/upload_01/original',
     '/api/admin/media/upload-intents/upload_01/original?chunk=invalid',
@@ -894,6 +1066,7 @@ describe('Media admin HTTP contract', () => {
         },
       },
       storage: {
+        async deleteOriginalChunk() {},
         async inspectOriginalChunk() {
           throw new Error('an invalid chunk must not reach storage')
         },
@@ -931,6 +1104,7 @@ describe('Media admin HTTP contract', () => {
         },
       },
       storage: {
+        async deleteOriginalChunk() {},
         async inspectOriginalChunk() {
           return null
         },

--- a/lib/media/admin/http.ts
+++ b/lib/media/admin/http.ts
@@ -18,6 +18,7 @@ import { MediaReconciliationError } from '../reconciliation/service'
 import { PhotoSelectionError } from '../photo-selection/service'
 import { originalUploadChunkCount } from '../storage/transfer'
 import { storeOriginalChunkFromSameOriginRequest } from '../storage/upload'
+import { MediaTransferError } from '../transfer/service'
 
 type Authenticator = {
   authenticate(request: Request): Promise<OwnerAccess>
@@ -62,6 +63,7 @@ function errorResponse(error: unknown) {
     error instanceof MediaAltTextError ||
     error instanceof MediaPurgeError ||
     error instanceof MediaReconciliationError ||
+    error instanceof MediaTransferError ||
     error instanceof PhotoSelectionError
       ? error.code
       : 'dependency_unavailable'
@@ -76,7 +78,8 @@ function errorResponse(error: unknown) {
             ? 429
             : code === 'dependency_unavailable' ||
                 code === 'generation_failed' ||
-                code === 'cache_invalidation_failed'
+                code === 'cache_invalidation_failed' ||
+                code === 'retryable_failure'
               ? 503
               : 409
   return json(status, { error: code })
@@ -301,6 +304,11 @@ export function createMediaAssetActionHandler(
       updateDisplayMetadata(input: Record<string, unknown>): Promise<unknown>
       approveAltText(input: Record<string, unknown>): Promise<unknown>
       archive(input: { ownerUserId: string; mediaAssetId: string }): Promise<unknown>
+      undoArchive(input: {
+        ownerUserId: string
+        mediaAssetId: string
+        operationId: string
+      }): Promise<unknown>
       restore(input: { ownerUserId: string; mediaAssetId: string }): Promise<unknown>
     }
   },
@@ -312,6 +320,7 @@ export function createMediaAssetActionHandler(
       const body = await requestJson(request)
       const common = { ownerUserId: access.principal.id, mediaAssetId }
       let asset: unknown
+      let undoOperationId: string | undefined
       let event: PrivilegedAuditEvent
       if (body.intent === 'update_display_metadata') {
         asset = await dependencies.review.updateDisplayMetadata({
@@ -329,8 +338,21 @@ export function createMediaAssetActionHandler(
         })
         event = 'media_asset.reviewed'
       } else if (body.intent === 'archive') {
-        asset = await dependencies.review.archive(common)
+        const archived = (await dependencies.review.archive(common)) as {
+          asset: unknown
+          undoOperationId?: string
+        }
+        asset = archived.asset
+        undoOperationId = archived.undoOperationId
         event = 'media_asset.archived'
+      } else if (body.intent === 'undo_archive') {
+        const undone = (await dependencies.review.undoArchive({
+          ...common,
+          operationId:
+            typeof body.operationId === 'string' ? body.operationId : '',
+        })) as { asset: unknown }
+        asset = undone.asset
+        event = 'media_asset.restored'
       } else if (body.intent === 'restore') {
         asset = await dependencies.review.restore(common)
         event = 'media_asset.restored'
@@ -338,7 +360,7 @@ export function createMediaAssetActionHandler(
         return json(400, { error: 'invalid_request' })
       }
       audit(dependencies, request, event, access.principal.actorId)
-      return json(200, { asset })
+      return json(200, { asset, ...(undoOperationId ? { undoOperationId } : {}) })
     } catch (error) {
       return errorResponse(error)
     }
@@ -592,6 +614,56 @@ export function createMediaUploadIntentHandler(
   }
 }
 
+export function createMediaTransferListHandler(
+  dependencies: BaseDependencies & {
+    transfer: {
+      list(ownerUserId: string): Promise<unknown>
+    }
+  },
+) {
+  return async function GET(request: Request) {
+    const access = await authenticate(dependencies, request, false)
+    if ('response' in access) return access.response
+    try {
+      const transfers = await dependencies.transfer.list(access.principal.id)
+      return json(200, { transfers })
+    } catch (error) {
+      return errorResponse(error)
+    }
+  }
+}
+
+export function createMediaTransferDiscardHandler(
+  dependencies: BaseDependencies & {
+    transfer: {
+      discard(input: {
+        ownerUserId: string
+        uploadIntentId: string
+      }): Promise<unknown>
+    }
+  },
+) {
+  return async function DELETE(request: Request, uploadIntentId: string) {
+    const access = await authenticate(dependencies, request, true)
+    if ('response' in access) return access.response
+    try {
+      const result = await dependencies.transfer.discard({
+        ownerUserId: access.principal.id,
+        uploadIntentId,
+      })
+      audit(
+        dependencies,
+        request,
+        'media_upload.discarded',
+        access.principal.actorId,
+      )
+      return json(200, { result })
+    } catch (error) {
+      return errorResponse(error)
+    }
+  }
+}
+
 export function createMediaOriginalUploadHandler(
   dependencies: BaseDependencies & {
     baseUrl: URL
@@ -609,7 +681,9 @@ export function createMediaOriginalUploadHandler(
     }
     storage: Parameters<
       typeof storeOriginalChunkFromSameOriginRequest
-    >[0]['storage']
+    >[0]['storage'] & {
+      deleteOriginalChunk(originalKey: string, chunkIndex: number): Promise<void>
+    }
     uploadChunkRateLimiter: {
       retryAfterSeconds: number
       limit(key: string): Promise<{ success: boolean }>
@@ -666,7 +740,7 @@ export function createMediaOriginalUploadHandler(
         ),
       })
     }
-    return storeOriginalChunkFromSameOriginRequest({
+    const response = await storeOriginalChunkFromSameOriginRequest({
       request,
       canonicalBaseUrl: dependencies.baseUrl,
       expectation: {
@@ -679,6 +753,32 @@ export function createMediaOriginalUploadHandler(
       authorize: () => true,
       storage: dependencies.storage,
     })
+    if (response.status !== 204) return response
+
+    // A Discard can win after the first claim but before Bunny finishes the
+    // write. Re-claim after storage commits; if the intent expired, was
+    // discarded, or disappeared, remove this just-written chunk so no orphan
+    // survives the race.
+    let stillActive
+    try {
+      stillActive = await dependencies.ingestionRepository.claimUploadIntentTransfer(
+        access.principal.id,
+        uploadIntentId,
+        new Date(),
+      )
+    } catch {
+      return json(503, { error: 'dependency_unavailable' })
+    }
+    if (stillActive) return response
+    try {
+      await dependencies.storage.deleteOriginalChunk(
+        intent.originalKey,
+        chunkIndex,
+      )
+    } catch {
+      return json(503, { error: 'dependency_unavailable' })
+    }
+    return json(404, { error: 'not_found' })
   }
 }
 

--- a/lib/media/admin/photo-selection-ui.test.tsx
+++ b/lib/media/admin/photo-selection-ui.test.tsx
@@ -163,7 +163,7 @@ describe('Photo curation UI contract', () => {
     })
   })
 
-  it('publishes after an inline confirmation that summarizes the change', async () => {
+  it('publishes from a fixed confirmation dialog that summarizes the change', async () => {
     document.documentElement.dataset.locale = 'en'
     const calls: Array<{ url: string; body: Record<string, unknown> }> = []
     vi.stubGlobal(
@@ -190,7 +190,7 @@ describe('Photo curation UI contract', () => {
     fireEvent.click(getByRole('button', { name: /Publish/ }))
     expect(getByText(/1 added/)).toBeTruthy()
 
-    fireEvent.click(getByRole('button', { name: /Confirm publish/ }))
+    fireEvent.click(getByRole('button', { name: /Publish$/ }))
     await waitFor(() =>
       expect(calls.some((call) => call.url.endsWith('/publish'))).toBe(true),
     )
@@ -229,7 +229,7 @@ describe('Photo curation UI contract', () => {
     fireEvent.click(getByRole('button', { name: /Position 2: Chinatown/ }))
     fireEvent.click(getByRole('button', { name: /Move earlier/ }))
     fireEvent.click(getByRole('button', { name: /Publish/ }))
-    fireEvent.click(getByRole('button', { name: /Confirm publish/ }))
+    fireEvent.click(getByRole('button', { name: /Publish$/ }))
 
     await waitFor(() =>
       expect(calls.some((call) => call.url.endsWith('/publish'))).toBe(true),
@@ -290,7 +290,7 @@ describe('Photo curation UI contract', () => {
     await new Promise((resolve) => setTimeout(resolve, 700))
 
     fireEvent.click(getByRole('button', { name: /Publish/ }))
-    fireEvent.click(getByRole('button', { name: /Confirm publish/ }))
+    fireEvent.click(getByRole('button', { name: /Publish$/ }))
 
     releases[0]!()
     await waitFor(() => expect(releases).toHaveLength(2))
@@ -400,11 +400,11 @@ describe('Photo curation UI contract', () => {
     )
 
     fireEvent.click(getByRole('button', { name: /Publish/ }))
-    fireEvent.click(getByRole('button', { name: /Confirm publish/ }))
+    fireEvent.click(getByRole('button', { name: /Publish$/ }))
     await findByText(/safe to retry/)
 
     // The confirmation panel stays open after a failure — retry directly.
-    fireEvent.click(getByRole('button', { name: /Confirm publish/ }))
+    fireEvent.click(getByRole('button', { name: /Publish$/ }))
     await waitFor(() => expect(publishBodies).toHaveLength(2))
     expect(publishBodies[0]!.idempotencyKey).toBe(publishBodies[1]!.idempotencyKey)
   })

--- a/lib/media/admin/server.test.ts
+++ b/lib/media/admin/server.test.ts
@@ -35,6 +35,7 @@ describe('Media admin page services', () => {
     expect(services).toEqual({
       getDraft: expect.any(Function),
       listAssets: expect.any(Function),
+      listTransfers: expect.any(Function),
     })
     expect(services).not.toHaveProperty('review')
     expect(services).not.toHaveProperty('selection')

--- a/lib/media/admin/server.ts
+++ b/lib/media/admin/server.ts
@@ -35,35 +35,41 @@ import { createMediaReconciliationService } from '../reconciliation/service'
 import { createPublicRenditionUrl } from '../storage/bunny'
 import { parseBunnyMediaCdnEnv } from '../storage/config'
 import { getMediaStorage } from '../storage/server'
+import { createMediaTransferRepository } from '../transfer/repository'
+import { createMediaTransferService } from '../transfer/service'
 
 let services: ReturnType<typeof createServices> | undefined
 let pageServices: ReturnType<typeof createPageServices> | undefined
 
 function createCatalogServices(publicRenditionUrl: (key: string) => string) {
   const database = () => getDatabase()
+  const invalidatePublicSelection = async () => {
+    revalidateTag(PUBLIC_PHOTO_SELECTION_CACHE_TAG, { expire: 0 })
+  }
   const review = createMediaAssetReviewService({
     repository: createMediaAssetReviewRepository(database, publicRenditionUrl),
+    invalidatePublicSelection,
   })
   const selection = createPhotoSelectionService({
     repository: createPhotoSelectionRepository(database),
-    invalidatePublicSelection: async () => {
-      // Next 16.3 requires a cache-life profile or expire object here;
-      // updateTag is restricted to Server Actions and this runs in a Route Handler.
-      revalidateTag(PUBLIC_PHOTO_SELECTION_CACHE_TAG, { expire: 0 })
-    },
+    // Next 16.3 requires a cache-life profile or expire object here;
+    // updateTag is restricted to Server Actions and this runs in a Route Handler.
+    invalidatePublicSelection,
   })
 
-  return { database, review, selection }
+  return { database, invalidatePublicSelection, review, selection }
 }
 
 function createPageServices() {
   const cdnBaseUrl = parseBunnyMediaCdnEnv(process.env)
-  const { review, selection } = createCatalogServices(
+  const { database, review, selection } = createCatalogServices(
     createPublicRenditionUrl(cdnBaseUrl),
   )
+  const transferRepository = createMediaTransferRepository(database)
   return {
     getDraft: selection.getDraft,
     listAssets: review.listAssets,
+    listTransfers: transferRepository.listOwnedTransferJobs,
   }
 }
 
@@ -79,9 +85,8 @@ function createServices() {
       windowSeconds: uploadChunkRateLimitWindowSeconds,
     },
   )
-  const { database, review, selection } = createCatalogServices(
-    storage.publicRenditionUrl,
-  )
+  const { database, invalidatePublicSelection, review, selection } =
+    createCatalogServices(storage.publicRenditionUrl)
   const ingestionRepository = createMediaIngestionRepository(database)
   const mediaEncryptionKey = process.env.MEDIA_ENCRYPTION_KEY
   if (!mediaEncryptionKey) {
@@ -95,6 +100,12 @@ function createServices() {
   })
   const purge = createMediaPurgeService({
     repository: createMediaPurgeRepository(database),
+    storage,
+    invalidatePublicSelection,
+  })
+  const transfer = createMediaTransferService({
+    repository: createMediaTransferRepository(database),
+    purge,
     storage,
   })
   const altTextConfig = parseMediaAltTextEnv(process.env)
@@ -138,6 +149,7 @@ function createServices() {
     selection,
     security: getOwnerAdminSecurity(),
     storage,
+    transfer,
     uploadChunkRateLimiter: {
       retryAfterSeconds: uploadChunkRateLimitWindowSeconds,
       limit: (key: string) => uploadChunkRateLimiter.limit(key),

--- a/lib/media/admin/ui.test.tsx
+++ b/lib/media/admin/ui.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { MediaLibrary } from '../../../app/admin/(protected)/media/MediaLibrary'
 import type { MediaAssetReviewRecord } from '../asset-review/service'
+import type { TransferJob } from '../transfer/service'
 
 // jsdom ships no ResizeObserver; the inspector dialog's scrollable body
 // observes its viewport to drive the edge fades. Assigned directly (not
@@ -53,6 +54,27 @@ const activeAsset: MediaAssetReviewRecord = {
   },
 }
 
+const failedTransfer: TransferJob = {
+  uploadIntentId: '22222222-2222-4222-8222-222222222222',
+  mediaAssetId: '33333333-3333-4333-8333-333333333333',
+  contentType: 'image/jpeg',
+  byteSize: 2_700_000,
+  checksumSha256: 'a'.repeat(64),
+  stage: 'failed',
+  processingState: 'retryable_failure',
+  processingErrorCode: 'dependency_unavailable',
+  createdAt: new Date('2026-07-20T08:00:00.000Z'),
+  updatedAt: new Date('2026-07-20T08:01:00.000Z'),
+  expiresAt: new Date('2026-07-20T08:15:00.000Z'),
+}
+
+const processingTransfer: TransferJob = {
+  ...failedTransfer,
+  stage: 'processing',
+  processingState: 'processing',
+  processingErrorCode: null,
+}
+
 beforeEach(() => {
   const entries = new Map<string, string>()
   vi.stubGlobal('localStorage', {
@@ -83,18 +105,18 @@ afterEach(() => {
 })
 
 describe('Media archive UI contract', () => {
-  it('renders the drop tray, contact sheet, and search without leaking private data', () => {
+  it('renders a stable contact sheet with Transfers outside page flow', () => {
     const html = renderToStaticMarkup(
       <MediaLibrary
         initialActive={[activeAsset]}
         initialArchived={[]}
+        initialTransfers={[]}
         selectionIds={[activeAsset.id]}
       />,
     )
 
-    expect(html).toContain('Drop or choose photos')
-    expect(html).toContain('multiple=""')
-    expect(html).toContain('image/heic')
+    expect(html).toContain('Transfers')
+    expect(html).not.toContain('multiple=""')
     expect(html).toContain('role="tablist"')
     expect(html).toContain('aria-haspopup="dialog"')
     // The selection mark shows what the photos page is using.
@@ -110,6 +132,7 @@ describe('Media archive UI contract', () => {
       <MediaLibrary
         initialActive={[activeAsset]}
         initialArchived={[]}
+        initialTransfers={[]}
         selectionIds={[]}
       />,
     )
@@ -136,6 +159,7 @@ describe('Media archive UI contract', () => {
       <MediaLibrary
         initialActive={[withoutCaptureLocation]}
         initialArchived={[]}
+        initialTransfers={[]}
         selectionIds={[]}
       />,
     )
@@ -179,6 +203,7 @@ describe('Media archive UI contract', () => {
       <MediaLibrary
         initialActive={[activeAsset]}
         initialArchived={[]}
+        initialTransfers={[]}
         selectionIds={[]}
       />,
     )
@@ -199,7 +224,7 @@ describe('Media archive UI contract', () => {
     expect(intents).toEqual(['update_display_metadata', 'approve_alt_text'])
   })
 
-  it('purges only through the typed in-dialog confirmation', async () => {
+  it('purges through one dedicated confirmation dialog', async () => {
     document.documentElement.dataset.locale = 'en'
     const archivedAsset: MediaAssetReviewRecord = {
       ...activeAsset,
@@ -212,6 +237,7 @@ describe('Media archive UI contract', () => {
       <MediaLibrary
         initialActive={[]}
         initialArchived={[archivedAsset]}
+        initialTransfers={[]}
         selectionIds={[]}
       />,
     )
@@ -222,16 +248,8 @@ describe('Media archive UI contract', () => {
     fireEvent.click(screen.getByRole('button', { name: /Purge$/ }))
 
     const confirmButton = screen.getByRole('button', {
-      name: /Confirm purge/,
+      name: /Purge$/,
     }) as HTMLButtonElement
-    const input = screen.getByRole('textbox', { name: /Type PURGE to confirm/ })
-
-    fireEvent.change(input, { target: { value: 'purge' } })
-    expect(confirmButton.disabled).toBe(true)
-    expect(fetchMock).not.toHaveBeenCalled()
-
-    fireEvent.change(input, { target: { value: 'PURGE' } })
-    expect(confirmButton.disabled).toBe(false)
     fireEvent.click(confirmButton)
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce())
@@ -244,7 +262,77 @@ describe('Media archive UI contract', () => {
     )
   })
 
-  it('retries a failed Original transfer before attempting completion', async () => {
+  it('restores failed Transfer Jobs after reload and discards through one dialog', async () => {
+    document.documentElement.dataset.locale = 'en'
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (
+        url ===
+          `/api/admin/media/upload-intents/${failedTransfer.uploadIntentId}` &&
+        init?.method === 'DELETE'
+      ) {
+        return Response.json({ result: { status: 'discarded' } })
+      }
+      if (url.endsWith('?view=active') || url.endsWith('?view=archived')) {
+        return Response.json({ assets: [] })
+      }
+      if (url === '/api/admin/media/upload-intents') {
+        return Response.json({ transfers: [] })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const { getByRole, getByText, queryByRole } = render(
+      <MediaLibrary
+        initialActive={[]}
+        initialArchived={[]}
+        initialTransfers={[failedTransfer]}
+        selectionIds={[]}
+      />,
+    )
+
+    expect(getByRole('button', { name: /Transfers/ }).textContent).toContain('1')
+    expect(getByText('The Library is empty — start a Transfer.')).toBeTruthy()
+    fireEvent.click(getByRole('button', { name: /Transfers/ }))
+    expect(
+      await screen.findByText(
+        'Storage is temporarily unavailable; it is safe to retry',
+      ),
+    ).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: /Discard/ }))
+
+    await screen.findByRole('dialog', { name: /Discard Transfer/ })
+    expect(queryByRole('textbox')).toBeNull()
+    fireEvent.click(
+      screen.getByRole('button', { name: /Discard Permanently/ }),
+    )
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/api/admin/media/upload-intents/${failedTransfer.uploadIntentId}`,
+        { method: 'DELETE' },
+      ),
+    )
+  })
+
+  it('keeps Discard available while a Transfer Job is processing', async () => {
+    document.documentElement.dataset.locale = 'en'
+    render(
+      <MediaLibrary
+        initialActive={[]}
+        initialArchived={[]}
+        initialTransfers={[processingTransfer]}
+        selectionIds={[]}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Transfers/ }))
+    expect(
+      await screen.findByRole('button', { name: /Discard/ }),
+    ).toBeTruthy()
+  })
+
+  it('automatically retries a transient Original transfer before completion', async () => {
     const digest = new Uint8Array(32).buffer
     vi.stubGlobal('crypto', {
       randomUUID: vi
@@ -300,7 +388,7 @@ describe('Media archive UI contract', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const { container, getByRole } = render(
-      <MediaLibrary initialActive={[]} initialArchived={[]} selectionIds={[]} />,
+      <MediaLibrary initialActive={[]} initialArchived={[]} initialTransfers={[]} selectionIds={[]} />,
     )
     const file = new File(
       [new Uint8Array(4 * 1024 * 1024 + 3)],
@@ -314,12 +402,11 @@ describe('Media archive UI contract', () => {
         value: async () => new Uint8Array(4 * 1024 * 1024 + 3).buffer,
       })
     }
-    fireEvent.change(container.querySelector('input[type="file"]')!, {
+    fireEvent.click(getByRole('button', { name: /Transfers/ }))
+    fireEvent.change(document.querySelector('input[type="file"]')!, {
       target: { files: [file] },
     })
 
-    await waitFor(() => expect(getByRole('button', { name: /Retry/ })).toBeTruthy())
-    fireEvent.click(getByRole('button', { name: /Retry/ }))
     await waitFor(() => {
       expect(originalAttempts).toEqual([
         '/api/admin/media/upload-intents/22222222-2222-4222-8222-222222222222/original?chunk=0',
@@ -355,6 +442,82 @@ describe('Media archive UI contract', () => {
     ) as { idempotencyKey: string }
     expect(intentBody.idempotencyKey).toBe('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb')
     expect(localStorage.length).toBe(0)
+  })
+
+  it('replaces an expired Upload Intent after the first chunk returns 404', async () => {
+    const digest = new Uint8Array(32).buffer
+    vi.stubGlobal('crypto', {
+      randomUUID: vi
+        .fn()
+        .mockReturnValueOnce('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')
+        .mockReturnValueOnce('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb')
+        .mockReturnValueOnce('cccccccc-cccc-4ccc-8ccc-cccccccccccc'),
+      subtle: { digest: vi.fn().mockResolvedValue(digest) },
+    })
+    const intentIds = [
+      '22222222-2222-4222-8222-222222222222',
+      '33333333-3333-4333-8333-333333333333',
+    ]
+    const originalAttempts: string[] = []
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === '/api/admin/media/upload-intents') {
+        return Response.json({ uploadIntent: { id: intentIds.shift() } })
+      }
+      if (url.includes('/original?chunk=')) {
+        originalAttempts.push(url)
+        return new Response(null, {
+          status: url.includes('22222222-2222-4222-8222-222222222222')
+            ? 404
+            : 204,
+        })
+      }
+      if (url.endsWith('/complete')) {
+        return Response.json({
+          mediaAsset: { id: activeAsset.id, processingState: 'ready' },
+        })
+      }
+      if (url.endsWith('/alt-text')) {
+        return Response.json({ suggestion: null, asset: null })
+      }
+      if (url.endsWith('?view=active')) {
+        return Response.json({ assets: [activeAsset] })
+      }
+      if (url.endsWith('?view=archived')) {
+        return Response.json({ assets: [] })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { getByRole, queryByRole } = render(
+      <MediaLibrary initialActive={[]} initialArchived={[]} initialTransfers={[]} selectionIds={[]} />,
+    )
+    const file = new File([new Uint8Array([1, 2, 3])], 'photo.jpg', {
+      type: 'image/jpeg',
+    })
+    if (!file.arrayBuffer) {
+      Object.defineProperty(file, 'arrayBuffer', {
+        value: async () => new Uint8Array([1, 2, 3]).buffer,
+      })
+    }
+    fireEvent.click(getByRole('button', { name: /Transfers/ }))
+    fireEvent.change(document.querySelector('input[type="file"]')!, {
+      target: { files: [file] },
+    })
+
+    await waitFor(() => {
+      expect(originalAttempts).toEqual([
+        '/api/admin/media/upload-intents/22222222-2222-4222-8222-222222222222/original?chunk=0',
+        '/api/admin/media/upload-intents/33333333-3333-4333-8333-333333333333/original?chunk=0',
+      ])
+    })
+    expect(
+      fetchMock.mock.calls.filter(
+        ([input]) => String(input) === '/api/admin/media/upload-intents',
+      ),
+    ).toHaveLength(2)
+    expect(queryByRole('button', { name: /Retry/ })).toBeNull()
   })
 
   it('restarts once from chunk zero after a missing-prior-chunk response', async () => {
@@ -406,8 +569,8 @@ describe('Media archive UI contract', () => {
     })
     vi.stubGlobal('fetch', fetchMock)
 
-    const { container, queryByRole } = render(
-      <MediaLibrary initialActive={[]} initialArchived={[]} selectionIds={[]} />,
+    const { getByRole, queryByRole } = render(
+      <MediaLibrary initialActive={[]} initialArchived={[]} initialTransfers={[]} selectionIds={[]} />,
     )
     const file = new File(
       [new Uint8Array(4 * 1024 * 1024 + 3)],
@@ -419,7 +582,8 @@ describe('Media archive UI contract', () => {
         value: async () => new Uint8Array(4 * 1024 * 1024 + 3).buffer,
       })
     }
-    fireEvent.change(container.querySelector('input[type="file"]')!, {
+    fireEvent.click(getByRole('button', { name: /Transfers/ }))
+    fireEvent.change(document.querySelector('input[type="file"]')!, {
       target: { files: [file] },
     })
 
@@ -467,18 +631,20 @@ describe('Media archive UI contract', () => {
     }
 
     const first = render(
-      <MediaLibrary initialActive={[]} initialArchived={[]} selectionIds={[]} />,
+      <MediaLibrary initialActive={[]} initialArchived={[]} initialTransfers={[]} selectionIds={[]} />,
     )
-    fireEvent.change(first.container.querySelector('input[type="file"]')!, {
+    fireEvent.click(first.getByRole('button', { name: /Transfers/ }))
+    fireEvent.change(document.querySelector('input[type="file"]')!, {
       target: { files: [file] },
     })
     await waitFor(() => expect(intentBodies).toHaveLength(1))
     first.unmount()
 
     const second = render(
-      <MediaLibrary initialActive={[]} initialArchived={[]} selectionIds={[]} />,
+      <MediaLibrary initialActive={[]} initialArchived={[]} initialTransfers={[]} selectionIds={[]} />,
     )
-    fireEvent.change(second.container.querySelector('input[type="file"]')!, {
+    fireEvent.click(second.getByRole('button', { name: /Transfers/ }))
+    fireEvent.change(document.querySelector('input[type="file"]')!, {
       target: { files: [file] },
     })
     await waitFor(() => expect(intentBodies).toHaveLength(2))
@@ -524,8 +690,8 @@ describe('Media archive UI contract', () => {
     })
     vi.stubGlobal('fetch', fetchMock)
 
-    const { container, getByText, queryByRole } = render(
-      <MediaLibrary initialActive={[]} initialArchived={[]} selectionIds={[]} />,
+    const { getByRole, getByText, queryByRole } = render(
+      <MediaLibrary initialActive={[]} initialArchived={[]} initialTransfers={[]} selectionIds={[]} />,
     )
     const file = new File([new Uint8Array([1, 2, 3])], 'photo.jpg', {
       type: 'image/jpeg',
@@ -535,7 +701,8 @@ describe('Media archive UI contract', () => {
         value: async () => new Uint8Array([1, 2, 3]).buffer,
       })
     }
-    fireEvent.change(container.querySelector('input[type="file"]')!, {
+    fireEvent.click(getByRole('button', { name: /Transfers/ }))
+    fireEvent.change(document.querySelector('input[type="file"]')!, {
       target: { files: [file] },
     })
 

--- a/lib/media/asset-review/repository.test.ts
+++ b/lib/media/asset-review/repository.test.ts
@@ -19,6 +19,7 @@ describe('Media Asset review repository', () => {
     '0006_photo_selection.sql',
     '0007_photo_publication_revision.sql',
     '0009_media_catalog_state.sql',
+    '0013_brief_yellowjacket.sql',
   ])
   let client: PGlite
   let repository: ReturnType<typeof createMediaAssetReviewRepository>
@@ -59,15 +60,57 @@ describe('Media Asset review repository', () => {
   })
 
   it('lists only owned catalogState views with public 640-pixel previews', async () => {
+    const incompleteIntentId = '77777777-7777-4777-8777-777777777777'
+    const incompleteAssetId = '88888888-8888-4888-8888-888888888888'
+    await client.query(
+      `INSERT INTO media_upload_intents
+        (id, owner_user_id, idempotency_key, original_key, content_type,
+         byte_size, checksum_sha256, expires_at, completed_at, created_at)
+       VALUES ($1, 'owner_01', 'incomplete', 'originals/incomplete.jpg',
+               'image/jpeg', 1000, $2, '2026-07-16T00:00:00Z',
+               '2026-07-15T01:00:00Z', '2026-07-15T00:00:00Z')`,
+      [incompleteIntentId, 'd'.repeat(64)],
+    )
+    await client.query(
+      `INSERT INTO media_assets
+        (id, upload_intent_id, processing_state, processing_error_code,
+         original_key, original_content_type, original_byte_size,
+         original_checksum_sha256)
+       VALUES ($1, $2, 'retryable_failure', 'dependency_unavailable',
+               'originals/incomplete.jpg', 'image/jpeg', 1000, $3)`,
+      [incompleteAssetId, incompleteIntentId, 'd'.repeat(64)],
+    )
+
     await expect(
       repository.listOwnedAssets({ ownerUserId: 'owner_02', view: 'active' }),
     ).resolves.toEqual([])
     await expect(
       repository.listOwnedAssets({ ownerUserId: 'owner_01', view: 'active' }),
-    ).resolves.toMatchObject([
+    ).resolves.toEqual([
       {
         id: assetId,
+        createdAt: expect.any(Date),
         catalogState: 'active',
+        processingState: 'ready',
+        width: 4032,
+        height: 3024,
+        capturedAt: new Date('2025-05-08T00:31:34.000Z'),
+        cameraMake: 'Google',
+        cameraModel: 'Pixel',
+        lens: null,
+        focalLengthMillimeters: 6.9,
+        aperture: 1.7,
+        shutterSpeedSeconds: 0.01,
+        iso: 80,
+        hasCaptureLocation: false,
+        locationLabelZhHans: null,
+        locationLabelEn: null,
+        focalPoint: null,
+        altTextSuggestion: null,
+        altTextZhHans: null,
+        altTextEn: null,
+        altTextApprovedAt: null,
+        archivedAt: null,
         previewRendition: {
           src: 'https://media.example.com/renditions/photo-640.jpg',
           width: 640,
@@ -192,7 +235,26 @@ describe('Media Asset review repository', () => {
     })
   })
 
-  it('blocks Archive for Draft and active Published membership', async () => {
+  it('withdraws Archive from Draft and Published selections and immediately undoes it', async () => {
+    const otherAssetId = '55555555-5555-4555-8555-555555555555'
+    const otherIntentId = '66666666-6666-4666-8666-666666666666'
+    await client.query(
+      `INSERT INTO media_upload_intents
+        (id, owner_user_id, idempotency_key, original_key, content_type,
+         byte_size, checksum_sha256, expires_at, created_at)
+       VALUES ($1, 'owner_01', 'upload_02', 'originals/other.jpg',
+               'image/jpeg', 1000, $2, '2026-07-16T00:00:00Z', '2026-07-15T00:00:00Z')`,
+      [otherIntentId, 'c'.repeat(64)],
+    )
+    await client.query(
+      `INSERT INTO media_assets
+        (id, upload_intent_id, processing_state, original_key,
+         original_content_type, original_byte_size, original_checksum_sha256,
+         width, height)
+       VALUES ($1, $2, 'ready', 'originals/other.jpg', 'image/jpeg',
+               1000, $3, 3024, 4032)`,
+      [otherAssetId, otherIntentId, 'c'.repeat(64)],
+    )
     await client.query(
       `INSERT INTO media_photo_selection_drafts (id, owner_user_id)
        VALUES ('33333333-3333-4333-8333-333333333333', 'owner_01')`,
@@ -200,33 +262,27 @@ describe('Media Asset review repository', () => {
     await client.query(
       `INSERT INTO media_photo_selection_draft_entries
         (draft_id, media_asset_id, position)
-       VALUES ('33333333-3333-4333-8333-333333333333', $1, 0)`,
-      [assetId],
+       VALUES
+        ('33333333-3333-4333-8333-333333333333', $1, 0),
+        ('33333333-3333-4333-8333-333333333333', $2, 1)`,
+      [assetId, otherAssetId],
     )
-
-    await expect(
-      repository.archive({
-        ownerUserId: 'owner_01',
-        mediaAssetId: assetId,
-        archivedAt: new Date('2026-07-15T12:00:00Z'),
-      }),
-    ).resolves.toEqual({ status: 'selection_conflict' })
-
-    await client.query('DELETE FROM media_photo_selection_draft_entries')
     const publicationId = '44444444-4444-4444-8444-444444444444'
     await client.query(
       `INSERT INTO media_published_photo_selections
         (id, owner_user_id, idempotency_key, draft_revision, item_count,
          published_at)
-       VALUES ($1, 'owner_01', 'publish_01', 1, 1, now())`,
+       VALUES ($1, 'owner_01', 'publish_01', 1, 2, now())`,
       [publicationId],
     )
     await client.query(
       `INSERT INTO media_published_photo_selection_entries
         (published_selection_id, source_media_asset_id, position, width,
          height, alt_text_zh_hans, alt_text_en)
-       VALUES ($1, $2, 0, 4032, 3024, '照片', 'A photo')`,
-      [publicationId, assetId],
+       VALUES
+        ($1, $2, 0, 4032, 3024, '照片', 'A photo'),
+        ($1, $3, 1, 3024, 4032, '另一张照片', 'Another photo')`,
+      [publicationId, assetId, otherAssetId],
     )
     await client.query(
       `INSERT INTO media_active_photo_publication (published_selection_id)
@@ -234,13 +290,131 @@ describe('Media Asset review repository', () => {
       [publicationId],
     )
 
+    const archivedAt = new Date('2026-07-15T12:00:00Z')
+    const archived = await repository.archive({
+      ownerUserId: 'owner_01',
+      mediaAssetId: assetId,
+      archivedAt,
+      undoExpiresAt: new Date('2026-07-15T12:00:10Z'),
+    })
+
+    expect(archived).toMatchObject({
+      status: 'updated',
+      asset: { catalogState: 'archived' },
+      undoOperationId: expect.any(String),
+      publicSelectionChanged: true,
+    })
+    const draftAfterArchive = await client.query<{
+      media_asset_id: string
+      position: number
+      revision: number
+    }>(
+      `SELECT e.media_asset_id, e.position, d.revision
+       FROM media_photo_selection_drafts d
+       JOIN media_photo_selection_draft_entries e ON e.draft_id = d.id
+       ORDER BY e.position`,
+    )
+    expect(draftAfterArchive.rows).toEqual([
+      { media_asset_id: otherAssetId, position: 0, revision: 1 },
+    ])
+    const publicationAfterArchive = await client.query<{
+      id: string
+      publication_kind: string
+      item_count: number
+      source_media_asset_id: string
+      position: number
+    }>(
+      `SELECT p.id, p.publication_kind, p.item_count,
+              e.source_media_asset_id, e.position
+       FROM media_active_photo_publication a
+       JOIN media_published_photo_selections p ON p.id = a.published_selection_id
+       JOIN media_published_photo_selection_entries e
+         ON e.published_selection_id = p.id
+       ORDER BY e.position`,
+    )
+    expect(publicationAfterArchive.rows[0]?.id).not.toBe(publicationId)
+    expect(publicationAfterArchive.rows).toMatchObject([
+      {
+        publication_kind: 'withdrawal',
+        item_count: 1,
+        source_media_asset_id: otherAssetId,
+        position: 0,
+      },
+    ])
+
+    if (archived.status !== 'updated') throw new Error('Expected Archive update')
+    if (!archived.undoOperationId) throw new Error('Expected Archive Undo')
+    const withdrawalPublicationId = publicationAfterArchive.rows[0]!.id
+    const newerPublicationId = '77777777-7777-4777-8777-777777777777'
+    await client.query(
+      `INSERT INTO media_published_photo_selections
+        (id, owner_user_id, idempotency_key, publication_kind,
+         draft_revision, item_count, published_at)
+       VALUES ($1, 'owner_01', 'newer_withdrawal', 'withdrawal', NULL, 0,
+               '2026-07-15T12:00:03Z')`,
+      [newerPublicationId],
+    )
+    await client.query(
+      `UPDATE media_active_photo_publication
+       SET published_selection_id = $1 WHERE id = 1`,
+      [newerPublicationId],
+    )
     await expect(
-      repository.archive({
+      repository.undoArchive({
         ownerUserId: 'owner_01',
         mediaAssetId: assetId,
-        archivedAt: new Date('2026-07-15T12:00:00Z'),
+        operationId: archived.undoOperationId,
+        undoneAt: new Date('2026-07-15T12:00:04Z'),
       }),
-    ).resolves.toEqual({ status: 'selection_conflict' })
+    ).resolves.toEqual({ status: 'revision_conflict' })
+    const draftAfterConflict = await client.query<{
+      media_asset_id: string
+      position: number
+      revision: number
+    }>(
+      `SELECT e.media_asset_id, e.position, d.revision
+       FROM media_photo_selection_drafts d
+       JOIN media_photo_selection_draft_entries e ON e.draft_id = d.id
+       ORDER BY e.position`,
+    )
+    expect(draftAfterConflict.rows).toEqual([
+      { media_asset_id: otherAssetId, position: 0, revision: 1 },
+    ])
+    await client.query(
+      `UPDATE media_active_photo_publication
+       SET published_selection_id = $1 WHERE id = 1`,
+      [withdrawalPublicationId],
+    )
+    await expect(
+      repository.undoArchive({
+        ownerUserId: 'owner_01',
+        mediaAssetId: assetId,
+        operationId: archived.undoOperationId,
+        undoneAt: new Date('2026-07-15T12:00:05Z'),
+      }),
+    ).resolves.toMatchObject({
+      status: 'updated',
+      asset: { catalogState: 'active' },
+      publicSelectionChanged: true,
+    })
+    const draftAfterUndo = await client.query<{
+      media_asset_id: string
+      position: number
+      revision: number
+    }>(
+      `SELECT e.media_asset_id, e.position, d.revision
+       FROM media_photo_selection_drafts d
+       JOIN media_photo_selection_draft_entries e ON e.draft_id = d.id
+       ORDER BY e.position`,
+    )
+    expect(draftAfterUndo.rows).toEqual([
+      { media_asset_id: assetId, position: 0, revision: 2 },
+      { media_asset_id: otherAssetId, position: 1, revision: 2 },
+    ])
+    const activeAfterUndo = await client.query<{ published_selection_id: string }>(
+      'SELECT published_selection_id FROM media_active_photo_publication WHERE id = 1',
+    )
+    expect(activeAfterUndo.rows[0]?.published_selection_id).toBe(publicationId)
   })
 
   it('ignores Draft membership owned by a different owner', async () => {
@@ -260,6 +434,7 @@ describe('Media Asset review repository', () => {
         ownerUserId: 'owner_01',
         mediaAssetId: assetId,
         archivedAt: new Date('2026-07-15T12:00:00Z'),
+        undoExpiresAt: new Date('2026-07-15T12:00:10Z'),
       }),
     ).resolves.toMatchObject({ status: 'updated' })
   })
@@ -269,6 +444,7 @@ describe('Media Asset review repository', () => {
       ownerUserId: 'owner_01',
       mediaAssetId: assetId,
       archivedAt: new Date('2026-07-15T12:00:00Z'),
+      undoExpiresAt: new Date('2026-07-15T12:00:10Z'),
     })
     const restored = await repository.restore({
       ownerUserId: 'owner_01',

--- a/lib/media/asset-review/repository.ts
+++ b/lib/media/asset-review/repository.ts
@@ -4,14 +4,18 @@ import { and, desc, eq, inArray, sql } from 'drizzle-orm'
 
 import type { getDatabase } from '~/db'
 import {
-  mediaActivePhotoPublication,
+  mediaAssetArchiveOperations,
   mediaAssets,
-  mediaPhotoSelectionDraftEntries,
-  mediaPhotoSelectionDrafts,
-  mediaPublishedPhotoSelectionEntries,
   mediaRenditions,
   mediaUploadIntents,
 } from '~/db/schema'
+
+import { lockPhotoSelectionMutations } from '../catalog/lifecycle-locks'
+
+import {
+  restoreMediaAssetSelections,
+  withdrawMediaAssetFromSelections,
+} from '../photo-selection/withdrawal'
 
 import type {
   MediaAssetReviewRecord,
@@ -191,9 +195,12 @@ export function createMediaAssetReviewRepository(
           ),
         )
         .where(
-          input.view === 'active'
-            ? eq(mediaAssets.catalogState, 'active')
-            : inArray(mediaAssets.catalogState, ['archived', 'purging']),
+          and(
+            input.view === 'active'
+              ? eq(mediaAssets.catalogState, 'active')
+              : inArray(mediaAssets.catalogState, ['archived', 'purging']),
+            eq(mediaAssets.processingState, 'ready'),
+          ),
         )
         .orderBy(desc(mediaAssets.createdAt))
       return rows.map(
@@ -265,44 +272,31 @@ export function createMediaAssetReviewRepository(
 
     async archive(input) {
       return database().transaction(async (transaction) => {
+        await lockPhotoSelectionMutations(transaction, input.ownerUserId)
         const [current] = await transaction
-          .select({ id: mediaAssets.id, catalogState: mediaAssets.catalogState })
+          .select({
+            id: mediaAssets.id,
+            catalogState: mediaAssets.catalogState,
+            processingState: mediaAssets.processingState,
+          })
           .from(mediaAssets)
           .where(ownedAssetCondition(input.ownerUserId, input.mediaAssetId))
           .limit(1)
           .for('update')
         if (!current) return { status: 'not_found' }
-        if (current.catalogState !== 'active') return { status: 'invalid_state' }
+        if (
+          current.catalogState !== 'active' ||
+          current.processingState !== 'ready'
+        ) {
+          return { status: 'invalid_state' }
+        }
 
-        const [selection] = await transaction
-          .select({ id: mediaAssets.id })
-          .from(mediaAssets)
-          .where(
-            and(
-              eq(mediaAssets.id, current.id),
-              sql`EXISTS (
-                SELECT 1
-                FROM ${mediaPhotoSelectionDraftEntries}
-                INNER JOIN ${mediaPhotoSelectionDrafts}
-                  ON ${mediaPhotoSelectionDrafts.id} =
-                     ${mediaPhotoSelectionDraftEntries.draftId}
-                WHERE ${mediaPhotoSelectionDraftEntries.mediaAssetId} = ${mediaAssets.id}
-                  AND ${mediaPhotoSelectionDrafts.ownerUserId} =
-                      ${input.ownerUserId}
-              ) OR EXISTS (
-                SELECT 1
-                FROM ${mediaActivePhotoPublication}
-                INNER JOIN ${mediaPublishedPhotoSelectionEntries}
-                  ON ${mediaPublishedPhotoSelectionEntries.publishedSelectionId} =
-                     ${mediaActivePhotoPublication.publishedSelectionId}
-                WHERE ${mediaActivePhotoPublication.id} = 1
-                  AND ${mediaPublishedPhotoSelectionEntries.sourceMediaAssetId} =
-                      ${mediaAssets.id}
-              )`,
-            ),
-          )
-          .limit(1)
-        if (selection) return { status: 'selection_conflict' }
+        const withdrawal = await withdrawMediaAssetFromSelections(transaction, {
+          ownerUserId: input.ownerUserId,
+          mediaAssetId: input.mediaAssetId,
+          idempotencyKey: `archive:${input.mediaAssetId}:${input.archivedAt.getTime()}`,
+          at: input.archivedAt,
+        })
 
         const [asset] = await transaction
           .update(mediaAssets)
@@ -318,15 +312,114 @@ export function createMediaAssetReviewRepository(
             ),
           )
           .returning(reviewAssetColumns)
+        if (!asset) return { status: 'invalid_state' }
+        const [operation] = await transaction
+          .insert(mediaAssetArchiveOperations)
+          .values({
+            ownerUserId: input.ownerUserId,
+            mediaAssetId: input.mediaAssetId,
+            draftId: withdrawal.draft?.id ?? null,
+            draftRevisionBefore: withdrawal.draft?.revisionBefore ?? null,
+            draftRevisionAfter: withdrawal.draft?.revisionAfter ?? null,
+            draftPosition: withdrawal.draft?.position ?? null,
+            publishedSelectionBefore: withdrawal.publication?.beforeId ?? null,
+            publishedSelectionAfter: withdrawal.publication?.afterId ?? null,
+            archivedAt: input.archivedAt,
+            undoExpiresAt: input.undoExpiresAt,
+          })
+          .returning({ id: mediaAssetArchiveOperations.id })
         const preview = asset
           ? await previewRendition(transaction, asset.id)
           : null
-        return asset
-          ? {
-              status: 'updated',
-              asset: record(asset, preview, publicRenditionUrl),
-            }
-          : { status: 'invalid_state' }
+        return {
+          status: 'updated',
+          asset: record(asset, preview, publicRenditionUrl),
+          undoOperationId: operation!.id,
+          publicSelectionChanged: withdrawal.publication !== null,
+        }
+      })
+    },
+
+    async undoArchive(input) {
+      return database().transaction(async (transaction) => {
+        await lockPhotoSelectionMutations(transaction, input.ownerUserId)
+        const [operation] = await transaction
+          .select()
+          .from(mediaAssetArchiveOperations)
+          .where(
+            and(
+              eq(mediaAssetArchiveOperations.id, input.operationId),
+              eq(mediaAssetArchiveOperations.ownerUserId, input.ownerUserId),
+              eq(mediaAssetArchiveOperations.mediaAssetId, input.mediaAssetId),
+            ),
+          )
+          .limit(1)
+          .for('update')
+        if (!operation) return { status: 'not_found' }
+        if (operation.undoneAt || operation.undoExpiresAt < input.undoneAt) {
+          return { status: 'undo_expired' }
+        }
+
+        const [current] = await transaction
+          .select({ catalogState: mediaAssets.catalogState })
+          .from(mediaAssets)
+          .where(ownedAssetCondition(input.ownerUserId, input.mediaAssetId))
+          .limit(1)
+          .for('update')
+        if (!current) return { status: 'not_found' }
+        if (current.catalogState !== 'archived') return { status: 'invalid_state' }
+
+        const restored = await restoreMediaAssetSelections(transaction, {
+          ownerUserId: input.ownerUserId,
+          mediaAssetId: input.mediaAssetId,
+          draft:
+            operation.draftId &&
+            operation.draftRevisionBefore !== null &&
+            operation.draftRevisionAfter !== null &&
+            operation.draftPosition !== null
+              ? {
+                  id: operation.draftId,
+                  revisionBefore: operation.draftRevisionBefore,
+                  revisionAfter: operation.draftRevisionAfter,
+                  position: operation.draftPosition,
+                }
+              : null,
+          publication:
+            operation.publishedSelectionBefore && operation.publishedSelectionAfter
+              ? {
+                  beforeId: operation.publishedSelectionBefore,
+                  afterId: operation.publishedSelectionAfter,
+                }
+              : null,
+          at: input.undoneAt,
+        })
+        if (!restored) return { status: 'revision_conflict' }
+
+        const [asset] = await transaction
+          .update(mediaAssets)
+          .set({
+            catalogState: 'active',
+            archivedAt: null,
+            updatedAt: input.undoneAt,
+          })
+          .where(
+            and(
+              eq(mediaAssets.id, input.mediaAssetId),
+              eq(mediaAssets.catalogState, 'archived'),
+            ),
+          )
+          .returning(reviewAssetColumns)
+        if (!asset) return { status: 'invalid_state' }
+        await transaction
+          .update(mediaAssetArchiveOperations)
+          .set({ undoneAt: input.undoneAt })
+          .where(eq(mediaAssetArchiveOperations.id, operation.id))
+        const preview = await previewRendition(transaction, asset.id)
+        return {
+          status: 'updated',
+          asset: record(asset, preview, publicRenditionUrl),
+          publicSelectionChanged: operation.publishedSelectionAfter !== null,
+        }
       })
     },
 

--- a/lib/media/asset-review/service.test.ts
+++ b/lib/media/asset-review/service.test.ts
@@ -42,7 +42,7 @@ function fixture() {
       height: 480,
     },
   }
-  let selectionConflict = false
+  let publicSelectionChanged = false
   const repository: MediaAssetReviewRepository = {
     async listOwnedAssets() {
       return [record]
@@ -71,14 +71,23 @@ function fixture() {
       return record
     },
     async archive(input) {
-      if (selectionConflict) return { status: 'selection_conflict' }
       if (record.catalogState !== 'active') return { status: 'invalid_state' }
       record = {
         ...record,
         catalogState: 'archived',
         archivedAt: input.archivedAt,
       }
-      return { status: 'updated', asset: record }
+      return {
+        status: 'updated',
+        asset: record,
+        undoOperationId: '22222222-2222-4222-8222-222222222222',
+        publicSelectionChanged,
+      }
+    },
+    async undoArchive() {
+      if (record.catalogState !== 'archived') return { status: 'invalid_state' }
+      record = { ...record, catalogState: 'active', archivedAt: null }
+      return { status: 'updated', asset: record, publicSelectionChanged }
     },
     async restore() {
       if (record.catalogState !== 'archived') return { status: 'invalid_state' }
@@ -86,14 +95,17 @@ function fixture() {
       return { status: 'updated', asset: record }
     },
   }
+  const invalidatePublicSelection = vi.fn(async () => undefined)
   const service = createMediaAssetReviewService({
     repository,
+    invalidatePublicSelection,
     clock: { now: () => new Date('2026-07-15T12:00:00.000Z') },
   })
   return {
     service,
-    setSelectionConflict(value: boolean) {
-      selectionConflict = value
+    invalidatePublicSelection,
+    setPublicSelectionChanged(value: boolean) {
+      publicSelectionChanged = value
     },
   }
 }
@@ -154,13 +166,18 @@ describe('Media Asset review service', () => {
     })
   })
 
-  it('blocks Archive while the Media Asset belongs to a Photo Selection', async () => {
-    const { service, setSelectionConflict } = fixture()
-    setSelectionConflict(true)
+  it('archives a selected Media Asset and invalidates its surgical publication', async () => {
+    const { invalidatePublicSelection, service, setPublicSelectionChanged } =
+      fixture()
+    setPublicSelectionChanged(true)
 
     await expect(
       service.archive({ ownerUserId: 'owner_01', mediaAssetId }),
-    ).rejects.toEqual(new MediaAssetReviewError('selection_conflict'))
+    ).resolves.toMatchObject({
+      asset: { catalogState: 'archived' },
+      undoOperationId: '22222222-2222-4222-8222-222222222222',
+    })
+    expect(invalidatePublicSelection).toHaveBeenCalledOnce()
   })
 
   it('archives and restores without changing reviewed metadata', async () => {
@@ -175,9 +192,11 @@ describe('Media Asset review service', () => {
     await expect(
       service.archive({ ownerUserId: 'owner_01', mediaAssetId }),
     ).resolves.toMatchObject({
-      catalogState: 'archived',
-      altTextEn: 'A cable car.',
-      archivedAt: new Date('2026-07-15T12:00:00.000Z'),
+      asset: {
+        catalogState: 'archived',
+        altTextEn: 'A cable car.',
+        archivedAt: new Date('2026-07-15T12:00:00.000Z'),
+      },
     })
     await expect(
       service.restore({ ownerUserId: 'owner_01', mediaAssetId }),

--- a/lib/media/asset-review/service.ts
+++ b/lib/media/asset-review/service.ts
@@ -43,10 +43,16 @@ export type MediaAssetReviewRecord = {
 }
 
 type CatalogStateResult =
-  | { status: 'updated'; asset: MediaAssetReviewRecord }
+  | {
+      status: 'updated'
+      asset: MediaAssetReviewRecord
+      undoOperationId?: string
+      publicSelectionChanged?: boolean
+    }
   | { status: 'invalid_state' }
   | { status: 'not_found' }
-  | { status: 'selection_conflict' }
+  | { status: 'revision_conflict' }
+  | { status: 'undo_expired' }
 
 export interface MediaAssetReviewRepository {
   listOwnedAssets(input: {
@@ -76,6 +82,13 @@ export interface MediaAssetReviewRepository {
     ownerUserId: string
     mediaAssetId: string
     archivedAt: Date
+    undoExpiresAt: Date
+  }): Promise<CatalogStateResult>
+  undoArchive(input: {
+    ownerUserId: string
+    mediaAssetId: string
+    operationId: string
+    undoneAt: Date
   }): Promise<CatalogStateResult>
   restore(input: {
     ownerUserId: string
@@ -85,11 +98,13 @@ export interface MediaAssetReviewRepository {
 }
 
 export type MediaAssetReviewErrorCode =
+  | 'cache_invalidation_failed'
   | 'dependency_unavailable'
   | 'invalid_request'
   | 'invalid_state'
   | 'not_found'
-  | 'selection_conflict'
+  | 'revision_conflict'
+  | 'undo_expired'
 
 export class MediaAssetReviewError extends Error {
   constructor(readonly code: MediaAssetReviewErrorCode) {
@@ -136,15 +151,23 @@ function validFocalPoint(value: { x: number; y: number } | null) {
 }
 
 function unwrapCatalogState(result: CatalogStateResult) {
-  if (result.status === 'updated') return result.asset
+  if (result.status === 'updated') return result
   throw new MediaAssetReviewError(result.status)
 }
 
+function unwrapAsset(result: CatalogStateResult) {
+  return unwrapCatalogState(result).asset
+}
+
+const ARCHIVE_UNDO_WINDOW_MS = 10_000
+
 export function createMediaAssetReviewService({
   repository,
+  invalidatePublicSelection,
   clock = { now: () => new Date() },
 }: {
   repository: MediaAssetReviewRepository
+  invalidatePublicSelection: () => Promise<void>
   clock?: { now(): Date }
 }) {
   return {
@@ -245,9 +268,53 @@ export function createMediaAssetReviewService({
         throw new MediaAssetReviewError('invalid_request')
       }
       try {
-        return unwrapCatalogState(
-          await repository.archive({ ...input, archivedAt: clock.now() }),
+        const archivedAt = clock.now()
+        const result = unwrapCatalogState(
+          await repository.archive({
+            ...input,
+            archivedAt,
+            undoExpiresAt: new Date(
+              archivedAt.getTime() + ARCHIVE_UNDO_WINDOW_MS,
+            ),
+          }),
         )
+        if (result.publicSelectionChanged) {
+          try {
+            await invalidatePublicSelection()
+          } catch {
+            throw new MediaAssetReviewError('cache_invalidation_failed')
+          }
+        }
+        return result
+      } catch (error) {
+        if (error instanceof MediaAssetReviewError) throw error
+        throw new MediaAssetReviewError('dependency_unavailable')
+      }
+    },
+
+    async undoArchive(input: {
+      ownerUserId: string
+      mediaAssetId: string
+      operationId: string
+    }) {
+      if (
+        !validIdentity(input.ownerUserId, input.mediaAssetId) ||
+        !uuidPattern.test(input.operationId)
+      ) {
+        throw new MediaAssetReviewError('invalid_request')
+      }
+      try {
+        const result = unwrapCatalogState(
+          await repository.undoArchive({ ...input, undoneAt: clock.now() }),
+        )
+        if (result.publicSelectionChanged) {
+          try {
+            await invalidatePublicSelection()
+          } catch {
+            throw new MediaAssetReviewError('cache_invalidation_failed')
+          }
+        }
+        return result
       } catch (error) {
         if (error instanceof MediaAssetReviewError) throw error
         throw new MediaAssetReviewError('dependency_unavailable')
@@ -259,7 +326,7 @@ export function createMediaAssetReviewService({
         throw new MediaAssetReviewError('invalid_request')
       }
       try {
-        return unwrapCatalogState(
+        return unwrapAsset(
           await repository.restore({ ...input, restoredAt: clock.now() }),
         )
       } catch (error) {

--- a/lib/media/catalog/lifecycle-locks.ts
+++ b/lib/media/catalog/lifecycle-locks.ts
@@ -1,0 +1,43 @@
+import 'server-only'
+
+import { sql } from 'drizzle-orm'
+
+import type { getDatabase } from '~/db'
+
+type MediaLifecycleDatabase = ReturnType<typeof getDatabase>
+export type MediaLifecycleTransaction = Parameters<
+  Parameters<MediaLifecycleDatabase['transaction']>[0]
+>[0]
+
+async function lockLifecycleKey(
+  transaction: MediaLifecycleTransaction,
+  key: string,
+) {
+  await transaction.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtextextended(${key}, 0))`,
+  )
+}
+
+/**
+ * Every Draft/Published mutation takes this owner-scoped lock before touching
+ * Media Asset rows. It gives Archive, Undo, Purge, Save, and Publish one lock
+ * order even when the owner has no Draft or active Publication row yet.
+ */
+export function lockPhotoSelectionMutations(
+  transaction: MediaLifecycleTransaction,
+  ownerUserId: string,
+) {
+  return lockLifecycleKey(transaction, `media:photo-selection:${ownerUserId}`)
+}
+
+/**
+ * A processing write and Discard/Purge cannot overlap for the same asset.
+ * Storage work runs while this transaction-scoped lock is held, so a Discard
+ * sees every committed Rendition manifest and no later write can escape it.
+ */
+export function lockMediaAssetProcessing(
+  transaction: MediaLifecycleTransaction,
+  mediaAssetId: string,
+) {
+  return lockLifecycleKey(transaction, `media:asset-processing:${mediaAssetId}`)
+}

--- a/lib/media/ingestion/repository.test.ts
+++ b/lib/media/ingestion/repository.test.ts
@@ -30,6 +30,7 @@ describe('Media Library ingestion repository', () => {
     '0007_photo_publication_revision.sql',
     '0009_media_catalog_state.sql',
     '0012_high_fidelity_photo_renditions.sql',
+    '0013_brief_yellowjacket.sql',
   ])
   let client: PGlite
   let repository: ReturnType<typeof createMediaIngestionRepository>
@@ -69,6 +70,23 @@ describe('Media Library ingestion repository', () => {
     await expect(
       repository.claimUploadIntentTransfer('other_owner', intent.id, activeAt),
     ).resolves.toBeNull()
+    await client.query(
+      `UPDATE media_upload_intents
+       SET discard_started_at = $2 WHERE id = $1`,
+      [intent.id, activeAt],
+    )
+    await expect(
+      repository.claimUploadIntentTransfer(
+        intent.ownerUserId,
+        intent.id,
+        new Date('2026-07-15T01:01:00.000Z'),
+      ),
+    ).resolves.toBeNull()
+    await client.query(
+      `UPDATE media_upload_intents
+       SET discard_started_at = NULL WHERE id = $1`,
+      [intent.id],
+    )
     await expect(
       repository.claimUploadIntentTransfer(
         intent.ownerUserId,
@@ -91,6 +109,7 @@ describe('Media Library ingestion repository', () => {
       uploadIntent: intent,
       completedAt,
     })
+    if (!asset) throw new Error('Expected a verified Media Asset')
 
     const claims = await Promise.all([
       repository.claimProcessing({
@@ -116,6 +135,24 @@ describe('Media Library ingestion repository', () => {
     })
   })
 
+  it('does not create a Media Asset after Discard closes the intent', async () => {
+    const intent = await repository.createUploadIntent(intentInput)
+    await client.query(
+      `UPDATE media_upload_intents
+       SET discard_started_at = '2026-07-15T01:00:00Z'
+       WHERE id = $1`,
+      [intent.id],
+    )
+
+    await expect(
+      repository.createVerifiedMediaAsset({
+        uploadIntent: intent,
+        completedAt: new Date('2026-07-15T01:01:00.000Z'),
+      }),
+    ).resolves.toBeNull()
+    await expect(repository.findMediaAsset(intent.id)).resolves.toBeNull()
+  })
+
   it('requires the complete Rendition manifest before storing ready metadata', async () => {
     const intent = await repository.createUploadIntent(intentInput)
     const now = new Date('2026-07-15T01:00:00.000Z')
@@ -123,6 +160,7 @@ describe('Media Library ingestion repository', () => {
       uploadIntent: intent,
       completedAt: now,
     })
+    if (!asset) throw new Error('Expected a verified Media Asset')
     await repository.claimProcessing({
       mediaAssetId: asset.id,
       claimedAt: now,
@@ -172,7 +210,19 @@ describe('Media Library ingestion repository', () => {
     await repository.recordRendition(rendition(1024))
     await repository.recordRendition(rendition(1600))
     await repository.recordRendition(rendition(2560))
-    const ready = await repository.markReady(readyInput)
+    const readyResult = await repository.withActiveProcessingAsset({
+      mediaAssetId: asset.id,
+      run: (session) =>
+        session.markReady({
+          metadata: readyInput.metadata,
+          completedAt: readyInput.completedAt,
+          requiredRenditionCount: readyInput.requiredRenditionCount,
+        }),
+    })
+    if (readyResult.status !== 'active') {
+      throw new Error('Expected active processing')
+    }
+    const ready = readyResult.value
 
     const staleFailure = await repository.markFailure({
       mediaAssetId: asset.id,

--- a/lib/media/ingestion/repository.ts
+++ b/lib/media/ingestion/repository.ts
@@ -9,7 +9,11 @@ import {
   mediaUploadIntents,
 } from '~/db/schema'
 
+import { lockMediaAssetProcessing } from '../catalog/lifecycle-locks'
+
 import type {
+  ActiveMediaAssetProcessingSession,
+  MarkMediaAssetReadyInput,
   MediaAssetRecord,
   MediaIngestionRepository,
   OriginalContentType,
@@ -103,6 +107,104 @@ export function createMediaIngestionRepository(
     return row ? mediaAssetRecord(row) : null
   }
 
+  async function findRenditionWith(
+    client: MediaIngestionDatabase | Parameters<
+      Parameters<MediaIngestionDatabase['transaction']>[0]
+    >[0],
+    mediaAssetId: string,
+    profileWidth: number,
+  ) {
+    const [row] = await client
+      .select()
+      .from(mediaRenditions)
+      .where(
+        and(
+          eq(mediaRenditions.mediaAssetId, mediaAssetId),
+          eq(mediaRenditions.profileWidth, profileWidth),
+        ),
+      )
+      .limit(1)
+    return row ? renditionRecord(row) : null
+  }
+
+  async function recordRenditionWith(
+    client: MediaIngestionDatabase | Parameters<
+      Parameters<MediaIngestionDatabase['transaction']>[0]
+    >[0],
+    input: RenditionRecord,
+  ) {
+    const [created] = await client
+      .insert(mediaRenditions)
+      .values(input)
+      .onConflictDoNothing({
+        target: [mediaRenditions.mediaAssetId, mediaRenditions.profileWidth],
+      })
+      .returning()
+    if (created) return renditionRecord(created)
+
+    const existing = await findRenditionWith(
+      client,
+      input.mediaAssetId,
+      input.profileWidth,
+    )
+    if (!existing) throw new Error('Rendition conflict was not readable')
+    return existing
+  }
+
+  async function markReadyWith(
+    client: MediaIngestionDatabase | Parameters<
+      Parameters<MediaIngestionDatabase['transaction']>[0]
+    >[0],
+    {
+      mediaAssetId,
+      metadata,
+      completedAt,
+      requiredRenditionCount,
+    }: MarkMediaAssetReadyInput,
+  ) {
+    const [ready] = await client
+      .update(mediaAssets)
+      .set({
+        processingState: 'ready',
+        processingErrorCode: null,
+        width: metadata.width,
+        height: metadata.height,
+        capturedAt: metadata.capturedAt,
+        cameraMake: metadata.cameraMake,
+        cameraModel: metadata.cameraModel,
+        lens: metadata.lens,
+        focalLengthMillimeters: numericValue(metadata.focalLengthMillimeters),
+        aperture: numericValue(metadata.aperture),
+        shutterSpeedSeconds: numericValue(metadata.shutterSpeedSeconds),
+        iso: metadata.iso,
+        captureLocationEnvelope: metadata.captureLocationEnvelope,
+        updatedAt: completedAt,
+      })
+      .where(
+        and(
+          eq(mediaAssets.id, mediaAssetId),
+          eq(mediaAssets.catalogState, 'active'),
+          eq(mediaAssets.processingState, 'processing'),
+          sql`(
+            SELECT count(*)
+            FROM ${mediaRenditions}
+            WHERE ${mediaRenditions.mediaAssetId} = ${mediaAssetId}
+          ) = ${requiredRenditionCount}`,
+        ),
+      )
+      .returning()
+    if (ready) return mediaAssetRecord(ready)
+
+    const [current] = await client
+      .select()
+      .from(mediaAssets)
+      .where(eq(mediaAssets.id, mediaAssetId))
+      .limit(1)
+    if (!current || current.catalogState !== 'active') return null
+    if (current.processingState === 'ready') return mediaAssetRecord(current)
+    throw new Error('Media Asset Rendition manifest is incomplete')
+  }
+
   return {
     async createUploadIntent(input) {
       const [created] = await database()
@@ -155,6 +257,7 @@ export function createMediaIngestionRepository(
             eq(mediaUploadIntents.ownerUserId, ownerUserId),
             gt(mediaUploadIntents.expiresAt, activeAt),
             isNull(mediaUploadIntents.completedAt),
+            isNull(mediaUploadIntents.discardStartedAt),
           ),
         )
         .returning()
@@ -173,6 +276,7 @@ export function createMediaIngestionRepository(
             completed_at = COALESCE(completed_at, ${completedAt}),
             updated_at = ${completedAt}
           WHERE id = ${uploadIntent.id}
+            AND discard_started_at IS NULL
           RETURNING id
         )
         INSERT INTO ${mediaAssets} (
@@ -198,7 +302,6 @@ export function createMediaIngestionRepository(
         ON CONFLICT (upload_intent_id) DO NOTHING
       `)
       const asset = await findAssetBy(mediaAssets.uploadIntentId, uploadIntent.id)
-      if (!asset) throw new Error('Verified Media Asset was not readable')
       return asset
     },
 
@@ -213,9 +316,11 @@ export function createMediaIngestionRepository(
         .where(
           and(
             eq(mediaAssets.id, mediaAssetId),
+            eq(mediaAssets.catalogState, 'active'),
             or(
               inArray(mediaAssets.processingState, [
                 'original_verified',
+                'repair_required',
                 'retryable_failure',
               ]),
               and(
@@ -233,84 +338,59 @@ export function createMediaIngestionRepository(
       return findAssetBy(mediaAssets.id, id)
     },
 
+    async withActiveProcessingAsset<T>({ mediaAssetId, run }: {
+      mediaAssetId: string
+      run(session: ActiveMediaAssetProcessingSession): Promise<T>
+    }) {
+      const result = await database().transaction(async (transaction) => {
+        await lockMediaAssetProcessing(transaction, mediaAssetId)
+        const [asset] = await transaction
+          .select({
+            catalogState: mediaAssets.catalogState,
+            processingState: mediaAssets.processingState,
+          })
+          .from(mediaAssets)
+          .where(eq(mediaAssets.id, mediaAssetId))
+          .limit(1)
+        if (
+          !asset ||
+          asset.catalogState !== 'active' ||
+          asset.processingState !== 'processing'
+        ) {
+          return { status: 'canceled' as const }
+        }
+
+        try {
+          const value = await run({
+            findRendition: (profileWidth) =>
+              findRenditionWith(transaction, mediaAssetId, profileWidth),
+            recordRendition: (input) =>
+              recordRenditionWith(transaction, input),
+            markReady: (input) =>
+              markReadyWith(transaction, { mediaAssetId, ...input }),
+          })
+          return { status: 'active' as const, value }
+        } catch (error) {
+          // The callback may have inserted a deterministic Rendition manifest
+          // before a Bunny failure. Return the error as data so the transaction
+          // commits that cleanup record, then rethrow outside the transaction.
+          return { status: 'failed' as const, error }
+        }
+      })
+      if (result.status === 'failed') throw result.error
+      return result
+    },
+
     async findRendition(mediaAssetId, profileWidth) {
-      const [row] = await database()
-        .select()
-        .from(mediaRenditions)
-        .where(
-          and(
-            eq(mediaRenditions.mediaAssetId, mediaAssetId),
-            eq(mediaRenditions.profileWidth, profileWidth),
-          ),
-        )
-        .limit(1)
-      return row ? renditionRecord(row) : null
+      return findRenditionWith(database(), mediaAssetId, profileWidth)
     },
 
     async recordRendition(input) {
-      const [created] = await database()
-        .insert(mediaRenditions)
-        .values(input)
-        .onConflictDoNothing({
-          target: [mediaRenditions.mediaAssetId, mediaRenditions.profileWidth],
-        })
-        .returning()
-      if (created) return renditionRecord(created)
-
-      const [existing] = await database()
-        .select()
-        .from(mediaRenditions)
-        .where(
-          and(
-            eq(mediaRenditions.mediaAssetId, input.mediaAssetId),
-            eq(mediaRenditions.profileWidth, input.profileWidth),
-          ),
-        )
-        .limit(1)
-      if (!existing) throw new Error('Rendition conflict was not readable')
-      return renditionRecord(existing)
+      return recordRenditionWith(database(), input)
     },
 
-    async markReady({
-      mediaAssetId,
-      metadata,
-      completedAt,
-      requiredRenditionCount,
-    }) {
-      const [ready] = await database()
-        .update(mediaAssets)
-        .set({
-          processingState: 'ready',
-          processingErrorCode: null,
-          width: metadata.width,
-          height: metadata.height,
-          capturedAt: metadata.capturedAt,
-          cameraMake: metadata.cameraMake,
-          cameraModel: metadata.cameraModel,
-          lens: metadata.lens,
-          focalLengthMillimeters: numericValue(
-            metadata.focalLengthMillimeters,
-          ),
-          aperture: numericValue(metadata.aperture),
-          shutterSpeedSeconds: numericValue(metadata.shutterSpeedSeconds),
-          iso: metadata.iso,
-          captureLocationEnvelope: metadata.captureLocationEnvelope,
-          updatedAt: completedAt,
-        })
-        .where(
-          and(
-            eq(mediaAssets.id, mediaAssetId),
-            eq(mediaAssets.processingState, 'processing'),
-            sql`(
-              SELECT count(*)
-              FROM ${mediaRenditions}
-              WHERE ${mediaRenditions.mediaAssetId} = ${mediaAssetId}
-            ) = ${requiredRenditionCount}`,
-          ),
-        )
-        .returning()
-      if (!ready) throw new Error('Media Asset Rendition manifest is incomplete')
-      return mediaAssetRecord(ready)
+    async markReady(input) {
+      return markReadyWith(database(), input)
     },
 
     async markFailure({
@@ -329,13 +409,19 @@ export function createMediaIngestionRepository(
         .where(
           and(
             eq(mediaAssets.id, mediaAssetId),
+            eq(mediaAssets.catalogState, 'active'),
             ne(mediaAssets.processingState, 'ready'),
           ),
         )
         .returning()
       if (!failed) {
-        const current = await findAssetBy(mediaAssets.id, mediaAssetId)
-        if (current?.processingState === 'ready') return current
+        const [current] = await database()
+          .select()
+          .from(mediaAssets)
+          .where(eq(mediaAssets.id, mediaAssetId))
+          .limit(1)
+        if (!current || current.catalogState !== 'active') return null
+        if (current.processingState === 'ready') return mediaAssetRecord(current)
         throw new Error('Media Asset failure was not recorded')
       }
       return mediaAssetRecord(failed)

--- a/lib/media/ingestion/service.test.ts
+++ b/lib/media/ingestion/service.test.ts
@@ -72,6 +72,9 @@ function fixture() {
   let originalReportedByteSize: number | null = null
   let originalMissing = false
   let failingRenditionProfile: number | null = null
+  let processingSessionCount = 0
+  let cancelProcessingAfter: number | null = null
+  let discardBeforeAsset = false
   const repository: MediaIngestionRepository = {
     async createUploadIntent(input) {
       const key = `${input.ownerUserId}:${input.idempotencyKey}`
@@ -96,6 +99,7 @@ function fixture() {
       return id ? assets.get(id) ?? null : null
     },
     async createVerifiedMediaAsset({ uploadIntent, completedAt }) {
+      if (discardBeforeAsset) return null
       const existingId = assetsByIntent.get(uploadIntent.id)
       if (existingId) return assets.get(existingId)!
       const asset: MediaAssetRecord = {
@@ -135,6 +139,25 @@ function fixture() {
     },
     async getMediaAsset(id) {
       return assets.get(id) ?? null
+    },
+    async withActiveProcessingAsset({ mediaAssetId, run }) {
+      if (
+        cancelProcessingAfter !== null &&
+        processingSessionCount >= cancelProcessingAfter
+      ) {
+        return { status: 'canceled' }
+      }
+      processingSessionCount += 1
+      return {
+        status: 'active',
+        value: await run({
+          findRendition: (profileWidth) =>
+            repository.findRendition(mediaAssetId, profileWidth),
+          recordRendition: (input) => repository.recordRendition(input),
+          markReady: (input) =>
+            repository.markReady({ mediaAssetId, ...input }),
+        }),
+      }
     },
     async findRendition(mediaAssetId, profileWidth) {
       return renditions.get(`${mediaAssetId}:${profileWidth}`) ?? null
@@ -196,6 +219,7 @@ function fixture() {
     deleteOriginalChunk: vi.fn(async (_originalKey: string, chunkIndex: number) => {
       originalChunks.delete(chunkIndex)
     }),
+    deleteOriginal: vi.fn(async () => undefined),
     storeRendition: vi.fn(async (input: {
       key: string
       bytes: Uint8Array
@@ -283,6 +307,12 @@ function fixture() {
     failRendition(profileWidth: number | null) {
       failingRenditionProfile = profileWidth
     },
+    cancelProcessingAfterSessions(count: number | null) {
+      cancelProcessingAfter = count
+    },
+    discardBeforeAssetCreation() {
+      discardBeforeAsset = true
+    },
   }
 }
 
@@ -362,14 +392,14 @@ describe('Media Library ingestion service', () => {
       'asset:original_verified',
       'asset:processing',
       'image:process',
-      'rendition:store:640',
       'rendition:record:640',
-      'rendition:store:1024',
+      'rendition:store:640',
       'rendition:record:1024',
-      'rendition:store:1600',
+      'rendition:store:1024',
       'rendition:record:1600',
-      'rendition:store:2560',
+      'rendition:store:1600',
       'rendition:record:2560',
+      'rendition:store:2560',
       'location:seal',
       'asset:ready',
     ])
@@ -497,6 +527,28 @@ describe('Media Library ingestion service', () => {
     expect(f.processor).not.toHaveBeenCalled()
   })
 
+  it('removes a late Original when Discard wins before asset creation', async () => {
+    const f = fixture()
+    const intent = await f.service.createUploadIntent({
+      ownerUserId: 'owner_01',
+      idempotencyKey: 'upload_01',
+      contentType: 'image/jpeg',
+      byteSize: originalBytes.byteLength,
+      checksumSha256: originalChecksum,
+    })
+    f.discardBeforeAssetCreation()
+
+    await expect(
+      f.service.completeUploadIntent({
+        ownerUserId: 'owner_01',
+        uploadIntentId: intent.id,
+      }),
+    ).rejects.toEqual(new MediaIngestionError('not_found'))
+
+    expect(f.storage.deleteOriginal).toHaveBeenCalledWith(intent.originalKey)
+    expect(f.processor).not.toHaveBeenCalled()
+  })
+
   it('does not read an Original after its stored size fails verification', async () => {
     const f = fixture()
     const intent = await f.service.createUploadIntent({
@@ -580,7 +632,7 @@ describe('Media Library ingestion service', () => {
       processingState: 'retryable_failure',
       processingErrorCode: 'dependency_unavailable',
     })
-    expect(f.renditions).toHaveLength(1)
+    expect(f.renditions).toHaveLength(2)
     const confirmedKey = [...f.renditions.values()][0]!.objectKey
     const confirmedInspections = f.storage.inspectRendition.mock.calls.filter(
       ([key]) => key === confirmedKey,
@@ -601,7 +653,7 @@ describe('Media Library ingestion service', () => {
       f.storage.inspectRendition.mock.calls.filter(
         ([key]) => key === confirmedKey,
       ),
-    ).toHaveLength(confirmedInspections)
+    ).toHaveLength(confirmedInspections + 1)
     expect(
       f.storage.readRendition.mock.calls.filter(([key]) => key === confirmedKey),
     ).toHaveLength(2)
@@ -630,6 +682,29 @@ describe('Media Library ingestion service', () => {
       ),
     ).toHaveLength(0)
     expect(f.renditions).toHaveLength(4)
+  })
+
+  it('stops before another storage write when Discard cancels processing', async () => {
+    const f = fixture()
+    const intent = await f.service.createUploadIntent({
+      ownerUserId: 'owner_01',
+      idempotencyKey: 'upload_01',
+      contentType: 'image/jpeg',
+      byteSize: originalBytes.byteLength,
+      checksumSha256: originalChecksum,
+    })
+    f.cancelProcessingAfterSessions(1)
+
+    await expect(
+      f.service.completeUploadIntent({
+        ownerUserId: 'owner_01',
+        uploadIntentId: intent.id,
+      }),
+    ).rejects.toEqual(new MediaIngestionError('not_found'))
+
+    expect(f.renditions).toHaveLength(1)
+    expect(f.storage.storeRendition).toHaveBeenCalledOnce()
+    expect(f.events).not.toContain('asset:retryable_failure')
   })
 
   it('marks a missing verified Original as repair required', async () => {

--- a/lib/media/ingestion/service.ts
+++ b/lib/media/ingestion/service.ts
@@ -79,6 +79,35 @@ export type RenditionRecord = {
   metadataStripped: true
 }
 
+export type MarkMediaAssetReadyInput = {
+  mediaAssetId: string
+  metadata: Omit<
+    MediaAssetRecord,
+    | 'id'
+    | 'uploadIntentId'
+    | 'processingState'
+    | 'processingErrorCode'
+    | 'originalKey'
+    | 'originalContentType'
+    | 'originalByteSize'
+    | 'originalChecksumSha256'
+  >
+  completedAt: Date
+  requiredRenditionCount: number
+}
+
+export type ActiveMediaAssetProcessingSession = {
+  findRendition(profileWidth: number): Promise<RenditionRecord | null>
+  recordRendition(input: RenditionRecord): Promise<RenditionRecord>
+  markReady(
+    input: Omit<MarkMediaAssetReadyInput, 'mediaAssetId'>,
+  ): Promise<MediaAssetRecord | null>
+}
+
+export type ActiveMediaAssetProcessingResult<T> =
+  | { status: 'active'; value: T }
+  | { status: 'canceled' }
+
 export interface MediaIngestionRepository {
   createUploadIntent(
     input: Omit<UploadIntentRecord, 'completedAt'>,
@@ -93,40 +122,29 @@ export interface MediaIngestionRepository {
   createVerifiedMediaAsset(input: {
     uploadIntent: UploadIntentRecord
     completedAt: Date
-  }): Promise<MediaAssetRecord>
+  }): Promise<MediaAssetRecord | null>
   claimProcessing(input: {
     mediaAssetId: string
     claimedAt: Date
     staleBefore: Date
   }): Promise<boolean>
   getMediaAsset(id: string): Promise<MediaAssetRecord | null>
+  withActiveProcessingAsset<T>(input: {
+    mediaAssetId: string
+    run(session: ActiveMediaAssetProcessingSession): Promise<T>
+  }): Promise<ActiveMediaAssetProcessingResult<T>>
   findRendition(
     mediaAssetId: string,
     profileWidth: number,
   ): Promise<RenditionRecord | null>
   recordRendition(input: RenditionRecord): Promise<RenditionRecord>
-  markReady(input: {
-    mediaAssetId: string
-    metadata: Omit<
-      MediaAssetRecord,
-      | 'id'
-      | 'uploadIntentId'
-      | 'processingState'
-      | 'processingErrorCode'
-      | 'originalKey'
-      | 'originalContentType'
-      | 'originalByteSize'
-      | 'originalChecksumSha256'
-    >
-    completedAt: Date
-    requiredRenditionCount: number
-  }): Promise<MediaAssetRecord>
+  markReady(input: MarkMediaAssetReadyInput): Promise<MediaAssetRecord | null>
   markFailure(input: {
     mediaAssetId: string
     processingState: 'retryable_failure' | 'repair_required'
     processingErrorCode: string
     failedAt: Date
-  }): Promise<MediaAssetRecord>
+  }): Promise<MediaAssetRecord | null>
 }
 
 export type MediaIngestionErrorCode =
@@ -165,6 +183,7 @@ type MediaIngestionDependencies = {
       originalKey: string,
       chunkIndex: number,
     ): Promise<void>
+    deleteOriginal(key: string): Promise<void>
     storeRendition(input: {
       key: string
       bytes: Uint8Array
@@ -410,6 +429,8 @@ function safeFailure(error: unknown) {
   }
 }
 
+class MediaAssetProcessingCanceled extends Error {}
+
 export function createMediaIngestionService({
   repository,
   storage,
@@ -464,30 +485,57 @@ export function createMediaIngestionService({
       let asset = await repository.findMediaAsset(intent.id)
       if (asset?.processingState === 'ready') return asset
 
-      let bytes: Uint8Array
-      try {
-        bytes = await verifyOriginal(storage, intent, asset === null)
-      } catch (error) {
-        if (!asset) throw error
-        const failure = safeFailure(error)
-        return repository.markFailure({
-          mediaAssetId: asset.id,
-          ...failure,
-          failedAt: clock.now(),
-        })
-      }
-
       const now = clock.now()
-      asset ??= await repository.createVerifiedMediaAsset({
-        uploadIntent: intent,
-        completedAt: now,
-      })
-      const claimed = await repository.claimProcessing({
-        mediaAssetId: asset.id,
-        claimedAt: now,
-        staleBefore: new Date(now.getTime() - PROCESSING_STALE_AFTER_MS),
-      })
-      if (!claimed) return (await repository.getMediaAsset(asset.id)) ?? asset
+      let bytes: Uint8Array
+      if (asset) {
+        const claimed = await repository.claimProcessing({
+          mediaAssetId: asset.id,
+          claimedAt: now,
+          staleBefore: new Date(now.getTime() - PROCESSING_STALE_AFTER_MS),
+        })
+        if (!claimed) return (await repository.getMediaAsset(asset.id)) ?? asset
+
+        try {
+          const verification = await repository.withActiveProcessingAsset({
+            mediaAssetId: asset.id,
+            run: () => verifyOriginal(storage, intent, false),
+          })
+          if (verification.status === 'canceled') {
+            throw new MediaAssetProcessingCanceled()
+          }
+          bytes = verification.value
+        } catch (error) {
+          if (error instanceof MediaAssetProcessingCanceled) {
+            throw new MediaIngestionError('not_found')
+          }
+          const failure = safeFailure(error)
+          const failed = await repository.markFailure({
+            mediaAssetId: asset.id,
+            ...failure,
+            failedAt: clock.now(),
+          })
+          if (!failed) throw new MediaIngestionError('not_found')
+          return failed
+        }
+      } else {
+        bytes = await verifyOriginal(storage, intent, true)
+        asset = await repository.createVerifiedMediaAsset({
+          uploadIntent: intent,
+          completedAt: now,
+        })
+        if (!asset) {
+          // Discard can close the intent after verification. Remove any
+          // assembled Original that completed after Discard's first cleanup.
+          await storage.deleteOriginal(intent.originalKey)
+          throw new MediaIngestionError('not_found')
+        }
+        const claimed = await repository.claimProcessing({
+          mediaAssetId: asset.id,
+          claimedAt: now,
+          staleBefore: new Date(now.getTime() - PROCESSING_STALE_AFTER_MS),
+        })
+        if (!claimed) return (await repository.getMediaAsset(asset.id)) ?? asset
+      }
 
       try {
         const processed = await processor(bytes)
@@ -520,83 +568,100 @@ export function createMediaIngestionService({
             progressive: rendition.progressive,
             metadataStripped: rendition.metadataStripped,
           }
-          const existing = await repository.findRendition(asset.id, profileWidth)
-          if (existing) {
-            if (!renditionMatches(existing, expected)) {
-              throw new MediaIngestionError('rendition_mismatch')
-            }
-            await verifyRendition(
-              storage,
-              existing.objectKey,
-              existing,
-              existing,
-            )
-            continue
-          }
-
-          let stored = await inspectOptionalRendition(storage, objectKey)
-          if (!stored) {
-            await storage.storeRendition({
-              key: objectKey,
-              bytes: rendition.bytes,
-              checksumSha256: rendition.checksumSha256,
-              contentType: rendition.contentType,
-            })
-            stored = await storage.inspectRendition(objectKey)
-          }
-          if (
-            stored.byteSize !== rendition.byteSize ||
-            stored.contentType !== rendition.contentType
-          ) {
-            throw new MediaIngestionError('rendition_mismatch')
-          }
-          await verifyRendition(storage, objectKey, expected, stored)
-          const recorded = await repository.recordRendition({
+          const processing = await repository.withActiveProcessingAsset({
             mediaAssetId: asset.id,
-            objectKey,
-            ...expected,
+            run: async (session) => {
+              const existing = await session.findRendition(profileWidth)
+              if (existing && !renditionMatches(existing, expected)) {
+                throw new MediaIngestionError('rendition_mismatch')
+              }
+
+              // Persist the deterministic manifest before Bunny. If the
+              // provider fails or the process exits after the write, Purge
+              // still knows the exact object key it must remove.
+              const recorded =
+                existing ??
+                (await session.recordRendition({
+                  mediaAssetId: asset.id,
+                  objectKey,
+                  ...expected,
+                }))
+              if (
+                recorded.objectKey !== objectKey ||
+                !renditionMatches(recorded, expected)
+              ) {
+                throw new MediaIngestionError('rendition_mismatch')
+              }
+
+              let stored = await inspectOptionalRendition(storage, objectKey)
+              if (!stored) {
+                await storage.storeRendition({
+                  key: objectKey,
+                  bytes: rendition.bytes,
+                  checksumSha256: rendition.checksumSha256,
+                  contentType: rendition.contentType,
+                })
+                stored = await storage.inspectRendition(objectKey)
+              }
+              if (
+                stored.byteSize !== rendition.byteSize ||
+                stored.contentType !== rendition.contentType
+              ) {
+                throw new MediaIngestionError('rendition_mismatch')
+              }
+              await verifyRendition(storage, objectKey, expected, stored)
+            },
           })
-          if (
-            recorded.objectKey !== objectKey ||
-            !renditionMatches(recorded, expected)
-          ) {
-            throw new MediaIngestionError('rendition_mismatch')
+          if (processing.status === 'canceled') {
+            throw new MediaAssetProcessingCanceled()
           }
         }
 
         const captureLocationEnvelope = processed.original.captureLocation
           ? captureLocationVault.seal(processed.original.captureLocation)
           : null
-        return repository.markReady({
+        const ready = await repository.withActiveProcessingAsset({
           mediaAssetId: asset.id,
-          metadata: {
-            width: processed.original.width,
-            height: processed.original.height,
-            capturedAt: processed.original.capturedAt,
-            cameraMake: processed.original.cameraMake,
-            cameraModel: processed.original.cameraModel,
-            lens: processed.original.lens,
-            focalLengthMillimeters:
-              processed.original.focalLengthMillimeters,
-            aperture: processed.original.aperture,
-            shutterSpeedSeconds: processed.original.shutterSpeedSeconds,
-            iso:
-              processed.original.iso !== null &&
-              Number.isSafeInteger(processed.original.iso)
-                ? processed.original.iso
-                : null,
-            captureLocationEnvelope,
-          },
-          completedAt: clock.now(),
-          requiredRenditionCount: RENDITION_PROFILE_WIDTHS.length,
+          run: (session) =>
+            session.markReady({
+              metadata: {
+                width: processed.original.width,
+                height: processed.original.height,
+                capturedAt: processed.original.capturedAt,
+                cameraMake: processed.original.cameraMake,
+                cameraModel: processed.original.cameraModel,
+                lens: processed.original.lens,
+                focalLengthMillimeters:
+                  processed.original.focalLengthMillimeters,
+                aperture: processed.original.aperture,
+                shutterSpeedSeconds: processed.original.shutterSpeedSeconds,
+                iso:
+                  processed.original.iso !== null &&
+                  Number.isSafeInteger(processed.original.iso)
+                    ? processed.original.iso
+                    : null,
+                captureLocationEnvelope,
+              },
+              completedAt: clock.now(),
+              requiredRenditionCount: RENDITION_PROFILE_WIDTHS.length,
+            }),
         })
+        if (ready.status === 'canceled' || ready.value === null) {
+          throw new MediaAssetProcessingCanceled()
+        }
+        return ready.value
       } catch (error) {
+        if (error instanceof MediaAssetProcessingCanceled) {
+          throw new MediaIngestionError('not_found')
+        }
         const failure = safeFailure(error)
-        return repository.markFailure({
+        const failed = await repository.markFailure({
           mediaAssetId: asset.id,
           ...failure,
           failedAt: clock.now(),
         })
+        if (!failed) throw new MediaIngestionError('not_found')
+        return failed
       }
     },
   }

--- a/lib/media/photo-selection/repository.test.ts
+++ b/lib/media/photo-selection/repository.test.ts
@@ -21,6 +21,7 @@ describe('Photo Selection repository', () => {
     '0007_photo_publication_revision.sql',
     '0009_media_catalog_state.sql',
     '0012_high_fidelity_photo_renditions.sql',
+    '0013_brief_yellowjacket.sql',
   ])
   let client: PGlite
   let repository: ReturnType<typeof createPhotoSelectionRepository>

--- a/lib/media/photo-selection/repository.ts
+++ b/lib/media/photo-selection/repository.ts
@@ -16,6 +16,7 @@ import {
 } from '~/db/schema'
 
 import { createPublicRenditionUrl } from '../storage/bunny'
+import { lockPhotoSelectionMutations } from '../catalog/lifecycle-locks'
 
 import type {
   DraftPhotoSelection,
@@ -262,6 +263,7 @@ export function createPhotoSelectionRepository(
     async saveDraft(input): Promise<SaveDraftRepositoryResult> {
       try {
         return await database().transaction(async (transaction) => {
+          await lockPhotoSelectionMutations(transaction, input.ownerUserId)
           const [current] = await transaction
             .select()
             .from(mediaPhotoSelectionDrafts)
@@ -349,6 +351,7 @@ export function createPhotoSelectionRepository(
     async publishDraft(input): Promise<PublishDraftRepositoryResult> {
       try {
         return await database().transaction(async (transaction) => {
+          await lockPhotoSelectionMutations(transaction, input.ownerUserId)
           const [existing] = await transaction
             .select()
             .from(mediaPublishedPhotoSelections)

--- a/lib/media/photo-selection/withdrawal.ts
+++ b/lib/media/photo-selection/withdrawal.ts
@@ -1,0 +1,329 @@
+import 'server-only'
+
+import { and, asc, eq, inArray } from 'drizzle-orm'
+
+import type { getDatabase } from '~/db'
+import {
+  mediaActivePhotoPublication,
+  mediaPhotoSelectionDraftEntries,
+  mediaPhotoSelectionDrafts,
+  mediaPublishedPhotoSelectionEntries,
+  mediaPublishedPhotoSelectionRenditions,
+  mediaPublishedPhotoSelections,
+} from '~/db/schema'
+
+import { lockPhotoSelectionMutations } from '../catalog/lifecycle-locks'
+
+export type MediaSelectionDatabase = ReturnType<typeof getDatabase>
+export type MediaSelectionTransaction = Parameters<
+  Parameters<MediaSelectionDatabase['transaction']>[0]
+>[0]
+
+export type SelectionWithdrawal = {
+  draft: null | {
+    id: string
+    revisionBefore: number
+    revisionAfter: number
+    position: number
+  }
+  publication: null | {
+    beforeId: string
+    afterId: string
+  }
+}
+
+async function replaceDraftEntries(
+  transaction: MediaSelectionTransaction,
+  input: {
+    draftId: string
+    mediaAssetIds: string[]
+    at: Date
+  },
+) {
+  await transaction
+    .delete(mediaPhotoSelectionDraftEntries)
+    .where(eq(mediaPhotoSelectionDraftEntries.draftId, input.draftId))
+  if (input.mediaAssetIds.length === 0) return
+  await transaction.insert(mediaPhotoSelectionDraftEntries).values(
+    input.mediaAssetIds.map((mediaAssetId, position) => ({
+      draftId: input.draftId,
+      mediaAssetId,
+      position,
+      createdAt: input.at,
+    })),
+  )
+}
+
+async function withdrawFromDraft(
+  transaction: MediaSelectionTransaction,
+  input: { ownerUserId: string; mediaAssetId: string; at: Date },
+) {
+  const [draft] = await transaction
+    .select()
+    .from(mediaPhotoSelectionDrafts)
+    .where(eq(mediaPhotoSelectionDrafts.ownerUserId, input.ownerUserId))
+    .limit(1)
+    .for('update')
+  if (!draft) return null
+
+  const entries = await transaction
+    .select({ mediaAssetId: mediaPhotoSelectionDraftEntries.mediaAssetId })
+    .from(mediaPhotoSelectionDraftEntries)
+    .where(eq(mediaPhotoSelectionDraftEntries.draftId, draft.id))
+    .orderBy(asc(mediaPhotoSelectionDraftEntries.position))
+  const position = entries.findIndex(
+    ({ mediaAssetId }) => mediaAssetId === input.mediaAssetId,
+  )
+  if (position < 0) return null
+
+  const revisionAfter = draft.revision + 1
+  await replaceDraftEntries(transaction, {
+    draftId: draft.id,
+    mediaAssetIds: entries
+      .map(({ mediaAssetId }) => mediaAssetId)
+      .filter((mediaAssetId) => mediaAssetId !== input.mediaAssetId),
+    at: input.at,
+  })
+  await transaction
+    .update(mediaPhotoSelectionDrafts)
+    .set({ revision: revisionAfter, updatedAt: input.at })
+    .where(
+      and(
+        eq(mediaPhotoSelectionDrafts.id, draft.id),
+        eq(mediaPhotoSelectionDrafts.revision, draft.revision),
+      ),
+    )
+
+  return {
+    id: draft.id,
+    revisionBefore: draft.revision,
+    revisionAfter,
+    position,
+  }
+}
+
+async function withdrawFromPublication(
+  transaction: MediaSelectionTransaction,
+  input: {
+    ownerUserId: string
+    mediaAssetId: string
+    idempotencyKey: string
+    at: Date
+  },
+) {
+  const [active] = await transaction
+    .select({ publishedSelectionId: mediaActivePhotoPublication.publishedSelectionId })
+    .from(mediaActivePhotoPublication)
+    .where(eq(mediaActivePhotoPublication.id, 1))
+    .limit(1)
+    .for('update')
+  if (!active) return null
+
+  const [publication] = await transaction
+    .select()
+    .from(mediaPublishedPhotoSelections)
+    .where(
+      and(
+        eq(mediaPublishedPhotoSelections.id, active.publishedSelectionId),
+        eq(mediaPublishedPhotoSelections.ownerUserId, input.ownerUserId),
+      ),
+    )
+    .limit(1)
+  if (!publication) return null
+
+  const entries = await transaction
+    .select()
+    .from(mediaPublishedPhotoSelectionEntries)
+    .where(
+      eq(
+        mediaPublishedPhotoSelectionEntries.publishedSelectionId,
+        publication.id,
+      ),
+    )
+    .orderBy(asc(mediaPublishedPhotoSelectionEntries.position))
+  if (
+    !entries.some(
+      ({ sourceMediaAssetId }) => sourceMediaAssetId === input.mediaAssetId,
+    )
+  ) {
+    return null
+  }
+
+  const retained = entries.filter(
+    ({ sourceMediaAssetId }) => sourceMediaAssetId !== input.mediaAssetId,
+  )
+  const [nextPublication] = await transaction
+    .insert(mediaPublishedPhotoSelections)
+    .values({
+      ownerUserId: input.ownerUserId,
+      idempotencyKey: input.idempotencyKey,
+      publicationKind: 'withdrawal',
+      draftRevision: null,
+      itemCount: retained.length,
+      publishedAt: input.at,
+    })
+    .returning({ id: mediaPublishedPhotoSelections.id })
+
+  if (retained.length > 0) {
+    const insertedEntries = await transaction
+      .insert(mediaPublishedPhotoSelectionEntries)
+      .values(
+        retained.map(
+          (
+            {
+              id: _id,
+              publishedSelectionId: _publishedSelectionId,
+              position: _position,
+              createdAt: _createdAt,
+              ...entry
+            },
+            position,
+          ) => ({
+            ...entry,
+            publishedSelectionId: nextPublication!.id,
+            position,
+            createdAt: input.at,
+          }),
+        ),
+      )
+      .returning({
+        id: mediaPublishedPhotoSelectionEntries.id,
+        sourceMediaAssetId: mediaPublishedPhotoSelectionEntries.sourceMediaAssetId,
+      })
+    const newEntryByAssetId = new Map(
+      insertedEntries.map(({ id, sourceMediaAssetId }) => [sourceMediaAssetId, id]),
+    )
+    const oldEntryByAssetId = new Map(
+      retained.map(({ id, sourceMediaAssetId }) => [sourceMediaAssetId, id]),
+    )
+    const renditions = await transaction
+      .select()
+      .from(mediaPublishedPhotoSelectionRenditions)
+      .where(
+        inArray(
+          mediaPublishedPhotoSelectionRenditions.publishedEntryId,
+          [...oldEntryByAssetId.values()],
+        ),
+      )
+    if (renditions.length > 0) {
+      const assetIdByOldEntry = new Map(
+        [...oldEntryByAssetId].map(([mediaAssetId, entryId]) => [
+          entryId,
+          mediaAssetId,
+        ]),
+      )
+      await transaction.insert(mediaPublishedPhotoSelectionRenditions).values(
+        renditions.map(
+          ({ id: _id, publishedEntryId, createdAt: _createdAt, ...rendition }) => ({
+            ...rendition,
+            publishedEntryId: newEntryByAssetId.get(
+              assetIdByOldEntry.get(publishedEntryId)!,
+            )!,
+            createdAt: input.at,
+          }),
+        ),
+      )
+    }
+  }
+
+  await transaction
+    .update(mediaActivePhotoPublication)
+    .set({ publishedSelectionId: nextPublication!.id, updatedAt: input.at })
+    .where(
+      and(
+        eq(mediaActivePhotoPublication.id, 1),
+        eq(mediaActivePhotoPublication.publishedSelectionId, publication.id),
+      ),
+    )
+
+  return { beforeId: publication.id, afterId: nextPublication!.id }
+}
+
+export async function withdrawMediaAssetFromSelections(
+  transaction: MediaSelectionTransaction,
+  input: {
+    ownerUserId: string
+    mediaAssetId: string
+    idempotencyKey: string
+    at: Date
+  },
+): Promise<SelectionWithdrawal> {
+  await lockPhotoSelectionMutations(transaction, input.ownerUserId)
+  const draft = await withdrawFromDraft(transaction, input)
+  const publication = await withdrawFromPublication(transaction, input)
+  return { draft, publication }
+}
+
+export async function restoreMediaAssetSelections(
+  transaction: MediaSelectionTransaction,
+  input: {
+    ownerUserId: string
+    mediaAssetId: string
+    draft: SelectionWithdrawal['draft']
+    publication: SelectionWithdrawal['publication']
+    at: Date
+  },
+) {
+  await lockPhotoSelectionMutations(transaction, input.ownerUserId)
+  let lockedDraft: typeof mediaPhotoSelectionDrafts.$inferSelect | null = null
+  let draftEntryIds: string[] = []
+  if (input.draft) {
+    const [draft] = await transaction
+      .select()
+      .from(mediaPhotoSelectionDrafts)
+      .where(
+        and(
+          eq(mediaPhotoSelectionDrafts.id, input.draft.id),
+          eq(mediaPhotoSelectionDrafts.ownerUserId, input.ownerUserId),
+        ),
+      )
+      .limit(1)
+      .for('update')
+    if (!draft || draft.revision !== input.draft.revisionAfter) return false
+    lockedDraft = draft
+    const entries = await transaction
+      .select({ mediaAssetId: mediaPhotoSelectionDraftEntries.mediaAssetId })
+      .from(mediaPhotoSelectionDraftEntries)
+      .where(eq(mediaPhotoSelectionDraftEntries.draftId, draft.id))
+      .orderBy(asc(mediaPhotoSelectionDraftEntries.position))
+    draftEntryIds = entries.map(({ mediaAssetId }) => mediaAssetId)
+  }
+
+  if (input.publication) {
+    const [active] = await transaction
+      .select({ publishedSelectionId: mediaActivePhotoPublication.publishedSelectionId })
+      .from(mediaActivePhotoPublication)
+      .where(eq(mediaActivePhotoPublication.id, 1))
+      .limit(1)
+      .for('update')
+    if (active?.publishedSelectionId !== input.publication.afterId) return false
+  }
+
+  // Validate and lock every revision before mutating either selection. A
+  // conflict must leave both Draft and Published membership untouched.
+  if (input.draft && lockedDraft) {
+    draftEntryIds.splice(input.draft.position, 0, input.mediaAssetId)
+    await replaceDraftEntries(transaction, {
+      draftId: lockedDraft.id,
+      mediaAssetIds: draftEntryIds,
+      at: input.at,
+    })
+    await transaction
+      .update(mediaPhotoSelectionDrafts)
+      .set({ revision: lockedDraft.revision + 1, updatedAt: input.at })
+      .where(
+        and(
+          eq(mediaPhotoSelectionDrafts.id, lockedDraft.id),
+          eq(mediaPhotoSelectionDrafts.revision, lockedDraft.revision),
+        ),
+      )
+  }
+
+  if (input.publication) {
+    await transaction
+      .update(mediaActivePhotoPublication)
+      .set({ publishedSelectionId: input.publication.beforeId, updatedAt: input.at })
+      .where(eq(mediaActivePhotoPublication.id, 1))
+  }
+  return true
+}

--- a/lib/media/photo-selection/withdrawal.ts
+++ b/lib/media/photo-selection/withdrawal.ts
@@ -84,7 +84,7 @@ async function withdrawFromDraft(
       .filter((mediaAssetId) => mediaAssetId !== input.mediaAssetId),
     at: input.at,
   })
-  await transaction
+  const [updated] = await transaction
     .update(mediaPhotoSelectionDrafts)
     .set({ revision: revisionAfter, updatedAt: input.at })
     .where(
@@ -93,6 +93,10 @@ async function withdrawFromDraft(
         eq(mediaPhotoSelectionDrafts.revision, draft.revision),
       ),
     )
+    .returning({ id: mediaPhotoSelectionDrafts.id })
+  if (!updated) {
+    throw new Error('Draft revision update failed: lock assumption violated')
+  }
 
   return {
     id: draft.id,

--- a/lib/media/purge/repository.test.ts
+++ b/lib/media/purge/repository.test.ts
@@ -22,6 +22,7 @@ describe('Media Asset Purge repository', () => {
     '0007_photo_publication_revision.sql',
     '0008_media_purge_progress.sql',
     '0009_media_catalog_state.sql',
+    '0013_brief_yellowjacket.sql',
   ])
   let client: PGlite
   let repository: ReturnType<typeof createMediaPurgeRepository>
@@ -78,6 +79,7 @@ describe('Media Asset Purge repository', () => {
   it('claims an Archived asset and snapshots every storage key', async () => {
     await expect(repository.claim(claimInput())).resolves.toEqual({
       status: 'claimed',
+      publicSelectionChanged: false,
       job: {
         mediaAssetId: assetId,
         originalKey: 'originals/photo.jpg',
@@ -115,7 +117,7 @@ describe('Media Asset Purge repository', () => {
     expect(asset.rows[0]).toMatchObject({ catalog_state: 'purging' })
   })
 
-  it('enforces ownership, Archived state, selection safety, and claim leases', async () => {
+  it('enforces ownership and state, withdraws selections, and leases claims', async () => {
     await expect(
       repository.claim(claimInput({ ownerUserId: 'owner_02' })),
     ).resolves.toEqual({ status: 'not_found' })
@@ -146,14 +148,39 @@ describe('Media Asset Purge repository', () => {
        VALUES ('55555555-5555-4555-8555-555555555555', $1, 0)`,
       [assetId],
     )
-    await expect(repository.claim(claimInput())).resolves.toEqual({
-      status: 'selection_conflict',
-    })
-    await client.query('DELETE FROM media_photo_selection_draft_entries')
+    const publicationId = '77777777-7777-4777-8777-777777777777'
+    await client.query(
+      `INSERT INTO media_published_photo_selections
+        (id, owner_user_id, idempotency_key, draft_revision, item_count,
+         published_at)
+       VALUES ($1, 'owner_01', 'publish_01', 1, 1, now())`,
+      [publicationId],
+    )
+    await client.query(
+      `INSERT INTO media_published_photo_selection_entries
+        (published_selection_id, source_media_asset_id, position, width,
+         height, alt_text_zh_hans, alt_text_en)
+       VALUES ($1, $2, 0, 1600, 1200, '照片', 'A photo')`,
+      [publicationId, assetId],
+    )
+    await client.query(
+      `INSERT INTO media_active_photo_publication (published_selection_id)
+       VALUES ($1)`,
+      [publicationId],
+    )
 
     await expect(repository.claim(claimInput())).resolves.toMatchObject({
       status: 'claimed',
+      publicSelectionChanged: true,
     })
+    const draftEntries = await client.query(
+      'SELECT id FROM media_photo_selection_draft_entries',
+    )
+    expect(draftEntries.rows).toEqual([])
+    const active = await client.query<{ published_selection_id: string }>(
+      'SELECT published_selection_id FROM media_active_photo_publication WHERE id = 1',
+    )
+    expect(active.rows[0]?.published_selection_id).not.toBe(publicationId)
     await expect(
       repository.claim(
         claimInput({
@@ -172,6 +199,18 @@ describe('Media Asset Purge repository', () => {
         }),
       ),
     ).resolves.toMatchObject({ status: 'claimed' })
+    await expect(
+      repository.claim(
+        claimInput({
+          claimToken: firstClaimToken,
+          claimedAt: new Date('2026-07-15T12:12:00Z'),
+          claimExpiresAt: new Date('2026-07-15T12:17:00Z'),
+        }),
+      ),
+    ).resolves.toMatchObject({
+      status: 'claimed',
+      publicSelectionChanged: true,
+    })
   })
 
   it('keeps progress durable and removes the catalog record last', async () => {

--- a/lib/media/purge/repository.ts
+++ b/lib/media/purge/repository.ts
@@ -4,15 +4,18 @@ import { and, asc, eq, sql } from 'drizzle-orm'
 
 import type { getDatabase } from '~/db'
 import {
-  mediaActivePhotoPublication,
   mediaAssetPurgeJobs,
   mediaAssetPurgeRenditions,
   mediaAssets,
-  mediaPhotoSelectionDraftEntries,
-  mediaPublishedPhotoSelectionEntries,
   mediaRenditions,
   mediaUploadIntents,
 } from '~/db/schema'
+
+import {
+  lockMediaAssetProcessing,
+  lockPhotoSelectionMutations,
+} from '../catalog/lifecycle-locks'
+import { withdrawMediaAssetFromSelections } from '../photo-selection/withdrawal'
 
 import type {
   ClaimMediaPurgeResult,
@@ -31,22 +34,6 @@ function ownedAssetCondition(ownerUserId: string, mediaAssetId: string) {
         AND ${mediaUploadIntents.ownerUserId} = ${ownerUserId}
     )`,
   )
-}
-
-function selectionConflictCondition() {
-  return sql`EXISTS (
-    SELECT 1 FROM ${mediaPhotoSelectionDraftEntries}
-    WHERE ${mediaPhotoSelectionDraftEntries.mediaAssetId} = ${mediaAssets.id}
-  ) OR EXISTS (
-    SELECT 1
-    FROM ${mediaActivePhotoPublication}
-    INNER JOIN ${mediaPublishedPhotoSelectionEntries}
-      ON ${mediaPublishedPhotoSelectionEntries.publishedSelectionId} =
-         ${mediaActivePhotoPublication.publishedSelectionId}
-    WHERE ${mediaActivePhotoPublication.id} = 1
-      AND ${mediaPublishedPhotoSelectionEntries.sourceMediaAssetId} =
-          ${mediaAssets.id}
-  )`
 }
 
 export function createMediaPurgeRepository(
@@ -95,6 +82,8 @@ export function createMediaPurgeRepository(
 
     async claim(input): Promise<ClaimMediaPurgeResult> {
       return database().transaction(async (transaction) => {
+        await lockPhotoSelectionMutations(transaction, input.ownerUserId)
+        await lockMediaAssetProcessing(transaction, input.mediaAssetId)
         const [knownJob] = await transaction
           .select()
           .from(mediaAssetPurgeJobs)
@@ -145,6 +134,7 @@ export function createMediaPurgeRepository(
           .for('update')
 
         let originalKey: string
+        let publicSelectionChanged = false
         if (existingJob) {
           if (existingJob.completedAt) return { status: 'completed' }
           if (
@@ -157,6 +147,10 @@ export function createMediaPurgeRepository(
             return { status: 'invalid_state' }
           }
           originalKey = existingJob.originalKey
+          // Cache invalidation is idempotent. Re-run it on every resumed
+          // Purge so a previous invalidation failure cannot be skipped before
+          // storage deletion continues.
+          publicSelectionChanged = true
           await transaction
             .update(mediaAssetPurgeJobs)
             .set({
@@ -168,17 +162,13 @@ export function createMediaPurgeRepository(
             .where(eq(mediaAssetPurgeJobs.mediaAssetId, input.mediaAssetId))
         } else {
           if (asset.catalogState !== 'archived') return { status: 'invalid_state' }
-          const [selection] = await transaction
-            .select({ id: mediaAssets.id })
-            .from(mediaAssets)
-            .where(
-              and(
-                eq(mediaAssets.id, asset.id),
-                selectionConflictCondition(),
-              ),
-            )
-            .limit(1)
-          if (selection) return { status: 'selection_conflict' }
+          const withdrawal = await withdrawMediaAssetFromSelections(transaction, {
+            ownerUserId: input.ownerUserId,
+            mediaAssetId: input.mediaAssetId,
+            idempotencyKey: `purge:${input.mediaAssetId}`,
+            at: input.claimedAt,
+          })
+          publicSelectionChanged = withdrawal.publication !== null
 
           const renditions = await transaction
             .select({ objectKey: mediaRenditions.objectKey })
@@ -225,6 +215,7 @@ export function createMediaPurgeRepository(
           .orderBy(asc(mediaAssetPurgeRenditions.objectKey))
         return {
           status: 'claimed',
+          publicSelectionChanged,
           job: {
             mediaAssetId: input.mediaAssetId,
             originalKey,

--- a/lib/media/purge/service.test.ts
+++ b/lib/media/purge/service.test.ts
@@ -16,9 +16,9 @@ const claimToken = '22222222-2222-4222-8222-222222222222'
 function fixture() {
   let completed = false
   let busy = false
-  let conflict = false
   let completeSucceeds = true
   let failureCode: string | null = null
+  let publicSelectionChanged = false
   const job: MediaPurgeJob = {
     mediaAssetId,
     originalKey: 'originals/photo.jpg',
@@ -58,9 +58,12 @@ function fixture() {
     async claim() {
       if (completed) return { status: 'completed' }
       if (busy) return { status: 'busy' }
-      if (conflict) return { status: 'selection_conflict' }
       failureCode = null
-      return { status: 'claimed', job: structuredClone(job) }
+      return {
+        status: 'claimed',
+        job: structuredClone(job),
+        publicSelectionChanged,
+      }
     },
     async markRenditionObjectDeleted({ objectKey, deletedAt }) {
       const rendition = job.renditions.find((item) => item.objectKey === objectKey)
@@ -107,6 +110,9 @@ function fixture() {
   const service = createMediaPurgeService({
     repository,
     storage,
+    invalidatePublicSelection: async () => {
+      calls.push('invalidate-public-selection')
+    },
     clock: { now: () => new Date('2026-07-15T12:00:00.000Z') },
     idGenerator: () => claimToken,
   })
@@ -125,11 +131,11 @@ function fixture() {
     setBusy: (value: boolean) => {
       busy = value
     },
-    setConflict: (value: boolean) => {
-      conflict = value
-    },
     setCompleteSucceeds: (value: boolean) => {
       completeSucceeds = value
+    },
+    setPublicSelectionChanged: (value: boolean) => {
+      publicSelectionChanged = value
     },
   }
 }
@@ -162,6 +168,14 @@ describe('Media Asset Purge service', () => {
       mediaAssetId,
     })
     expect(calls).toHaveLength(5)
+  })
+
+  it('invalidates a surgical publication before deleting storage objects', async () => {
+    const { calls, input, service, setPublicSelectionChanged } = fixture()
+    setPublicSelectionChanged(true)
+
+    await expect(service.purge(input)).resolves.toMatchObject({ status: 'purged' })
+    expect(calls[0]).toBe('invalidate-public-selection')
   })
 
   it('records partial failure and resumes from confirmed progress', async () => {
@@ -198,14 +212,8 @@ describe('Media Asset Purge service', () => {
     )
   })
 
-  it('reports selection conflicts and active claims safely', async () => {
-    const { input, service, setBusy, setConflict } = fixture()
-    setConflict(true)
-    await expect(service.purge(input)).rejects.toEqual(
-      new MediaPurgeError('selection_conflict'),
-    )
-
-    setConflict(false)
+  it('reports active claims safely', async () => {
+    const { input, service, setBusy } = fixture()
     setBusy(true)
     await expect(service.purge(input)).rejects.toEqual(
       new MediaPurgeError('busy'),

--- a/lib/media/purge/service.ts
+++ b/lib/media/purge/service.ts
@@ -32,12 +32,15 @@ export type MediaPurgeStatusRecord = {
 }
 
 export type ClaimMediaPurgeResult =
-  | { status: 'claimed'; job: MediaPurgeJob }
+  | {
+      status: 'claimed'
+      job: MediaPurgeJob
+      publicSelectionChanged: boolean
+    }
   | { status: 'completed' }
   | { status: 'busy' }
   | { status: 'invalid_state' }
   | { status: 'not_found' }
-  | { status: 'selection_conflict' }
 
 export interface MediaPurgeRepository {
   getStatus(input: {
@@ -90,13 +93,16 @@ export type MediaPurgeErrorCode =
   | 'invalid_state'
   | 'not_found'
   | 'retryable_failure'
-  | 'selection_conflict'
 
 export class MediaPurgeError extends Error {
   constructor(
     readonly code: MediaPurgeErrorCode,
     readonly details?: {
-      step?: 'rendition_object' | 'rendition_cdn' | 'original'
+      step?:
+        | 'publication_cache'
+        | 'rendition_object'
+        | 'rendition_cdn'
+        | 'original'
     },
   ) {
     super(`Media Asset Purge failed: ${code}`)
@@ -111,6 +117,7 @@ type MediaPurgeDependencies = {
     deleteRendition(key: string): Promise<void>
     purgeRendition(key: string): Promise<void>
   }
+  invalidatePublicSelection: () => Promise<void>
   clock?: { now(): Date }
   idGenerator?: () => string
 }
@@ -136,6 +143,7 @@ function throwClaimFailure(
 export function createMediaPurgeService({
   repository,
   storage,
+  invalidatePublicSelection,
   clock = { now: () => new Date() },
   idGenerator = randomUUID,
 }: MediaPurgeDependencies) {
@@ -199,6 +207,14 @@ export function createMediaPurgeService({
           throw new MediaPurgeError('dependency_unavailable')
         }
         throw new MediaPurgeError('retryable_failure', { step })
+      }
+
+      if (claim.publicSelectionChanged) {
+        try {
+          await invalidatePublicSelection()
+        } catch {
+          await fail('publication_cache')
+        }
       }
 
       for (const rendition of claim.job.renditions) {

--- a/lib/media/reconciliation/repository.ts
+++ b/lib/media/reconciliation/repository.ts
@@ -179,6 +179,7 @@ export function createMediaReconciliationRepository(
             inArray(mediaAssets.processingState, [
               'original_verified',
               'processing',
+              'repair_required',
               'retryable_failure',
             ]),
           ),

--- a/lib/media/transfer/client.test.ts
+++ b/lib/media/transfer/client.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { uploadChunkWithRetry } from './client'
+
+describe('Media Transfer chunk client', () => {
+  it('returns authentication failures without retrying them', async () => {
+    const fetcher = vi.fn(async () =>
+      Response.json({ error: 'unauthorized' }, { status: 401 }),
+    )
+    const wait = vi.fn(async () => undefined)
+
+    const response = await uploadChunkWithRetry('/upload', {}, { fetcher, wait })
+
+    expect(response.status).toBe(401)
+    expect(fetcher).toHaveBeenCalledOnce()
+    expect(wait).not.toHaveBeenCalled()
+  })
+
+  it('honors Retry-After seconds before retrying a rate limit', async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        Response.json(
+          { error: 'rate_limited' },
+          { status: 429, headers: { 'retry-after': '7' } },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+    const wait = vi.fn(async () => undefined)
+
+    const response = await uploadChunkWithRetry('/upload', {}, { fetcher, wait })
+
+    expect(response.status).toBe(204)
+    expect(fetcher).toHaveBeenCalledTimes(2)
+    expect(wait).toHaveBeenCalledOnce()
+    expect(wait).toHaveBeenCalledWith(7_000)
+  })
+
+  it('honors Retry-After HTTP dates on transient failures', async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 503,
+          headers: { 'retry-after': 'Mon, 20 Jul 2026 10:00:05 GMT' },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+    const wait = vi.fn(async () => undefined)
+
+    await uploadChunkWithRetry('/upload', {}, {
+      fetcher,
+      wait,
+      now: () => Date.parse('2026-07-20T10:00:00.000Z'),
+    })
+
+    expect(wait).toHaveBeenCalledWith(5_000)
+  })
+
+  it('uses bounded backoff for network failures', async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new TypeError('offline'))
+      .mockRejectedValueOnce(new TypeError('offline'))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+    const wait = vi.fn(async () => undefined)
+
+    await expect(
+      uploadChunkWithRetry('/upload', {}, { fetcher, wait }),
+    ).resolves.toMatchObject({ status: 204 })
+    expect(wait.mock.calls).toEqual([[150], [300]])
+  })
+})

--- a/lib/media/transfer/client.ts
+++ b/lib/media/transfer/client.ts
@@ -1,0 +1,54 @@
+type UploadChunkRetryDependencies = {
+  fetcher?: typeof fetch
+  now?: () => number
+  wait?: (milliseconds: number) => Promise<void>
+}
+
+const MAX_UPLOAD_ATTEMPTS = 3
+
+function retryAfterMilliseconds(response: Response, now: () => number) {
+  const value = response.headers.get('retry-after')?.trim()
+  if (!value) return null
+
+  if (/^\d+$/.test(value)) return Number(value) * 1_000
+
+  const retryAt = Date.parse(value)
+  if (Number.isNaN(retryAt)) return null
+  return Math.max(0, retryAt - now())
+}
+
+function isRetryableStatus(status: number) {
+  return status === 429 || (status >= 500 && status < 600)
+}
+
+export async function uploadChunkWithRetry(
+  url: string,
+  init: RequestInit,
+  {
+    fetcher = fetch,
+    now = Date.now,
+    wait = (milliseconds) =>
+      new Promise((resolve) => globalThis.setTimeout(resolve, milliseconds)),
+  }: UploadChunkRetryDependencies = {},
+) {
+  let lastResponse: Response | null = null
+  for (let attempt = 0; attempt < MAX_UPLOAD_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await fetcher(url, init)
+      if (!isRetryableStatus(response.status)) return response
+      lastResponse = response
+
+      if (attempt < MAX_UPLOAD_ATTEMPTS - 1) {
+        await wait(
+          retryAfterMilliseconds(response, now) ?? 150 * (attempt + 1),
+        )
+      }
+    } catch {
+      if (attempt === MAX_UPLOAD_ATTEMPTS - 1) {
+        throw new Error('upload_failed')
+      }
+      await wait(150 * (attempt + 1))
+    }
+  }
+  return lastResponse ?? new Response(null, { status: 503 })
+}

--- a/lib/media/transfer/repository.test.ts
+++ b/lib/media/transfer/repository.test.ts
@@ -171,5 +171,14 @@ describe('Media Transfer repository', () => {
       [processingAssetId],
     )
     expect(processing.rows[0]?.catalog_state).toBe('archived')
+    await expect(repository.listOwnedTransferJobs('owner_01')).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          uploadIntentId: processingIntentId,
+          mediaAssetId: processingAssetId,
+          stage: 'discarding',
+        }),
+      ]),
+    )
   })
 })

--- a/lib/media/transfer/repository.test.ts
+++ b/lib/media/transfer/repository.test.ts
@@ -1,0 +1,175 @@
+import type { PGlite } from '@electric-sql/pglite'
+import { drizzle } from 'drizzle-orm/pglite'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import { usePGliteTestClient } from '~/db/testing/pglite'
+
+import {
+  createMediaTransferRepository,
+  type MediaTransferDatabase,
+} from './repository'
+
+const bareIntentId = '11111111-1111-4111-8111-111111111111'
+const failedIntentId = '22222222-2222-4222-8222-222222222222'
+const readyIntentId = '33333333-3333-4333-8333-333333333333'
+const failedAssetId = '44444444-4444-4444-8444-444444444444'
+const readyAssetId = '55555555-5555-4555-8555-555555555555'
+const processingIntentId = '77777777-7777-4777-8777-777777777777'
+const processingAssetId = '88888888-8888-4888-8888-888888888888'
+
+describe('Media Transfer repository', () => {
+  const getClient = usePGliteTestClient([
+    '0005_media_catalog.sql',
+    '0006_photo_selection.sql',
+    '0007_photo_publication_revision.sql',
+    '0008_media_purge_progress.sql',
+    '0009_media_catalog_state.sql',
+    '0013_brief_yellowjacket.sql',
+  ])
+  let client: PGlite
+  let repository: ReturnType<typeof createMediaTransferRepository>
+
+  beforeEach(async () => {
+    client = getClient()
+    for (const [id, owner, key, completedAt] of [
+      [bareIntentId, 'owner_01', 'bare', null],
+      [failedIntentId, 'owner_01', 'failed', '2026-07-20T08:01:00Z'],
+      [readyIntentId, 'owner_01', 'ready', '2026-07-20T08:02:00Z'],
+      [
+        processingIntentId,
+        'owner_01',
+        'processing',
+        '2026-07-20T08:03:00Z',
+      ],
+      ['66666666-6666-4666-8666-666666666666', 'owner_02', 'other', null],
+    ] as const) {
+      await client.query(
+        `INSERT INTO media_upload_intents
+          (id, owner_user_id, idempotency_key, original_key, content_type,
+           byte_size, checksum_sha256, expires_at, completed_at, created_at,
+           updated_at)
+         VALUES ($1, $2, $3, $4, 'image/jpeg', 1000, $5,
+                 '2026-07-20T08:15:00Z', $6::timestamptz,
+                 '2026-07-20T08:00:00Z',
+                 COALESCE($6::timestamptz, '2026-07-20T08:00:00Z'))`,
+        [id, owner, key, `originals/${key}.jpg`, 'a'.repeat(64), completedAt],
+      )
+    }
+    await client.query(
+      `INSERT INTO media_assets
+        (id, upload_intent_id, processing_state, processing_error_code,
+         original_key, original_content_type, original_byte_size,
+         original_checksum_sha256, created_at, updated_at)
+       VALUES
+        ($1, $2, 'retryable_failure', 'dependency_unavailable',
+         'originals/failed.jpg', 'image/jpeg', 1000, $5,
+         '2026-07-20T08:01:00Z', '2026-07-20T08:01:00Z'),
+        ($3, $4, 'ready', NULL, 'originals/ready.jpg', 'image/jpeg', 1000,
+         $6, '2026-07-20T08:02:00Z', '2026-07-20T08:02:00Z'),
+        ($7, $8, 'processing', NULL, 'originals/processing.jpg', 'image/jpeg',
+         1000, $9, '2026-07-20T08:03:00Z', '2026-07-20T08:03:00Z')`,
+      [
+        failedAssetId,
+        failedIntentId,
+        readyAssetId,
+        readyIntentId,
+        'f'.repeat(64),
+        'c'.repeat(64),
+        processingAssetId,
+        processingIntentId,
+        'd'.repeat(64),
+      ],
+    )
+    const database = drizzle(client) as unknown as MediaTransferDatabase
+    repository = createMediaTransferRepository(() => database)
+  })
+
+  it('lists incomplete owner jobs without ready or historical records', async () => {
+    await expect(repository.listOwnedTransferJobs('owner_01')).resolves.toEqual([
+      expect.objectContaining({
+        uploadIntentId: processingIntentId,
+        mediaAssetId: processingAssetId,
+        stage: 'processing',
+      }),
+      expect.objectContaining({
+        uploadIntentId: failedIntentId,
+        mediaAssetId: failedAssetId,
+        stage: 'failed',
+        processingErrorCode: 'dependency_unavailable',
+      }),
+      expect.objectContaining({
+        uploadIntentId: bareIntentId,
+        mediaAssetId: null,
+        stage: 'awaiting_file',
+      }),
+    ])
+  })
+
+  it('claims a bare intent for Discard before removing its row', async () => {
+    const discardedAt = new Date('2026-07-20T08:05:00.000Z')
+
+    await expect(
+      repository.prepareDiscard({
+        ownerUserId: 'owner_01',
+        uploadIntentId: bareIntentId,
+        discardedAt,
+      }),
+    ).resolves.toEqual({
+      status: 'bare_intent',
+      originalKey: 'originals/bare.jpg',
+      byteSize: 1000,
+    })
+    const stored = await client.query<{ discard_started_at: Date }>(
+      'SELECT discard_started_at FROM media_upload_intents WHERE id = $1',
+      [bareIntentId],
+    )
+    expect(stored.rows[0]?.discard_started_at).toEqual(discardedAt)
+    await expect(
+      repository.deleteBareIntent({
+        ownerUserId: 'owner_01',
+        uploadIntentId: bareIntentId,
+      }),
+    ).resolves.toBe(true)
+  })
+
+  it('archives only a failed owned asset before resumable Purge', async () => {
+    await expect(
+      repository.prepareDiscard({
+        ownerUserId: 'owner_01',
+        uploadIntentId: failedIntentId,
+        discardedAt: new Date('2026-07-20T08:05:00.000Z'),
+      }),
+    ).resolves.toEqual({ status: 'asset', mediaAssetId: failedAssetId })
+    const failed = await client.query<{ catalog_state: string }>(
+      'SELECT catalog_state FROM media_assets WHERE id = $1',
+      [failedAssetId],
+    )
+    expect(failed.rows[0]?.catalog_state).toBe('archived')
+
+    await expect(
+      repository.prepareDiscard({
+        ownerUserId: 'owner_01',
+        uploadIntentId: readyIntentId,
+        discardedAt: new Date('2026-07-20T08:05:00.000Z'),
+      }),
+    ).resolves.toEqual({ status: 'invalid_state' })
+  })
+
+  it('cancels an in-flight processing asset before resumable Purge', async () => {
+    await expect(
+      repository.prepareDiscard({
+        ownerUserId: 'owner_01',
+        uploadIntentId: processingIntentId,
+        discardedAt: new Date('2026-07-20T08:05:00.000Z'),
+      }),
+    ).resolves.toEqual({ status: 'asset', mediaAssetId: processingAssetId })
+
+    const processing = await client.query<{ catalog_state: string }>(
+      'SELECT catalog_state FROM media_assets WHERE id = $1',
+      [processingAssetId],
+    )
+    expect(processing.rows[0]?.catalog_state).toBe('archived')
+  })
+})

--- a/lib/media/transfer/repository.ts
+++ b/lib/media/transfer/repository.ts
@@ -42,7 +42,10 @@ export function createMediaTransferRepository(
             eq(mediaUploadIntents.ownerUserId, ownerUserId),
             or(
               and(isNull(mediaAssets.id), isNull(mediaUploadIntents.completedAt)),
-              and(ne(mediaAssets.processingState, 'ready')),
+              and(
+                isNotNull(mediaAssets.id),
+                ne(mediaAssets.processingState, 'ready'),
+              ),
             ),
           ),
         )
@@ -55,7 +58,9 @@ export function createMediaTransferRepository(
         byteSize: row.byteSize,
         checksumSha256: row.checksumSha256,
         stage:
-          row.discardStartedAt !== null || row.catalogState === 'purging'
+          row.discardStartedAt !== null ||
+          row.catalogState === 'archived' ||
+          row.catalogState === 'purging'
             ? 'discarding'
             : row.mediaAssetId === null
               ? 'awaiting_file'

--- a/lib/media/transfer/repository.ts
+++ b/lib/media/transfer/repository.ts
@@ -1,0 +1,154 @@
+import 'server-only'
+
+import { and, desc, eq, isNotNull, isNull, ne, or } from 'drizzle-orm'
+
+import type { getDatabase } from '~/db'
+import { mediaAssets, mediaUploadIntents } from '~/db/schema'
+
+import { lockMediaAssetProcessing } from '../catalog/lifecycle-locks'
+
+import type { MediaTransferRepository, TransferJob } from './service'
+
+export type MediaTransferDatabase = ReturnType<typeof getDatabase>
+
+export function createMediaTransferRepository(
+  database: () => MediaTransferDatabase,
+): MediaTransferRepository {
+  return {
+    async listOwnedTransferJobs(ownerUserId) {
+      const rows = await database()
+        .select({
+          uploadIntentId: mediaUploadIntents.id,
+          mediaAssetId: mediaAssets.id,
+          contentType: mediaUploadIntents.contentType,
+          byteSize: mediaUploadIntents.byteSize,
+          checksumSha256: mediaUploadIntents.checksumSha256,
+          completedAt: mediaUploadIntents.completedAt,
+          discardStartedAt: mediaUploadIntents.discardStartedAt,
+          processingState: mediaAssets.processingState,
+          processingErrorCode: mediaAssets.processingErrorCode,
+          catalogState: mediaAssets.catalogState,
+          createdAt: mediaUploadIntents.createdAt,
+          updatedAt: mediaUploadIntents.updatedAt,
+          expiresAt: mediaUploadIntents.expiresAt,
+        })
+        .from(mediaUploadIntents)
+        .leftJoin(
+          mediaAssets,
+          eq(mediaAssets.uploadIntentId, mediaUploadIntents.id),
+        )
+        .where(
+          and(
+            eq(mediaUploadIntents.ownerUserId, ownerUserId),
+            or(
+              and(isNull(mediaAssets.id), isNull(mediaUploadIntents.completedAt)),
+              and(ne(mediaAssets.processingState, 'ready')),
+            ),
+          ),
+        )
+        .orderBy(desc(mediaUploadIntents.updatedAt))
+
+      return rows.map((row): TransferJob => ({
+        uploadIntentId: row.uploadIntentId,
+        mediaAssetId: row.mediaAssetId,
+        contentType: row.contentType,
+        byteSize: row.byteSize,
+        checksumSha256: row.checksumSha256,
+        stage:
+          row.discardStartedAt !== null || row.catalogState === 'purging'
+            ? 'discarding'
+            : row.mediaAssetId === null
+              ? 'awaiting_file'
+              : row.processingState === 'retryable_failure' ||
+                  row.processingState === 'repair_required'
+                ? 'failed'
+                : 'processing',
+        processingState: row.processingState,
+        processingErrorCode: row.processingErrorCode,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        expiresAt: row.expiresAt,
+      }))
+    },
+
+    async prepareDiscard(input) {
+      return database().transaction(async (transaction) => {
+        const [intent] = await transaction
+          .select()
+          .from(mediaUploadIntents)
+          .where(
+            and(
+              eq(mediaUploadIntents.id, input.uploadIntentId),
+              eq(mediaUploadIntents.ownerUserId, input.ownerUserId),
+            ),
+          )
+          .limit(1)
+          .for('update')
+        if (!intent) return { status: 'not_found' as const }
+        const [assetIdentity] = await transaction
+          .select({ id: mediaAssets.id })
+          .from(mediaAssets)
+          .where(eq(mediaAssets.uploadIntentId, intent.id))
+          .limit(1)
+        if (!assetIdentity) {
+          if (intent.completedAt) return { status: 'invalid_state' as const }
+          await transaction
+            .update(mediaUploadIntents)
+            .set({
+              discardStartedAt: input.discardedAt,
+              updatedAt: input.discardedAt,
+            })
+            .where(
+              and(
+                eq(mediaUploadIntents.id, intent.id),
+                isNull(mediaUploadIntents.completedAt),
+              ),
+            )
+          return {
+            status: 'bare_intent' as const,
+            originalKey: intent.originalKey,
+            byteSize: intent.byteSize,
+          }
+        }
+
+        await lockMediaAssetProcessing(transaction, assetIdentity.id)
+        const [asset] = await transaction
+          .select()
+          .from(mediaAssets)
+          .where(eq(mediaAssets.id, assetIdentity.id))
+          .limit(1)
+          .for('update')
+        if (!asset) return { status: 'not_found' as const }
+        if (asset.processingState === 'ready') {
+          return { status: 'invalid_state' as const }
+        }
+        if (asset.catalogState === 'active') {
+          await transaction
+            .update(mediaAssets)
+            .set({
+              catalogState: 'archived',
+              archivedAt: input.discardedAt,
+              updatedAt: input.discardedAt,
+            })
+            .where(eq(mediaAssets.id, asset.id))
+        }
+        return { status: 'asset' as const, mediaAssetId: asset.id }
+      })
+    },
+
+    async deleteBareIntent(input) {
+      const [deleted] = await database()
+        .delete(mediaUploadIntents)
+        .where(
+          and(
+            eq(mediaUploadIntents.id, input.uploadIntentId),
+            eq(mediaUploadIntents.ownerUserId, input.ownerUserId),
+            isNull(mediaUploadIntents.completedAt),
+            isNotNull(mediaUploadIntents.discardStartedAt),
+          ),
+        )
+        .returning({ id: mediaUploadIntents.id })
+      return deleted !== undefined
+    },
+  }
+}

--- a/lib/media/transfer/service.test.ts
+++ b/lib/media/transfer/service.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import {
+  createMediaTransferService,
+  MediaTransferError,
+  type MediaTransferRepository,
+  type TransferJob,
+} from './service'
+
+const uploadIntentId = '11111111-1111-4111-8111-111111111111'
+const mediaAssetId = '22222222-2222-4222-8222-222222222222'
+const now = new Date('2026-07-20T08:00:00.000Z')
+
+function transfer(overrides: Partial<TransferJob> = {}): TransferJob {
+  return {
+    uploadIntentId,
+    mediaAssetId: null,
+    contentType: 'image/jpeg',
+    byteSize: 8 * 1024 * 1024 + 1,
+    checksumSha256: 'a'.repeat(64),
+    stage: 'awaiting_file',
+    processingState: null,
+    processingErrorCode: null,
+    createdAt: now,
+    updatedAt: now,
+    expiresAt: new Date('2026-07-20T08:15:00.000Z'),
+    ...overrides,
+  }
+}
+
+function fixture() {
+  const repository: MediaTransferRepository = {
+    listOwnedTransferJobs: vi.fn(async () => [transfer()]),
+    prepareDiscard: vi.fn(async () => ({
+      status: 'bare_intent' as const,
+      originalKey: `originals/${uploadIntentId}.jpg`,
+      byteSize: 8 * 1024 * 1024 + 1,
+    })),
+    deleteBareIntent: vi.fn(async () => true),
+  }
+  const purge = { purge: vi.fn(async () => ({})) }
+  const storage = {
+    deleteOriginal: vi.fn(async () => {}),
+    deleteOriginalChunk: vi.fn(async () => {}),
+  }
+  return {
+    repository,
+    purge,
+    storage,
+    service: createMediaTransferService({
+      repository,
+      purge,
+      storage,
+      clock: { now: () => now },
+    }),
+  }
+}
+
+describe('Media Transfer service', () => {
+  it('lists only the authenticated owner Transfer Jobs', async () => {
+    const f = fixture()
+
+    await expect(f.service.list('owner_01')).resolves.toEqual([transfer()])
+    expect(f.repository.listOwnedTransferJobs).toHaveBeenCalledWith('owner_01')
+    await expect(f.service.list(' owner_01')).rejects.toEqual(
+      new MediaTransferError('invalid_request'),
+    )
+  })
+
+  it('permanently discards a bare Upload Intent and all possible chunks', async () => {
+    const f = fixture()
+
+    await expect(
+      f.service.discard({ ownerUserId: 'owner_01', uploadIntentId }),
+    ).resolves.toEqual({ status: 'discarded', uploadIntentId })
+
+    expect(f.storage.deleteOriginal).toHaveBeenCalledWith(
+      `originals/${uploadIntentId}.jpg`,
+    )
+    expect(f.storage.deleteOriginalChunk.mock.calls).toEqual([
+      [`originals/${uploadIntentId}.jpg`, 0],
+      [`originals/${uploadIntentId}.jpg`, 1],
+      [`originals/${uploadIntentId}.jpg`, 2],
+    ])
+    expect(f.repository.deleteBareIntent).toHaveBeenCalledWith({
+      ownerUserId: 'owner_01',
+      uploadIntentId,
+    })
+  })
+
+  it('routes a failed Media Asset through resumable Purge', async () => {
+    const f = fixture()
+    vi.mocked(f.repository.prepareDiscard).mockResolvedValueOnce({
+      status: 'asset',
+      mediaAssetId,
+    })
+
+    await f.service.discard({ ownerUserId: 'owner_01', uploadIntentId })
+
+    expect(f.purge.purge).toHaveBeenCalledWith({
+      ownerUserId: 'owner_01',
+      mediaAssetId,
+      confirmation: 'PURGE',
+    })
+    expect(f.storage.deleteOriginal).not.toHaveBeenCalled()
+    expect(f.repository.deleteBareIntent).not.toHaveBeenCalled()
+  })
+
+  it('keeps the durable job when storage deletion fails', async () => {
+    const f = fixture()
+    f.storage.deleteOriginal.mockRejectedValueOnce(new Error('Bunny offline'))
+
+    await expect(
+      f.service.discard({ ownerUserId: 'owner_01', uploadIntentId }),
+    ).rejects.toEqual(new MediaTransferError('retryable_failure'))
+    expect(f.repository.deleteBareIntent).not.toHaveBeenCalled()
+  })
+})

--- a/lib/media/transfer/service.ts
+++ b/lib/media/transfer/service.ts
@@ -1,0 +1,148 @@
+import 'server-only'
+
+import { originalUploadChunkCount } from '../storage/transfer'
+
+export type TransferJob = {
+  uploadIntentId: string
+  mediaAssetId: string | null
+  contentType: string
+  byteSize: number
+  checksumSha256: string
+  stage: 'awaiting_file' | 'processing' | 'failed' | 'discarding'
+  processingState: string | null
+  processingErrorCode: string | null
+  createdAt: Date
+  updatedAt: Date
+  expiresAt: Date
+}
+
+export interface MediaTransferRepository {
+  listOwnedTransferJobs(ownerUserId: string): Promise<TransferJob[]>
+  prepareDiscard(input: {
+    ownerUserId: string
+    uploadIntentId: string
+    discardedAt: Date
+  }): Promise<
+    | { status: 'asset'; mediaAssetId: string }
+    | {
+        status: 'bare_intent'
+        originalKey: string
+        byteSize: number
+      }
+    | { status: 'invalid_state' }
+    | { status: 'not_found' }
+  >
+  deleteBareIntent(input: {
+    ownerUserId: string
+    uploadIntentId: string
+  }): Promise<boolean>
+}
+
+export type MediaTransferErrorCode =
+  | 'dependency_unavailable'
+  | 'invalid_request'
+  | 'invalid_state'
+  | 'not_found'
+  | 'retryable_failure'
+
+export class MediaTransferError extends Error {
+  constructor(readonly code: MediaTransferErrorCode) {
+    super(`Media Transfer failed: ${code}`)
+    this.name = 'MediaTransferError'
+  }
+}
+
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function validOwnerUserId(value: string) {
+  return value === value.trim() && value.length > 0 && value.length <= 255
+}
+
+export function createMediaTransferService({
+  repository,
+  purge,
+  storage,
+  clock = { now: () => new Date() },
+}: {
+  repository: MediaTransferRepository
+  purge: {
+    purge(input: {
+      ownerUserId: string
+      mediaAssetId: string
+      confirmation: string
+    }): Promise<unknown>
+  }
+  storage: {
+    deleteOriginal(key: string): Promise<void>
+    deleteOriginalChunk(originalKey: string, chunkIndex: number): Promise<void>
+  }
+  clock?: { now(): Date }
+}) {
+  return {
+    async list(ownerUserId: string) {
+      if (!validOwnerUserId(ownerUserId)) {
+        throw new MediaTransferError('invalid_request')
+      }
+      try {
+        return await repository.listOwnedTransferJobs(ownerUserId)
+      } catch {
+        throw new MediaTransferError('dependency_unavailable')
+      }
+    },
+
+    async discard(input: { ownerUserId: string; uploadIntentId: string }) {
+      if (
+        !validOwnerUserId(input.ownerUserId) ||
+        !uuidPattern.test(input.uploadIntentId)
+      ) {
+        throw new MediaTransferError('invalid_request')
+      }
+      let target: Awaited<ReturnType<MediaTransferRepository['prepareDiscard']>>
+      try {
+        target = await repository.prepareDiscard({
+          ...input,
+          discardedAt: clock.now(),
+        })
+      } catch {
+        throw new MediaTransferError('dependency_unavailable')
+      }
+      if (target.status === 'not_found' || target.status === 'invalid_state') {
+        throw new MediaTransferError(target.status)
+      }
+      if (target.status === 'asset') {
+        try {
+          await purge.purge({
+            ownerUserId: input.ownerUserId,
+            mediaAssetId: target.mediaAssetId,
+            confirmation: 'PURGE',
+          })
+        } catch {
+          throw new MediaTransferError('retryable_failure')
+        }
+        return { status: 'discarded' as const, uploadIntentId: input.uploadIntentId }
+      }
+
+      try {
+        await Promise.all([
+          storage.deleteOriginal(target.originalKey),
+          ...Array.from(
+            { length: originalUploadChunkCount(target.byteSize) },
+            (_, chunkIndex) =>
+              storage.deleteOriginalChunk(target.originalKey, chunkIndex),
+          ),
+        ])
+      } catch {
+        throw new MediaTransferError('retryable_failure')
+      }
+      try {
+        const deleted = await repository.deleteBareIntent(input)
+        if (!deleted) throw new MediaTransferError('invalid_state')
+      } catch (error) {
+        if (error instanceof MediaTransferError) throw error
+        throw new MediaTransferError('dependency_unavailable')
+      }
+      return { status: 'discarded' as const, uploadIntentId: input.uploadIntentId }
+    },
+  }
+}

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -1,9 +1,13 @@
 /**
  * Full-page navigation behind one seam. jsdom cannot stub
- * `window.location.assign` directly (the Location object is sealed), so
- * flows that hand off to Stripe Checkout or route across pages go through
- * this helper, which tests replace with `vi.mock`.
+ * `window.location` methods directly (the Location object is sealed), so
+ * flows that hand off across pages or re-enter authentication go through
+ * these helpers, which tests replace with `vi.mock`.
  */
 export function assignLocation(url: string) {
   window.location.assign(url)
+}
+
+export function reloadLocation() {
+  window.location.reload()
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:media:purge": "vitest run lib/media/purge",
     "test:media:reconciliation": "vitest run lib/media/reconciliation",
     "test:media:storage": "vitest run lib/media/storage --exclude='**/*.live.test.ts'",
+    "test:media:transfer": "vitest run lib/media/transfer",
     "test:media:storage:live": "vitest run lib/media/storage/bunny.live.test.ts",
     "verify:legacy-urls": "node scripts/verify-legacy-url-contract.mjs",
     "verify:links": "node scripts/verify-public-links.mjs",


### PR DESCRIPTION
## Summary

- Persist incomplete uploads as Transfer Jobs with Retry and safe Discard, including during processing.
- Recover expired admin sessions on 401 responses and honor `Retry-After` for rate-limited or transient chunk uploads.
- Withdraw only the target asset when archiving or purging, preserve unrelated Draft edits, and offer a ten-second Archive Undo.
- Keep Transfers, Media inspection, Purge, Photo Selection, and Publish in fixed-geometry dialogs with stable status regions.
- Serialize selection and processing mutations so Purge cannot miss a late Rendition write.

## Root cause

The previous flow coupled upload progress to one browser session and treated incomplete processing records like catalog assets. Archive and Purge also rejected selected assets instead of withdrawing only that membership. Separate mutation paths acquired selection and asset locks in different orders, while chunk requests bypassed the shared authentication response handling.

This change makes transfer and selection operations durable, gives their mutations one lock order, and keeps incomplete work out of Library and Archived views.

## Validation

- `pnpm typecheck`
- `pnpm test:unit` (124 files, 1,140 tests)
- `pnpm db:validate`
- `pnpm test:localization`
- `pnpm test:deployment`
- `pnpm build` with shaped local placeholder environment values

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR overhauls the media upload, archive, and purge workflows to make transfer jobs durable across sessions, serialise processing/selection mutations via PostgreSQL advisory locks, offer a ten-second archive undo, and withdraw only the target asset from selections instead of rejecting the operation when a conflict is detected.

- **New Transfer-Job layer** (`lib/media/transfer/`) — persists incomplete uploads as queryable jobs, supports safe discard for both bare intents and partially-processed assets, and retries chunk uploads with `Retry-After` honour.
- **Advisory-lock serialisation** (`lib/media/catalog/lifecycle-locks.ts`) — `lockPhotoSelectionMutations` and `lockMediaAssetProcessing` enforce a single lock-acquisition order across Archive, Undo, Purge, Discard, and Ingestion paths.
- **Withdrawal-based selection management** (`lib/media/photo-selection/withdrawal.ts`) — replaces the old conflict-rejection guard with a transactional withdraw/restore mechanism that keeps draft and published selections consistent and supports undo replay.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The advisory-lock ordering is consistent across all mutation paths, transactional semantics correctly handle the discard/processing race, and the schema migration is additive with no destructive changes to live data.

All core mutation paths are serialised correctly and the withdraw/restore mechanism is fully transactional. The only notable concern is schema drift for the idempotency index, which has no runtime impact today and will surface as an explicit DROP on the next migration generation.

db/schema.ts — the removed idempotency index declaration creates drift that will materialise as a DROP INDEX on the next drizzle-kit generate; worth confirming the drop is intentional before that migration is cut.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/media/transfer/service.ts | New service layer for Transfer Jobs: list, discard (bare-intent and asset paths). Both retry paths are correct; advisory-lock and state-machine contracts are respected. |
| lib/media/transfer/repository.ts | Implements listOwnedTransferJobs, prepareDiscard (with correct FOR UPDATE locking and advisory lock on asset path), and deleteBareIntent. Stage computation is accurate given the DB constraint that discardStartedAt can only be set while completedAt IS NULL. |
| lib/media/photo-selection/withdrawal.ts | New transactional withdraw/restore helpers. Withdraw removes an asset from both draft and published selection in a single transaction. Restore validates revision numbers before re-inserting. Both operations re-acquire the advisory lock (redundant with callers but harmless). |
| lib/media/catalog/lifecycle-locks.ts | Introduces two advisory-lock helpers. Lock order (photo-selection mutations first, asset-processing second) prevents deadlocks across archive, purge, discard, and ingestion paths. |
| lib/media/asset-review/repository.ts | archive() now calls withdrawMediaAssetFromSelections and records an archive operation for undo. undoArchive() validates the operation window and restores both draft and published selections atomically. |
| lib/media/purge/repository.ts | claim() now acquires both advisory locks before withdrawing from selections. Resumed purges set publicSelectionChanged=true unconditionally to ensure cache invalidation is re-tried even if a previous invalidation failed. |
| lib/media/ingestion/service.ts | Processing now wraps each per-rendition mutation and the markReady call in withActiveProcessingAsset, holding the advisory lock during storage I/O to prevent Purge from missing a late rendition write. Discard races at createVerifiedMediaAsset are handled with storage cleanup. |
| db/schema.ts | Adds discard_started_at to mediaUploadIntents, publicationKind to mediaPublishedPhotoSelections (making draftRevision nullable for withdrawals), and new mediaAssetArchiveOperations table. The idempotency unique index on mediaPublishedPhotoSelections is preserved in the DB snapshot but removed from schema.ts, creating drift that the next drizzle-kit generate will resolve with a DROP. |
| lib/admin/client-response.ts | New helper for 401 recovery: triggers a page reload on session expiry before attempting to parse the response body, preventing crashes on non-JSON auth responses. |
| lib/media/admin/http.ts | Adds transfer list and discard handlers, undo_archive intent handling, and post-chunk-write re-claim check. retryable_failure now maps to 503 in the error response helper. |

<sub>Reviews (2): Last reviewed commit: ["fix(media): harden transfer recovery"](https://github.com/calicastle/cali.so/commit/65a459b66b6adc3096d27d8ed3f6e33c64a6523e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45595390)</sub>

<!-- /greptile_comment -->