### PR TITLE
Fix promotion review and CI gates

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -61,6 +61,8 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      # The canonical glob includes app, components, db, and lib, covering
+      # security plus every non-live Media suite without rerunning subsets.
       - name: Test unit and integration suites
         run: pnpm test:unit
 

--- a/docs/v3-cutover-ops-runbook.md
+++ b/docs/v3-cutover-ops-runbook.md
@@ -228,7 +228,7 @@ automatically. The `main`-only `production` environment exposes the migration
 credential to that workflow without an additional deployment review.
 
 The workflow hash-locks the immutable legacy baseline `0000` and reviewed v3
-migrations `0001` through `0012`, rejecting any modification or deletion.
+migrations `0001` through `0015`, rejecting any modification or deletion.
 Migration `0000` stays outside the v3 Drizzle journal and is not rerun. Future
 migrations fail closed unless every SQL
 statement is an explicitly allowed expand operation: create a new table, type,

--- a/lib/ama/availability/service.ts
+++ b/lib/ama/availability/service.ts
@@ -276,6 +276,14 @@ export function createAvailabilityService(dependencies: AvailabilityServiceDepen
         }
       }
 
+      if (calendarResult.status !== 'connected') {
+        return {
+          status: calendarResult.status,
+          diagnosis: 'calendar-unavailable' as const,
+          slots: [],
+        }
+      }
+
       const policyEligible = computeAvailableSlots({
         ...common,
         googleBusy: [],
@@ -286,14 +294,6 @@ export function createAvailabilityService(dependencies: AvailabilityServiceDepen
         return {
           status: calendarResult.status,
           diagnosis: 'no-policy-eligible-hours' as const,
-          slots: [],
-        }
-      }
-
-      if (calendarResult.status !== 'connected') {
-        return {
-          status: calendarResult.status,
-          diagnosis: 'calendar-unavailable' as const,
           slots: [],
         }
       }

--- a/lib/security/headers.test.ts
+++ b/lib/security/headers.test.ts
@@ -36,7 +36,7 @@ describe('site security headers', () => {
   it('allows the Clerk instance origins only on the admin policies', async () => {
     vi.stubEnv(
       'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY',
-      `pk_test_${Buffer.from('example.clerk.accounts.dev$').toString('base64')}`,
+      `pk_test_${Buffer.from('Example.Clerk.Accounts.Dev$').toString('base64')}`,
     )
     const {
       adminSecurityHeader,

--- a/lib/security/headers.ts
+++ b/lib/security/headers.ts
@@ -19,7 +19,7 @@ function optionalClerkSource() {
   const encoded = /^pk_(?:live|test)_([A-Za-z0-9+/=]+)$/.exec(key)?.[1]
   if (!encoded) return ''
   try {
-    const domain = atob(encoded)
+    const domain = atob(encoded).toLowerCase()
     return /^[a-z0-9][a-z0-9.-]*\$$/.test(domain)
       ? ` https://${domain.slice(0, -1)}`
       : ''

--- a/scripts/check-production-migrations.mjs
+++ b/scripts/check-production-migrations.mjs
@@ -60,6 +60,14 @@ const reviewedMigrationDigests = new Map([
     'db/migrations/0013_brief_yellowjacket.sql',
     '4b684dc6d280978e76d23600cc21ed731f87df52bef96bcbfc55bb71c1d200fa',
   ],
+  [
+    'db/migrations/0014_ama_availability_overrides.sql',
+    '01da301a410adc42fa0b98b9da9892c0e9f86fbd7283f19d9419b12edd2ee2bd',
+  ],
+  [
+    'db/migrations/0015_ama_availability_weekdays.sql',
+    '389c391df3654f437b1be2bc5703fa8eb37d39423674c616e45e0a8b67676203',
+  ],
 ])
 
 function dollarDelimiterAt(sql, index) {

--- a/scripts/check-production-migrations.test.mjs
+++ b/scripts/check-production-migrations.test.mjs
@@ -178,6 +178,8 @@ test('admits exact reviewed migration baselines without weakening future checks'
     'db/migrations/0011_ama_booking_system.sql',
     'db/migrations/0012_high_fidelity_photo_renditions.sql',
     'db/migrations/0013_brief_yellowjacket.sql',
+    'db/migrations/0014_ama_availability_overrides.sql',
+    'db/migrations/0015_ama_availability_weekdays.sql',
   ]) {
     const sql = await readFile(path, 'utf8')
     assert.deepEqual(productionMigrationFindings(path, sql), [])

--- a/scripts/deployment-workflows.test.mjs
+++ b/scripts/deployment-workflows.test.mjs
@@ -194,6 +194,13 @@ test('release pull requests reject unsafe migrations before merging to main', as
 test('quality runs the canonical Vitest suite exactly once', async () => {
   const config = await workflow('security')
   const job = config.jobs.quality
+  const packageJson = JSON.parse(await text('package.json'))
+
+  assert.equal(
+    packageJson.scripts['test:unit'],
+    "vitest run app components db lib --exclude='**/*.live.test.ts'",
+    'the canonical suite must include security and every non-live Media test',
+  )
 
   const unitSteps = job.steps.filter(
     (step) => typeof step.run === 'string' && step.run.includes('pnpm test:unit'),


### PR DESCRIPTION
## Summary

- make the consolidated non-live test coverage explicit in Quality CI and its workflow regression test
- normalize Clerk publishable-key hostnames before adding them to the admin CSP
- return early when Calendar is unavailable before computing policy-eligible AMA slots
- hash-lock reviewed AMA migrations `0014` and `0015` so the Production compatibility gate admits the additive release

## Verification

- `pnpm test:unit` (124 files, 1,183 tests)
- `pnpm test:deployment` (32 tests)
- `pnpm exec vitest run lib/security/headers.test.ts lib/ama/availability/service.test.ts` (17 tests)
- `pnpm typecheck`
- `node scripts/check-production-migrations.mjs $(git rev-parse origin/main) $(git rev-parse origin/dev)`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies four targeted fixes: a CSP hostname normalisation bug in the Clerk key decoder, a diagnostic ordering bug in the AMA availability preview, hash-locks for two new reviewed migrations, and a package.json assertion in the CI workflow test to keep the canonical Vitest glob explicit.

- **`lib/security/headers.ts`**: `atob(encoded)` can return a mixed-case hostname (e.g. `Example.Clerk.Accounts.Dev$`); without `.toLowerCase()` the lowercase-only regex guard silently discarded the origin and the CSP omitted the Clerk script/connect sources on admin pages. The fix normalises before the regex test.
- **`lib/ama/availability/service.ts`**: The `calendarResult.status !== 'connected'` guard was placed after the `policyEligible` computation, so a disconnected calendar could be reported as `no-policy-eligible-hours` instead of `calendar-unavailable`; moving the guard earlier ensures the more-actionable diagnosis is returned first.
- **`scripts/check-production-migrations.mjs` + test**: SHA-256 hash entries are added for `0014_ama_availability_overrides.sql` and `0015_ama_availability_weekdays.sql`; both files contain only expand-only DDL, and the test reads the actual files to confirm the hashes match.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all four changes are narrow, well-targeted fixes each accompanied by a test that directly exercises the corrected behaviour.

The Clerk hostname normalisation and AMA diagnostic ordering fixes are both straightforward and backed by updated or new tests. The migration hash-locks are verified by the existing test suite reading the actual files on disk, so a mismatched hash would fail CI. The deployment workflow assertion in deployment-workflows.test.mjs is an additive guard with no risk of false positives. No regressions or logical gaps were found across the changed paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/security/headers.ts | Adds `.toLowerCase()` to the Clerk-key-decoded domain so mixed-case hostnames are normalised before the regex guard and before insertion into the CSP `script-src`/`connect-src` directives. |
| lib/security/headers.test.ts | Test input updated to use a mixed-case Clerk domain (`Example.Clerk.Accounts.Dev$`) to exercise the new `.toLowerCase()` normalisation path; assertions remain unchanged and expect the lowercased URL. |
| lib/ama/availability/service.ts | Moves the `calendarResult.status !== 'connected'` early-return guard before the `computeAvailableSlots` policy-eligible call, so a disconnected calendar always surfaces `calendar-unavailable` rather than being masked by `no-policy-eligible-hours`. |
| scripts/check-production-migrations.mjs | Appends SHA-256 hash-lock entries for migrations 0014 and 0015; both files exist and contain only expand-only DDL (CREATE TABLE, ADD CONSTRAINT, CREATE INDEX), which the test suite directly verifies against the actual files. |
| scripts/check-production-migrations.test.mjs | Extends the "admits exact reviewed migration baselines" test to include 0014 and 0015, which implicitly validates the hardcoded hashes against the real migration files on disk. |
| scripts/deployment-workflows.test.mjs | New assertion reads `package.json` at test-time and asserts the exact `test:unit` script string, ensuring the CI workflow and the canonical Vitest glob stay in sync. |
| .github/workflows/security.yml | Adds an explanatory comment above the `pnpm test:unit` step; no functional change to the workflow. |
| docs/v3-cutover-ops-runbook.md | Updates the hash-lock range in the runbook from `0001–0012` to `0001–0015` to reflect the two new reviewed migrations. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[preview called] --> B{hasConfiguredHours?}
    B -- No --> C[return 'no-configured-hours']
    B -- Yes --> D{calendarResult.status\n=== 'connected'?}
    D -- No --> E[return 'calendar-unavailable']
    D -- Yes --> F[computeAvailableSlots\ngoogleBusy: empty]
    F --> G{policyEligible\nlength === 0?}
    G -- Yes --> H[return 'no-policy-eligible-hours']
    G -- No --> I[computeAvailableSlots\ngoogleBusy: real]
    I --> J{afterCalendar\nlength === 0?}
    J -- Yes --> K[return 'calendar-conflicts']
    J -- No --> L[computeAvailableSlots\nwith holds + bookings]
    L --> M{slots.length > 0?}
    M -- Yes --> N[return 'open']
    M -- No --> O[return 'holds-or-bookings']
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[preview called] --> B{hasConfiguredHours?}
    B -- No --> C[return 'no-configured-hours']
    B -- Yes --> D{calendarResult.status\n=== 'connected'?}
    D -- No --> E[return 'calendar-unavailable']
    D -- Yes --> F[computeAvailableSlots\ngoogleBusy: empty]
    F --> G{policyEligible\nlength === 0?}
    G -- Yes --> H[return 'no-policy-eligible-hours']
    G -- No --> I[computeAvailableSlots\ngoogleBusy: real]
    I --> J{afterCalendar\nlength === 0?}
    J -- Yes --> K[return 'calendar-conflicts']
    J -- No --> L[computeAvailableSlots\nwith holds + bookings]
    L --> M{slots.length > 0?}
    M -- Yes --> N[return 'open']
    M -- No --> O[return 'holds-or-bookings']
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(release): clear promotion gates"](https://github.com/calicastle/cali.so/commit/424f5874b64c60eb80dba8851143718c4c21cb8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45666576)</sub>

<!-- /greptile_comment -->