### PR TITLE
Fix admin Alt Text 503s and Clerk session redirect churn

### DIFF
--- a/app/admin/layout.test.tsx
+++ b/app/admin/layout.test.tsx
@@ -1,7 +1,12 @@
+import { ClerkProvider } from '@clerk/nextjs'
 import { describe, expect, it, vi } from 'vitest'
 
 import { SiteDocument } from '../_components/site-document'
 import AdminRootLayout from './layout'
+
+vi.mock('@clerk/nextjs', () => ({
+  ClerkProvider: vi.fn(),
+}))
 
 vi.mock('../_components/site-document', () => ({
   rootMetadata: {},
@@ -9,15 +14,19 @@ vi.mock('../_components/site-document', () => ({
 }))
 
 describe('admin root layout', () => {
-  it('renders a static admin document with no client auth provider', () => {
+  it('keeps a non-dynamic Clerk provider inside the static document', () => {
     const children = <div>Admin</div>
     const layout = AdminRootLayout({ children })
 
     expect(layout.type).toBe(SiteDocument)
     expect(layout.props).toMatchObject({
-      children,
       isAdmin: true,
       restoreLocale: true,
     })
+    expect(layout.props.children.type).toBe(ClerkProvider)
+    expect(layout.props.children.props.children).toBe(children)
+    // `dynamic` must stay unset (false): opting in would force per-request
+    // rendering and break the prerendered admin shell.
+    expect(layout.props.children.props.dynamic).toBeUndefined()
   })
 })

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -23,6 +23,11 @@ export const metadata: Metadata = {
 // so clerk-js keeps refreshing the 60-second session-token cookie in the
 // background. Without it every idle minute ends in a handshake redirect
 // and admin API 401 reloads.
+//
+// The static guarantee was verified against @clerk/nextjs 7.5.20: only the
+// `dynamic` prop opts the server provider into request data. Clerk does not
+// document that contract, so re-verify (and reconfirm the `◐` build marker
+// on admin routes) when the lockfile bumps @clerk/nextjs.
 export default function AdminRootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <SiteDocument isAdmin locale="zh" restoreLocale>

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,4 +1,5 @@
 import '../globals.css'
+import { ClerkProvider } from '@clerk/nextjs'
 import type { Metadata } from 'next'
 
 import { rootMetadata, SiteDocument } from '../_components/site-document'
@@ -17,12 +18,15 @@ export const metadata: Metadata = {
 // owner dock prerender and prefetch, while everything the owner actually
 // sees streams from per-request loaders behind each page's Suspense
 // boundary. Ownership is enforced by clerkMiddleware plus requireOwnerPage
-// inside those loaders — no client-side Clerk remains, so there is no
-// provider here.
+// inside those loaders. The ClerkProvider below stays non-dynamic (no
+// request data, shell still prerenders) and renders no UI — it exists only
+// so clerk-js keeps refreshing the 60-second session-token cookie in the
+// background. Without it every idle minute ends in a handshake redirect
+// and admin API 401 reloads.
 export default function AdminRootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <SiteDocument isAdmin locale="zh" restoreLocale>
-      {children}
+      <ClerkProvider>{children}</ClerkProvider>
     </SiteDocument>
   )
 }

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -76,11 +76,16 @@ Current as of July 2026.
   streams behind per-page Suspense loaders that each call
   `requireOwnerPage` before touching data; `clerkMiddleware` still gates
   every request, and `/admin/login` stays a deliberate `instant = false`
-  redirect. Consequences: the admin has no client-side ClerkProvider (no
-  Clerk JS ships to the admin at all), and the former per-request nonce
-  admin CSP is retired because nonces force dynamic rendering. Admin pages
-  use the static site policy from `lib/security/headers.ts`; AMA settings
-  extends only `form-action` for the redirect to Google OAuth.
+  redirect. Consequences: the former per-request nonce admin CSP is
+  retired because nonces force dynamic rendering. The admin ships one
+  non-dynamic `ClerkProvider` (no UI, no request data, shell still
+  prerenders) purely so clerk-js keeps refreshing Clerk's 60-second
+  session-token cookie — without it, every idle minute ended in a
+  handshake redirect or an admin API 401 full-page reload. Admin pages
+  therefore use a static admin policy from `lib/security/headers.ts` that
+  extends `script-src` and `connect-src` with the Clerk instance origin
+  (derived from the publishable key); AMA settings additionally extends
+  `form-action` for the redirect to Google OAuth.
 - The complete paid AMA booking system (#79, slices #82 through #87) is
   implemented and enabled by default (maintainer decision, July 2026; the
   former `AMA_*_ENABLED` switches are removed): public `/ama` and

--- a/docs/security/baseline.md
+++ b/docs/security/baseline.md
@@ -105,10 +105,13 @@ static, ISR, and partial-prerendered output includes inline hydration payloads.
 A per-request nonce would disable those rendering modes. Next.js SRI is enabled
 for supported build assets, `unsafe-eval` is development-only, script
 attributes are blocked, and all other directives remain restricted. The
-partially prerendered `/admin` surface uses the same static script policy so its
-Instant Navigation shells remain cacheable; it has no client-side Clerk
-provider or provider script or connection allowance. The AMA settings page
-alone extends `form-action` to `https://accounts.google.com` so its same-origin
+partially prerendered `/admin` surface uses a static admin policy so its
+Instant Navigation shells remain cacheable; it additionally allows the
+Clerk instance origin (derived at build from the publishable key) in
+`script-src` and `connect-src`, because the admin ships a non-dynamic
+ClerkProvider whose clerk-js keeps the 60-second session-token cookie
+fresh. The AMA settings page keeps those Clerk origins and alone extends
+`form-action` to `https://accounts.google.com` so its same-origin
 connect form may follow the server's redirect into Google OAuth. Inline styles
 remain allowed because shared React UI emits style attributes. Revisit the
 script and shared style exceptions when Next.js and the UI can remove them

--- a/docs/security/clerk-admin-operations.md
+++ b/docs/security/clerk-admin-operations.md
@@ -58,11 +58,15 @@ owner prompt.
 
 Alongside it, the admin's per-request nonce CSP was retired when admin
 routes adopted prerendered instant-navigation shells (nonces require
-dynamic rendering). Admin pages use the static site policy from
-`lib/security/headers.ts`; with no client-side Clerk remaining, no Clerk
-provider origins are needed. The AMA settings page has one narrow exception:
-its `form-action` also permits `https://accounts.google.com` so the native
-connect form can enter Google OAuth after the same-origin handler redirects.
+dynamic rendering). Admin pages use a static admin policy from
+`lib/security/headers.ts` that allows the Clerk instance origin (derived
+at build from the publishable key) in `script-src` and `connect-src`: the
+admin ships a non-dynamic ClerkProvider purely so clerk-js keeps the
+60-second session-token cookie fresh, preventing handshake-redirect and
+401-reload churn. The AMA settings page keeps those origins and has one
+further exception: its `form-action` also permits
+`https://accounts.google.com` so the native connect form can enter Google
+OAuth after the same-origin handler redirects.
 
 Passkeys remain the recommended Clerk sign-in method, and every recovery
 procedure below still applies. Reintroducing a step-up boundary would need

--- a/lib/media/alt-text/gateway.test.ts
+++ b/lib/media/alt-text/gateway.test.ts
@@ -45,8 +45,7 @@ describe('Media Library AI Gateway Alt Text Suggestion generator', () => {
     const call = generateTextMock.mock.calls[0]![0]
     expect(call).toMatchObject({
       model: { model: config.primaryModel },
-      temperature: 0.2,
-      maxOutputTokens: 320,
+      maxOutputTokens: 2048,
       maxRetries: 1,
       timeout: 12_000,
       providerOptions: {
@@ -61,10 +60,11 @@ describe('Media Library AI Gateway Alt Text Suggestion generator', () => {
     })
     const content = call.messages[0].content
     expect(content[1]).toEqual({
-      type: 'image',
-      image: bytes,
+      type: 'file',
+      data: bytes,
       mediaType: 'image/jpeg',
     })
+    expect(call.temperature).toBeUndefined()
     expect(JSON.stringify(content)).not.toMatch(
       /IMG_|originals\/|latitude|longitude|EXIF/i,
     )

--- a/lib/media/alt-text/gateway.ts
+++ b/lib/media/alt-text/gateway.ts
@@ -42,15 +42,18 @@ export function createMediaAltTextGenerator(config: MediaAltTextGatewayConfig) {
             content: [
               { type: 'text', text: instructions },
               {
-                type: 'image',
-                image: input.imageBytes,
+                type: 'file',
+                data: input.imageBytes,
                 mediaType: 'image/jpeg',
               },
             ],
           },
         ],
-        temperature: 0.2,
-        maxOutputTokens: 320,
+        // No temperature: the configured gpt-5.x models are reasoning models
+        // and reject sampling parameters. The budget must also cover hidden
+        // reasoning tokens before the structured output, so 320 would starve
+        // the JSON payload (280 chars per language plus schema overhead).
+        maxOutputTokens: 2048,
         maxRetries: config.maxRetries,
         timeout: config.timeoutMs,
         providerOptions: {

--- a/lib/media/alt-text/service.test.ts
+++ b/lib/media/alt-text/service.test.ts
@@ -147,6 +147,9 @@ describe('Media Library Alt Text Suggestion service', () => {
   })
 
   it('leaves the Media Asset unchanged when generation fails', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
     const harness = createHarness({
       generationError: new Error('provider down'),
     })
@@ -158,6 +161,11 @@ describe('Media Library Alt Text Suggestion service', () => {
       }),
     ).rejects.toEqual(new MediaAltTextError('generation_failed'))
     expect(harness.repository.saveSuggestion).not.toHaveBeenCalled()
+    expect(consoleError).toHaveBeenCalledWith(
+      '[media-alt-text] Suggestion generation failed',
+      new Error('provider down'),
+    )
+    consoleError.mockRestore()
   })
 
   it('does not save after the Media Asset becomes ineligible', async () => {

--- a/lib/media/alt-text/service.ts
+++ b/lib/media/alt-text/service.ts
@@ -177,7 +177,8 @@ export function createMediaAltTextService({
           ownerUserId: input.ownerUserId,
           imageBytes,
         })
-      } catch {
+      } catch (error) {
+        console.error('[media-alt-text] Suggestion generation failed', error)
         throw new MediaAltTextError('generation_failed')
       }
       if (

--- a/lib/security/headers.test.ts
+++ b/lib/security/headers.test.ts
@@ -33,6 +33,47 @@ describe('site security headers', () => {
     expect(headers['permissions-policy']).toContain('payment=()')
   })
 
+  it('allows the Clerk instance origins only on the admin policies', async () => {
+    vi.stubEnv(
+      'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY',
+      `pk_test_${Buffer.from('example.clerk.accounts.dev$').toString('base64')}`,
+    )
+    const {
+      adminSecurityHeader,
+      googleOAuthFormSecurityHeader,
+      securityHeaders: configuredHeaders,
+    } = await import('./headers')
+    const publicPolicy = configuredHeaders.find(
+      ({ key }) => key === 'Content-Security-Policy',
+    )?.value
+
+    for (const policy of [
+      adminSecurityHeader.value,
+      googleOAuthFormSecurityHeader.value,
+    ]) {
+      expect(policy).toContain(
+        "script-src 'self' 'unsafe-inline' https://example.clerk.accounts.dev",
+      )
+      expect(policy).toContain(
+        "connect-src 'self' https://example.clerk.accounts.dev",
+      )
+    }
+    expect(googleOAuthFormSecurityHeader.value).toContain(
+      "form-action 'self' https://accounts.google.com",
+    )
+    expect(publicPolicy).not.toContain('clerk')
+  })
+
+  it('omits Clerk origins when the publishable key is missing or malformed', async () => {
+    vi.stubEnv('NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY', 'pk_live_not-base64!!')
+    const { adminSecurityHeader } = await import('./headers')
+
+    expect(adminSecurityHeader.value).toContain(
+      "script-src 'self' 'unsafe-inline'; ",
+    )
+    expect(adminSecurityHeader.value).toContain("connect-src 'self'; ")
+  })
+
   it('allows only the configured Bunny Media origin for images', async () => {
     vi.stubEnv(
       'BUNNY_MEDIA_CDN_URL',

--- a/lib/security/headers.ts
+++ b/lib/security/headers.ts
@@ -13,6 +13,21 @@ function optionalMediaImageSource() {
   }
 }
 
+function optionalClerkSource() {
+  const key = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+  if (!key) return ''
+  const encoded = /^pk_(?:live|test)_([A-Za-z0-9+/=]+)$/.exec(key)?.[1]
+  if (!encoded) return ''
+  try {
+    const domain = atob(encoded)
+    return /^[a-z0-9][a-z0-9.-]*\$$/.test(domain)
+      ? ` https://${domain.slice(0, -1)}`
+      : ''
+  } catch {
+    return ''
+  }
+}
+
 function contentSecurityPolicy(
   scriptSources: string,
   styleSources: string,
@@ -42,17 +57,42 @@ function contentSecurityPolicy(
 
 // Static policies keep the admin's prerendered shell cacheable. Its former
 // nonce policy was retired in July 2026: nonces require dynamic rendering,
-// which is incompatible with instant navigation. No Clerk provider origins
-// are needed; the Google settings page extends only the form destination.
+// which is incompatible with instant navigation.
 const publicContentSecurityPolicy = contentSecurityPolicy(
   `'self' 'unsafe-inline'${isDevelopment ? " 'unsafe-eval'" : ''}`,
   "'self' 'unsafe-inline'",
 )
 
-const googleOAuthFormContentSecurityPolicy = contentSecurityPolicy(
-  `'self' 'unsafe-inline'${isDevelopment ? " 'unsafe-eval'" : ''}`,
+// Admin pages ship clerk-js so the 60-second Clerk session token keeps
+// refreshing in the background (July 2026). The script and Frontend API
+// origin is derived from the publishable key, which encodes the instance
+// domain by Clerk convention, so the policy stays static per build.
+const clerkSource = optionalClerkSource()
+
+const adminScriptSources = `'self' 'unsafe-inline'${
+  isDevelopment ? " 'unsafe-eval'" : ''
+}${clerkSource}`
+
+const adminContentSecurityPolicy = contentSecurityPolicy(
+  adminScriptSources,
   "'self' 'unsafe-inline'",
-  { formActionSources: "'self' https://accounts.google.com" },
+  { connectSources: clerkSource },
+)
+
+export const adminSecurityHeader = {
+  key: 'Content-Security-Policy',
+  value: adminContentSecurityPolicy,
+} as const
+
+// The AMA settings page sits under /admin, so it keeps the admin's Clerk
+// origins and extends only the form destination for Google OAuth.
+const googleOAuthFormContentSecurityPolicy = contentSecurityPolicy(
+  adminScriptSources,
+  "'self' 'unsafe-inline'",
+  {
+    formActionSources: "'self' https://accounts.google.com",
+    connectSources: clerkSource,
+  },
 )
 
 export const googleOAuthFormSecurityHeader = {

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from 'next'
 
 import legacyUrlManifest from './content/legacy-url-manifest.json'
 import {
+  adminSecurityHeader,
   googleOAuthFormSecurityHeader,
   securityHeaders,
 } from './lib/security/headers'
@@ -88,6 +89,13 @@ const nextConfig: NextConfig = {
       // admin API responses must never disclose their origin to another site.
       source: '/api/admin/:path*',
       headers: [{ key: 'Referrer-Policy', value: 'no-referrer' }],
+    },
+    {
+      // Admin pages ship clerk-js for background session-token refresh, so
+      // their policy alone allows the Clerk instance origins. The AMA
+      // settings entry below overrides this for its Google OAuth form.
+      source: '/admin/:path*',
+      headers: [adminSecurityHeader],
     },
     {
       // The native connect form receives a same-origin 303 whose destination


### PR DESCRIPTION
## Summary

Three owner-admin reliability fixes with a shared theme: the real errors were invisible.

### fix(media): unblock Alt Text generation on gpt-5.x models

The July 17 model switch (`ee88913`) to `openai/gpt-5.6-luna` + `openai/gpt-5.4-mini` broke every suggestion — gpt-5.x reasoning models reject non-default `temperature` with a 400, and the 320-token output cap starved the structured JSON payload once hidden reasoning tokens were counted. Both primary and fallback are gpt-5.x, so every request failed twice, was swallowed by the service's bare `catch`, and surfaced only as a 503 with a stray AI SDK deprecation warning in the logs.

- Drop `temperature`; raise `maxOutputTokens` to 2048 (280 chars × 2 languages + schema + reasoning budget)
- Migrate the deprecated `image` content part to a `file` part (silences the AI SDK v7 warning; verified v7 converts it to the identical wire shape)
- Log the underlying provider error before wrapping it into `generation_failed`, following the `[photo-selection]` precedent, so the next failure is diagnosable from runtime logs

### fix(admin): keep Clerk session token fresh in the background

The July 18 redesign (#171) removed all client-side Clerk, so nothing refreshed Clerk's 60-second session-token JWT. After a minute idle, every navigation bounced through the clerkMiddleware handshake redirect, and every admin API fetch hit 401 → `adminResponseJson` full-page reload.

- Mount a non-dynamic `<ClerkProvider>` in the admin root layout, purely so clerk-js silently refreshes the token cookie
- No `dynamic` prop: verified against @clerk/nextjs 7.5.20 source that the non-dynamic path never touches request data, so the prerendered admin shell (PPR decision from #171) is preserved — unlike the pre-redesign `<ClerkProvider dynamic>` this partially restores
- Layout test asserts `dynamic` stays unset

### fix(admin): allow Clerk origins in the admin CSP

The static site policy limits `script-src`/`connect-src` to `'self'`, which would have blocked the clerk-js script and its Frontend API calls, making the provider above inert.

- `/admin/:path*` now gets a static admin policy whose `script-src` and `connect-src` include the Clerk instance origin, derived at build from `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` (the key base64-encodes the instance domain by Clerk convention; malformed/missing keys degrade to no extra origins)
- The AMA settings page keeps the Clerk origins alongside its existing `form-action https://accounts.google.com` exception
- Public routes are unchanged and still never reference Clerk
- Handoff + security docs that recorded the former "no Clerk JS in the admin" consequence are synced

## Testing

- `vitest`: alt-text (17), admin (27), and security header suites pass; new tests cover Clerk-origin derivation and its absence on public policies
- `tsc --noEmit` clean
- Pre-existing, unrelated: `lib/security/typegpu-csp-fallback.test.ts` fails on a clean tree (warn-once fires 3×) — spun off separately
- Not verifiable locally: a real gateway call (needs deployed OIDC) and the PPR build markers (needs build secrets) — after deploy, confirm admin routes still show `◐`, trigger one Alt Text generation, and idle >1 min in the admin to confirm no redirect bounce

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Three reliability fixes for the admin panel: Alt Text generation is unblocked for gpt-5.x reasoning models (dropped `temperature`, raised `maxOutputTokens`, migrated to AI SDK v7 `file` content part), provider errors are now logged before being wrapped into `generation_failed`, and a non-dynamic `ClerkProvider` is added to the admin layout so clerk-js silently keeps the 60-second session token fresh — along with a matching static admin CSP that allows the Clerk instance origin derived from the publishable key.

- **Alt Text gateway** (`gateway.ts`): removes `temperature` (rejected by gpt-5.x) and bumps `maxOutputTokens` to 2048 to cover hidden reasoning tokens; migrates deprecated `image` content part to `{ type: 'file', data, mediaType }` per the AI SDK v7 migration guide.
- **Admin session refresh** (`layout.tsx`): non-dynamic `ClerkProvider` added purely for background token refresh; the `dynamic` guard is explicitly tested and documented with the verified `@clerk/nextjs` version.
- **Admin CSP** (`headers.ts`, `next.config.ts`): `optionalClerkSource()` decodes the publishable key's base64 instance domain with a strict allowlist regex and injects it into `script-src`/`connect-src` only on admin routes, with safe degradation when the key is absent or malformed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three fixes target confirmed, reproducible regressions and each is accompanied by tests that directly exercise the changed behavior.

The gateway change corrects parameters that gpt-5.x models actively reject (400 responses on temperature) and bumps a token budget that was too small for the reasoning overhead. The CSP change uses a regex-validated, strict-allowlist domain extraction — no injection path — and degrades safely to no extra origins when the key is absent. The ClerkProvider change is limited to token-refresh plumbing with no UI surface, and its non-dynamic contract is both code-commented and test-guarded.

No files require special attention; the admin layout's reliance on @clerk/nextjs internals is already documented in code and noted in prior review discussion.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/media/alt-text/gateway.ts | Removes incompatible temperature param, raises maxOutputTokens to 2048, and migrates image content part to file (correct AI SDK v7 shape: type/data/mediaType). |
| lib/media/alt-text/service.ts | Adds console.error logging before rethrowing generation_failed, making provider errors visible in runtime logs. |
| lib/security/headers.ts | Introduces optionalClerkSource() with strict domain validation and a new adminContentSecurityPolicy that extends script-src and connect-src with the Clerk instance origin; correctly propagates to googleOAuthFormContentSecurityPolicy. |
| next.config.ts | Inserts adminSecurityHeader for /admin/:path* before the /admin/ama/settings entry, preserving last-write-wins override order for CSP. |
| app/admin/layout.tsx | Wraps children in a non-dynamic ClerkProvider for background token refresh; relies on @clerk/nextjs internal behavior verified at 7.5.20 (noted in code comment). |
| lib/security/headers.test.ts | New tests cover Clerk origin inclusion in both admin policies and correct omission from public policy; also tests graceful degradation on missing/malformed publishable key. |
| lib/media/alt-text/gateway.test.ts | Updated assertions to match new file content part shape and verify temperature is absent from the generateText call. |
| lib/media/alt-text/service.test.ts | Adds assertion that console.error is called with the expected prefix and error on generation failure; properly restores the spy. |
| app/admin/layout.test.tsx | Revised test asserts ClerkProvider wraps children and dynamic prop is unset, guarding against accidental opt-in to request-scoped rendering. |

<sub>Reviews (3): Last reviewed commit: ["docs(admin): cite the verified Clerk ver..."](https://github.com/calicastle/cali.so/commit/fee2a4a4554a39175ba74c663c8ae6899f90a8b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45642682)</sub>

<!-- /greptile_comment -->