### PR TITLE
fix(links): harden preview media failures

### DIFF
--- a/app/link-media/[kind]/route.test.ts
+++ b/app/link-media/[kind]/route.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('next/cache', () => ({
+  cacheLife: () => undefined,
+}))
+
+import { GET } from './route'
+
+const request = () =>
+  new Request(
+    'https://cali.so/link-media/favicon?url=https%3A%2F%2Fastro.build',
+  )
+
+const context = () => ({
+  params: Promise.resolve({ kind: 'favicon' }),
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('link media proxy', () => {
+  it('serves valid upstream images with the long-lived media cache contract', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(new Uint8Array([137, 80, 78, 71]), {
+          headers: {
+            'content-type': 'image/png',
+            'content-length': '4',
+          },
+        }),
+      ),
+    )
+
+    const response = await GET(request(), context())
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('image/png')
+    expect(response.headers.get('cache-control')).toBe(
+      'public, max-age=86400, s-maxage=604800, stale-while-revalidate=604800',
+    )
+    await expect(response.arrayBuffer()).resolves.toEqual(
+      new Uint8Array([137, 80, 78, 71]).buffer,
+    )
+  })
+
+  it.each([404, 500])(
+    'degrades an upstream %s to a short-lived missing asset',
+    async (status) => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => new Response('upstream failure', { status })),
+      )
+
+      const response = await GET(request(), context())
+
+      expect(response.status).toBe(404)
+      expect(response.headers.get('cache-control')).toBe(
+        'public, max-age=60',
+      )
+    },
+  )
+
+  it('degrades an upstream timeout to a short-lived missing asset', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new DOMException('The operation timed out', 'TimeoutError')
+      }),
+    )
+
+    const response = await GET(request(), context())
+
+    expect(response.status).toBe(404)
+    expect(response.headers.get('cache-control')).toBe('public, max-age=60')
+  })
+
+  it('degrades an unexpected upstream content type to a short-lived missing asset', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response('<html>not an image</html>', {
+          headers: { 'content-type': 'text/html' },
+        }),
+      ),
+    )
+
+    const response = await GET(request(), context())
+
+    expect(response.status).toBe(404)
+    expect(response.headers.get('cache-control')).toBe('public, max-age=60')
+  })
+})

--- a/app/link-media/[kind]/route.ts
+++ b/app/link-media/[kind]/route.ts
@@ -9,31 +9,47 @@ const MAX_MEDIA_BYTES = 4 * 1024 * 1024
 // Server-side cache for proxied link favicons and Open Graph images:
 // entries live in the data cache and refresh in the background, so the
 // browser talks only to this origin and repeat views never re-fetch
-// upstream. Failures throw and are never cached.
+// upstream. Expected upstream failures are values, not exceptions, and
+// are cached only briefly so they neither flood production errors nor
+// pin a missing asset after the service recovers.
 async function fetchLinkMedia(upstream: string) {
   'use cache'
+  let media: { body: Uint8Array<ArrayBuffer>; contentType: string } | null = null
+
+  try {
+    const res = await fetch(upstream, { signal: AbortSignal.timeout(10_000) })
+    const contentType = res.headers.get('content-type')?.trim() ?? ''
+
+    // Reject an oversized *declared* length before buffering the body at
+    // all; an absent or non-numeric header falls through to the
+    // post-buffer check below.
+    const declaredLength = Number(res.headers.get('content-length'))
+    const declaredLengthIsSafe =
+      !Number.isFinite(declaredLength) || declaredLength <= MAX_MEDIA_BYTES
+
+    if (
+      res.ok &&
+      contentType.toLowerCase().startsWith('image/') &&
+      declaredLengthIsSafe
+    ) {
+      const body = new Uint8Array(await res.arrayBuffer())
+      if (body.byteLength && body.byteLength <= MAX_MEDIA_BYTES) {
+        media = { body, contentType }
+      }
+    }
+  } catch {
+    // Network failures, timeouts, and interrupted bodies are expected for
+    // optional third-party media. The missing-media response below is the
+    // observable contract.
+  }
+
+  if (!media) {
+    cacheLife({ stale: 30, revalidate: 1, expire: 60 })
+    return null
+  }
+
   cacheLife({ stale: 86_400, revalidate: 604_800, expire: 2_592_000 })
-
-  const res = await fetch(upstream, { signal: AbortSignal.timeout(10_000) })
-  if (!res.ok) throw new Error(`upstream ${res.status}`)
-
-  const contentType = res.headers.get('content-type') ?? ''
-  if (!contentType.startsWith('image/')) throw new Error('unexpected content type')
-
-  // reject an oversized *declared* length before buffering the body at
-  // all; an absent or non-numeric header falls through to the
-  // post-buffer check below
-  const declaredLength = Number(res.headers.get('content-length'))
-  if (Number.isFinite(declaredLength) && declaredLength > MAX_MEDIA_BYTES) {
-    throw new Error('unexpected content length')
-  }
-
-  const body = new Uint8Array(await res.arrayBuffer())
-  if (!body.byteLength || body.byteLength > MAX_MEDIA_BYTES) {
-    throw new Error('unexpected content length')
-  }
-
-  return { body, contentType }
+  return media
 }
 
 export async function GET(
@@ -51,24 +67,25 @@ export async function GET(
     })
   }
 
