### PR TITLE
fix(nav): anchor dock transitions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2449,6 +2449,19 @@ html[data-visited] .enter-polaroid .polaroid {
   animation: none;
 }
 
+::view-transition-group(site-dock) {
+  z-index: var(--z-nav);
+  animation: none;
+}
+
+::view-transition-old(site-dock) {
+  display: none;
+}
+
+::view-transition-new(site-dock) {
+  animation: none;
+}
+
 ::view-transition-old(.route-content) {
   animation: vt-defocus 250ms var(--ease-swift) both;
 }

--- a/components/dock.test.tsx
+++ b/components/dock.test.tsx
@@ -38,6 +38,7 @@ describe('DockFallback', () => {
 
     const navigation = screen.getByRole('navigation', { name: entry.label })
     expect(navigation.getAttribute('aria-busy')).toBe('true')
+    expect(navigation.style.viewTransitionName).toBe('site-dock')
     expect(screen.getByRole('link', { name: /首页|Home/ }).getAttribute('href')).toBe(
       entry.home,
     )

--- a/components/dock.tsx
+++ b/components/dock.tsx
@@ -32,6 +32,10 @@ const ITEMS = [
   { href: '/ama', zh: '咨询', en: 'AMA', icon: AmaIcon },
 ] as const
 
+const DOCK_VIEW_TRANSITION_STYLE = {
+  viewTransitionName: 'site-dock',
+} as React.CSSProperties
+
 export function DockTip({
   zh,
   en,
@@ -111,6 +115,7 @@ export function DockFallback({ locale }: { locale: Locale }) {
   return (
     <nav
       className="dock"
+      style={DOCK_VIEW_TRANSITION_STYLE}
       aria-label={localize(locale, '主导航', 'Main navigation')}
       aria-busy="true"
     >
@@ -184,7 +189,12 @@ export function Dock() {
   }, [])
 
   return (
-    <nav ref={dockRef} className="dock" aria-label={localize(locale, '主导航', 'Main navigation')}>
+    <nav
+      ref={dockRef}
+      className="dock"
+      style={DOCK_VIEW_TRANSITION_STYLE}
+      aria-label={localize(locale, '主导航', 'Main navigation')}
+    >
       <LiquidGlass />
       <span ref={indicatorRef} className="dock-active-indicator" aria-hidden />
       <DockItem


### PR DESCRIPTION
## Summary

- assign the public dock a stable view-transition name in both its live and fallback shells
- keep the dock fixed above route snapshots and suppress the duplicate old snapshot
- cover the fallback contract with a focused assertion

## Verification

- `pnpm exec vitest run components/dock.test.tsx components/route-motion-controller.test.tsx`
- `pnpm typecheck`
- Next.js MCP compilation and runtime error checks
- live browser navigation from home to writing and into an article, with one stationary named dock throughout the transition

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps the public dock stationary during route view transitions. The main changes are:

- Assigns the `site-dock` transition name to live and fallback dock shells.
- Keeps the dock snapshot above transitioning route content.
- Hides the duplicate old dock snapshot.
- Tests the fallback shell's transition name.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/globals.css | Adds scoped stacking and animation rules for the named dock transition snapshot. |
| components/dock.tsx | Applies the same stable transition name to the mutually exclusive live and fallback dock shells. |
| components/dock.test.tsx | Checks that the fallback navigation exposes the expected transition name. |

<sub>Reviews (1): Last reviewed commit: ["fix(nav): anchor dock transitions"](https://github.com/calicastle/cali.so/commit/f5a1c2f218b426a5969bbf6cbc55c8e80f70f86c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46029296)</sub>

<!-- /greptile_comment -->