### PR TITLE
Harden AMA reschedule completion

### DIFF
--- a/app/admin/(protected)/ama/bookings/[bookingId]/BookingDetail.tsx
+++ b/app/admin/(protected)/ama/bookings/[bookingId]/BookingDetail.tsx
@@ -72,6 +72,8 @@ export type BookingEventViewModel = {
 type SlotViewModel = { startsAt: string; endsAt: string }
 
 const MANAGE_CUTOFF_MS = 24 * 60 * 60 * 1000
+const FINALIZING_REFRESH_MS = 10_000
+const FINALIZING_REFRESH_WINDOW_MS = 5 * 60 * 1000
 
 // Decorative reinforcement of the lifecycle the badge already announces —
 // rendered only for the linear states (diverged states have no honest rung).
@@ -249,6 +251,28 @@ export function BookingDetail({
   const [refundChecked, setRefundChecked] = useState(
     () => Date.parse(booking.startsAt) - Date.now() > MANAGE_CUTOFF_MS,
   )
+
+  useEffect(() => {
+    setStatus(booking.status)
+    setRefundStatus(booking.refundStatus)
+    setStartsAt(booking.startsAt)
+    setEndsAt(booking.endsAt)
+  }, [booking.status, booking.refundStatus, booking.startsAt, booking.endsAt])
+
+  useEffect(() => {
+    if (fixtureMode || status !== 'finalizing' || pending !== null) return
+    const interval = window.setInterval(() => {
+      if (document.visibilityState !== 'hidden') router.refresh()
+    }, FINALIZING_REFRESH_MS)
+    const timeout = window.setTimeout(
+      () => window.clearInterval(interval),
+      FINALIZING_REFRESH_WINDOW_MS,
+    )
+    return () => {
+      window.clearInterval(interval)
+      window.clearTimeout(timeout)
+    }
+  }, [fixtureMode, pending, router, status])
 
   useEffect(() => {
     if (notice) noticeRef.current?.focus()
@@ -452,6 +476,11 @@ export function BookingDetail({
       ? { zh: '中文', en: 'Chinese' }
       : { zh: '英文', en: 'English' }
   const provider = providerLabels[booking.meetingProvider]
+  const hasStoredMeetingArtifacts = Boolean(
+    booking.meetingUrl ||
+      booking.googleCalendarEventId ||
+      booking.tencentMeetingId,
+  )
 
   return (
     <div className="pb-10">
@@ -905,7 +934,26 @@ export function BookingDetail({
         <h2 id="meeting-heading" className="text-sm font-medium">
           <T zh="会议" en="Meeting" />
         </h2>
-        {booking.meetingUrl || booking.googleCalendarEventId || booking.tencentMeetingId ? (
+        {status === 'finalizing' ? (
+          <p
+            className="mt-2 text-sm leading-6 text-muted-foreground"
+            role="status"
+          >
+            {hasStoredMeetingArtifacts ? (
+              <T
+                zh="会议资料正在更新。请勿使用之前的链接；预约确认后，这里会显示新链接。"
+                en="Meeting details are being updated. Do not use a previous link. The new link appears once this Booking is confirmed."
+              />
+            ) : (
+              <T
+                zh="会议资料正在创建。预约确认后，这里会显示会议链接。"
+                en="Meeting details are being created. The meeting link appears once this Booking is confirmed."
+              />
+            )}
+          </p>
+        ) : booking.meetingUrl ||
+          booking.googleCalendarEventId ||
+          booking.tencentMeetingId ? (
           <dl className="spec-nameplate mt-3 mb-6">
             {booking.meetingUrl && (
               <DefinitionRow term={<T zh="会议链接" en="Meeting link" />}>

--- a/components/ama/booking-confirmation.test.tsx
+++ b/components/ama/booking-confirmation.test.tsx
@@ -106,6 +106,29 @@ describe('BookingConfirmation', () => {
     expect(document.querySelector('[data-ama-success-stage]')).not.toBeNull()
   })
 
+  it('hides a stale meeting link while a paid Booking is finalizing', async () => {
+    respondWithHoldStates([
+      jsonResponse(200, {
+        hold: {
+          state: 'paid',
+          bookingStatus: 'finalizing',
+          startsAt: '2026-08-10T12:00:00.000Z',
+          endsAt: '2026-08-10T13:00:00.000Z',
+          meetingProvider: 'tencent-meeting',
+          guestTimeZone: 'Asia/Shanghai',
+          meetingUrl: 'https://meeting.tencent.com/stale-room',
+        },
+      }),
+    ])
+
+    render(<BookingConfirmation />)
+    await flush()
+
+    expect(screen.getByText(/being finalized/)).toBeTruthy()
+    expect(screen.queryByRole('link', { name: /stale-room/ })).toBeNull()
+    expect(screen.queryByText(/stale-room/)).toBeNull()
+  })
+
   it('tells the truth when payment landed but the time was taken', async () => {
     respondWithHoldStates([
       jsonResponse(200, { hold: { state: 'paid', bookingStatus: 'needs_reschedule' } }),

--- a/components/ama/booking-confirmation.tsx
+++ b/components/ama/booking-confirmation.tsx
@@ -100,7 +100,13 @@ function sessionTime(iso: string, timeZone: string, locale: 'zh' | 'en') {
 
 // The booked session as its spec sheet — the nameplate register, printed in
 // the stage's paper ink. Rendered only from server-sent facts.
-function SessionPlate({ session }: { session: PaidSession }) {
+function SessionPlate({
+  session,
+  showMeetingUrl,
+}: {
+  session: PaidSession
+  showMeetingUrl: boolean
+}) {
   const minutes = Math.round(
     (Date.parse(session.endsAt) - Date.parse(session.startsAt)) / 60_000,
   )
@@ -143,7 +149,7 @@ function SessionPlate({ session }: { session: PaidSession }) {
           <T zh={provider.zh} en={provider.en} />
         </dd>
       </div>
-      {session.meetingUrl && (
+      {showMeetingUrl && session.meetingUrl && (
         <div>
           <dt>
             <T zh="会议链接" en="Link" />
@@ -418,7 +424,10 @@ export function BookingConfirmation() {
                 </p>
               </div>
             )}
-            <SessionPlate session={state.session} />
+            <SessionPlate
+              session={state.session}
+              showMeetingUrl={state.bookingStatus === 'confirmed'}
+            />
           </div>
         )}
         {/* Ornamental proof-sheet foot: the barcode derives from the hold id,

--- a/components/ama/manage-booking.test.tsx
+++ b/components/ama/manage-booking.test.tsx
@@ -87,7 +87,12 @@ async function renderManage({
       return (
         reschedule?.() ??
         jsonResponse(200, {
-          booking: booking({ startsAt: SLOTS[0]!.startsAt, endsAt: SLOTS[0]!.endsAt }),
+          booking: booking({
+            status: 'finalizing',
+            startsAt: SLOTS[0]!.startsAt,
+            endsAt: SLOTS[0]!.endsAt,
+            meetingUrl: view.meetingUrl,
+          }),
         })
       )
     }
@@ -150,11 +155,15 @@ describe('ManageBooking', () => {
 
   it('notes a Finalizing Booking instead of pretending it is complete', async () => {
     await renderManage({
-      view: booking({ status: 'finalizing', meetingUrl: null }),
+      view: booking({
+        status: 'finalizing',
+        meetingUrl: 'https://meet.google.com/stale-room',
+      }),
     })
 
     expect(screen.getByText(/meeting details being finalized/)).toBeTruthy()
-    expect(screen.queryByRole('link', { name: /Open meeting link/ })).toBeNull()
+    expect(screen.queryByRole('link', { name: /stale-room/ })).toBeNull()
+    expect(screen.queryByText(/stale-room/)).toBeNull()
   })
 
   it('cancels only after an explicit two-step confirmation', async () => {
@@ -205,6 +214,8 @@ describe('ManageBooking', () => {
     const [, init] = requestsTo(`/api/ama/manage/${TOKEN}/reschedule`)[0]!
     expect(JSON.parse(String(init?.body))).toEqual({ startsAt: SLOTS[0]!.startsAt })
     expect(screen.getByText(/Rescheduled\./)).toBeTruthy()
+    expect(screen.getByText(/meeting details being finalized/)).toBeTruthy()
+    expect(screen.queryByRole('link', { name: /abc-defg-hij/ })).toBeNull()
   })
 
   it('explains the 24 hour rule when the reschedule window has closed', async () => {

--- a/components/ama/manage-booking.tsx
+++ b/components/ama/manage-booking.tsx
@@ -355,10 +355,17 @@ export function ManageBooking({ token }: { token: string }) {
               )}
               {isFinalizing && (
                 <span className="block leading-5 text-muted-foreground">
-                  <T
-                    zh="会议链接正在创建，准备好后会通过邮件送达。"
-                    en="The meeting link is being created and will arrive by email once ready."
-                  />
+                  {booking.meetingUrl ? (
+                    <T
+                      zh="会议资料正在更新。请勿使用之前的链接；新链接准备好后会通过邮件送达。"
+                      en="Meeting details are being updated. Do not use a previous link. The new link will arrive by email once ready."
+                    />
+                  ) : (
+                    <T
+                      zh="会议链接正在创建，准备好后会通过邮件送达。"
+                      en="The meeting link is being created and will arrive by email once ready."
+                    />
+                  )}
                 </span>
               )}
               {booking.refundStatus && booking.refundStatus !== 'none' && (
@@ -379,7 +386,7 @@ export function ManageBooking({ token }: { token: string }) {
             </dd>
           </div>
 
-          {booking.meetingUrl && !isCancelled && (
+          {booking.meetingUrl && !isCancelled && !isFinalizing && (
             <div>
               <dt>
                 <T zh="会议链接" en="Link" />

--- a/lib/ama/admin/booking-detail.test.tsx
+++ b/lib/ama/admin/booking-detail.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const router = vi.hoisted(() => ({
@@ -29,6 +29,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup()
+  vi.useRealTimers()
   fetchMock.mockReset()
   router.refresh.mockReset()
   delete document.documentElement.dataset.locale
@@ -153,6 +154,111 @@ describe('AMA booking detail', () => {
     expect(text).toContain('(America/New_York)')
     // Operations for this Booking render with the shared rows.
     expect(text).toContain('Send reminder')
+  })
+
+  it('hides stale meeting artifacts while finalizing', () => {
+    const { container } = renderDetail(
+      makeBooking({
+        status: 'finalizing',
+        meetingProvider: 'tencent-meeting',
+        meetingUrl: 'https://meeting.tencent.com/stale-room',
+        googleCalendarEventId: 'stale_calendar_event',
+        tencentMeetingId: 'stale_tencent_meeting',
+      }),
+    )
+
+    expect(container.textContent).toContain('Meeting details are being updated.')
+    expect(container.textContent).not.toContain('stale-room')
+    expect(container.textContent).not.toContain('stale_calendar_event')
+    expect(container.textContent).not.toContain('stale_tencent_meeting')
+  })
+
+  it('uses creation-oriented copy for initial finalization', () => {
+    const { container } = renderDetail(
+      makeBooking({
+        status: 'finalizing',
+        meetingUrl: null,
+        googleCalendarEventId: null,
+        tencentMeetingId: null,
+      }),
+    )
+
+    expect(container.textContent).toContain('Meeting details are being created.')
+    expect(container.textContent).not.toContain('Do not use a previous link.')
+  })
+
+  it('refreshes while finalizing and reveals only refreshed meeting artifacts', () => {
+    vi.useFakeTimers()
+    const staleBooking = makeBooking({
+      status: 'finalizing',
+      meetingUrl: 'https://meeting.tencent.com/stale-room',
+      googleCalendarEventId: 'stale_calendar_event',
+      tencentMeetingId: 'stale_tencent_meeting',
+    })
+    const { container, rerender } = renderDetail(staleBooking)
+
+    act(() => vi.advanceTimersByTime(10_000))
+    expect(router.refresh).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <BookingDetail
+        booking={
+          makeBooking({
+            status: 'confirmed',
+            meetingUrl: 'https://meeting.tencent.com/new-room',
+            googleCalendarEventId: 'new_calendar_event',
+            tencentMeetingId: 'new_tencent_meeting',
+          })
+        }
+        events={events}
+        operations={operations}
+      />,
+    )
+
+    expect(container.textContent).toContain('new-room')
+    expect(container.textContent).toContain('new_calendar_event')
+    expect(container.textContent).toContain('new_tencent_meeting')
+    expect(container.textContent).not.toContain('stale-room')
+
+    act(() => vi.advanceTimersByTime(20_000))
+    expect(router.refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not poll for fixture bookings', () => {
+    vi.useFakeTimers()
+    render(
+      <BookingDetail
+        booking={makeBooking({ status: 'finalizing' })}
+        events={events}
+        operations={operations}
+        fixtureMode
+      />,
+    )
+
+    act(() => vi.advanceTimersByTime(30_000))
+
+    expect(router.refresh).not.toHaveBeenCalled()
+  })
+
+  it('stops polling after the finalizing refresh window', () => {
+    vi.useFakeTimers()
+    renderDetail(makeBooking({ status: 'finalizing' }))
+
+    act(() => vi.advanceTimersByTime(10 * 60_000))
+
+    expect(router.refresh).toHaveBeenCalledTimes(30)
+  })
+
+  it('pauses finalizing refreshes during an admin mutation', () => {
+    vi.useFakeTimers()
+    fetchMock.mockReturnValue(new Promise<Response>(() => {}))
+    const { container } = renderDetail(makeBooking({ status: 'finalizing' }))
+
+    fireEvent.click(buttonWithText(container, 'Cancel Booking'))
+    fireEvent.click(buttonWithText(container, 'Confirm cancellation'))
+    act(() => vi.advanceTimersByTime(30_000))
+
+    expect(router.refresh).not.toHaveBeenCalled()
   })
 
   it('notes a purged Booking Brief instead of its content', () => {

--- a/lib/ama/operations/repository.test.ts
+++ b/lib/ama/operations/repository.test.ts
@@ -127,6 +127,25 @@ describe('Durable Operations repository', () => {
     expect(claimed[0]?.leaseToken).toBeTruthy()
   })
 
+  it('claims only the requested operation kinds', async () => {
+    const email = await repository.enqueue(enqueueInput('email:filtered'))
+    const artifacts = await repository.enqueue(
+      enqueueInput('artifacts:filtered', { kind: 'update_booking_artifacts' }),
+    )
+
+    const claimed = await repository.claimDue({
+      now,
+      leaseSeconds: 60,
+      limit: 10,
+      kinds: ['send_booking_email'],
+    })
+
+    expect(claimed.map((operation) => operation.id)).toEqual([email.operation.id])
+    await expect(repository.get(artifacts.operation.id)).resolves.toMatchObject({
+      status: 'pending',
+    })
+  })
+
   it('does not claim operations scheduled for the future', async () => {
     await repository.enqueue(
       enqueueInput('email:future', { nextAttemptAt: new Date(now.getTime() + HOUR) }),

--- a/lib/ama/operations/repository.ts
+++ b/lib/ama/operations/repository.ts
@@ -98,21 +98,28 @@ export function createDurableOperationsRepository(database: () => OperationsData
       now: Date
       leaseSeconds: number
       limit: number
+      kinds?: DurableOperationKind[]
     }): Promise<DurableOperationRecord[]> {
+      if (input.kinds?.length === 0) return []
       const leaseToken = randomUUID()
       const leaseExpiresAt = new Date(input.now.getTime() + input.leaseSeconds * 1000)
       const due = database()
         .select({ id: amaDurableOperations.id })
         .from(amaDurableOperations)
         .where(
-          or(
-            and(
-              eq(amaDurableOperations.status, 'pending'),
-              lte(amaDurableOperations.nextAttemptAt, input.now),
-            ),
-            and(
-              eq(amaDurableOperations.status, 'running'),
-              lte(amaDurableOperations.leaseExpiresAt, input.now),
+          and(
+            input.kinds
+              ? inArray(amaDurableOperations.kind, input.kinds)
+              : undefined,
+            or(
+              and(
+                eq(amaDurableOperations.status, 'pending'),
+                lte(amaDurableOperations.nextAttemptAt, input.now),
+              ),
+              and(
+                eq(amaDurableOperations.status, 'running'),
+                lte(amaDurableOperations.leaseExpiresAt, input.now),
+              ),
             ),
           ),
         )

--- a/lib/ama/operations/runner.test.ts
+++ b/lib/ama/operations/runner.test.ts
@@ -53,8 +53,11 @@ function fixture(input: {
 }) {
   const completes: { operationId: string; leaseToken: string; now: Date }[] = []
   const fails: FailInput[] = []
+  let claimed = false
   const operations = {
     async claimDue() {
+      if (claimed) return []
+      claimed = true
       return input.batch
     },
     async complete(operationId: string, leaseToken: string, now: Date) {
@@ -223,6 +226,127 @@ describe('operations runner', () => {
     expect(f.completes).toEqual([
       { operationId: 'op_good', leaseToken: 'lease-good', now: NOW },
     ])
+  })
+
+  it('claims due work enqueued by a handler in the same run', async () => {
+    const queue = [makeOperation({ id: 'op_parent', leaseToken: 'lease-parent' })]
+    const handled: string[] = []
+    const claims: Array<{ limit: number; kinds?: string[] }> = []
+    const operations = {
+      async claimDue(input: { limit: number; kinds?: string[] }) {
+        claims.push(input)
+        return queue.splice(0, input.limit)
+      },
+      async complete(operationId: string) {
+        return makeOperation({ id: operationId, status: 'succeeded' })
+      },
+      async fail() {
+        throw new Error('unexpected fail call')
+      },
+    } as unknown as DurableOperationsRepository
+    const runner = createOperationsRunner({
+      operations,
+      handler: async (operation) => {
+        handled.push(operation.id)
+        if (operation.id === 'op_parent') {
+          queue.push(makeOperation({ id: 'op_child', leaseToken: 'lease-child' }))
+        }
+      },
+      clock: { now: () => NOW },
+    })
+
+    const result = await runner.run()
+
+    expect(handled).toEqual(['op_parent', 'op_child'])
+    expect(claims.map(({ limit, kinds }) => ({ limit, kinds }))).toEqual([
+      { limit: 10, kinds: undefined },
+      { limit: 1, kinds: ['send_booking_email'] },
+      { limit: 1, kinds: ['send_booking_email'] },
+    ])
+    expect(result).toEqual({
+      claimed: 2,
+      succeeded: 2,
+      retried: 0,
+      failed: 0,
+      deferred: 0,
+    })
+  })
+
+  it('keeps the total claimed work within the batch size across rounds', async () => {
+    const queue = [makeOperation({ id: 'op_1', leaseToken: 'lease-1' })]
+    const handled: string[] = []
+    const claimLimits: number[] = []
+    const operations = {
+      async claimDue(input: { limit: number }) {
+        claimLimits.push(input.limit)
+        return queue.splice(0, input.limit)
+      },
+      async complete(operationId: string) {
+        return makeOperation({ id: operationId, status: 'succeeded' })
+      },
+      async fail() {
+        throw new Error('unexpected fail call')
+      },
+    } as unknown as DurableOperationsRepository
+    const runner = createOperationsRunner({
+      operations,
+      handler: async (operation) => {
+        handled.push(operation.id)
+        const next = Number(operation.id.slice('op_'.length)) + 1
+        queue.push(
+          makeOperation({ id: `op_${next}`, leaseToken: `lease-${next}` }),
+        )
+      },
+      clock: { now: () => NOW },
+      batchSize: 3,
+    })
+
+    const result = await runner.run()
+
+    expect(handled).toEqual(['op_1', 'op_2', 'op_3'])
+    expect(claimLimits).toEqual([3, 1, 1])
+    expect(queue.map((operation) => operation.id)).toEqual(['op_4'])
+    expect(result.claimed).toBe(3)
+    expect(result.succeeded).toBe(3)
+  })
+
+  it('does not start a follow-up claim without provider timeout headroom', async () => {
+    const queue = [makeOperation({ id: 'op_parent', leaseToken: 'lease-parent' })]
+    const claimLimits: number[] = []
+    let nowMs = NOW.getTime()
+    const operations = {
+      async claimDue(input: { limit: number }) {
+        claimLimits.push(input.limit)
+        return queue.splice(0, input.limit)
+      },
+      async complete(operationId: string) {
+        return makeOperation({ id: operationId, status: 'succeeded' })
+      },
+      async fail() {
+        throw new Error('unexpected fail call')
+      },
+    } as unknown as DurableOperationsRepository
+    const runner = createOperationsRunner({
+      operations,
+      handler: async () => {
+        queue.push(makeOperation({ id: 'op_child', leaseToken: 'lease-child' }))
+        nowMs += 36_000
+      },
+      clock: { now: () => new Date(nowMs) },
+      timeBudgetMs: 45_000,
+    })
+
+    const result = await runner.run()
+
+    expect(claimLimits).toEqual([10])
+    expect(queue.map((operation) => operation.id)).toEqual(['op_child'])
+    expect(result).toEqual({
+      claimed: 1,
+      succeeded: 1,
+      retried: 0,
+      failed: 0,
+      deferred: 0,
+    })
   })
 
   it('skips claimed rows without a lease token', async () => {

--- a/lib/ama/operations/runner.ts
+++ b/lib/ama/operations/runner.ts
@@ -9,6 +9,10 @@ import type { DurableOperationsRepository } from './repository'
 
 const BASE_RETRY_SECONDS = 30
 const MAX_RETRY_SECONDS = 3600
+// Follow-up passes only drain single-call email work. Keeping one provider
+// timeout in reserve prevents a late claim from crossing the function limit.
+const FOLLOW_UP_START_HEADROOM_MS = 10_000
+const FOLLOW_UP_OPERATION_KINDS = ['send_booking_email'] as const
 
 export type OperationsRunResult = {
   claimed: number
@@ -60,50 +64,74 @@ export function createOperationsRunner(dependencies: OperationsRunnerDependencie
   return {
     async run(): Promise<OperationsRunResult> {
       const startedAtMs = clock.now().getTime()
-      const claimed = await operations.claimDue({
-        now: clock.now(),
-        leaseSeconds,
-        limit: batchSize,
-      })
       const result: OperationsRunResult = {
-        claimed: claimed.length,
+        claimed: 0,
         succeeded: 0,
         retried: 0,
         failed: 0,
         deferred: 0,
       }
-      for (const operation of claimed) {
-        if (!operation.leaseToken) continue
-        if (clock.now().getTime() - startedAtMs >= timeBudgetMs) {
-          result.deferred += 1
-          continue
+
+      while (result.claimed < batchSize) {
+        const isFollowUp = result.claimed > 0
+        const startHeadroomMs = isFollowUp ? FOLLOW_UP_START_HEADROOM_MS : 0
+        if (
+          clock.now().getTime() - startedAtMs >=
+          timeBudgetMs - startHeadroomMs
+        ) {
+          break
         }
-        try {
-          await handler(operation)
-          await operations.complete(operation.id, operation.leaseToken, clock.now())
-          result.succeeded += 1
-        } catch (error) {
-          const now = clock.now()
-          const terminal = error instanceof TerminalOperationError
-          const retryAt =
-            error instanceof RetryableOperationError && error.retryAt
-              ? error.retryAt
-              : backoffAt(operation.attemptCount, now)
-          const errorCode =
-            error instanceof RetryableOperationError ||
-            error instanceof TerminalOperationError
-              ? error.code
-              : 'unexpected_error'
-          const failed = await operations.fail({
-            operationId: operation.id,
-            leaseToken: operation.leaseToken,
-            errorCode,
-            retryAt,
-            now,
-            terminal,
-          })
-          if (failed?.status === 'failed') result.failed += 1
-          else result.retried += 1
+        const claimed = await operations.claimDue({
+          now: clock.now(),
+          leaseSeconds,
+          limit: isFollowUp ? 1 : batchSize - result.claimed,
+          ...(isFollowUp
+            ? { kinds: [...FOLLOW_UP_OPERATION_KINDS] }
+            : {}),
+        })
+        if (claimed.length === 0) break
+        result.claimed += claimed.length
+
+        for (const operation of claimed) {
+          if (!operation.leaseToken) continue
+          if (
+            clock.now().getTime() - startedAtMs >=
+            timeBudgetMs - startHeadroomMs
+          ) {
+            result.deferred += 1
+            continue
+          }
+          try {
+            await handler(operation)
+            await operations.complete(
+              operation.id,
+              operation.leaseToken,
+              clock.now(),
+            )
+            result.succeeded += 1
+          } catch (error) {
+            const now = clock.now()
+            const terminal = error instanceof TerminalOperationError
+            const retryAt =
+              error instanceof RetryableOperationError && error.retryAt
+                ? error.retryAt
+                : backoffAt(operation.attemptCount, now)
+            const errorCode =
+              error instanceof RetryableOperationError ||
+              error instanceof TerminalOperationError
+                ? error.code
+                : 'unexpected_error'
+            const failed = await operations.fail({
+              operationId: operation.id,
+              leaseToken: operation.leaseToken,
+              errorCode,
+              retryAt,
+              now,
+              terminal,
+            })
+            if (failed?.status === 'failed') result.failed += 1
+            else result.retried += 1
+          }
         }
       }
       return result


### PR DESCRIPTION
## Summary

- hide superseded meeting links and provider artifacts while a Booking is finalizing across the admin detail, Manage Link, and checkout confirmation surfaces
- refresh the admin detail until replacement artifacts arrive, with visibility, mutation, fixture, and five-minute polling bounds
- let the durable worker claim newly queued reschedule emails in the same invocation while preserving the total batch cap
- scope follow-up claims to email work and reserve provider timeout headroom before Vercel's function deadline
- add regression coverage for stale artifacts, refreshed props, queue draining, operation-kind filtering, batch limits, and time budgets

## Why

Rescheduling correctly recreated Tencent and Calendar artifacts, then queued the replacement email. However, stored artifacts remained visible while that durable work was pending, and the newly queued email waited for the next five-minute worker run. This made a healthy recovery look stuck and briefly presented an obsolete meeting link as current.

## Verification

- `pnpm test:unit` (133 files, 1,245 tests)
- `pnpm test:ama` (33 files, 668 tests plus 9 migration checks)
- `pnpm typecheck`
- `pnpm audit:prod`
- `pnpm build` with documented local build-only placeholder environment
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents superseded meeting artifacts from appearing while an AMA booking is finalizing and adds bounded admin refreshes so replacement details appear automatically. It also extends the durable worker to claim newly queued booking emails within the same invocation while retaining operation-kind, batch-size, lease, and time-budget safeguards.

- Synchronizes refreshed booking lifecycle fields into the admin detail and polls finalizing bookings for up to five minutes.
- Hides meeting links and provider identifiers on confirmation, Manage Link, and admin surfaces until the booking is confirmed.
- Adds optional operation-kind filtering and a batch-capped email follow-up pass with provider timeout headroom.
- Adds regression coverage for stale artifacts, refreshed props, queue draining, filtering, limits, and timing.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defect identified.

The artifact visibility gates match the reschedule lifecycle, admin refreshes are explicitly bounded, and the worker’s additional claims preserve lease safety, operation filtering, total batch size, and execution headroom.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/ama/operations/runner.ts | Adds batch-capped, email-only follow-up claims and reserves ten seconds before starting follow-up provider work. |
| lib/ama/operations/repository.ts | Adds optional durable-operation kind filtering while preserving the existing lease compare-and-set. |
| app/admin/(protected)/ama/bookings/[bookingId]/BookingDetail.tsx | Synchronizes refreshed lifecycle props, adds bounded finalizing-state polling, and suppresses stored artifacts until confirmation. |
| components/ama/manage-booking.tsx | Prevents a finalizing Manage Link from presenting a stored meeting URL as current. |
| components/ama/booking-confirmation.tsx | Shows a meeting URL on checkout confirmation only after the booking reaches confirmed status. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant W as Durable worker
  participant Q as Operations repository
  participant A as Artifact handler
  participant E as Email handler
  participant UI as Booking surfaces
  W->>Q: Claim initial batch
  Q-->>W: Due operations
  W->>A: Finalize or update artifacts
  A->>Q: Enqueue booking email
  A-->>UI: Booking becomes confirmed
  W->>Q: Claim one due booking email
  Q-->>W: Email operation
  W->>E: Send replacement confirmation
  Note over UI: Artifacts remain hidden while finalizing
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ama): harden reschedule completion"](https://github.com/calicastle/cali.so/commit/93b491deb47730914b3b64109f3dc41bd8154a9a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53602722)</sub>

**Context used:**

- Knowledge Base — [AMA Admin Operations](https://app.greptile.com/zolplay/-/custom-context/knowledge-base/calicastle/cali.so/-/docs/ama-admin-operations.md)
- Knowledge Base — [AMA booking flow](https://app.greptile.com/zolplay/-/custom-context/knowledge-base/calicastle/cali.so/-/docs/ama-booking-flow.md)

<!-- /greptile_comment -->