### PR TITLE
Harden the TypeGPU CSP fallback test against stale installs

### DIFF
--- a/lib/security/typegpu-csp-fallback.test.ts
+++ b/lib/security/typegpu-csp-fallback.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process'
-import { readFileSync, realpathSync } from 'node:fs'
+import { existsSync, readFileSync, realpathSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
@@ -19,6 +19,10 @@ it('warns only once when TypeGPU falls back under a strict CSP', () => {
     resolve(process.cwd(), 'node_modules/shaders'),
   )
   const compiledIoPath = resolve(shadersDir, '../typegpu/data/compiledIO.js')
+  expect(
+    existsSync(compiledIoPath),
+    `typegpu is no longer linked beside shaders (${compiledIoPath}) — update this test's resolution path`,
+  ).toBe(true)
   expect(
     readFileSync(compiledIoPath, 'utf8'),
     'patches/typegpu@0.11.9.patch is not applied — run pnpm install',

--- a/lib/security/typegpu-csp-fallback.test.ts
+++ b/lib/security/typegpu-csp-fallback.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process'
-import { globSync } from 'node:fs'
+import { readFileSync, realpathSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
@@ -9,16 +9,23 @@ const CSP_FALLBACK_WARNING =
   'This environment does not allow eval - using default writer as fallback'
 
 it('warns only once when TypeGPU falls back under a strict CSP', () => {
-  const [compiledIoRelativePath] = globSync(
-    'node_modules/.pnpm/typegpu@*/node_modules/typegpu/data/compiledIO.js',
-    { cwd: process.cwd() },
+  // Locate typegpu through its dependent: typegpu is a transitive
+  // dependency of shaders, so the copy pnpm links next to shaders is the
+  // one the app actually loads — with the warn-once patch applied.
+  // Globbing .pnpm directly can surface an orphaned pre-patch copy in
+  // unspecified match order. (compiledIO.js is not an exported subpath,
+  // so it is loaded by file URL instead of a bare specifier.)
+  const shadersDir = realpathSync(
+    resolve(process.cwd(), 'node_modules/shaders'),
   )
-
-  expect(compiledIoRelativePath).toBeDefined()
-  const compiledIoPath = resolve(process.cwd(), compiledIoRelativePath!)
+  const compiledIoPath = resolve(shadersDir, '../typegpu/data/compiledIO.js')
+  expect(
+    readFileSync(compiledIoPath, 'utf8'),
+    'patches/typegpu@0.11.9.patch is not applied — run pnpm install',
+  ).toContain('didWarnAboutEvalFallback')
 
   const script = `
-    const { getCompiledWriter } = await import(${JSON.stringify(pathToFileURL(compiledIoPath!).href)})
+    const { getCompiledWriter } = await import(${JSON.stringify(pathToFileURL(compiledIoPath).href)})
     getCompiledWriter({})
     getCompiledWriter({})
     getCompiledWriter({})


### PR DESCRIPTION
## Root cause — no product bug

`lib/security/typegpu-csp-fallback.test.ts` was failing locally with 3 warnings instead of 1. Investigation showed the warn-once behavior lives in `patches/typegpu@0.11.9.patch` (from `bf9631a`) and **CI on `dev` is green** — the local failure came from a stale `node_modules` where the patch had never been applied (same drift that had `ai` at v6 while the lockfile pins 7.0.31). `pnpm install --frozen-lockfile` fixes the environment.

## Why change the test anyway

After syncing, `.pnpm` contained **both** an orphaned pre-patch `typegpu@0.11.9/` and the patched `typegpu@0.11.9_patch_hash=…/`. The test globbed `node_modules/.pnpm/typegpu@*` and took the first match with unspecified ordering — it only passed by luck, and any machine where the orphan sorts first fails spuriously.

The test now locates `compiledIO.js` through `shaders` (typegpu's dependent, the same edge Node resolution follows), so it always exercises the copy the app actually loads. A precondition assertion makes a missing patch fail with `patches/typegpu@0.11.9.patch is not applied — run pnpm install` instead of a confusing warning count. Deep-file specifiers stay file-URL loaded because typegpu's exports map only exposes directory entries; `shaders` exports no resolvable main or package.json, hence the realpath-sibling approach rather than `createRequire` chaining (both verified).

## Testing

- `vitest run lib/security/`: 3 files, 6 tests pass
- `tsc --noEmit` clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the TypeGPU CSP fallback test by replacing a non-deterministic `globSync` over `.pnpm/typegpu@*` with a stable resolution path: it follows the symlink to `node_modules/shaders` via `realpathSync`, then steps to the sibling `typegpu` that pnpm actually links for the app. Two new precondition assertions provide actionable error messages when the layout changes or the patch isn't applied, rather than raw Node errors or a confusing warning-count failure.

- **Path resolution** changed from a glob that could return an orphaned pre-patch copy in unspecified order to a deterministic `realpathSync` → sibling approach, always hitting the patched copy the app loads.
- **Preconditions** now fail with `typegpu is no longer linked beside shaders — update this test's resolution path` (missing file) or `patches/typegpu@0.11.9.patch is not applied — run pnpm install` (unpatched file), addressing the prior review comment about raw ENOENT errors.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is confined to a single test file and only improves reliability of path resolution.

The new realpathSync + sibling approach is deterministic and correctly mirrors how pnpm lays out packages in the virtual store. Both precondition assertions produce clear, actionable messages for the scenarios they guard. The previous reviewer concern about a raw ENOENT on a missing compiledIoPath has been addressed with the existsSync check; a missing shaders itself still yields a raw error from realpathSync, but that only happens when pnpm hasn't been run at all — a state that would break every test in the repo regardless.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/security/typegpu-csp-fallback.test.ts | Replaces glob-based typegpu discovery with a deterministic realpathSync + sibling resolution through shaders, adds an existsSync precondition with an actionable message, and a readFileSync content check to guard the patch state before exercising the warn-once behavior. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Test starts] --> B["realpathSync(node_modules/shaders)"]
    B -->|symlink resolves| C[".pnpm/shaders@ver/node_modules/shaders"]
    B -->|shaders missing ENOENT| ERR0["Raw Node ENOENT\n(pnpm not run)"]
    C --> D["resolve(shadersDir, '../typegpu/data/compiledIO.js')"]
    D --> E["existsSync(compiledIoPath)"]
    E -->|false| ERR1["typegpu is no longer linked beside shaders\n— update this test's resolution path"]
    E -->|true| F["readFileSync(compiledIoPath, 'utf8')"]
    F -->|does not contain 'didWarnAboutEvalFallback'| ERR2["patches/typegpu@0.11.9.patch is not applied\n— run pnpm install"]
    F -->|patch applied| G["spawnSync node --disallow-code-generation-from-strings"]
    G --> H["getCompiledWriter called 3 times"]
    H --> I["Assert exit code === 0"]
    I --> J["Assert CSP warning appears exactly once"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Test starts] --> B["realpathSync(node_modules/shaders)"]
    B -->|symlink resolves| C[".pnpm/shaders@ver/node_modules/shaders"]
    B -->|shaders missing ENOENT| ERR0["Raw Node ENOENT\n(pnpm not run)"]
    C --> D["resolve(shadersDir, '../typegpu/data/compiledIO.js')"]
    D --> E["existsSync(compiledIoPath)"]
    E -->|false| ERR1["typegpu is no longer linked beside shaders\n— update this test's resolution path"]
    E -->|true| F["readFileSync(compiledIoPath, 'utf8')"]
    F -->|does not contain 'didWarnAboutEvalFallback'| ERR2["patches/typegpu@0.11.9.patch is not applied\n— run pnpm install"]
    F -->|patch applied| G["spawnSync node --disallow-code-generation-from-strings"]
    G --> H["getCompiledWriter called 3 times"]
    H --> I["Assert exit code === 0"]
    I --> J["Assert CSP warning appears exactly once"]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["test(security): give the missing-module ..."](https://github.com/calicastle/cali.so/commit/8d7558104691137b1921ae1380c8ed694a9d870d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45646269)</sub>

<!-- /greptile_comment -->