-  try {
-    const { body, contentType } = await fetchLinkMedia(upstream)
-    return new Response(body, {
-      headers: {
-        'Content-Type': contentType,
-        // browsers keep a copy for a day, the CDN for a week (serving
-        // stale while it refreshes against the data cache). The strict
-        // media CSP (sandbox) comes from next.config.ts, which already
-        // sends the global security headers — setting it here as well
-        // would emit a duplicate Content-Security-Policy header.
-        'Cache-Control': 'public, max-age=86400, s-maxage=604800, stale-while-revalidate=604800',
-      },
-    })
-  } catch {
-    // short-lived so a transient upstream failure never pins a missing icon
-    return new Response('Bad gateway', {
-      status: 502,
+  const media = await fetchLinkMedia(upstream)
+  if (!media) {
+    // A missing asset keeps the existing non-blocking <img> error path
+    // without turning an optional upstream failure into a production 5xx.
+    return new Response('Not found', {
+      status: 404,
       headers: { 'Cache-Control': 'public, max-age=60' },
     })
   }
+
+  return new Response(media.body, {
+    headers: {
+      'Content-Type': media.contentType,
+      // browsers keep a copy for a day, the CDN for a week (serving
+      // stale while it refreshes against the data cache). The strict
+      // media CSP (sandbox) comes from next.config.ts, which already
+      // sends the global security headers — setting it here as well
+      // would emit a duplicate Content-Security-Policy header.
+      'Cache-Control': 'public, max-age=86400, s-maxage=604800, stale-while-revalidate=604800',
+    },
+  })
 }


### PR DESCRIPTION
## Summary

- Treat upstream 404s, 500s, timeouts, interrupted bodies, and non-image responses as short-lived missing assets instead of 5xx responses.
- Preserve the successful media cache contract and the existing non-blocking image fallback behavior.
- Add focused route coverage for successful media and each expected upstream failure mode.

## Root cause

Expected upstream failures were thrown inside the cached media fetch and returned as 502 responses. Optional external preview media could therefore appear as production errors even though the page already degrades safely when an image is missing.

## Verification

- `pnpm typecheck`
- `pnpm test:unit` (126 files, 1,197 tests)
- `pnpm build` compiled and typechecked successfully, then stopped during prerender because the local environment does not provide `DATABASE_URL`, `ADMIN_EMAIL`, `AMA_ENCRYPTION_KEY`, or `RATE_LIMIT_HASH_KEY`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes optional link-preview media failures return short-lived missing-asset responses. The main changes are:

- Cache failed upstream media fetches briefly as missing assets.
- Preserve long-lived caching for successful images.
- Cover HTTP errors, timeouts, invalid content types, and successful media in route tests.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- Conditional cache lifetimes match the supported cache API pattern.
- Failed entries remain isolated by upstream URL and expire quickly.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/link-media/[kind]/route.ts | Maps expected upstream media failures to briefly cached 404 responses while preserving validation, size limits, and successful-media caching. |
| app/link-media/[kind]/route.test.ts | Adds route coverage for successful images and the expected upstream failure modes. |

<sub>Reviews (1): Last reviewed commit: ["fix(links): harden preview media failure..."](https://github.com/calicastle/cali.so/commit/fd44cda543e20800dfb7a6810183d14a9c8d6c13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45877164)</sub>

<!-- /greptile_comment -->