### PR TITLE
fix(dock): frost the backdrop before the liquid glass lens

### DIFF
--- a/components/liquid-glass.tsx
+++ b/components/liquid-glass.tsx
@@ -15,7 +15,7 @@ import { useEffect, useRef, useState } from 'react'
 // the refraction; Safari/Firefox can't do SVG filters in backdrop-filter
 // and quietly ignore the layer, leaving the host's own translucency.
 
-const TAU = { depth: 16, curve: 1.6, scale: 44, chroma: 0.1 }
+const TAU = { depth: 16, curve: 1.6, scale: 32, chroma: 0.05, frost: 7 }
 
 function makeDisplacementMap(w: number, h: number, radius: number): string {
   const canvas = document.createElement('canvas')
@@ -150,10 +150,14 @@ export function LiquidGlass({ blur = 4, saturate = 1.25 }: { blur?: number; satu
               preserveAspectRatio="none"
               result="map"
             />
+            {/* frost before the lens: the displacement bends diffused
+                light, not raw glyphs — refracting sharp text smears it
+                into legible-but-warped ghosts that read as grime */}
+            <feGaussianBlur in="SourceGraphic" stdDeviation={TAU.frost} result="frost" />
             {/* chromatic fringe: each channel refracts at a slightly
                 different strength, recombined additively */}
             <feDisplacementMap
-              in="SourceGraphic"
+              in="frost"
               in2="map"
               scale={TAU.scale * (1 - TAU.chroma)}
               xChannelSelector="R"
@@ -162,7 +166,7 @@ export function LiquidGlass({ blur = 4, saturate = 1.25 }: { blur?: number; satu
             />
             <feColorMatrix in="dr" type="matrix" values={channel(0)} result="r" />
             <feDisplacementMap
-              in="SourceGraphic"
+              in="frost"
               in2="map"
               scale={TAU.scale}
               xChannelSelector="R"
@@ -171,7 +175,7 @@ export function LiquidGlass({ blur = 4, saturate = 1.25 }: { blur?: number; satu
             />
             <feColorMatrix in="dg" type="matrix" values={channel(1)} result="g" />
             <feDisplacementMap
-              in="SourceGraphic"
+              in="frost"
               in2="map"
               scale={TAU.scale * (1 + TAU.chroma)}
               xChannelSelector="R"

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -965,7 +965,10 @@ SDF, four-fold symmetric — one quadrant computed, mirrored into four; R/G
 channels encode the x/y bend, ramping outward through a 16px edge band,
 curve 1.6) drives an SVG `feDisplacementMap` applied as an inline-style
 `backdrop-filter: url(#…) blur(4px) saturate(1.25)` over a 68% paper
-background. Three displacement passes at staggered scales (44 ±10%) split
+background. The backdrop is frosted first (7px Gaussian inside the filter)
+so the lens bends diffused light — refracting raw glyphs smears them into
+legible-but-warped ghosts that read as grime. Three displacement passes at
+staggered scales (32 ±5%) split
 the RGB channels for a faint chromatic fringe along the rim, recombined
 with screen blends; an inset top highlight (white 0.2 over, 0.06 under) plays the
 specular. The map and


### PR DESCRIPTION
## What changed

The liquid glass dock's refraction filter displaced the **sharp** backdrop directly — the only blur (4px) came *after* the lens. Over body text, legible glyphs got warped into doubled, smeared ghosts through the pill's edge band, and the ±10% chromatic fringe painted rainbow edges on top of them. The glass read as dirty and messy (both the site dock and the admin dock share `LiquidGlass`).

Fix: diffuse first, then bend.

- Added a 7px `feGaussianBlur` inside the SVG filter so all three displacement passes refract **frost** instead of raw text — the clean lens-over-frost look.
- Calmed the displacement scale 44 → 32 and the chromatic fringe ±10% → ±5%, so the rim reads as a subtle glass bend rather than noise.
- Updated the liquid-glass paragraph in `docs/design-language.md` to match.

The Safari/Firefox fallback (plain frosted pane, no SVG filter) is untouched.

## Why

Reported against the dev deployment: the glass pill over article text had a "very dirty and messy look in the background." Production/main predates the liquid glass feature, which is why it doesn't show there.

## Verification

Verified in the dev preview with a post row passing directly under the pill: the backdrop is now a soft milky frost with a gentle bend at the rim — no ghost glyphs, no color fringing — in both light and dark schemes, with no console errors. `dock.test.tsx` mocks `LiquidGlass`, so no test changes needed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the "dirty and messy" appearance of the liquid glass dock pill over article text by inserting a 7px `feGaussianBlur` inside the SVG filter *before* the three chromatic displacement passes, so the lens bends frosted backdrop pixels rather than sharp glyphs. Displacement scale is calmed from 44 → 32 and the chromatic fringe from ±10% → ±5%, and the design-language docs are updated to match.

- `components/liquid-glass.tsx`: adds `feGaussianBlur in="SourceGraphic" stdDeviation=7 result="frost"` between the `feImage` (displacement map) and the three `feDisplacementMap` primitives, then switches all three `in` attributes from `SourceGraphic` to `frost`; also lowers `TAU.scale` and `TAU.chroma`.
- `docs/design-language.md`: prose updated to describe the frost-before-lens pipeline and the revised parameter values (32 ±5%).

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a visual tuning change with no data flow, API surface, or state management impact.

The SVG filter primitive ordering and named-result references are valid: feGaussianBlur correctly takes SourceGraphic (the captured backdrop), produces frost, and all three feDisplacementMap passes then consume frost instead of the raw backdrop. The downstream feColorMatrix / feBlend chain is untouched. The outer backdrop-filter continues to apply a post-pass blur and saturation. Safari/Firefox fallback is unaffected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| components/liquid-glass.tsx | Adds a 7px feGaussianBlur before the three feDisplacementMap passes so refraction bends frosted light instead of raw glyphs; also reduces scale 44→32 and chroma 0.1→0.05. SVG filter primitive ordering and named-result references are all correct. |
| docs/design-language.md | Documentation updated to accurately reflect the new frost-before-lens pipeline, revised scale (32 ±5%), and the rationale for pre-blurring. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    BG["Backdrop capture\n(SourceGraphic)"]
    MAP["feImage → map\n(displacement canvas data URL)"]
    FROST["feGaussianBlur stdDeviation=7 → frost\n NEW: blur first, then displace"]
    DR["feDisplacementMap in=frost, scale=30.4 → dr\n(R channel, chroma low)"]
    DG["feDisplacementMap in=frost, scale=32 → dg\n(G channel, neutral)"]
    DB["feDisplacementMap in=frost, scale=33.6 → db\n(B channel, chroma high)"]
    R["feColorMatrix → r\n(red only)"]
    G["feColorMatrix → g\n(green only)"]
    B["feColorMatrix → b\n(blue only)"]
    RG["feBlend screen → rg"]
    OUT["feBlend screen → output"]
    POST["blur(4px) saturate(1.25)\n(outer backdrop-filter chain)"]

    BG --> FROST
    MAP --> DR
    MAP --> DG
    MAP --> DB
    FROST --> DR
    FROST --> DG
    FROST --> DB
    DR --> R
    DG --> G
    DB --> B
    R --> RG
    G --> RG
    RG --> OUT
    B --> OUT
    OUT --> POST
```

<sub>Reviews (1): Last reviewed commit: ["fix(dock): frost the backdrop before the..."](https://github.com/calicastle/cali.so/commit/f5f796261fc4657cdf94a4c731b665d95808c393) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46919025)</sub>

<!-- /greptile_comment -->