### PR TITLE
chore(amp): add Grok 4.5 workspace mode

### DIFF
--- a/.amp/plugins/grok-45-mode.ts
+++ b/.amp/plugins/grok-45-mode.ts
@@ -1,0 +1,52 @@
+// @amp-plugin updated automatically from https://ampcode.com/@amp/plugins/grok-45-mode.ts
+// @amp-agent-mode {"key":"grok45","label":"Grok 4.5"}
+
+import type { PluginAPI } from '@ampcode/plugin'
+
+const GROK_45_PROMPT = 'You are Amp. Help the user complete software engineering tasks.'
+
+const DEEP_TOOL_NAMES = [
+	'apply_patch',
+	'create_file',
+	'edit_file',
+	'find_thread',
+	'finder',
+	'librarian',
+	'oracle',
+	'painter',
+	'Read',
+	'read_mcp_resource',
+	'read_thread',
+	'read_web_page',
+	'shell_command',
+	'shell_command_status',
+	'skill',
+	'Task',
+	'view_media',
+	'web_search',
+	'mcp__*',
+] as const
+
+export default function (amp: PluginAPI) {
+	if (!amp.experimental) {
+		amp.logger.log('Experimental plugin API is not available.')
+		return
+	}
+
+	const agent = amp.experimental.createAgent({
+		name: 'grok-4-5',
+		model: 'xai/grok-4.5',
+		instructions: GROK_45_PROMPT,
+		tools: DEEP_TOOL_NAMES,
+		reasoningEffort: 'high',
+		display: { label: 'Grok 4.5', color: '#10b981' },
+	})
+
+	amp.experimental.registerAgentMode({
+		key: 'grok45',
+		label: 'Grok 4.5',
+		description: 'Grok 4.5 with deep-mode tools and a minimal prompt',
+		color: '#10b981',
+		agent: agent.definition,
+	})
+}


### PR DESCRIPTION
## Summary

- install `@amp/grok-45-mode` as an auto-updating project plugin
- register the `grok45` / **Grok 4.5** custom agent mode for Amp sessions in this repository
- keep the plugin source discoverable from `.amp/plugins` so new repository-backed threads can offer the mode

## Testing

Passed:

- `pnpm typecheck`
- `pnpm test:unit` (1,230 tests)
- `pnpm test:localization` (149 tests)
- `pnpm test:ama` (654 tests plus migration validation)
- `pnpm test:deployment` (32 tests)
- `PUBLIC_SITE_URL=https://cali.so SITE_URL=https://cali.so pnpm build`
- `PUBLIC_SITE_URL=https://cali.so SITE_URL=https://cali.so pnpm test:browser` (25 tests)
- `pnpm test:security`
- all non-live media suites: storage, catalog, processing, ingestion, geocoding, alt text, admin, asset review, photo selection, purge, reconciliation, and transfer
- `pnpm db:validate`
- `pnpm verify:legacy-urls`
- `PUBLIC_SITE_URL=https://cali.so SITE_URL=https://cali.so pnpm verify:links`
- `PUBLIC_SITE_URL=https://cali.so SITE_URL=https://cali.so pnpm verify:public-discovery`
- `pnpm audit:prod` (419 production package versions; no known vulnerabilities)

Known unrelated failure:

- `PUBLIC_SITE_URL=https://cali.so SITE_URL=https://cali.so pnpm verify:security-boundary` reaches the unchanged `/api/admin/media/assets` endpoint, which returns HTTP 500 instead of the expected unauthenticated HTTP 401 in the local orb environment. This branch changes only `.amp/plugins/grok-45-mode.ts` and does not touch application, authentication, or media code.

The first HTTP-gate run inherited the orb's local `.env.local` discovery origin (`http://127.0.0.1:3000`); the production-origin build and affected browser/link/discovery gates were rerun with the explicit production origins shown above and passed.
