### PR TITLE
Refine locale suggestion banner

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4533,9 +4533,8 @@ a:focus-visible .external-label .external-mark {
   position: fixed;
   z-index: var(--z-toast);
   top: env(safe-area-inset-top);
-  left: 50%;
-  width: min(37.5rem, calc(100vw - 1rem));
-  transform: translateX(-50%);
+  left: 0;
+  width: 100%;
   pointer-events: none;
 }
 
@@ -4566,16 +4565,22 @@ a:focus-visible .external-label .external-mark {
 .locale-suggestion {
   position: relative;
   isolation: isolate;
-  display: grid;
-  grid-template-columns: 0.75rem 3rem minmax(0, 1fr) auto 0.75rem;
-  align-items: center;
-  min-height: 3.75rem;
-  border: var(--border-hairline) solid var(--border);
-  border-top: 0;
-  border-radius: 0 0 2px 2px;
+  width: 100%;
+  border-bottom: var(--border-hairline) solid var(--border);
   background: var(--surface-2);
   pointer-events: auto;
   animation: locale-suggestion-enter 150ms var(--ease-swift) backwards;
+}
+
+.locale-suggestion-inner {
+  display: grid;
+  grid-template-columns: 0.75rem 3rem minmax(0, 1fr) auto 0.75rem;
+  align-items: center;
+  width: min(37.5rem, calc(100vw - 1rem));
+  min-height: 3.75rem;
+  margin: 0 auto;
+  border-right: var(--border-hairline) solid var(--border);
+  border-left: var(--border-hairline) solid var(--border);
 }
 
 .locale-suggestion-screw {
@@ -4601,22 +4606,16 @@ a:focus-visible .external-label .external-mark {
   transform: translate(-50%, -50%) rotate(-42deg);
 }
 
-.locale-suggestion-meta {
+.locale-suggestion-hatch {
   align-self: stretch;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0.0625rem;
-  padding: 0 0.5rem;
   border-right: var(--border-hairline) solid var(--border);
-  color: color-mix(in oklab, var(--muted-foreground) 72%, transparent);
-  font-family: var(--font-geist-mono), var(--font-frex-gb, ui-monospace), ui-monospace, monospace;
-  font-size: 0.625rem;
-  font-variant-numeric: tabular-nums;
-  letter-spacing: 0.08em;
-  line-height: 1.25;
-  white-space: nowrap;
+  background: repeating-linear-gradient(
+    -45deg,
+    color-mix(in oklab, var(--muted-foreground) 55%, transparent) 0,
+    color-mix(in oklab, var(--muted-foreground) 55%, transparent) 1px,
+    transparent 1px,
+    transparent 3.5px
+  );
   user-select: none;
 }
 
@@ -4644,22 +4643,17 @@ a:focus-visible .external-label .external-mark {
 @keyframes locale-suggestion-enter {
   from {
     opacity: 0;
-    transform: translateY(-4px) scale(0.985);
+    transform: translateY(-4px);
   }
   to {
     opacity: 1;
-    transform: translateY(0) scale(1);
+    transform: translateY(0);
   }
 }
 
 @media (max-width: 39.999rem) {
-  .locale-suggestion {
+  .locale-suggestion-inner {
     grid-template-columns: 0.625rem 2.625rem minmax(0, 1fr) auto 0.625rem;
-  }
-
-  .locale-suggestion-meta {
-    padding: 0 0.375rem;
-    font-size: 0.5625rem;
   }
 
   .locale-suggestion-copy {

--- a/app/globals.css
+++ b/app/globals.css
@@ -4567,7 +4567,7 @@ a:focus-visible .external-label .external-mark {
   position: relative;
   isolation: isolate;
   display: grid;
-  grid-template-columns: 0.75rem 6.75rem minmax(0, 1fr) auto 0.75rem;
+  grid-template-columns: 0.75rem 4.75rem minmax(0, 1fr) auto 0.75rem;
   align-items: center;
   min-height: 3.75rem;
   border: var(--border-hairline) solid var(--border);
@@ -4604,9 +4604,8 @@ a:focus-visible .external-label .external-mark {
 .locale-suggestion-meta {
   align-self: stretch;
   display: flex;
-  flex-direction: column;
+  align-items: center;
   justify-content: center;
-  gap: 0.1875rem;
   padding: 0 0.75rem;
   border-right: var(--border-hairline) solid var(--border);
   color: color-mix(in oklab, var(--muted-foreground) 72%, transparent);
@@ -4640,16 +4639,6 @@ a:focus-visible .external-label .external-mark {
   border-left: var(--border-hairline) solid var(--border);
 }
 
-.locale-suggestion-action {
-  min-width: 3.25rem;
-  border-radius: 1px;
-  font-family: var(--font-geist-mono), var(--font-frex-gb, ui-monospace), ui-monospace, monospace;
-  font-size: 0.6875rem;
-  font-variant-numeric: tabular-nums;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
 @keyframes locale-suggestion-enter {
   from {
     opacity: 0;
@@ -4663,7 +4652,7 @@ a:focus-visible .external-label .external-mark {
 
 @media (max-width: 39.999rem) {
   .locale-suggestion {
-    grid-template-columns: 0.625rem 4.625rem minmax(0, 1fr) auto 0.625rem;
+    grid-template-columns: 0.625rem 3.875rem minmax(0, 1fr) auto 0.625rem;
   }
 
   .locale-suggestion-meta {
@@ -4677,11 +4666,6 @@ a:focus-visible .external-label .external-mark {
 
   .locale-suggestion-actions {
     padding-inline: 0.375rem;
-  }
-
-  .locale-suggestion-action {
-    min-width: auto;
-    padding-inline: 0.625rem;
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -4577,7 +4577,7 @@ a:focus-visible .external-label .external-mark {
   grid-template-columns: 0.75rem 3rem minmax(0, 1fr) auto 0.75rem;
   align-items: center;
   width: min(37.5rem, calc(100vw - 1rem));
-  min-height: 1.875rem;
+  min-height: 2rem;
   margin: 0 auto;
   border-right: var(--border-hairline) solid var(--border);
   border-left: var(--border-hairline) solid var(--border);
@@ -4636,7 +4636,7 @@ a:focus-visible .external-label .external-mark {
   align-items: center;
   justify-content: flex-end;
   gap: 0.1875rem;
-  padding: 0.1875rem 0.625rem;
+  padding: 0.25rem 0.625rem;
   border-left: var(--border-hairline) solid var(--border);
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -4577,7 +4577,7 @@ a:focus-visible .external-label .external-mark {
   grid-template-columns: 0.75rem 3rem minmax(0, 1fr) auto 0.75rem;
   align-items: center;
   width: min(37.5rem, calc(100vw - 1rem));
-  min-height: 2.5rem;
+  min-height: 2.75rem;
   margin: 0 auto;
   border-right: var(--border-hairline) solid var(--border);
   border-left: var(--border-hairline) solid var(--border);
@@ -4622,7 +4622,7 @@ a:focus-visible .external-label .external-mark {
 .locale-suggestion-copy {
   min-width: 0;
   margin: 0;
-  padding: 0.5rem 0.875rem;
+  padding: 0.625rem 0.875rem;
   font-size: 0.8125rem;
   line-height: 1.4;
   letter-spacing: -0.011em;
@@ -4636,7 +4636,7 @@ a:focus-visible .external-label .external-mark {
   align-items: center;
   justify-content: flex-end;
   gap: 0.1875rem;
-  padding: 0.5rem 0.625rem;
+  padding: 0.625rem;
   border-left: var(--border-hairline) solid var(--border);
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -4577,7 +4577,7 @@ a:focus-visible .external-label .external-mark {
   grid-template-columns: 0.75rem 3rem minmax(0, 1fr) auto 0.75rem;
   align-items: center;
   width: min(37.5rem, calc(100vw - 1rem));
-  min-height: 2rem;
+  min-height: 2.5rem;
   margin: 0 auto;
   border-right: var(--border-hairline) solid var(--border);
   border-left: var(--border-hairline) solid var(--border);
@@ -4622,7 +4622,7 @@ a:focus-visible .external-label .external-mark {
 .locale-suggestion-copy {
   min-width: 0;
   margin: 0;
-  padding: 0.25rem 0.875rem;
+  padding: 0.5rem 0.875rem;
   font-size: 0.8125rem;
   line-height: 1.4;
   letter-spacing: -0.011em;
@@ -4636,7 +4636,7 @@ a:focus-visible .external-label .external-mark {
   align-items: center;
   justify-content: flex-end;
   gap: 0.1875rem;
-  padding: 0.25rem 0.625rem;
+  padding: 0.5rem 0.625rem;
   border-left: var(--border-hairline) solid var(--border);
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -4567,7 +4567,7 @@ a:focus-visible .external-label .external-mark {
   position: relative;
   isolation: isolate;
   display: grid;
-  grid-template-columns: 0.75rem 4.75rem minmax(0, 1fr) auto 0.75rem;
+  grid-template-columns: 0.75rem 3rem minmax(0, 1fr) auto 0.75rem;
   align-items: center;
   min-height: 3.75rem;
   border: var(--border-hairline) solid var(--border);
@@ -4604,9 +4604,11 @@ a:focus-visible .external-label .external-mark {
 .locale-suggestion-meta {
   align-self: stretch;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 0 0.75rem;
+  gap: 0.0625rem;
+  padding: 0 0.5rem;
   border-right: var(--border-hairline) solid var(--border);
   color: color-mix(in oklab, var(--muted-foreground) 72%, transparent);
   font-family: var(--font-geist-mono), var(--font-frex-gb, ui-monospace), ui-monospace, monospace;
@@ -4652,11 +4654,11 @@ a:focus-visible .external-label .external-mark {
 
 @media (max-width: 39.999rem) {
   .locale-suggestion {
-    grid-template-columns: 0.625rem 3.875rem minmax(0, 1fr) auto 0.625rem;
+    grid-template-columns: 0.625rem 2.625rem minmax(0, 1fr) auto 0.625rem;
   }
 
   .locale-suggestion-meta {
-    padding: 0 0.5rem;
+    padding: 0 0.375rem;
     font-size: 0.5625rem;
   }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -4527,48 +4527,127 @@ a:focus-visible .external-label .external-mark {
   }
 }
 
-/* ── Locale suggestion: a fixed instrument strip ─────────────────── */
+/* ── Locale suggestion: an edge-mounted instrument plate ────────── */
 
 .locale-suggestion-positioner {
   position: fixed;
   z-index: var(--z-toast);
-  top: calc(env(safe-area-inset-top) + 0.75rem);
+  top: env(safe-area-inset-top);
   left: 50%;
-  width: min(37.5rem, calc(100vw - 1.5rem));
+  width: min(37.5rem, calc(100vw - 1rem));
   transform: translateX(-50%);
   pointer-events: none;
 }
 
+.locale-suggestion-positioner::before,
+.locale-suggestion-positioner::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  z-index: 1;
+  background: var(--muted-foreground);
+  opacity: 0.52;
+  pointer-events: none;
+}
+
+.locale-suggestion-positioner::before {
+  bottom: -0.3125rem;
+  width: var(--border-hairline);
+  height: 0.625rem;
+}
+
+.locale-suggestion-positioner::after {
+  bottom: -0.0625rem;
+  width: 0.5625rem;
+  height: var(--border-hairline);
+  transform: translateX(-50%);
+}
+
 .locale-suggestion {
+  position: relative;
+  isolation: isolate;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: 0.75rem 6.75rem minmax(0, 1fr) auto 0.75rem;
   align-items: center;
-  gap: 0.5rem 1rem;
-  min-height: 3.5rem;
-  padding: 0.625rem 0.75rem;
-  border-radius: 2px;
-  outline: var(--border-hairline) solid var(--border);
-  outline-offset: calc(-1 * var(--border-hairline));
+  min-height: 3.75rem;
+  border: var(--border-hairline) solid var(--border);
+  border-top: 0;
+  border-radius: 0 0 2px 2px;
+  background: var(--surface-2);
   pointer-events: auto;
   animation: locale-suggestion-enter 150ms var(--ease-swift) backwards;
 }
 
+.locale-suggestion-screw {
+  position: relative;
+  width: 0.5rem;
+  height: 0.5rem;
+  justify-self: center;
+  border-radius: 50%;
+  background: var(--surface-1);
+  box-shadow:
+    0 0 0 var(--border-hairline) var(--border),
+    inset 0.0625rem 0.0625rem 0 color-mix(in oklab, white 38%, transparent);
+}
+
+.locale-suggestion-screw::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0.3125rem;
+  height: var(--border-hairline);
+  background: var(--muted-foreground);
+  transform: translate(-50%, -50%) rotate(-42deg);
+}
+
+.locale-suggestion-meta {
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.1875rem;
+  padding: 0 0.75rem;
+  border-right: var(--border-hairline) solid var(--border);
+  color: color-mix(in oklab, var(--muted-foreground) 72%, transparent);
+  font-family: var(--font-geist-mono), var(--font-frex-gb, ui-monospace), ui-monospace, monospace;
+  font-size: 0.625rem;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.08em;
+  line-height: 1.25;
+  white-space: nowrap;
+  user-select: none;
+}
+
 .locale-suggestion-copy {
-  font-size: 0.875rem;
-  line-height: 1.5;
+  min-width: 0;
+  margin: 0;
+  padding: 0.625rem 0.875rem;
+  font-size: 0.8125rem;
+  line-height: 1.4;
   letter-spacing: -0.011em;
+  text-wrap: balance;
 }
 
 .locale-suggestion-actions {
+  align-self: stretch;
   display: flex;
   flex-shrink: 0;
   align-items: center;
   justify-content: flex-end;
-  gap: 0.25rem;
+  gap: 0.1875rem;
+  padding: 0.5rem 0.625rem;
+  border-left: var(--border-hairline) solid var(--border);
 }
 
-.locale-suggestion-actions :is(a, button) {
-  font-size: 0.875rem;
+.locale-suggestion-action {
+  min-width: 3.25rem;
+  border-radius: 1px;
+  font-family: var(--font-geist-mono), var(--font-frex-gb, ui-monospace), ui-monospace, monospace;
+  font-size: 0.6875rem;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 @keyframes locale-suggestion-enter {
@@ -4584,11 +4663,25 @@ a:focus-visible .external-label .external-mark {
 
 @media (max-width: 39.999rem) {
   .locale-suggestion {
-    grid-template-columns: minmax(0, 1fr);
+    grid-template-columns: 0.625rem 4.625rem minmax(0, 1fr) auto 0.625rem;
+  }
+
+  .locale-suggestion-meta {
+    padding: 0 0.5rem;
+    font-size: 0.5625rem;
+  }
+
+  .locale-suggestion-copy {
+    padding-inline: 0.625rem;
   }
 
   .locale-suggestion-actions {
-    justify-content: flex-start;
+    padding-inline: 0.375rem;
+  }
+
+  .locale-suggestion-action {
+    min-width: auto;
+    padding-inline: 0.625rem;
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -4577,7 +4577,7 @@ a:focus-visible .external-label .external-mark {
   grid-template-columns: 0.75rem 3rem minmax(0, 1fr) auto 0.75rem;
   align-items: center;
   width: min(37.5rem, calc(100vw - 1rem));
-  min-height: 3.75rem;
+  min-height: 1.875rem;
   margin: 0 auto;
   border-right: var(--border-hairline) solid var(--border);
   border-left: var(--border-hairline) solid var(--border);
@@ -4622,7 +4622,7 @@ a:focus-visible .external-label .external-mark {
 .locale-suggestion-copy {
   min-width: 0;
   margin: 0;
-  padding: 0.625rem 0.875rem;
+  padding: 0.25rem 0.875rem;
   font-size: 0.8125rem;
   line-height: 1.4;
   letter-spacing: -0.011em;
@@ -4636,7 +4636,7 @@ a:focus-visible .external-label .external-mark {
   align-items: center;
   justify-content: flex-end;
   gap: 0.1875rem;
-  padding: 0.5rem 0.625rem;
+  padding: 0.1875rem 0.625rem;
   border-left: var(--border-hairline) solid var(--border);
 }
 

--- a/components/locale-suggestion.test.tsx
+++ b/components/locale-suggestion.test.tsx
@@ -50,8 +50,12 @@ describe('LocaleSuggestion', () => {
     expect(screen.getByRole('button', { name: '继续使用中文' }).textContent).toBe(
       'No',
     )
-    expect(screen.getByText('LANG')).not.toBeNull()
-    expect(screen.getByText('EN')).not.toBeNull()
+    expect(
+      screen
+        .getByRole('region', { name: 'Language suggestion' })
+        .querySelector('.locale-suggestion-hatch'),
+    ).not.toBeNull()
+    expect(screen.queryByText('LANG')).toBeNull()
   })
 
   it('prefers a saved site language over the browser language', async () => {

--- a/components/locale-suggestion.test.tsx
+++ b/components/locale-suggestion.test.tsx
@@ -44,10 +44,10 @@ describe('LocaleSuggestion', () => {
     expect(
       (await screen.findByRole('region', { name: 'Language suggestion' }))
         .textContent,
-    ).toContain('Would you prefer to view this page in English?')
-    expect(
-      screen.getByRole('button', { name: 'View in English' }),
-    ).not.toBeNull()
+    ).toContain('View in English?')
+    const switchButton = screen.getByRole('button', { name: 'View in English' })
+    expect(switchButton.textContent).toBe('English')
+    expect(screen.getByText('PREF / EN')).not.toBeNull()
   })
 
   it('prefers a saved site language over the browser language', async () => {
@@ -60,7 +60,7 @@ describe('LocaleSuggestion', () => {
 
     expect(
       (await screen.findByRole('region', { name: '语言建议' })).textContent,
-    ).toContain('是否切换到中文浏览？')
+    ).toContain('切换到中文？')
     expect(
       screen.getByRole('button', { name: '切换到中文' }),
     ).not.toBeNull()
@@ -101,7 +101,7 @@ describe('LocaleSuggestion', () => {
 
     expect(
       (await screen.findByRole('region', { name: '语言建议' })).textContent,
-    ).toContain('是否切换到中文浏览？')
+    ).toContain('切换到中文？')
   })
 
   it('ignores unsupported browser languages', () => {

--- a/components/locale-suggestion.test.tsx
+++ b/components/locale-suggestion.test.tsx
@@ -46,8 +46,11 @@ describe('LocaleSuggestion', () => {
         .textContent,
     ).toContain('View in English?')
     const switchButton = screen.getByRole('button', { name: 'View in English' })
-    expect(switchButton.textContent).toBe('English')
-    expect(screen.getByText('PREF / EN')).not.toBeNull()
+    expect(switchButton.textContent).toBe('Yes')
+    expect(screen.getByRole('button', { name: '继续使用中文' }).textContent).toBe(
+      'No',
+    )
+    expect(screen.getByText('LANG / EN')).not.toBeNull()
   })
 
   it('prefers a saved site language over the browser language', async () => {
@@ -61,9 +64,12 @@ describe('LocaleSuggestion', () => {
     expect(
       (await screen.findByRole('region', { name: '语言建议' })).textContent,
     ).toContain('切换到中文？')
+    expect(screen.getByRole('button', { name: '切换到中文' }).textContent).toBe(
+      '是',
+    )
     expect(
-      screen.getByRole('button', { name: '切换到中文' }),
-    ).not.toBeNull()
+      screen.getByRole('button', { name: 'Continue in English' }).textContent,
+    ).toBe('否')
   })
 
   it('remembers the current language when the visitor chooses to stay', async () => {

--- a/components/locale-suggestion.test.tsx
+++ b/components/locale-suggestion.test.tsx
@@ -47,9 +47,9 @@ describe('LocaleSuggestion', () => {
     ).toContain('View in English?')
     const switchButton = screen.getByRole('button', { name: 'View in English' })
     expect(switchButton.textContent).toBe('Yes')
-    expect(screen.getByRole('button', { name: '继续使用中文' }).textContent).toBe(
-      'No',
-    )
+    const stayButton = screen.getByRole('button', { name: '继续使用中文' })
+    expect(stayButton.textContent).toBe('No')
+    expect(stayButton.hasAttribute('lang')).toBe(false)
     expect(
       screen
         .getByRole('region', { name: 'Language suggestion' })

--- a/components/locale-suggestion.test.tsx
+++ b/components/locale-suggestion.test.tsx
@@ -50,7 +50,8 @@ describe('LocaleSuggestion', () => {
     expect(screen.getByRole('button', { name: '继续使用中文' }).textContent).toBe(
       'No',
     )
-    expect(screen.getByText('LANG / EN')).not.toBeNull()
+    expect(screen.getByText('LANG')).not.toBeNull()
+    expect(screen.getByText('EN')).not.toBeNull()
   })
 
   it('prefers a saved site language over the browser language', async () => {

--- a/components/locale-suggestion.tsx
+++ b/components/locale-suggestion.tsx
@@ -119,7 +119,7 @@ export function LocaleSuggestion({ locale }: { locale: Locale }) {
           <div className="locale-suggestion-actions">
             <Button
               type="button"
-              expandHitArea
+              size="sm"
               aria-label={copy.switchAriaLabel}
               onClick={switchLocale}
             >
@@ -128,7 +128,7 @@ export function LocaleSuggestion({ locale }: { locale: Locale }) {
             <Button
               type="button"
               variant="ghost"
-              expandHitArea
+              size="sm"
               aria-label={copy.stayAriaLabel}
               lang={copy.stayLanguage}
               onClick={stay}

--- a/components/locale-suggestion.tsx
+++ b/components/locale-suggestion.tsx
@@ -112,34 +112,32 @@ export function LocaleSuggestion({ locale }: { locale: Locale }) {
         data-locale-suggestion={suggestedLocale}
         className="locale-suggestion"
       >
-        <span aria-hidden="true" className="locale-suggestion-screw" />
-        <span aria-hidden="true" className="locale-suggestion-meta">
-          <span>LANG</span>
-          <span>/</span>
-          <span>{suggestedLocale.toUpperCase()}</span>
-        </span>
-        <p className="locale-suggestion-copy">{copy.message}</p>
-        <div className="locale-suggestion-actions">
-          <Button
-            type="button"
-            expandHitArea
-            aria-label={copy.switchAriaLabel}
-            onClick={switchLocale}
-          >
-            {copy.switchLabel}
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            expandHitArea
-            aria-label={copy.stayAriaLabel}
-            lang={copy.stayLanguage}
-            onClick={stay}
-          >
-            {copy.stayLabel}
-          </Button>
+        <div className="locale-suggestion-inner">
+          <span aria-hidden="true" className="locale-suggestion-screw" />
+          <span aria-hidden="true" className="locale-suggestion-hatch" />
+          <p className="locale-suggestion-copy">{copy.message}</p>
+          <div className="locale-suggestion-actions">
+            <Button
+              type="button"
+              expandHitArea
+              aria-label={copy.switchAriaLabel}
+              onClick={switchLocale}
+            >
+              {copy.switchLabel}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              expandHitArea
+              aria-label={copy.stayAriaLabel}
+              lang={copy.stayLanguage}
+              onClick={stay}
+            >
+              {copy.stayLabel}
+            </Button>
+          </div>
+          <span aria-hidden="true" className="locale-suggestion-screw" />
         </div>
-        <span aria-hidden="true" className="locale-suggestion-screw" />
       </section>
     </div>
   )

--- a/components/locale-suggestion.tsx
+++ b/components/locale-suggestion.tsx
@@ -4,23 +4,26 @@ import { usePathname } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
 import { Button } from '~/components/ui/button'
-import { Elevated } from '~/lib/elevated'
 import { localePath, type Locale } from '~/lib/locale-route'
 
 const SUGGESTION_COPY = {
   zh: {
     regionLabel: '语言建议',
-    message: '是否切换到中文浏览？',
-    switchLabel: '切换到中文',
-    stayLabel: 'Continue in English',
+    message: '切换到中文？',
+    switchLabel: '中文',
+    switchAriaLabel: '切换到中文',
+    stayLabel: 'English',
+    stayAriaLabel: 'Continue in English',
     language: 'zh-CN',
     stayLanguage: 'en',
   },
   en: {
     regionLabel: 'Language suggestion',
-    message: 'Would you prefer to view this page in English?',
-    switchLabel: 'View in English',
-    stayLabel: '继续使用中文',
+    message: 'View in English?',
+    switchLabel: 'English',
+    switchAriaLabel: 'View in English',
+    stayLabel: '中文',
+    stayAriaLabel: '继续使用中文',
     language: 'en',
     stayLanguage: 'zh-CN',
   },
@@ -30,7 +33,9 @@ const SUGGESTION_COPY = {
     regionLabel: string
     message: string
     switchLabel: string
+    switchAriaLabel: string
     stayLabel: string
+    stayAriaLabel: string
     language: string
     stayLanguage: string
   }
@@ -98,9 +103,7 @@ export function LocaleSuggestion({ locale }: { locale: Locale }) {
 
   return (
     <div className="locale-suggestion-positioner">
-      <Elevated
-        offset={2}
-        shadowLevel={3}
+      <section
         role="region"
         aria-label={copy.regionLabel}
         aria-live="polite"
@@ -109,12 +112,19 @@ export function LocaleSuggestion({ locale }: { locale: Locale }) {
         data-locale-suggestion={suggestedLocale}
         className="locale-suggestion"
       >
+        <span aria-hidden="true" className="locale-suggestion-screw" />
+        <span aria-hidden="true" className="locale-suggestion-meta">
+          <span>LANG / 01</span>
+          <span>PREF / {suggestedLocale.toUpperCase()}</span>
+        </span>
         <p className="locale-suggestion-copy">{copy.message}</p>
         <div className="locale-suggestion-actions">
           <Button
             type="button"
             size="lg"
             expandHitArea
+            aria-label={copy.switchAriaLabel}
+            className="locale-suggestion-action"
             onClick={switchLocale}
           >
             {copy.switchLabel}
@@ -124,13 +134,16 @@ export function LocaleSuggestion({ locale }: { locale: Locale }) {
             variant="ghost"
             size="lg"
             expandHitArea
+            aria-label={copy.stayAriaLabel}
+            className="locale-suggestion-action"
             lang={copy.stayLanguage}
             onClick={stay}
           >
             {copy.stayLabel}
           </Button>
         </div>
-      </Elevated>
+        <span aria-hidden="true" className="locale-suggestion-screw" />
+      </section>
     </div>
   )
 }

--- a/components/locale-suggestion.tsx
+++ b/components/locale-suggestion.tsx
@@ -114,7 +114,9 @@ export function LocaleSuggestion({ locale }: { locale: Locale }) {
       >
         <span aria-hidden="true" className="locale-suggestion-screw" />
         <span aria-hidden="true" className="locale-suggestion-meta">
-          LANG / {suggestedLocale.toUpperCase()}
+          <span>LANG</span>
+          <span>/</span>
+          <span>{suggestedLocale.toUpperCase()}</span>
         </span>
         <p className="locale-suggestion-copy">{copy.message}</p>
         <div className="locale-suggestion-actions">

--- a/components/locale-suggestion.tsx
+++ b/components/locale-suggestion.tsx
@@ -10,9 +10,9 @@ const SUGGESTION_COPY = {
   zh: {
     regionLabel: '语言建议',
     message: '切换到中文？',
-    switchLabel: '中文',
+    switchLabel: '是',
     switchAriaLabel: '切换到中文',
-    stayLabel: 'English',
+    stayLabel: '否',
     stayAriaLabel: 'Continue in English',
     language: 'zh-CN',
     stayLanguage: 'en',
@@ -20,9 +20,9 @@ const SUGGESTION_COPY = {
   en: {
     regionLabel: 'Language suggestion',
     message: 'View in English?',
-    switchLabel: 'English',
+    switchLabel: 'Yes',
     switchAriaLabel: 'View in English',
-    stayLabel: '中文',
+    stayLabel: 'No',
     stayAriaLabel: '继续使用中文',
     language: 'en',
     stayLanguage: 'zh-CN',
@@ -114,17 +114,14 @@ export function LocaleSuggestion({ locale }: { locale: Locale }) {
       >
         <span aria-hidden="true" className="locale-suggestion-screw" />
         <span aria-hidden="true" className="locale-suggestion-meta">
-          <span>LANG / 01</span>
-          <span>PREF / {suggestedLocale.toUpperCase()}</span>
+          LANG / {suggestedLocale.toUpperCase()}
         </span>
         <p className="locale-suggestion-copy">{copy.message}</p>
         <div className="locale-suggestion-actions">
           <Button
             type="button"
-            size="lg"
             expandHitArea
             aria-label={copy.switchAriaLabel}
-            className="locale-suggestion-action"
             onClick={switchLocale}
           >
             {copy.switchLabel}
@@ -132,10 +129,8 @@ export function LocaleSuggestion({ locale }: { locale: Locale }) {
           <Button
             type="button"
             variant="ghost"
-            size="lg"
             expandHitArea
             aria-label={copy.stayAriaLabel}
-            className="locale-suggestion-action"
             lang={copy.stayLanguage}
             onClick={stay}
           >

--- a/components/locale-suggestion.tsx
+++ b/components/locale-suggestion.tsx
@@ -15,7 +15,6 @@ const SUGGESTION_COPY = {
     stayLabel: '否',
     stayAriaLabel: 'Continue in English',
     language: 'zh-CN',
-    stayLanguage: 'en',
   },
   en: {
     regionLabel: 'Language suggestion',
@@ -25,7 +24,6 @@ const SUGGESTION_COPY = {
     stayLabel: 'No',
     stayAriaLabel: '继续使用中文',
     language: 'en',
-    stayLanguage: 'zh-CN',
   },
 } as const satisfies Record<
   Locale,
@@ -37,7 +35,6 @@ const SUGGESTION_COPY = {
     stayLabel: string
     stayAriaLabel: string
     language: string
-    stayLanguage: string
   }
 >
 
@@ -130,7 +127,6 @@ export function LocaleSuggestion({ locale }: { locale: Locale }) {
               variant="ghost"
               size="sm"
               aria-label={copy.stayAriaLabel}
-              lang={copy.stayLanguage}
               onClick={stay}
             >
               {copy.stayLabel}

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -729,7 +729,7 @@ explicit: switch, or stay in the current language. Either choice becomes the
 saved site preference; unsupported browser languages produce no prompt. The
 plate uses the surface ladder and `--z-toast`, with no drop shadow. It never
 redirects automatically, shifts layout, or steals focus, and disables its brief
-transform-and-opacity entrance under reduced motion. The plate has 4px of inner
+transform-and-opacity entrance under reduced motion. The plate has 8px of inner
 padding above and below its 24px shared small buttons, and uses no expanded hit
 areas; this is a maintainer-approved exception to the site's usual 44px
 touch-target minimum (July 2026).

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -719,15 +719,16 @@ first supported language in `navigator.languages` becomes the preference. If
 that resolved preference differs from the explicit route, one fixed top-center
 instrument plate offers the equivalent route. It clamps to the viewport edge
 and the 37.5rem content grid instead of floating above the page: no drop shadow,
-a ruled surface, a center registration tick, compact machine labels, and two
-restrained screw heads. The short human prompt speaks in the offered language;
-the squared actions name the two languages while retaining descriptive
-accessible labels. The choice preserves the path, query, and fragment and is
-explicit: switch, or stay in the current language. Either choice becomes the
-saved site preference; unsupported browser languages produce no prompt. The
-plate uses the surface ladder, 2px print-register corner, and `--z-toast`. It
-never redirects automatically, never shifts layout or steals focus, and
-disables its brief transform-and-opacity entrance under reduced motion.
+a ruled surface, a center registration tick, one compact `LANG / EN` machine
+label, and two restrained screw heads. The short human prompt speaks in the
+offered language; the shared pill buttons answer with localized Yes and No
+while retaining descriptive accessible labels. The choice preserves the path,
+query, and fragment and is explicit: switch, or stay in the current language.
+Either choice becomes the saved site preference; unsupported browser languages
+produce no prompt. The plate uses the surface ladder, 2px print-register corner,
+and `--z-toast`. It never redirects automatically, never shifts layout or steals
+focus, and disables its brief transform-and-opacity entrance under reduced
+motion.
 
 Each post keeps its Chinese source in `index.mdx` and a complete English
 translation in `index.en.mdx`. The matching route renders only that source and

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -717,14 +717,17 @@ images share the same route identity.
 On a public route, a saved site preference takes priority; without one, the
 first supported language in `navigator.languages` becomes the preference. If
 that resolved preference differs from the explicit route, one fixed top-center
-instrument strip offers the equivalent route. The suggestion speaks in the
-offered language, preserves the path, query, and fragment, and requires an
-explicit choice: switch, or stay in the current language. Either choice becomes
-the saved site preference; unsupported browser languages produce no prompt.
-The strip uses the surface ladder, 2px print-register corner, compact chrome
-type, existing button hierarchy, and `--z-toast`. It never redirects
-automatically, never shifts layout or steals focus, and disables its brief
-transform-and-opacity entrance under reduced motion.
+instrument plate offers the equivalent route. It clamps to the viewport edge
+and the 37.5rem content grid instead of floating above the page: no drop shadow,
+a ruled surface, a center registration tick, compact machine labels, and two
+restrained screw heads. The short human prompt speaks in the offered language;
+the squared actions name the two languages while retaining descriptive
+accessible labels. The choice preserves the path, query, and fragment and is
+explicit: switch, or stay in the current language. Either choice becomes the
+saved site preference; unsupported browser languages produce no prompt. The
+plate uses the surface ladder, 2px print-register corner, and `--z-toast`. It
+never redirects automatically, never shifts layout or steals focus, and
+disables its brief transform-and-opacity entrance under reduced motion.
 
 Each post keeps its Chinese source in `index.mdx` and a complete English
 translation in `index.en.mdx`. The matching route renders only that source and

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -719,16 +719,16 @@ first supported language in `navigator.languages` becomes the preference. If
 that resolved preference differs from the explicit route, one fixed top-center
 instrument plate offers the equivalent route. It clamps to the viewport edge
 and the 37.5rem content grid instead of floating above the page: no drop shadow,
-a ruled surface, a center registration tick, one compact `LANG / EN` machine
-label, and two restrained screw heads. The short human prompt speaks in the
-offered language; the shared pill buttons answer with localized Yes and No
-while retaining descriptive accessible labels. The choice preserves the path,
-query, and fragment and is explicit: switch, or stay in the current language.
-Either choice becomes the saved site preference; unsupported browser languages
-produce no prompt. The plate uses the surface ladder, 2px print-register corner,
-and `--z-toast`. It never redirects automatically, never shifts layout or steals
-focus, and disables its brief transform-and-opacity entrance under reduced
-motion.
+a ruled surface, a center registration tick, one narrow machine label stacking
+`LANG`, `/`, and the offered locale code, and two restrained screw heads. The
+short human prompt speaks in the offered language; the shared pill buttons
+answer with localized Yes and No while retaining descriptive accessible labels.
+The choice preserves the path, query, and fragment and is explicit: switch, or
+stay in the current language. Either choice becomes the saved site preference;
+unsupported browser languages produce no prompt. The plate uses the surface
+ladder, 2px print-register corner, and `--z-toast`. It never redirects
+automatically, never shifts layout or steals focus, and disables its brief
+transform-and-opacity entrance under reduced motion.
 
 Each post keeps its Chinese source in `index.mdx` and a complete English
 translation in `index.en.mdx`. The matching route renders only that source and

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -729,7 +729,7 @@ explicit: switch, or stay in the current language. Either choice becomes the
 saved site preference; unsupported browser languages produce no prompt. The
 plate uses the surface ladder and `--z-toast`, with no drop shadow. It never
 redirects automatically, shifts layout, or steals focus, and disables its brief
-transform-and-opacity entrance under reduced motion. The plate has 8px of inner
+transform-and-opacity entrance under reduced motion. The plate has 10px of inner
 padding above and below its 24px shared small buttons, and uses no expanded hit
 areas; this is a maintainer-approved exception to the site's usual 44px
 touch-target minimum (July 2026).

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -729,7 +729,10 @@ explicit: switch, or stay in the current language. Either choice becomes the
 saved site preference; unsupported browser languages produce no prompt. The
 plate uses the surface ladder and `--z-toast`, with no drop shadow. It never
 redirects automatically, shifts layout, or steals focus, and disables its brief
-transform-and-opacity entrance under reduced motion.
+transform-and-opacity entrance under reduced motion. The plate is intentionally
+30px tall and uses the shared small buttons without expanded hit areas; this is
+a maintainer-approved exception to the site's usual 44px touch-target minimum
+(July 2026).
 
 Each post keeps its Chinese source in `index.mdx` and a complete English
 translation in `index.en.mdx`. The matching route renders only that source and

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -729,10 +729,10 @@ explicit: switch, or stay in the current language. Either choice becomes the
 saved site preference; unsupported browser languages produce no prompt. The
 plate uses the surface ladder and `--z-toast`, with no drop shadow. It never
 redirects automatically, shifts layout, or steals focus, and disables its brief
-transform-and-opacity entrance under reduced motion. The plate is intentionally
-30px tall and uses the shared small buttons without expanded hit areas; this is
-a maintainer-approved exception to the site's usual 44px touch-target minimum
-(July 2026).
+transform-and-opacity entrance under reduced motion. The plate has 4px of inner
+padding above and below its 24px shared small buttons, and uses no expanded hit
+areas; this is a maintainer-approved exception to the site's usual 44px
+touch-target minimum (July 2026).
 
 Each post keeps its Chinese source in `index.mdx` and a complete English
 translation in `index.en.mdx`. The matching route renders only that source and

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -716,18 +716,19 @@ images share the same route identity.
 
 On a public route, a saved site preference takes priority; without one, the
 first supported language in `navigator.languages` becomes the preference. If
-that resolved preference differs from the explicit route, one fixed top-center
-instrument plate offers the equivalent route. It clamps to the viewport edge
-and the 37.5rem content grid instead of floating above the page: no drop shadow,
-a ruled surface, a center registration tick, one narrow machine label stacking
-`LANG`, `/`, and the offered locale code, and two restrained screw heads. The
-short human prompt speaks in the offered language; the shared pill buttons
-answer with localized Yes and No while retaining descriptive accessible labels.
-The choice preserves the path, query, and fragment and is explicit: switch, or
-stay in the current language. Either choice becomes the saved site preference;
-unsupported browser languages produce no prompt. The plate uses the surface
-ladder, 2px print-register corner, and `--z-toast`. It never redirects
-automatically, never shifts layout or steals focus, and disables its brief
+that resolved preference differs from the explicit route, one fixed instrument
+plate offers the equivalent route. Its ruled surface spans the full viewport
+width and clamps to the top edge instead of floating above the page; the hatch,
+two balanced screw heads, prompt, and actions stay aligned inside the centered
+37.5rem site grid. A full-height diagonal hatch in the existing section-tag
+register replaces the language label, while the center registration tick marks
+the plate below. The short human prompt speaks in the offered language; the
+shared pill buttons answer with localized Yes and No while retaining descriptive
+accessible labels. The choice preserves the path, query, and fragment and is
+explicit: switch, or stay in the current language. Either choice becomes the
+saved site preference; unsupported browser languages produce no prompt. The
+plate uses the surface ladder and `--z-toast`, with no drop shadow. It never
+redirects automatically, shifts layout, or steals focus, and disables its brief
 transform-and-opacity entrance under reduced motion.
 
 Each post keeps its Chinese source in `index.mdx` and a complete English


### PR DESCRIPTION
## Summary

- replace the floating locale card with a full-width instrument plate aligned to the site grid
- add the technical-print hatch, balanced screw heads, registration tick, and shadow-free surface
- shorten the localized prompt to Yes/No actions using the shared button component
- keep the behavior, accessible labels, reduced-motion handling, tests, and design specification aligned

## Why

The previous banner looked separate from the site's technical-print system. Its elevated card, drop shadow, and one-off action styling conflicted with the established surface and button language.

## Verification

- `pnpm typecheck`
- `pnpm exec vitest run components/locale-suggestion.test.tsx app/site-document.test.tsx`
- browser inspection at 390px and 1280px in light and dark modes
- verified full-width geometry, zero horizontal overflow, and no banner shadow

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the floating, card-style locale suggestion banner with a full-width "instrument plate" that sits flush to the top edge of the viewport, aligned to the site's 37.5rem content grid. It also shortens the call-to-action copy to localized Yes/No pill buttons while preserving descriptive `aria-label` attributes for screen readers.

- **Visual redesign**: removes `Elevated` wrapper (drop shadow, rounded card), adopts edge-mount with hairline borders, a diagonal hatch panel, and decorative screw heads to match the site's existing technical-print design language.
- **Copy & accessibility update**: shrinks prompts ("View in English?" / "切换到中文？") and button labels to Yes/No, adds `switchAriaLabel`/`stayAriaLabel` fields, removes the previously-flagged `lang={copy.stayLanguage}` attribute from the stay button, and carries the section-level `lang` correctly for the suggested locale.
- **Test & doc alignment**: all affected test assertions updated to match new copy and DOM structure; `docs/design-language.md` documents the maintainer-approved 44px touch-target exception.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely visual and copy-level with no modifications to routing, state management, or storage logic.

All behavioral logic (locale resolution, localStorage read/write, cross-tab sync, navigation) is identical to before. The diff touches only presentation: markup structure, CSS classes, and string copy. Tests are updated in lock-step, all existing scenarios are covered, and the design-language doc records the intentional touch-target exception.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| components/locale-suggestion.tsx | Replaces Elevated wrapper with a plain section, adds inner grid with screw/hatch decorators, updates copy constants to include aria-labels and remove stayLanguage; behavior and state management unchanged. |
| app/globals.css | Rewrites locale-suggestion styles: full-width positioner, inner 5-column grid, screw and hatch decorators, pseudo-element registration tick; reduced-motion and responsive breakpoint rules preserved. |
| components/locale-suggestion.test.tsx | Test assertions updated to match new copy (Yes/No labels, shortened prompts), verifies hatch element presence, and explicitly asserts that the stay button no longer carries a lang attribute. |
| docs/design-language.md | Prose updated to describe the new full-width plate layout, hatch, registration tick, and Yes/No buttons; adds an explicit maintainer-approved exception for the sub-44px touch targets. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Component mounts with locale prop] --> B[useEffect: resolve suggestion]
    B --> C{savedLocale in localStorage?}
    C -- yes --> D[preferred = savedLocale]
    C -- no --> E[preferred = first supported\nbrowser language]
    D --> F{preferred !== locale?}
    E --> F
    F -- yes --> G[setSuggestedLocale preferred]
    F -- no --> H[setSuggestedLocale null]
    G --> I[Render instrument plate lang=copy.language]
    I --> J[Yes button aria-label=switchAriaLabel]
    I --> K[No button aria-label=stayAriaLabel]
    J -- click --> L[rememberLocale suggested window.location.pathname = localePath]
    K -- click --> M[rememberLocale current locale setSuggestedLocale null]
    N[cross-tab StorageEvent key=locale] --> B
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Component mounts with locale prop] --> B[useEffect: resolve suggestion]
    B --> C{savedLocale in localStorage?}
    C -- yes --> D[preferred = savedLocale]
    C -- no --> E[preferred = first supported\nbrowser language]
    D --> F{preferred !== locale?}
    E --> F
    F -- yes --> G[setSuggestedLocale preferred]
    F -- no --> H[setSuggestedLocale null]
    G --> I[Render instrument plate lang=copy.language]
    I --> J[Yes button aria-label=switchAriaLabel]
    I --> K[No button aria-label=stayAriaLabel]
    J -- click --> L[rememberLocale suggested window.location.pathname = localePath]
    K -- click --> M[rememberLocale current locale setSuggestedLocale null]
    N[cross-tab StorageEvent key=locale] --> B
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix: align locale button language"](https://github.com/calicastle/cali.so/commit/1117ab306fc7b18cda8fa161d4297bfd488e2407) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45595742)</sub>

<!-- /greptile_comment -->