### PR TITLE
Consolidate unit-test infrastructure (#176)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Test unit and integration suites
         run: pnpm test:unit
 
-      - name: Test AMA and migrations
-        run: pnpm test:ama
+      - name: Validate database migrations
+        run: pnpm db:validate
 
       - name: Test deployment workflows
         run: pnpm test:deployment
@@ -76,42 +76,6 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node scripts/check-production-migrations.mjs "$BASE_SHA" "$HEAD_SHA"
-
-      - name: Test security controls
-        run: pnpm test:security
-
-      - name: Test media storage contract
-        run: pnpm test:media:storage
-
-      - name: Test media catalog constraints
-        run: pnpm test:media:catalog
-
-      - name: Test media image processing
-        run: pnpm test:media:processing
-
-      - name: Test media ingestion workflow
-        run: pnpm test:media:ingestion
-
-      - name: Test media reconciliation
-        run: pnpm test:media:reconciliation
-
-      - name: Test media Location Label suggestions
-        run: pnpm test:media:geocoding
-
-      - name: Test media Alt Text Suggestions
-        run: pnpm test:media:alt-text
-
-      - name: Test Photo Selection publication
-        run: pnpm test:media:photo-selection
-
-      - name: Test Media Asset review
-        run: pnpm test:media:asset-review
-
-      - name: Test Media admin
-        run: pnpm test:media:admin
-
-      - name: Test Media Asset Purge
-        run: pnpm test:media:purge
 
       - name: Test localization
         run: pnpm test:localization

--- a/lib/rate-limit/repository.test.ts
+++ b/lib/rate-limit/repository.test.ts
@@ -1,34 +1,24 @@
-import { readFile } from 'node:fs/promises'
-
-import { PGlite } from '@electric-sql/pglite'
+import type { PGlite } from '@electric-sql/pglite'
 import { drizzle } from 'drizzle-orm/pglite'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('server-only', () => ({}))
+
+import { usePGliteTestClient } from '~/db/testing/pglite'
 
 import {
   createDatabaseRateLimiter,
   type RateLimitDatabase,
 } from './repository'
 
-const migrationUrl = new URL(
-  '../../db/migrations/0010_rate_limit_windows.sql',
-  import.meta.url,
-)
-
 describe('database rate limiter', () => {
+  const getClient = usePGliteTestClient(['0010_rate_limit_windows.sql'])
   let client: PGlite
   let now: Date
 
-  beforeEach(async () => {
-    client = new PGlite()
-    const migration = await readFile(migrationUrl, 'utf8')
-    await client.exec(migration.replaceAll('--> statement-breakpoint', ''))
+  beforeEach(() => {
+    client = getClient()
     now = new Date('2026-07-16T06:00:00.000Z')
-  })
-
-  afterEach(async () => {
-    await client.close()
   })
 
   it('allows only the configured number of concurrent requests', async () => {

--- a/scripts/deployment-workflows.test.mjs
+++ b/scripts/deployment-workflows.test.mjs
@@ -191,6 +191,66 @@ test('release pull requests reject unsafe migrations before merging to main', as
   assertOrdered(job.steps, 'Build', 'Test browser release gate')
 })
 
+test('quality runs the canonical Vitest suite exactly once', async () => {
+  const config = await workflow('security')
+  const job = config.jobs.quality
+
+  const unitSteps = job.steps.filter(
+    (step) => typeof step.run === 'string' && step.run.includes('pnpm test:unit'),
+  )
+  assert.equal(unitSteps.length, 1, 'quality must run pnpm test:unit once')
+
+  const validate = job.steps.find(
+    (step) => step.name === 'Validate database migrations',
+  )
+  assert.equal(validate?.run, 'pnpm db:validate')
+
+  // The focused suites stay as local diagnostic commands; quality must not
+  // rerun what the canonical non-live glob already owns.
+  const rerun = job.steps.filter(
+    (step) =>
+      typeof step.run === 'string' &&
+      /pnpm test:(ama|security|media:)/.test(step.run),
+  )
+  assert.deepEqual(
+    rerun.map((step) => step.name),
+    [],
+    'quality must not rerun suites owned by pnpm test:unit',
+  )
+
+  assertOrdered(job.steps, 'Typecheck', 'Test unit and integration suites')
+  assertOrdered(
+    job.steps,
+    'Test unit and integration suites',
+    'Validate database migrations',
+  )
+  assertOrdered(job.steps, 'Validate database migrations', 'Test deployment workflows')
+  assertOrdered(job.steps, 'Test deployment workflows', 'Test localization')
+  assertOrdered(job.steps, 'Test localization', 'Audit production dependencies')
+  assertOrdered(job.steps, 'Audit production dependencies', 'Build')
+  assertOrdered(job.steps, 'Build', 'Install Playwright browsers')
+  assertOrdered(job.steps, 'Install Playwright browsers', 'Test browser release gate')
+  assertOrdered(job.steps, 'Test browser release gate', 'Verify public links')
+  assertOrdered(job.steps, 'Verify public links', 'Verify legacy URL contract')
+  assertOrdered(
+    job.steps,
+    'Verify legacy URL contract',
+    'Verify public discovery and failure handling',
+  )
+  assertOrdered(
+    job.steps,
+    'Verify public discovery and failure handling',
+    'Verify production security boundary',
+  )
+  const install = job.steps.find(
+    (step) => step.name === 'Install Playwright browsers',
+  )
+  assert.equal(
+    install?.run,
+    'pnpm exec playwright install --with-deps chromium webkit',
+  )
+})
+
 test('branch deletion cleans only ephemeral Neon and Vercel Previews', async () => {
   const config = await workflow('cleanup-preview')
   assert.ok(Object.hasOwn(config.on, 'delete'))


### PR DESCRIPTION
Closes #176. Implements the issue exactly as specified, with live assumptions refreshed against current `dev` (`9944604`).

## Changes

**`lib/rate-limit/repository.test.ts`** — replaces the per-test `new PGlite()` + manual migration + `afterEach` close with the shared `usePGliteTestClient(['0010_rate_limit_windows.sql'])` per-file harness. All three test names, clocks, prefixes, inputs, and expectations are unchanged; `db/testing/pglite.ts` is untouched.

**`.github/workflows/security.yml`** — Quality now runs the canonical non-live Vitest glob once:
- `Test AMA and migrations` → `Validate database migrations` running `pnpm db:validate` (the only half of `test:ama` outside the canonical glob)
- removed the separate `pnpm test:security` step and all eleven non-live `pnpm test:media:*` steps
- every non-duplicate gate (deployment tests, production migration compatibility, localization, audit, build, Playwright install, browser gate, links, legacy URLs, discovery, security boundary) remains in its existing order

**`scripts/deployment-workflows.test.mjs`** — new parsed-workflow test (`quality runs the canonical Vitest suite exactly once`) asserting: exactly one `pnpm test:unit` step; `Validate database migrations` runs `pnpm db:validate`; no step re-runs `test:ama`/`test:security`/`test:media:*`; and the surviving non-Vitest Quality commands, including the Playwright browser install, keep their relative order. Follows the existing YAML-parser + `stepIndex`/`assertOrdered` style.

## Verification (issue's own commands)

- Focused DB test: 1 file, 3 tests pass; negative scan for `new PGlite|readFile|migrationUrl|afterEach` is empty
- Step 2 scans: one `test:unit`, one `db:validate`, zero duplicated suites, all retained commands present; focused package scripts asserted intact
- `pnpm test:deployment`: **32 pass** (31 + the new ownership test)
- `pnpm test:unit`: **124 files / 1141 tests**, all pass except `lib/security/typegpu-csp-fallback.test.ts` — since diagnosed as a stale local node_modules (the warn-once pnpm patch was not applied; CI is green). Environment fixed with `pnpm install --frozen-lockfile`; the test itself is hardened against this failure mode in #237. Baseline counts grew from the issue's 119/1109 because the plan was cut at `5158299`.
- `pnpm typecheck` exit 0; `git diff --check` clean; `vitest.config.ts`, `db/testing/pglite.ts`, `package.json`, `pnpm-lock.yaml` untouched; status lists only the three Modify paths

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consolidates the unit-test CI infrastructure by removing 13 redundant workflow steps whose file globs are already fully covered by the canonical `pnpm test:unit` (`vitest run app components db lib`), and migrates the rate-limit repository test from a per-test `new PGlite()` pattern to the shared `usePGliteTestClient` harness.

- **`lib/rate-limit/repository.test.ts`**: Drops the inline `readFile`/migration/`afterEach close` boilerplate and delegates setup and teardown to `usePGliteTestClient(['0010_rate_limit_windows.sql'])`; all three test names, clock values, prefixes, and expectations are unchanged.
- **`.github/workflows/security.yml`**: Replaces `pnpm test:ama` with `pnpm db:validate` (the only part of `test:ama` outside the Vitest glob) and removes the separate `test:security` and eleven `test:media:*` steps, which were all already owned by the `lib` glob in `test:unit`.
- **`scripts/deployment-workflows.test.mjs`**: Adds a new parsed-YAML test that locks in the simplified workflow shape — exactly one `pnpm test:unit` invocation, the `db:validate` step, absence of the removed suites, and correct relative ordering of every surviving Quality step.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three changes are narrowly scoped removals and a test refactor with no behavior changes to production code.

The workflow simplification correctly relies on `test:unit`'s `vitest run app components db lib` glob already owning every file path that the removed steps targeted. The `usePGliteTestClient` migration follows the established pattern exactly, and the hook registration order (harness `beforeAll`/`beforeEach` before the test's own `beforeEach`) is correct. The new deployment-workflow test accurately locks in the simplified shape of the YAML, including step ordering and the absence of the removed commands.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/rate-limit/repository.test.ts | Replaces per-test PGlite instantiation/teardown with the shared `usePGliteTestClient` harness; all test names, assertions, and clock setup are preserved correctly. |
| .github/workflows/security.yml | Removes 13 redundant CI steps (`test:security`, `test:ama`, eleven `test:media:*`) already covered by `test:unit`'s `vitest run app components db lib` glob; replaces `test:ama` with the `db:validate` half that the glob does not own. |
| scripts/deployment-workflows.test.mjs | Adds a structural test that parses the YAML and asserts: exactly one `pnpm test:unit` step, `db:validate` step present and correctly named, no re-run of owned suites, and the correct ordering of all surviving Quality steps. |

<sub>Reviews (1): Last reviewed commit: ["test: consolidate unit-test infrastructu..."](https://github.com/calicastle/cali.so/commit/3d2cca3556250ece1ee3333e40ef5cc96f678fc3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45644808)</sub>

<!-- /greptile_comment -->
