### PR TITLE
fix(blog): stop cover veils printing solid ink on mobile

### DIFF
--- a/components/dither-veil.test.tsx
+++ b/components/dither-veil.test.tsx
@@ -44,6 +44,66 @@ afterEach(() => {
   vi.unstubAllGlobals()
 })
 
+function stubLoadedImage() {
+  const originals = {
+    complete: Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, 'complete'),
+    naturalWidth: Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, 'naturalWidth'),
+    decode: Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, 'decode'),
+  }
+  Object.defineProperty(HTMLImageElement.prototype, 'complete', {
+    configurable: true,
+    get: () => true,
+  })
+  Object.defineProperty(HTMLImageElement.prototype, 'naturalWidth', {
+    configurable: true,
+    get: () => 1,
+  })
+  Object.defineProperty(HTMLImageElement.prototype, 'decode', {
+    configurable: true,
+    value: () => Promise.resolve(),
+  })
+  return () => {
+    for (const [key, desc] of Object.entries(originals)) {
+      if (desc) Object.defineProperty(HTMLImageElement.prototype, key, desc)
+      else delete (HTMLImageElement.prototype as unknown as Record<string, unknown>)[key]
+    }
+  }
+}
+
+function mockVeilContext(alpha: number) {
+  const fillRect = vi.fn()
+  const ctx = {
+    setTransform: vi.fn(),
+    clearRect: vi.fn(),
+    drawImage: vi.fn(),
+    fillRect,
+    fillText: vi.fn(),
+    fillStyle: '',
+    font: '',
+    textBaseline: 'top',
+    getImageData: (_x: number, _y: number, w: number, h: number) => {
+      const data = new Uint8ClampedArray(w * h * 4)
+      for (let i = 3; i < data.length; i += 4) data[i] = alpha
+      return { data }
+    },
+  }
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+    ctx as unknown as CanvasRenderingContext2D,
+  )
+  vi.spyOn(HTMLCanvasElement.prototype, 'getBoundingClientRect').mockReturnValue({
+    width: 64,
+    height: 44,
+    top: 0,
+    left: 0,
+    right: 64,
+    bottom: 44,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  } as DOMRect)
+  return fillRect
+}
+
 describe('DitheredImage', () => {
   it('samples the rendered optimized image without creating another request', () => {
     const imageConstructor = vi.fn()
@@ -60,5 +120,36 @@ describe('DitheredImage', () => {
 
     expect(container.querySelectorAll('img')).toHaveLength(1)
     expect(imageConstructor).not.toHaveBeenCalled()
+  })
+
+  // iOS Safari can report the image loaded before its pixels decode —
+  // sampling then reads fully transparent, which used to dither every
+  // cell to solid ink (the "black grid" mobile bug)
+  it('does not print ink when the image samples blank', async () => {
+    const restoreImage = stubLoadedImage()
+    const fillRect = mockVeilContext(0)
+    try {
+      render(<DitheredImage src="/cover.png" alt="" width={64} height={44} />)
+      await vi.waitFor(() => {
+        expect(HTMLCanvasElement.prototype.getContext).toHaveBeenCalled()
+      })
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(fillRect).not.toHaveBeenCalled()
+    } finally {
+      restoreImage()
+    }
+  })
+
+  it('prints the dither once the image has decodable pixels', async () => {
+    const restoreImage = stubLoadedImage()
+    const fillRect = mockVeilContext(255)
+    try {
+      render(<DitheredImage src="/cover.png" alt="" width={64} height={44} />)
+      await vi.waitFor(() => {
+        expect(fillRect).toHaveBeenCalled()
+      })
+    } finally {
+      restoreImage()
+    }
   })
 })

--- a/components/dither-veil.tsx
+++ b/components/dither-veil.tsx
@@ -119,6 +119,18 @@ function DitherVeil({
       if (!octx) return null
       octx.drawImage(img, 0, 0, cols, rows)
       const data = octx.getImageData(0, 0, cols, rows).data
+      // iOS Safari can report the image loaded before its pixels are
+      // decodable (or after evicting them under memory pressure) — the
+      // draw then lands fully transparent, which would dither to solid
+      // ink. Report failure so the caller retries instead of printing it.
+      let sampled = false
+      for (let i = 3; i < data.length; i += 4) {
+        if (data[i] > 0) {
+          sampled = true
+          break
+        }
+      }
+      if (!sampled) return null
       const lums = new Float32Array(cols * rows)
       for (let i = 0; i < lums.length; i++) {
         const j = i * 4
@@ -139,11 +151,11 @@ function DitherVeil({
       ctx.clearRect(0, 0, rect.width, rect.height)
     }
 
-    function drawDitherFull(rect: DOMRect) {
+    function drawDitherFull(rect: DOMRect): boolean {
       const cols = Math.max(1, Math.round(rect.width / PIXEL))
       const rows = Math.max(1, Math.round(rect.height / PIXEL))
       const sample = levels(cols, rows)
-      if (!sample) return
+      if (!sample) return false
       const cw = rect.width / cols
       const ch = rect.height / rows
       ctx.fillStyle = PAPER
@@ -155,6 +167,7 @@ function DitherVeil({
           if (1 - lum > BAYER[r % 4][c % 4]) ctx.fillRect(c * cw, r * ch, cw, ch)
         }
       }
+      return true
     }
 
     // — collage glitch machinery —
@@ -356,18 +369,20 @@ function DitherVeil({
       if (!stepTimer) tick()
     }
 
-    function render() {
+    function render(): boolean {
       const rect = canvas.getBoundingClientRect()
-      if (rect.width < 4) return
+      if (rect.width < 4) return true
       if (mode === 'dither') {
         sizeCanvas(rect)
-        drawDitherFull(rect)
-        return
+        // a failed sample leaves the canvas clear — the plain photo is
+        // the graceful fallback while the retries chase the decode
+        return drawDitherFull(rect)
       }
       // collage glitch: prepare grids, play the entry rhythm once
       const first = !prepared
       sizeCanvas(rect)
       prepare(rect)
+      if (!prepared) return false
       if (first) play()
       // resize: the canvas was cleared, so snap to wherever the walker
       // was headed
@@ -377,13 +392,35 @@ function DitherVeil({
       } else {
         level = 0
       }
+      return true
     }
 
-    if (img.complete && img.naturalWidth > 0) render()
-    else img.addEventListener('load', render, { once: true })
+    let cancelled = false
+    let retries = 0
+
+    function attemptRender() {
+      if (cancelled) return
+      if (!render() && retries < 4) {
+        retries += 1
+        timers.push(setTimeout(attemptRender, 150 * retries))
+      }
+    }
+
+    // load/complete only promise the bytes, not decoded pixels — iOS
+    // Safari samples blank in that gap. Render right away (a blank
+    // sample retries instead of printing), and treat decode() purely as
+    // an extra retry signal: it can stay pending forever in hidden
+    // documents, so it must never gate the print.
+    const startRender = () => {
+      attemptRender()
+      if (typeof img.decode === 'function') img.decode().then(attemptRender, () => {})
+    }
+
+    if (img.complete && img.naturalWidth > 0) startRender()
+    else img.addEventListener('load', startRender, { once: true })
 
     const ro = new ResizeObserver(() => {
-      if (img.complete && img.naturalWidth > 0) render()
+      if (img.complete && img.naturalWidth > 0) attemptRender()
     })
     ro.observe(canvas)
 
@@ -394,7 +431,8 @@ function DitherVeil({
     }
 
     return () => {
-      img.removeEventListener('load', render)
+      cancelled = true
+      img.removeEventListener('load', startRender)
       ro.disconnect()
       if (host) {
         host.removeEventListener('click', onToggle)


### PR DESCRIPTION
## What changed

The blog cover dither veil (`components/dither-veil.tsx`) no longer prints a solid-ink grid when it samples the cover image before its pixels are decodable.

- `levels()` now detects a fully transparent sample (blank `drawImage`) and reports failure instead of dithering it into 100% ink.
- Failed renders retry with backoff (up to 4 attempts), and `img.decode()` resolution triggers an extra retry — it's the strongest "pixels are ready" signal, but it is deliberately **not** a gate: `decode()` can stay pending forever in hidden/backgrounded documents, which would leave covers blank in background tabs.
- If sampling never succeeds, the canvas stays clear and the plain photo shows — a graceful fallback.
- Regression test feeds the veil a blank sample and asserts no ink is printed (fails on the old code with 469 ink `fillRect` calls), plus a test that normal covers still print.

## Why

On mobile, blog list covers sometimes rendered as a dark grid texture instead of the dithered print. The veil samples the `<img>` via `drawImage` + `getImageData`; iOS Safari can fire `load` before pixels are decodable (and evicts decoded data under memory pressure), so the sample occasionally reads fully transparent. Every cell then dithers to luminance 0 → all-ink fill, and the antialiased seams between cells produce the grid look. Because the veil's hover reveal is gated on `(hover: hover)`, touch devices had no way out of the bad print.

## Reviewer notes

- Verified on the dev server: all `/blog` veils paint per-image dither prints (ink coverage varies 21–68% per cover, no degenerate all-ink canvases).
- Unit suite passes; the 9 failures in AMA booking-flow and TypeGPU CSP tests also fail on the clean baseline and are unrelated.
- The collage-mode entry glitch and Bayer-dissolve click toggle are untouched apart from inheriting the same retry path.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the blog cover dither veil so blank image samples do not print as solid ink. The main changes are:

- Fully transparent canvas samples are treated as failed samples.
- Failed dither renders retry with bounded backoff.
- `img.decode()` is used as an extra retry signal without blocking the initial render.
- Tests cover blank-sample fallback and normal dither output.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to the dither veil render path and keeps the canvas clear when sampling fails. Tests cover the reported blank-sample case and the normal dither render path. No functional or security issues were identified in the changed files.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the mobile validation workflow to exercise blog page rendering and cover loading.
- Verified that coverCount equals 10 and that every inspected cover image is complete, visible, and has non-zero natural dimensions.
- Checked canvas properties and near-black coverage, confirming all canvases had allInk: false and near-black coverage of 0 with mixed pixels rather than a solid ink grid.
- Inspected browser console output and confirmed there were no dither veil errors, only expected analytics/CSP noise.
- Compiled artifacts (images, video, logs, and JSON) from the run to support independent verification.

<a href="https://app.greptile.com/trex/runs/15771620/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| components/dither-veil.tsx | Adds transparent-sample detection and bounded retry/decode-triggered rendering so blank canvas samples fall back to the underlying image instead of printing solid ink. |
| components/dither-veil.test.tsx | Adds jsdom canvas/image stubs covering blank transparent samples and normal decodable samples for the dither veil tests. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Img as Cover image element
  participant Veil as DitherVeil effect
  participant Canvas as Veil canvas
  participant Offscreen as Offscreen sample canvas
  participant Decode as img.decode()

  Img->>Veil: complete/load signal
  Veil->>Canvas: size + clear canvas
  Veil->>Offscreen: drawImage(img) and getImageData()
  alt sample has alpha pixels
    Offscreen-->>Veil: luminance levels
    Veil->>Canvas: paint paper and ink dither
  else sample is fully transparent
    Offscreen-->>Veil: failed sample
    Veil->>Canvas: leave canvas clear so photo shows
    Veil->>Veil: retry with bounded backoff
  end
  Veil->>Decode: request extra readiness signal
  Decode-->>Veil: resolve triggers another render attempt
```

<sub>Reviews (1): Last reviewed commit: ["fix(blog): stop cover veils printing sol..."](https://github.com/calicastle/cali.so/commit/fa19188f1ef586021ab1992424653be275185445) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47054015)</sub>

<!-- /greptile_comment -->