### PR TITLE
Promote dev to main: AMA resilience and Cali Baby discovery

### DIFF
--- a/app/(en)/en/projects/page.tsx
+++ b/app/(en)/en/projects/page.tsx
@@ -11,5 +11,5 @@ export const metadata = localeMetadata({
 })
 
 export default function EnglishProjectsPage() {
-  return <ProjectsPageView />
+  return <ProjectsPageView locale="en" />
 }

--- a/app/(zh)/projects/page.tsx
+++ b/app/(zh)/projects/page.tsx
@@ -11,5 +11,5 @@ export const metadata = localeMetadata({
 })
 
 export default function ChineseProjectsPage() {
-  return <ProjectsPageView />
+  return <ProjectsPageView locale="zh" />
 }

--- a/app/_components/calibaby-document.tsx
+++ b/app/_components/calibaby-document.tsx
@@ -13,6 +13,8 @@ import styles from '../_views/calibaby-pages.module.css'
 export const caliBabyRootMetadata: Metadata = {
   metadataBase: seo.url,
   applicationName: 'Cali Baby',
+  creator: 'Zolplay',
+  publisher: 'Zolplay',
   title: {
     default: 'Cali Baby',
     template: '%s',

--- a/app/_components/calibaby-document.tsx
+++ b/app/_components/calibaby-document.tsx
@@ -13,8 +13,6 @@ import styles from '../_views/calibaby-pages.module.css'
 export const caliBabyRootMetadata: Metadata = {
   metadataBase: seo.url,
   applicationName: 'Cali Baby',
-  creator: 'Zolplay',
-  publisher: 'Zolplay',
   title: {
     default: 'Cali Baby',
     template: '%s',

--- a/app/_views/calibaby-landing.module.css
+++ b/app/_views/calibaby-landing.module.css
@@ -132,6 +132,75 @@
   height: 3rem;
 }
 
+.productDetails {
+  width: min(100%, 68rem);
+  margin-inline: auto;
+  padding: 0 clamp(1rem, 4vw, 3rem) clamp(4.5rem, 8vw, 7rem);
+}
+
+.productDetailsHeader {
+  max-width: 43rem;
+  margin-inline: auto;
+  text-align: center;
+}
+
+.productDetailsHeader h2 {
+  color: var(--cb-text);
+  font-size: clamp(1.65rem, 3vw, 2.5rem);
+  font-weight: 400;
+  letter-spacing: -0.032em;
+  line-height: 1.08;
+  text-wrap: balance;
+}
+
+.productIntroduction {
+  margin-top: 1.5rem;
+  color: var(--cb-secondary);
+  font-size: 1rem;
+  letter-spacing: -0.015em;
+  line-height: 1.7;
+  text-wrap: pretty;
+}
+
+.productFacts {
+  margin-top: 1rem;
+  color: var(--cb-tertiary);
+  font-size: 0.8125rem;
+  line-height: 1.65;
+  text-wrap: balance;
+}
+
+.featureGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 2rem clamp(2rem, 6vw, 5rem);
+  padding: 0;
+  margin: clamp(2.75rem, 6vw, 4.5rem) 0 0;
+  list-style: none;
+}
+
+.feature {
+  min-width: 0;
+  padding-top: 1.25rem;
+  box-shadow: inset 0 1px 0 var(--cb-edge);
+}
+
+.feature h3 {
+  color: var(--cb-text);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  letter-spacing: -0.012em;
+}
+
+.feature p {
+  margin-top: 0.625rem;
+  color: var(--cb-secondary);
+  font-size: 0.9375rem;
+  letter-spacing: -0.012em;
+  line-height: 1.65;
+  text-wrap: pretty;
+}
+
 .gallery {
   width: 100%;
   padding-bottom: clamp(4.5rem, 8vw, 7rem);
@@ -337,6 +406,20 @@
     font-size: clamp(1.85rem, 8vw, 2.45rem);
     letter-spacing: -0.03em;
     line-height: 1;
+  }
+
+  .productDetailsHeader {
+    text-align: start;
+  }
+
+  .productFacts {
+    text-wrap: pretty;
+  }
+
+  .featureGrid {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1.75rem;
+    margin-top: 2.75rem;
   }
 
   .carouselFrame {

--- a/app/_views/calibaby-landing.tsx
+++ b/app/_views/calibaby-landing.tsx
@@ -136,6 +136,13 @@ export function CaliBabyLandingPage({ locale }: { locale: Locale }) {
           </div>
         </section>
 
+        <section className={styles.gallery} aria-labelledby="calibaby-gallery-title">
+          <h2 id="calibaby-gallery-title" className={styles.srOnly}>
+            {copy.galleryLabel}
+          </h2>
+          <CaliBabyScreenshotCarousel locale={locale} />
+        </section>
+
         <section
           className={styles.productDetails}
           aria-labelledby="calibaby-product-details-title"
@@ -156,13 +163,6 @@ export function CaliBabyLandingPage({ locale }: { locale: Locale }) {
               </li>
             ))}
           </ul>
-        </section>
-
-        <section className={styles.gallery} aria-labelledby="calibaby-gallery-title">
-          <h2 id="calibaby-gallery-title" className={styles.srOnly}>
-            {copy.galleryLabel}
-          </h2>
-          <CaliBabyScreenshotCarousel locale={locale} />
         </section>
       </main>
 

--- a/app/_views/calibaby-landing.tsx
+++ b/app/_views/calibaby-landing.tsx
@@ -2,11 +2,14 @@ import Image from 'next/image'
 import Link from 'next/link'
 
 import { CaliBabyScreenshotCarousel } from '../_components/calibaby-screenshot-carousel'
+import {
+  CALI_BABY_APP_STORE_URL,
+  CALI_BABY_PRODUCT_DETAILS,
+  caliBabyLandingStructuredData,
+} from '~/lib/calibaby-public-content'
 import { localePath, type Locale } from '~/lib/locale-route'
 
 import styles from './calibaby-landing.module.css'
-
-const APP_STORE_URL = 'https://apps.apple.com/app/id6769728441'
 
 const APP_STORE_BADGES = {
   zh: {
@@ -86,9 +89,17 @@ function LandingHeader({ locale }: { locale: Locale }) {
 export function CaliBabyLandingPage({ locale }: { locale: Locale }) {
   const copy = LANDING_COPY[locale]
   const appStoreBadge = APP_STORE_BADGES[locale]
+  const productDetails = CALI_BABY_PRODUCT_DETAILS[locale]
+  const structuredData = caliBabyLandingStructuredData(locale)
 
   return (
     <div className={styles.landingPage}>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(structuredData).replace(/</g, '\\u003c'),
+        }}
+      />
       <LandingHeader locale={locale} />
 
       <main>
@@ -108,7 +119,7 @@ export function CaliBabyLandingPage({ locale }: { locale: Locale }) {
           <p>{copy.description}</p>
           <div className={styles.heroActions}>
             <a
-              href={APP_STORE_URL}
+              href={CALI_BABY_APP_STORE_URL}
               target="_blank"
               rel="noreferrer"
               className={styles.appStoreLink}
@@ -123,6 +134,28 @@ export function CaliBabyLandingPage({ locale }: { locale: Locale }) {
               />
             </a>
           </div>
+        </section>
+
+        <section
+          className={styles.productDetails}
+          aria-labelledby="calibaby-product-details-title"
+        >
+          <header className={styles.productDetailsHeader}>
+            <h2 id="calibaby-product-details-title">{productDetails.title}</h2>
+            <p className={styles.productIntroduction}>
+              {productDetails.introduction}
+            </p>
+            <p className={styles.productFacts}>{productDetails.facts}</p>
+          </header>
+
+          <ul className={styles.featureGrid}>
+            {productDetails.features.map((feature) => (
+              <li key={feature.title} className={styles.feature}>
+                <h3>{feature.title}</h3>
+                <p>{feature.description}</p>
+              </li>
+            ))}
+          </ul>
         </section>
 
         <section className={styles.gallery} aria-labelledby="calibaby-gallery-title">

--- a/app/_views/projects-page.tsx
+++ b/app/_views/projects-page.tsx
@@ -1,14 +1,16 @@
 import Image from 'next/image'
+import Link from 'next/link'
 
 import { ExternalLabel } from '~/components/external-mark'
 import { GhostSchematic } from '~/components/ghost-schematic'
 import { ProjectsBlueprintStage } from '~/components/hidden-list-stage'
 import { PixelCluster } from '~/components/pixel-cluster'
 import { T } from '~/lib/i18n'
+import { localePath, type Locale } from '~/lib/locale-route'
 import { publicPageMetadata } from '~/lib/public-page-metadata'
 import { projects } from '~/lib/projects'
 
-export function ProjectsPageView() {
+export function ProjectsPageView({ locale }: { locale: Locale }) {
   const center = (projects.length - 1) / 2
 
   return (
@@ -44,10 +46,14 @@ export function ProjectsPageView() {
                 } as React.CSSProperties
               }
             >
-              <a
-                href={project.url}
-                target="_blank"
-                rel="noreferrer"
+              <Link
+                href={
+                  project.url.startsWith('/')
+                    ? localePath(locale, project.url)
+                    : project.url
+                }
+                target={project.url.startsWith('/') ? undefined : '_blank'}
+                rel={project.url.startsWith('/') ? undefined : 'noreferrer'}
                 className="project-row hairline-top group"
                 data-list-stage-row
                 data-list-stage-id={project.name}
@@ -63,16 +69,20 @@ export function ProjectsPageView() {
                 </span>
                 <span className="project-identity">
                   <span className="project-name font-medium">
-                    <ExternalLabel>
+                    {project.url.startsWith('/') ? (
                       <T zh={project.name} en={project.nameEn} />
-                    </ExternalLabel>
+                    ) : (
+                      <ExternalLabel>
+                        <T zh={project.name} en={project.nameEn} />
+                      </ExternalLabel>
+                    )}
                   </span>
                   <span className="project-domain text-muted-foreground">{project.domain}</span>
                 </span>
                 <span className="project-description text-muted-foreground">
                   <T zh={project.description} en={project.descriptionEn ?? project.description} />
                 </span>
-              </a>
+              </Link>
             </li>
           ))}
         </ul>

--- a/app/admin/(protected)/ama/bookings/[bookingId]/BookingDetail.tsx
+++ b/app/admin/(protected)/ama/bookings/[bookingId]/BookingDetail.tsx
@@ -72,6 +72,8 @@ export type BookingEventViewModel = {
 type SlotViewModel = { startsAt: string; endsAt: string }
 
 const MANAGE_CUTOFF_MS = 24 * 60 * 60 * 1000
+const FINALIZING_REFRESH_MS = 10_000
+const FINALIZING_REFRESH_WINDOW_MS = 5 * 60 * 1000
 
 // Decorative reinforcement of the lifecycle the badge already announces —
 // rendered only for the linear states (diverged states have no honest rung).
@@ -249,6 +251,28 @@ export function BookingDetail({
   const [refundChecked, setRefundChecked] = useState(
     () => Date.parse(booking.startsAt) - Date.now() > MANAGE_CUTOFF_MS,
   )
+
+  useEffect(() => {
+    setStatus(booking.status)
+    setRefundStatus(booking.refundStatus)
+    setStartsAt(booking.startsAt)
+    setEndsAt(booking.endsAt)
+  }, [booking.status, booking.refundStatus, booking.startsAt, booking.endsAt])
+
+  useEffect(() => {
+    if (fixtureMode || status !== 'finalizing' || pending !== null) return
+    const interval = window.setInterval(() => {
+      if (document.visibilityState !== 'hidden') router.refresh()
+    }, FINALIZING_REFRESH_MS)
+    const timeout = window.setTimeout(
+      () => window.clearInterval(interval),
+      FINALIZING_REFRESH_WINDOW_MS,
+    )
+    return () => {
+      window.clearInterval(interval)
+      window.clearTimeout(timeout)
+    }
+  }, [fixtureMode, pending, router, status])
 
   useEffect(() => {
     if (notice) noticeRef.current?.focus()
@@ -452,6 +476,11 @@ export function BookingDetail({
       ? { zh: '中文', en: 'Chinese' }
       : { zh: '英文', en: 'English' }
   const provider = providerLabels[booking.meetingProvider]
+  const hasStoredMeetingArtifacts = Boolean(
+    booking.meetingUrl ||
+      booking.googleCalendarEventId ||
+      booking.tencentMeetingId,
+  )
 
   return (
     <div className="pb-10">
@@ -905,7 +934,26 @@ export function BookingDetail({
         <h2 id="meeting-heading" className="text-sm font-medium">
           <T zh="会议" en="Meeting" />
         </h2>
-        {booking.meetingUrl || booking.googleCalendarEventId || booking.tencentMeetingId ? (
+        {status === 'finalizing' ? (
+          <p
+            className="mt-2 text-sm leading-6 text-muted-foreground"
+            role="status"
+          >
+            {hasStoredMeetingArtifacts ? (
+              <T
+                zh="会议资料正在更新。请勿使用之前的链接；预约确认后，这里会显示新链接。"
+                en="Meeting details are being updated. Do not use a previous link. The new link appears once this Booking is confirmed."
+              />
+            ) : (
+              <T
+                zh="会议资料正在创建。预约确认后，这里会显示会议链接。"
+                en="Meeting details are being created. The meeting link appears once this Booking is confirmed."
+              />
+            )}
+          </p>
+        ) : booking.meetingUrl ||
+          booking.googleCalendarEventId ||
+          booking.tencentMeetingId ? (
           <dl className="spec-nameplate mt-3 mb-6">
             {booking.meetingUrl && (
               <DefinitionRow term={<T zh="会议链接" en="Meeting link" />}>

--- a/app/globals.css
+++ b/app/globals.css
@@ -2512,6 +2512,12 @@ img.tweet-card-avatar {
   transition: opacity 200ms ease 140ms;
 }
 
+.zoom-overlay[data-motion='instant'] .zoom-overlay-backdrop,
+.zoom-overlay[data-motion='instant'] img,
+.zoom-overlay[data-motion='instant'] .zoom-overlay-marks {
+  transition: none;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .zoom-overlay-backdrop,
   .zoom-overlay img,
@@ -5667,6 +5673,11 @@ html[data-locale='en'] [data-en-block] {
 .zoom-overlay[data-state='open'] .zoom-detail-frame {
   opacity: 1;
   transition: opacity 200ms ease 120ms;
+}
+
+.zoom-overlay[data-motion='instant'] .zoom-detail-item,
+.zoom-overlay[data-motion='instant'] .zoom-detail-frame {
+  transition: none;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/app/llms.txt/route.test.ts
+++ b/app/llms.txt/route.test.ts
@@ -43,6 +43,8 @@ describe('llms.txt', () => {
       expect(text).toContain(new URL(`/en/newsletters/${id}`, seo.url).href)
     }
 
-    for (const project of projects) expect(text).toContain(project.url)
+    for (const project of projects) {
+      expect(text).toContain(new URL(project.url, seo.url).href)
+    }
   })
 })

--- a/app/llms.txt/route.test.ts
+++ b/app/llms.txt/route.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import { CALI_BABY_APP_STORE_URL } from '~/lib/calibaby-public-content'
+import { getAllPosts } from '~/lib/content'
+import { archivedNewsletterIds } from '~/lib/newsletters'
+import { projects } from '~/lib/projects'
+import { seo } from '~/lib/seo'
+
+import { buildLlmsText } from './route'
+
+describe('llms.txt', () => {
+  it('publishes a concise Markdown map of every public content family', () => {
+    const text = buildLlmsText()
+
+    expect(text).toMatch(/^# Cali Castle and Cali Baby\n\n>/)
+    expect(text.length).toBeGreaterThan(50)
+    expect(text).toContain(CALI_BABY_APP_STORE_URL)
+
+    for (const path of [
+      '/',
+      '/en',
+      '/calibaby',
+      '/en/calibaby',
+      '/calibaby/help',
+      '/en/calibaby/help',
+      '/calibaby/privacy',
+      '/en/calibaby/privacy',
+      '/calibaby/terms',
+      '/en/calibaby/terms',
+    ]) {
+      expect(text).toContain(`](${new URL(path, seo.url).href})`)
+    }
+
+    for (const post of getAllPosts()) {
+      expect(text).toContain(new URL(`/blog/${post.slug}`, seo.url).href)
+      expect(text).toContain(new URL(`/en/blog/${post.slug}`, seo.url).href)
+    }
+
+    for (const id of archivedNewsletterIds) {
+      expect(text).toContain(new URL(`/newsletters/${id}`, seo.url).href)
+      expect(text).toContain(new URL(`/en/newsletters/${id}`, seo.url).href)
+    }
+
+    for (const project of projects) expect(text).toContain(project.url)
+  })
+})

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,0 +1,185 @@
+import { cacheLife } from 'next/cache'
+
+import {
+  CALI_BABY_APP_STORE_URL,
+  CALI_BABY_PRODUCT_DETAILS,
+  getCaliBabyPublicContent,
+  type CaliBabyPageKind,
+} from '~/lib/calibaby-public-content'
+import { getAllPosts } from '~/lib/content'
+import {
+  archivedNewsletterIds,
+  getArchivedNewsletter,
+} from '~/lib/newsletters'
+import { projects } from '~/lib/projects'
+import { publicPageMetadata } from '~/lib/public-page-metadata'
+import { seo } from '~/lib/seo'
+
+function absoluteUrl(path: string) {
+  return new URL(path, seo.url).href
+}
+
+function oneLine(value: string) {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function markdownLink(label: string, url: string, note: string) {
+  const safeLabel = oneLine(label).replaceAll('[', '\\[').replaceAll(']', '\\]')
+  return `- [${safeLabel}](${url}): ${oneLine(note)}`
+}
+
+export function buildLlmsText() {
+  const posts = getAllPosts()
+  const caliBabyPages = (
+    [
+      ['support', '/calibaby/help'],
+      ['privacy', '/calibaby/privacy'],
+      ['terms', '/calibaby/terms'],
+    ] as const satisfies ReadonlyArray<readonly [CaliBabyPageKind, string]>
+  ).flatMap(([kind, path]) => {
+    const zh = getCaliBabyPublicContent('zh', kind)
+    const en = getCaliBabyPublicContent('en', kind)
+    return [
+      markdownLink(zh.metadataTitle, absoluteUrl(path), zh.metadataDescription),
+      markdownLink(
+        en.metadataTitle,
+        absoluteUrl(`/en${path}`),
+        en.metadataDescription,
+      ),
+    ]
+  })
+  const sections = ['blog', 'photos', 'projects', 'ama'] as const
+
+  return [
+    '# Cali Castle and Cali Baby',
+    '',
+    '> The bilingual public site of design engineer Cali Castle and the official product, support, and legal information for Cali Baby, a baby tracker by Zolplay.',
+    '',
+    'Chinese pages use unprefixed URLs. English versions use `/en`. Prefer the page matching the user’s language, and use each page’s canonical URL when citing it.',
+    '',
+    'Cali Baby is a Health & Fitness app for parents, guardians, and caregivers. Version 1.0.0 launched on the App Store on August 15, 2026. The app is free to download with optional Cali Baby Pro purchases.',
+    '',
+    `It supports iPhone and Apple Watch, requires iOS 18 or later, and is available in English and Simplified Chinese. ${CALI_BABY_PRODUCT_DETAILS.en.introduction}`,
+    '',
+    'Cali Baby records and organizes everyday observations. It does not provide diagnosis, treatment, emergency services, or a substitute for professional medical care.',
+    '',
+    '## Cali Baby',
+    '',
+    markdownLink(
+      'Cali Baby: Baby Tracker',
+      absoluteUrl('/en/calibaby'),
+      'Official English product page with features, screenshots, platform requirements, and the App Store download.',
+    ),
+    markdownLink(
+      'Cali 宝宝',
+      absoluteUrl('/calibaby'),
+      '官方中文产品页，包含功能、应用画面、系统要求与 App Store 下载入口。',
+    ),
+    markdownLink(
+      'Cali Baby on the App Store',
+      CALI_BABY_APP_STORE_URL,
+      'Official Apple listing for the current app version, compatibility, pricing, and App Privacy details.',
+    ),
+    ...caliBabyPages,
+    '',
+    '## Cali Castle',
+    '',
+    markdownLink(
+      publicPageMetadata.home.en.title,
+      absoluteUrl('/en'),
+      publicPageMetadata.home.en.description,
+    ),
+    markdownLink(
+      publicPageMetadata.home.zh.title,
+      absoluteUrl('/'),
+      publicPageMetadata.home.zh.description,
+    ),
+    ...sections.flatMap((section) => [
+      markdownLink(
+        publicPageMetadata[section].en.title,
+        absoluteUrl(`/en/${section}`),
+        publicPageMetadata[section].en.description,
+      ),
+      markdownLink(
+        publicPageMetadata[section].zh.title,
+        absoluteUrl(`/${section}`),
+        publicPageMetadata[section].zh.description,
+      ),
+    ]),
+    '',
+    '## Writing',
+    '',
+    ...posts.flatMap((post) => [
+      markdownLink(
+        post.titleEn,
+        absoluteUrl(`/en/blog/${post.slug}`),
+        post.descriptionEn,
+      ),
+      markdownLink(
+        post.title,
+        absoluteUrl(`/blog/${post.slug}`),
+        post.description ?? `Cali 的文章：${post.title}`,
+      ),
+    ]),
+    '',
+    '## Newsletter archive',
+    '',
+    ...archivedNewsletterIds.flatMap((id) => {
+      const newsletter = getArchivedNewsletter(id)
+      return [
+        markdownLink(
+          newsletter.titleEn,
+          absoluteUrl(`/en/newsletters/${id}`),
+          newsletter.descriptionEn,
+        ),
+        markdownLink(
+          newsletter.title,
+          absoluteUrl(`/newsletters/${id}`),
+          newsletter.description,
+        ),
+      ]
+    }),
+    '',
+    '## Projects',
+    '',
+    ...projects.map((project) =>
+      markdownLink(
+        project.nameEn,
+        project.url,
+        project.descriptionEn ?? project.description,
+      ),
+    ),
+    '',
+    '## Optional',
+    '',
+    markdownLink(
+      'Chinese RSS feed',
+      absoluteUrl('/feed.xml'),
+      'Latest Chinese writing in RSS format.',
+    ),
+    markdownLink(
+      'English RSS feed',
+      absoluteUrl('/feed.en.xml'),
+      'Latest English writing in RSS format.',
+    ),
+    markdownLink(
+      'Sitemap',
+      absoluteUrl('/sitemap.xml'),
+      'Complete index of canonical public URLs and language alternates.',
+    ),
+    '',
+  ].join('\n')
+}
+
+async function getLlmsText() {
+  'use cache'
+  cacheLife('max')
+
+  return buildLlmsText()
+}
+
+export async function GET() {
+  return new Response(await getLlmsText(), {
+    headers: { 'content-type': 'text/markdown; charset=utf-8' },
+  })
+}

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -145,7 +145,7 @@ export function buildLlmsText() {
     ...projects.map((project) =>
       markdownLink(
         project.nameEn,
-        project.url,
+        absoluteUrl(project.url),
         project.descriptionEn ?? project.description,
       ),
     ),

--- a/app/seo-routes.test.ts
+++ b/app/seo-routes.test.ts
@@ -51,9 +51,6 @@ describe('localized discovery routes', () => {
       '/projects',
       '/ama',
       '/calibaby',
-      '/calibaby/help',
-      '/calibaby/privacy',
-      '/calibaby/terms',
       ...archivedNewsletterIds.map((id) => `/newsletters/${id}`),
       ...getAllPosts().map((post) => `/blog/${post.slug}`),
     ]
@@ -76,6 +73,19 @@ describe('localized discovery routes', () => {
           }),
         )
       }
+    }
+
+    for (const path of [
+      '/calibaby/help',
+      '/calibaby/privacy',
+      '/calibaby/terms',
+    ]) {
+      expect(entries).not.toContainEqual(
+        expect.objectContaining({ url: new URL(path, seo.url).href }),
+      )
+      expect(entries).not.toContainEqual(
+        expect.objectContaining({ url: new URL(`/en${path}`, seo.url).href }),
+      )
     }
   })
 })

--- a/app/seo-routes.test.ts
+++ b/app/seo-routes.test.ts
@@ -50,6 +50,10 @@ describe('localized discovery routes', () => {
       '/photos',
       '/projects',
       '/ama',
+      '/calibaby',
+      '/calibaby/help',
+      '/calibaby/privacy',
+      '/calibaby/terms',
       ...archivedNewsletterIds.map((id) => `/newsletters/${id}`),
       ...getAllPosts().map((post) => `/blog/${post.slug}`),
     ]

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -26,9 +26,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
     ...pairedEntry('/projects', latest),
     ...pairedEntry('/ama'),
     ...pairedEntry('/calibaby'),
-    ...pairedEntry('/calibaby/help'),
-    ...pairedEntry('/calibaby/privacy'),
-    ...pairedEntry('/calibaby/terms'),
     ...archivedNewsletterIds.flatMap((id) => pairedEntry(`/newsletters/${id}`)),
     ...posts.flatMap((post) => pairedEntry(`/blog/${post.slug}`, post.publishedAt)),
   ]

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -25,6 +25,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
     ...pairedEntry('/photos', latest),
     ...pairedEntry('/projects', latest),
     ...pairedEntry('/ama'),
+    ...pairedEntry('/calibaby'),
+    ...pairedEntry('/calibaby/help'),
+    ...pairedEntry('/calibaby/privacy'),
+    ...pairedEntry('/calibaby/terms'),
     ...archivedNewsletterIds.flatMap((id) => pairedEntry(`/newsletters/${id}`)),
     ...posts.flatMap((post) => pairedEntry(`/blog/${post.slug}`, post.publishedAt)),
   ]

--- a/components/ama/booking-confirmation.test.tsx
+++ b/components/ama/booking-confirmation.test.tsx
@@ -106,6 +106,29 @@ describe('BookingConfirmation', () => {
     expect(document.querySelector('[data-ama-success-stage]')).not.toBeNull()
   })
 
+  it('hides a stale meeting link while a paid Booking is finalizing', async () => {
+    respondWithHoldStates([
+      jsonResponse(200, {
+        hold: {
+          state: 'paid',
+          bookingStatus: 'finalizing',
+          startsAt: '2026-08-10T12:00:00.000Z',
+          endsAt: '2026-08-10T13:00:00.000Z',
+          meetingProvider: 'tencent-meeting',
+          guestTimeZone: 'Asia/Shanghai',
+          meetingUrl: 'https://meeting.tencent.com/stale-room',
+        },
+      }),
+    ])
+
+    render(<BookingConfirmation />)
+    await flush()
+
+    expect(screen.getByText(/being finalized/)).toBeTruthy()
+    expect(screen.queryByRole('link', { name: /stale-room/ })).toBeNull()
+    expect(screen.queryByText(/stale-room/)).toBeNull()
+  })
+
   it('tells the truth when payment landed but the time was taken', async () => {
     respondWithHoldStates([
       jsonResponse(200, { hold: { state: 'paid', bookingStatus: 'needs_reschedule' } }),

--- a/components/ama/booking-confirmation.tsx
+++ b/components/ama/booking-confirmation.tsx
@@ -100,7 +100,13 @@ function sessionTime(iso: string, timeZone: string, locale: 'zh' | 'en') {
 
 // The booked session as its spec sheet — the nameplate register, printed in
 // the stage's paper ink. Rendered only from server-sent facts.
-function SessionPlate({ session }: { session: PaidSession }) {
+function SessionPlate({
+  session,
+  showMeetingUrl,
+}: {
+  session: PaidSession
+  showMeetingUrl: boolean
+}) {
   const minutes = Math.round(
     (Date.parse(session.endsAt) - Date.parse(session.startsAt)) / 60_000,
   )
@@ -143,7 +149,7 @@ function SessionPlate({ session }: { session: PaidSession }) {
           <T zh={provider.zh} en={provider.en} />
         </dd>
       </div>
-      {session.meetingUrl && (
+      {showMeetingUrl && session.meetingUrl && (
         <div>
           <dt>
             <T zh="会议链接" en="Link" />
@@ -418,7 +424,10 @@ export function BookingConfirmation() {
                 </p>
               </div>
             )}
-            <SessionPlate session={state.session} />
+            <SessionPlate
+              session={state.session}
+              showMeetingUrl={state.bookingStatus === 'confirmed'}
+            />
           </div>
         )}
         {/* Ornamental proof-sheet foot: the barcode derives from the hold id,

--- a/components/ama/manage-booking.test.tsx
+++ b/components/ama/manage-booking.test.tsx
@@ -87,7 +87,12 @@ async function renderManage({
       return (
         reschedule?.() ??
         jsonResponse(200, {
-          booking: booking({ startsAt: SLOTS[0]!.startsAt, endsAt: SLOTS[0]!.endsAt }),
+          booking: booking({
+            status: 'finalizing',
+            startsAt: SLOTS[0]!.startsAt,
+            endsAt: SLOTS[0]!.endsAt,
+            meetingUrl: view.meetingUrl,
+          }),
         })
       )
     }
@@ -150,11 +155,15 @@ describe('ManageBooking', () => {
 
   it('notes a Finalizing Booking instead of pretending it is complete', async () => {
     await renderManage({
-      view: booking({ status: 'finalizing', meetingUrl: null }),
+      view: booking({
+        status: 'finalizing',
+        meetingUrl: 'https://meet.google.com/stale-room',
+      }),
     })
 
     expect(screen.getByText(/meeting details being finalized/)).toBeTruthy()
-    expect(screen.queryByRole('link', { name: /Open meeting link/ })).toBeNull()
+    expect(screen.queryByRole('link', { name: /stale-room/ })).toBeNull()
+    expect(screen.queryByText(/stale-room/)).toBeNull()
   })
 
   it('cancels only after an explicit two-step confirmation', async () => {
@@ -205,6 +214,8 @@ describe('ManageBooking', () => {
     const [, init] = requestsTo(`/api/ama/manage/${TOKEN}/reschedule`)[0]!
     expect(JSON.parse(String(init?.body))).toEqual({ startsAt: SLOTS[0]!.startsAt })
     expect(screen.getByText(/Rescheduled\./)).toBeTruthy()
+    expect(screen.getByText(/meeting details being finalized/)).toBeTruthy()
+    expect(screen.queryByRole('link', { name: /abc-defg-hij/ })).toBeNull()
   })
 
   it('explains the 24 hour rule when the reschedule window has closed', async () => {

--- a/components/ama/manage-booking.tsx
+++ b/components/ama/manage-booking.tsx
@@ -355,10 +355,17 @@ export function ManageBooking({ token }: { token: string }) {
               )}
               {isFinalizing && (
                 <span className="block leading-5 text-muted-foreground">
-                  <T
-                    zh="会议链接正在创建，准备好后会通过邮件送达。"
-                    en="The meeting link is being created and will arrive by email once ready."
-                  />
+                  {booking.meetingUrl ? (
+                    <T
+                      zh="会议资料正在更新。请勿使用之前的链接；新链接准备好后会通过邮件送达。"
+                      en="Meeting details are being updated. Do not use a previous link. The new link will arrive by email once ready."
+                    />
+                  ) : (
+                    <T
+                      zh="会议链接正在创建，准备好后会通过邮件送达。"
+                      en="The meeting link is being created and will arrive by email once ready."
+                    />
+                  )}
                 </span>
               )}
               {booking.refundStatus && booking.refundStatus !== 'none' && (
@@ -379,7 +386,7 @@ export function ManageBooking({ token }: { token: string }) {
             </dd>
           </div>
 
-          {booking.meetingUrl && !isCancelled && (
+          {booking.meetingUrl && !isCancelled && !isFinalizing && (
             <div>
               <dt>
                 <T zh="会议链接" en="Link" />

--- a/components/zoom-image.test.tsx
+++ b/components/zoom-image.test.tsx
@@ -39,6 +39,8 @@ beforeEach(() => {
 
   Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1200 })
   Object.defineProperty(window, 'innerHeight', { configurable: true, value: 900 })
+  Object.defineProperty(window, 'scrollX', { configurable: true, value: 0 })
+  Object.defineProperty(window, 'scrollY', { configurable: true, value: 0 })
   document.documentElement.style.fontSize = ''
   vi.spyOn(HTMLImageElement.prototype, 'getBoundingClientRect').mockReturnValue({
     bottom: 300,
@@ -117,10 +119,26 @@ describe('ZoomImage', () => {
       detail: 0,
     })
 
-    expect(
-      screen.getByRole('dialog', { name: 'Taipei' }).getAttribute('data-state'),
-    ).toBe('open')
+    const dialog = screen.getByRole('dialog', { name: 'Taipei' })
+    expect(dialog.getAttribute('data-state')).toBe('open')
+    expect(dialog.getAttribute('data-motion')).toBe('instant')
     expect(requestAnimationFrame).not.toHaveBeenCalled()
+  })
+
+  it('ignores stale scroll events until the viewport position changes', () => {
+    Object.defineProperty(window, 'scrollX', { configurable: true, value: 0 })
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: 100 })
+    render(<ZoomImage src="/photo.jpg" alt="Taipei" width={800} height={600} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Zoom image: Taipei' }), {
+      detail: 0,
+    })
+
+    fireEvent.scroll(window)
+    expect(screen.getByRole('dialog', { name: 'Taipei' })).not.toBeNull()
+
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: 101 })
+    fireEvent.scroll(window)
+    expect(screen.queryByRole('dialog', { name: 'Taipei' })).toBeNull()
   })
 
   it('closes on Escape immediately and restores trigger focus', () => {
@@ -160,6 +178,7 @@ describe('ZoomImage', () => {
 
     const dialog = screen.getByRole('dialog', { name: 'Taipei' })
     expect(dialog.getAttribute('data-state')).toBe('opening')
+    expect(dialog.getAttribute('data-motion')).toBe('animated')
     expect(frames).toHaveLength(1)
 
     act(() => frames.shift()?.(0))

--- a/components/zoom-image.tsx
+++ b/components/zoom-image.tsx
@@ -84,6 +84,7 @@ export function ZoomImage({
     expandedSrc: string
     target: { left: number; top: number; width: number; height: number }
     from: string
+    motion: 'animated' | 'instant'
   } | null>(null)
   const [state, setState] = useState<'opening' | 'open' | 'closing'>('opening')
   const stateRef = useRef(state)
@@ -144,13 +145,15 @@ export function ZoomImage({
     const s = rect.width / w
     const tx = rect.left + rect.width / 2 - (target.left + w / 2)
     const ty = rect.top + rect.height / 2 - (target.top + h / 2)
+    const reduced = prefersReducedMotion()
+    const instant = event.detail === 0 || reduced
     setZoom({
       expandedSrc,
       target,
       from: `translate(${tx}px, ${ty}px) scale(${s})`,
+      motion: instant ? 'instant' : 'animated',
     })
-    const reduced = prefersReducedMotion()
-    setState(event.detail === 0 || reduced ? 'open' : 'opening')
+    setState(instant ? 'open' : 'opening')
   }, [expandedSrc, width, height, expandedContent])
 
   const unmount = useCallback(() => {
@@ -161,9 +164,14 @@ export function ZoomImage({
 
   const close = useCallback((reason: CloseReason) => {
     // Nothing to reverse if the enter transition never started, and
-    // reduced motion never fires transitionend — unmount directly.
+    // instant motion never fires transitionend — unmount directly.
     const reduced = prefersReducedMotion()
-    if (reason === 'escape' || reduced || stateRef.current === 'opening') {
+    if (
+      reason === 'escape' ||
+      reduced ||
+      zoom?.motion === 'instant' ||
+      stateRef.current === 'opening'
+    ) {
       unmount()
       return
     }
@@ -182,7 +190,7 @@ export function ZoomImage({
       })
     }
     setState('closing')
-  }, [unmount])
+  }, [unmount, zoom?.motion])
 
   // Promote opening -> open one frame later so the transform transition runs
   useEffect(() => {
@@ -219,18 +227,28 @@ export function ZoomImage({
     }
     // Scrolls that bypass wheel/touch (keyboard, scrollbar drag) still close;
     // close() re-measures the landing spot, so the flight stays correct.
-    const onViewportChange = () => close('viewport')
+    const scrollPosition = { x: window.scrollX, y: window.scrollY }
+    const onScroll = () => {
+      if (
+        window.scrollX === scrollPosition.x &&
+        window.scrollY === scrollPosition.y
+      ) {
+        return
+      }
+      close('viewport')
+    }
+    const onResize = () => close('viewport')
     window.addEventListener('keydown', onKey)
     window.addEventListener('wheel', onGesture, { passive: false })
     window.addEventListener('touchmove', onGesture, { passive: false })
-    window.addEventListener('scroll', onViewportChange)
-    window.addEventListener('resize', onViewportChange)
+    window.addEventListener('scroll', onScroll)
+    window.addEventListener('resize', onResize)
     return () => {
       window.removeEventListener('keydown', onKey)
       window.removeEventListener('wheel', onGesture)
       window.removeEventListener('touchmove', onGesture)
-      window.removeEventListener('scroll', onViewportChange)
-      window.removeEventListener('resize', onViewportChange)
+      window.removeEventListener('scroll', onScroll)
+      window.removeEventListener('resize', onResize)
     }
   }, [zoom, close])
 
@@ -274,6 +292,7 @@ export function ZoomImage({
             tabIndex={-1}
             className="zoom-overlay"
             data-state={floating ? 'open' : state}
+            data-motion={zoom.motion}
             role="dialog"
             aria-modal="true"
             aria-label={alt || localize(locale, '图片', 'Image')}

--- a/lib/ama/admin/booking-detail.test.tsx
+++ b/lib/ama/admin/booking-detail.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const router = vi.hoisted(() => ({
@@ -29,6 +29,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup()
+  vi.useRealTimers()
   fetchMock.mockReset()
   router.refresh.mockReset()
   delete document.documentElement.dataset.locale
@@ -153,6 +154,111 @@ describe('AMA booking detail', () => {
     expect(text).toContain('(America/New_York)')
     // Operations for this Booking render with the shared rows.
     expect(text).toContain('Send reminder')
+  })
+
+  it('hides stale meeting artifacts while finalizing', () => {
+    const { container } = renderDetail(
+      makeBooking({
+        status: 'finalizing',
+        meetingProvider: 'tencent-meeting',
+        meetingUrl: 'https://meeting.tencent.com/stale-room',
+        googleCalendarEventId: 'stale_calendar_event',
+        tencentMeetingId: 'stale_tencent_meeting',
+      }),
+    )
+
+    expect(container.textContent).toContain('Meeting details are being updated.')
+    expect(container.textContent).not.toContain('stale-room')
+    expect(container.textContent).not.toContain('stale_calendar_event')
+    expect(container.textContent).not.toContain('stale_tencent_meeting')
+  })
+
+  it('uses creation-oriented copy for initial finalization', () => {
+    const { container } = renderDetail(
+      makeBooking({
+        status: 'finalizing',
+        meetingUrl: null,
+        googleCalendarEventId: null,
+        tencentMeetingId: null,
+      }),
+    )
+
+    expect(container.textContent).toContain('Meeting details are being created.')
+    expect(container.textContent).not.toContain('Do not use a previous link.')
+  })
+
+  it('refreshes while finalizing and reveals only refreshed meeting artifacts', () => {
+    vi.useFakeTimers()
+    const staleBooking = makeBooking({
+      status: 'finalizing',
+      meetingUrl: 'https://meeting.tencent.com/stale-room',
+      googleCalendarEventId: 'stale_calendar_event',
+      tencentMeetingId: 'stale_tencent_meeting',
+    })
+    const { container, rerender } = renderDetail(staleBooking)
+
+    act(() => vi.advanceTimersByTime(10_000))
+    expect(router.refresh).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <BookingDetail
+        booking={
+          makeBooking({
+            status: 'confirmed',
+            meetingUrl: 'https://meeting.tencent.com/new-room',
+            googleCalendarEventId: 'new_calendar_event',
+            tencentMeetingId: 'new_tencent_meeting',
+          })
+        }
+        events={events}
+        operations={operations}
+      />,
+    )
+
+    expect(container.textContent).toContain('new-room')
+    expect(container.textContent).toContain('new_calendar_event')
+    expect(container.textContent).toContain('new_tencent_meeting')
+    expect(container.textContent).not.toContain('stale-room')
+
+    act(() => vi.advanceTimersByTime(20_000))
+    expect(router.refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not poll for fixture bookings', () => {
+    vi.useFakeTimers()
+    render(
+      <BookingDetail
+        booking={makeBooking({ status: 'finalizing' })}
+        events={events}
+        operations={operations}
+        fixtureMode
+      />,
+    )
+
+    act(() => vi.advanceTimersByTime(30_000))
+
+    expect(router.refresh).not.toHaveBeenCalled()
+  })
+
+  it('stops polling after the finalizing refresh window', () => {
+    vi.useFakeTimers()
+    renderDetail(makeBooking({ status: 'finalizing' }))
+
+    act(() => vi.advanceTimersByTime(10 * 60_000))
+
+    expect(router.refresh).toHaveBeenCalledTimes(30)
+  })
+
+  it('pauses finalizing refreshes during an admin mutation', () => {
+    vi.useFakeTimers()
+    fetchMock.mockReturnValue(new Promise<Response>(() => {}))
+    const { container } = renderDetail(makeBooking({ status: 'finalizing' }))
+
+    fireEvent.click(buttonWithText(container, 'Cancel Booking'))
+    fireEvent.click(buttonWithText(container, 'Confirm cancellation'))
+    act(() => vi.advanceTimersByTime(30_000))
+
+    expect(router.refresh).not.toHaveBeenCalled()
   })
 
   it('notes a purged Booking Brief instead of its content', () => {

--- a/lib/ama/operations/repository.test.ts
+++ b/lib/ama/operations/repository.test.ts
@@ -127,6 +127,25 @@ describe('Durable Operations repository', () => {
     expect(claimed[0]?.leaseToken).toBeTruthy()
   })
 
+  it('claims only the requested operation kinds', async () => {
+    const email = await repository.enqueue(enqueueInput('email:filtered'))
+    const artifacts = await repository.enqueue(
+      enqueueInput('artifacts:filtered', { kind: 'update_booking_artifacts' }),
+    )
+
+    const claimed = await repository.claimDue({
+      now,
+      leaseSeconds: 60,
+      limit: 10,
+      kinds: ['send_booking_email'],
+    })
+
+    expect(claimed.map((operation) => operation.id)).toEqual([email.operation.id])
+    await expect(repository.get(artifacts.operation.id)).resolves.toMatchObject({
+      status: 'pending',
+    })
+  })
+
   it('does not claim operations scheduled for the future', async () => {
     await repository.enqueue(
       enqueueInput('email:future', { nextAttemptAt: new Date(now.getTime() + HOUR) }),

--- a/lib/ama/operations/repository.ts
+++ b/lib/ama/operations/repository.ts
@@ -98,21 +98,28 @@ export function createDurableOperationsRepository(database: () => OperationsData
       now: Date
       leaseSeconds: number
       limit: number
+      kinds?: DurableOperationKind[]
     }): Promise<DurableOperationRecord[]> {
+      if (input.kinds?.length === 0) return []
       const leaseToken = randomUUID()
       const leaseExpiresAt = new Date(input.now.getTime() + input.leaseSeconds * 1000)
       const due = database()
         .select({ id: amaDurableOperations.id })
         .from(amaDurableOperations)
         .where(
-          or(
-            and(
-              eq(amaDurableOperations.status, 'pending'),
-              lte(amaDurableOperations.nextAttemptAt, input.now),
-            ),
-            and(
-              eq(amaDurableOperations.status, 'running'),
-              lte(amaDurableOperations.leaseExpiresAt, input.now),
+          and(
+            input.kinds
+              ? inArray(amaDurableOperations.kind, input.kinds)
+              : undefined,
+            or(
+              and(
+                eq(amaDurableOperations.status, 'pending'),
+                lte(amaDurableOperations.nextAttemptAt, input.now),
+              ),
+              and(
+                eq(amaDurableOperations.status, 'running'),
+                lte(amaDurableOperations.leaseExpiresAt, input.now),
+              ),
             ),
           ),
         )

--- a/lib/ama/operations/runner.test.ts
+++ b/lib/ama/operations/runner.test.ts
@@ -53,8 +53,11 @@ function fixture(input: {
 }) {
   const completes: { operationId: string; leaseToken: string; now: Date }[] = []
   const fails: FailInput[] = []
+  let claimed = false
   const operations = {
     async claimDue() {
+      if (claimed) return []
+      claimed = true
       return input.batch
     },
     async complete(operationId: string, leaseToken: string, now: Date) {
@@ -223,6 +226,127 @@ describe('operations runner', () => {
     expect(f.completes).toEqual([
       { operationId: 'op_good', leaseToken: 'lease-good', now: NOW },
     ])
+  })
+
+  it('claims due work enqueued by a handler in the same run', async () => {
+    const queue = [makeOperation({ id: 'op_parent', leaseToken: 'lease-parent' })]
+    const handled: string[] = []
+    const claims: Array<{ limit: number; kinds?: string[] }> = []
+    const operations = {
+      async claimDue(input: { limit: number; kinds?: string[] }) {
+        claims.push(input)
+        return queue.splice(0, input.limit)
+      },
+      async complete(operationId: string) {
+        return makeOperation({ id: operationId, status: 'succeeded' })
+      },
+      async fail() {
+        throw new Error('unexpected fail call')
+      },
+    } as unknown as DurableOperationsRepository
+    const runner = createOperationsRunner({
+      operations,
+      handler: async (operation) => {
+        handled.push(operation.id)
+        if (operation.id === 'op_parent') {
+          queue.push(makeOperation({ id: 'op_child', leaseToken: 'lease-child' }))
+        }
+      },
+      clock: { now: () => NOW },
+    })
+
+    const result = await runner.run()
+
+    expect(handled).toEqual(['op_parent', 'op_child'])
+    expect(claims.map(({ limit, kinds }) => ({ limit, kinds }))).toEqual([
+      { limit: 10, kinds: undefined },
+      { limit: 1, kinds: ['send_booking_email'] },
+      { limit: 1, kinds: ['send_booking_email'] },
+    ])
+    expect(result).toEqual({
+      claimed: 2,
+      succeeded: 2,
+      retried: 0,
+      failed: 0,
+      deferred: 0,
+    })
+  })
+
+  it('keeps the total claimed work within the batch size across rounds', async () => {
+    const queue = [makeOperation({ id: 'op_1', leaseToken: 'lease-1' })]
+    const handled: string[] = []
+    const claimLimits: number[] = []
+    const operations = {
+      async claimDue(input: { limit: number }) {
+        claimLimits.push(input.limit)
+        return queue.splice(0, input.limit)
+      },
+      async complete(operationId: string) {
+        return makeOperation({ id: operationId, status: 'succeeded' })
+      },
+      async fail() {
+        throw new Error('unexpected fail call')
+      },
+    } as unknown as DurableOperationsRepository
+    const runner = createOperationsRunner({
+      operations,
+      handler: async (operation) => {
+        handled.push(operation.id)
+        const next = Number(operation.id.slice('op_'.length)) + 1
+        queue.push(
+          makeOperation({ id: `op_${next}`, leaseToken: `lease-${next}` }),
+        )
+      },
+      clock: { now: () => NOW },
+      batchSize: 3,
+    })
+
+    const result = await runner.run()
+
+    expect(handled).toEqual(['op_1', 'op_2', 'op_3'])
+    expect(claimLimits).toEqual([3, 1, 1])
+    expect(queue.map((operation) => operation.id)).toEqual(['op_4'])
+    expect(result.claimed).toBe(3)
+    expect(result.succeeded).toBe(3)
+  })
+
+  it('does not start a follow-up claim without provider timeout headroom', async () => {
+    const queue = [makeOperation({ id: 'op_parent', leaseToken: 'lease-parent' })]
+    const claimLimits: number[] = []
+    let nowMs = NOW.getTime()
+    const operations = {
+      async claimDue(input: { limit: number }) {
+        claimLimits.push(input.limit)
+        return queue.splice(0, input.limit)
+      },
+      async complete(operationId: string) {
+        return makeOperation({ id: operationId, status: 'succeeded' })
+      },
+      async fail() {
+        throw new Error('unexpected fail call')
+      },
+    } as unknown as DurableOperationsRepository
+    const runner = createOperationsRunner({
+      operations,
+      handler: async () => {
+        queue.push(makeOperation({ id: 'op_child', leaseToken: 'lease-child' }))
+        nowMs += 36_000
+      },
+      clock: { now: () => new Date(nowMs) },
+      timeBudgetMs: 45_000,
+    })
+
+    const result = await runner.run()
+
+    expect(claimLimits).toEqual([10])
+    expect(queue.map((operation) => operation.id)).toEqual(['op_child'])
+    expect(result).toEqual({
+      claimed: 1,
+      succeeded: 1,
+      retried: 0,
+      failed: 0,
+      deferred: 0,
+    })
   })
 
   it('skips claimed rows without a lease token', async () => {

--- a/lib/ama/operations/runner.ts
+++ b/lib/ama/operations/runner.ts
@@ -9,6 +9,10 @@ import type { DurableOperationsRepository } from './repository'
 
 const BASE_RETRY_SECONDS = 30
 const MAX_RETRY_SECONDS = 3600
+// Follow-up passes only drain single-call email work. Keeping one provider
+// timeout in reserve prevents a late claim from crossing the function limit.
+const FOLLOW_UP_START_HEADROOM_MS = 10_000
+const FOLLOW_UP_OPERATION_KINDS = ['send_booking_email'] as const
 
 export type OperationsRunResult = {
   claimed: number
@@ -60,50 +64,74 @@ export function createOperationsRunner(dependencies: OperationsRunnerDependencie
   return {
     async run(): Promise<OperationsRunResult> {
       const startedAtMs = clock.now().getTime()
-      const claimed = await operations.claimDue({
-        now: clock.now(),
-        leaseSeconds,
-        limit: batchSize,
-      })
       const result: OperationsRunResult = {
-        claimed: claimed.length,
+        claimed: 0,
         succeeded: 0,
         retried: 0,
         failed: 0,
         deferred: 0,
       }
-      for (const operation of claimed) {
-        if (!operation.leaseToken) continue
-        if (clock.now().getTime() - startedAtMs >= timeBudgetMs) {
-          result.deferred += 1
-          continue
+
+      while (result.claimed < batchSize) {
+        const isFollowUp = result.claimed > 0
+        const startHeadroomMs = isFollowUp ? FOLLOW_UP_START_HEADROOM_MS : 0
+        if (
+          clock.now().getTime() - startedAtMs >=
+          timeBudgetMs - startHeadroomMs
+        ) {
+          break
         }
-        try {
-          await handler(operation)
-          await operations.complete(operation.id, operation.leaseToken, clock.now())
-          result.succeeded += 1
-        } catch (error) {
-          const now = clock.now()
-          const terminal = error instanceof TerminalOperationError
-          const retryAt =
-            error instanceof RetryableOperationError && error.retryAt
-              ? error.retryAt
-              : backoffAt(operation.attemptCount, now)
-          const errorCode =
-            error instanceof RetryableOperationError ||
-            error instanceof TerminalOperationError
-              ? error.code
-              : 'unexpected_error'
-          const failed = await operations.fail({
-            operationId: operation.id,
-            leaseToken: operation.leaseToken,
-            errorCode,
-            retryAt,
-            now,
-            terminal,
-          })
-          if (failed?.status === 'failed') result.failed += 1
-          else result.retried += 1
+        const claimed = await operations.claimDue({
+          now: clock.now(),
+          leaseSeconds,
+          limit: isFollowUp ? 1 : batchSize - result.claimed,
+          ...(isFollowUp
+            ? { kinds: [...FOLLOW_UP_OPERATION_KINDS] }
+            : {}),
+        })
+        if (claimed.length === 0) break
+        result.claimed += claimed.length
+
+        for (const operation of claimed) {
+          if (!operation.leaseToken) continue
+          if (
+            clock.now().getTime() - startedAtMs >=
+            timeBudgetMs - startHeadroomMs
+          ) {
+            result.deferred += 1
+            continue
+          }
+          try {
+            await handler(operation)
+            await operations.complete(
+              operation.id,
+              operation.leaseToken,
+              clock.now(),
+            )
+            result.succeeded += 1
+          } catch (error) {
+            const now = clock.now()
+            const terminal = error instanceof TerminalOperationError
+            const retryAt =
+              error instanceof RetryableOperationError && error.retryAt
+                ? error.retryAt
+                : backoffAt(operation.attemptCount, now)
+            const errorCode =
+              error instanceof RetryableOperationError ||
+              error instanceof TerminalOperationError
+                ? error.code
+                : 'unexpected_error'
+            const failed = await operations.fail({
+              operationId: operation.id,
+              leaseToken: operation.leaseToken,
+              errorCode,
+              retryAt,
+              now,
+              terminal,
+            })
+            if (failed?.status === 'failed') result.failed += 1
+            else result.retried += 1
+          }
         }
       }
       return result

--- a/lib/calibaby-public-content.test.ts
+++ b/lib/calibaby-public-content.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it, vi } from 'vitest'
 vi.mock('server-only', () => ({}))
 
 import {
+  CALI_BABY_APP_STORE_ID,
+  CALI_BABY_APP_STORE_URL,
   caliBabyLandingMetadata,
+  caliBabyLandingStructuredData,
   caliBabyPageMetadata,
   getCaliBabyPublicContent,
   type CaliBabyPageKind,
@@ -37,7 +40,7 @@ describe('Cali Baby public content', () => {
   )
 
   it.each(expected)(
-    'publishes paired metadata for %s %s while publication gates remain closed',
+    'publishes indexable paired metadata for %s %s',
     (locale, kind, route) => {
       const metadata = caliBabyPageMetadata(locale, kind)
       const canonical = metadata.alternates?.canonical
@@ -58,7 +61,8 @@ describe('Cali Baby public content', () => {
           seo.url,
         ).href,
       })
-      expect(metadata.robots).toEqual({ index: false, follow: true })
+      expect(metadata.itunes).toEqual({ appId: CALI_BABY_APP_STORE_ID })
+      expect(metadata.robots).toBeUndefined()
       expect(metadata.openGraph?.siteName).toBe('Cali Baby')
       expect(metadata.openGraph?.images).toEqual([
         expect.objectContaining({
@@ -87,14 +91,14 @@ describe('Cali Baby public content', () => {
     [
       'zh',
       '/calibaby',
-      'Cali 宝宝｜宝宝的事很多，不必都靠脑子记',
-      '胎动、喂奶、睡眠、尿布，发生了就顺手记一下。家里人都能看到刚刚发生了什么，换谁来照顾，都不用再从头问一遍。',
+      'Cali 宝宝｜喂奶、睡眠、尿布与胎动记录',
+      '从孕期到宝宝出生后，记录胎动、宫缩、喂奶、睡眠、尿布、成长等日常，并通过家庭同步与授权照顾者共享近况。现已上线 App Store。',
     ],
     [
       'en',
       '/en/calibaby',
-      'Cali Baby | You don’t have to remember every feed.',
-      'Log kicks, feeds, sleep, and diapers as they happen. Everyone caring for the baby can see what happened and when, so whoever takes over doesn’t have to start with a round of questions.',
+      'Cali Baby: Baby Tracker for Feeding, Sleep & Diapers',
+      'Track kicks, contractions, feeding, sleep, diapers, growth, and more. Keep authorized caregivers in sync with Cali Baby for iPhone and Apple Watch.',
     ],
   ] as const)(
     'publishes paired landing metadata for %s',
@@ -117,7 +121,40 @@ describe('Cali Baby public content', () => {
       expect(metadata.twitter).toEqual(
         expect.objectContaining({ title, description }),
       )
-      expect(metadata.robots).toEqual({ index: false, follow: true })
+      expect(metadata.robots).toBeUndefined()
+      expect(metadata.category).toBe('Health & Fitness')
+      expect(metadata.itunes).toEqual({ appId: CALI_BABY_APP_STORE_ID })
     },
   )
+
+  it.each([
+    ['zh', '/calibaby', 'Cali 宝宝'],
+    ['en', '/en/calibaby', 'Cali Baby: Baby Tracker'],
+  ] as const)('publishes verified MobileApplication data for %s', (locale, path, name) => {
+    const structuredData = caliBabyLandingStructuredData(locale)
+
+    expect(structuredData).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'MobileApplication',
+      '@id': `${new URL(path, seo.url).href}#app`,
+      name,
+      url: new URL(path, seo.url).href,
+      sameAs: CALI_BABY_APP_STORE_URL,
+      downloadUrl: CALI_BABY_APP_STORE_URL,
+      applicationCategory: 'HealthApplication',
+      operatingSystem: 'iOS 18.0 or later; watchOS 11.0 or later',
+      isAccessibleForFree: true,
+      offers: {
+        '@type': 'Offer',
+        price: 0,
+        priceCurrency: 'USD',
+        url: CALI_BABY_APP_STORE_URL,
+      },
+      publisher: {
+        '@type': 'Organization',
+        name: 'Zolplay',
+      },
+    })
+    expect(structuredData.featureList).toHaveLength(4)
+  })
 })

--- a/lib/calibaby-public-content.test.ts
+++ b/lib/calibaby-public-content.test.ts
@@ -91,14 +91,14 @@ describe('Cali Baby public content', () => {
     [
       'zh',
       '/calibaby',
-      'Cali 宝宝｜喂奶、睡眠、尿布与胎动记录',
-      '从孕期到宝宝出生后，记录胎动、宫缩、喂奶、睡眠、尿布、成长等日常，并通过家庭同步与授权照顾者共享近况。现已上线 App Store。',
+      'Cali 宝宝｜宝宝的事很多，不必都靠脑子记',
+      '胎动、喂奶、睡眠、尿布，发生了就顺手记一下。家里人都能看到刚刚发生了什么，换谁来照顾，都不用再从头问一遍。',
     ],
     [
       'en',
       '/en/calibaby',
-      'Cali Baby: Baby Tracker for Feeding, Sleep & Diapers',
-      'Track kicks, contractions, feeding, sleep, diapers, growth, and more. Keep authorized caregivers in sync with Cali Baby for iPhone and Apple Watch.',
+      'Cali Baby | You don’t have to remember every feed.',
+      'Log kicks, feeds, sleep, and diapers as they happen. Everyone caring for the baby can see what happened and when, so whoever takes over doesn’t have to start with a round of questions.',
     ],
   ] as const)(
     'publishes paired landing metadata for %s',
@@ -122,7 +122,6 @@ describe('Cali Baby public content', () => {
         expect.objectContaining({ title, description }),
       )
       expect(metadata.robots).toBeUndefined()
-      expect(metadata.category).toBe('Health & Fitness')
       expect(metadata.itunes).toEqual({ appId: CALI_BABY_APP_STORE_ID })
     },
   )

--- a/lib/calibaby-public-content.test.ts
+++ b/lib/calibaby-public-content.test.ts
@@ -40,7 +40,7 @@ describe('Cali Baby public content', () => {
   )
 
   it.each(expected)(
-    'publishes indexable paired metadata for %s %s',
+    'keeps publication-gated paired metadata for %s %s',
     (locale, kind, route) => {
       const metadata = caliBabyPageMetadata(locale, kind)
       const canonical = metadata.alternates?.canonical
@@ -62,7 +62,7 @@ describe('Cali Baby public content', () => {
         ).href,
       })
       expect(metadata.itunes).toEqual({ appId: CALI_BABY_APP_STORE_ID })
-      expect(metadata.robots).toBeUndefined()
+      expect(metadata.robots).toEqual({ index: false, follow: true })
       expect(metadata.openGraph?.siteName).toBe('Cali Baby')
       expect(metadata.openGraph?.images).toEqual([
         expect.objectContaining({

--- a/lib/calibaby-public-content.ts
+++ b/lib/calibaby-public-content.ts
@@ -9,21 +9,84 @@ import type { Locale } from './locale-route'
 
 export type CaliBabyPageKind = 'support' | 'privacy' | 'terms'
 
+export const CALI_BABY_APP_STORE_ID = '6769728441'
+export const CALI_BABY_APP_STORE_URL =
+  'https://apps.apple.com/app/id6769728441'
+
 const LANDING_METADATA: Record<
   Locale,
   { title: string; description: string }
 > = {
   zh: {
-    title: 'Cali 宝宝｜宝宝的事很多，不必都靠脑子记',
+    title: 'Cali 宝宝｜喂奶、睡眠、尿布与胎动记录',
     description:
-      '胎动、喂奶、睡眠、尿布，发生了就顺手记一下。家里人都能看到刚刚发生了什么，换谁来照顾，都不用再从头问一遍。',
+      '从孕期到宝宝出生后，记录胎动、宫缩、喂奶、睡眠、尿布、成长等日常，并通过家庭同步与授权照顾者共享近况。现已上线 App Store。',
   },
   en: {
-    title: 'Cali Baby | You don’t have to remember every feed.',
+    title: 'Cali Baby: Baby Tracker for Feeding, Sleep & Diapers',
     description:
-      'Log kicks, feeds, sleep, and diapers as they happen. Everyone caring for the baby can see what happened and when, so whoever takes over doesn’t have to start with a round of questions.',
+      'Track kicks, contractions, feeding, sleep, diapers, growth, and more. Keep authorized caregivers in sync with Cali Baby for iPhone and Apple Watch.',
   },
 }
+
+export const CALI_BABY_PRODUCT_DETAILS = {
+  zh: {
+    title: '从孕期到宝宝出生后的每一天',
+    introduction:
+      'Cali 宝宝把胎动、宫缩、喂养、睡眠、尿布和成长记录放在一处。无需账号即可开始，常用记录也能从锁定画面、Siri 或 Apple Watch 随手完成。',
+    facts:
+      'Zolplay 出品 · 适用于 iPhone 与 Apple Watch · 需 iOS 18 与 watchOS 11 或更高版本 · 支持简体中文与英文 · 免费下载，可选 Cali Baby Pro',
+    features: [
+      {
+        title: '孕期记录',
+        description: '记录胎动、宫缩、孕期体重、产检和待产包，陪你走到宝宝出生。',
+      },
+      {
+        title: '日常照顾',
+        description: '记录母乳、奶瓶、吸奶、辅食、睡眠、尿布、洗澡、体温和成长。',
+      },
+      {
+        title: '随手记录',
+        description:
+          '通过小组件、实时活动、Siri、快捷指令和 Apple Watch，少几步完成常用记录。',
+      },
+      {
+        title: '一起照顾',
+        description:
+          '按需开启家庭同步，让获得授权的照顾者查看并记录同一个宝宝的近况。',
+      },
+    ],
+  },
+  en: {
+    title: 'From pregnancy through everyday care',
+    introduction:
+      'Cali Baby keeps kicks, contractions, feeding, sleep, diapers, and growth in one calm place. Start without an account, then log common care from the Lock Screen, Siri, or Apple Watch.',
+    facts:
+      'By Zolplay · For iPhone and Apple Watch · Requires iOS 18 and watchOS 11 or later · English and Simplified Chinese · Free with optional Cali Baby Pro',
+    features: [
+      {
+        title: 'Pregnancy',
+        description:
+          'Track kicks, contractions, pregnancy weight, prenatal checkups, and a hospital bag checklist.',
+      },
+      {
+        title: 'Daily care',
+        description:
+          'Log nursing, bottles, pumping, solids, sleep, diapers, baths, temperature, growth, and more.',
+      },
+      {
+        title: 'Quick entry',
+        description:
+          'Use widgets, Live Activities, Siri, Shortcuts, and Apple Watch to record common care with fewer steps.',
+      },
+      {
+        title: 'Care together',
+        description:
+          'Turn on Family Sync when needed so authorized caregivers can view and log care for the same baby.',
+      },
+    ],
+  },
+} as const
 
 type CaliBabyPublicContent = {
   route: string
@@ -119,7 +182,50 @@ export function caliBabyPageMetadata(
 
 export function caliBabyLandingMetadata(locale: Locale): Metadata {
   const copy = LANDING_METADATA[locale]
-  return caliBabyMetadata(locale, '/calibaby', copy.title, copy.description)
+  return {
+    ...caliBabyMetadata(locale, '/calibaby', copy.title, copy.description),
+    category: 'Health & Fitness',
+  }
+}
+
+export function caliBabyLandingStructuredData(locale: Locale) {
+  const copy = LANDING_METADATA[locale]
+  const details = CALI_BABY_PRODUCT_DETAILS[locale]
+  const canonical = localeRoutePair('/calibaby')[locale]
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'MobileApplication',
+    '@id': `${canonical.href}#app`,
+    name: locale === 'en' ? 'Cali Baby: Baby Tracker' : 'Cali 宝宝',
+    alternateName: locale === 'en' ? 'Cali Baby' : 'Cali Baby: Baby Tracker',
+    description: copy.description,
+    url: canonical.href,
+    sameAs: CALI_BABY_APP_STORE_URL,
+    downloadUrl: CALI_BABY_APP_STORE_URL,
+    image: new URL('/images/calibaby-app-icon.png', canonical).href,
+    applicationCategory: 'HealthApplication',
+    applicationSubCategory: 'Health & Fitness',
+    operatingSystem: 'iOS 18.0 or later; watchOS 11.0 or later',
+    availableOnDevice: ['iPhone', 'Apple Watch'],
+    inLanguage: ['en', 'zh-CN'],
+    isAccessibleForFree: true,
+    featureList: details.features.map(
+      (feature) => `${feature.title}: ${feature.description}`,
+    ),
+    offers: {
+      '@type': 'Offer',
+      price: 0,
+      priceCurrency: 'USD',
+      url: CALI_BABY_APP_STORE_URL,
+      availability: 'https://schema.org/InStock',
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'Zolplay',
+      url: 'https://zolplay.com',
+    },
+  }
 }
 
 function caliBabyMetadata(
@@ -141,14 +247,11 @@ function caliBabyMetadata(
   return {
     title,
     description,
+    itunes: { appId: CALI_BABY_APP_STORE_ID },
     alternates: {
       canonical,
       languages: pair.languages,
     },
-    // The approved publication checklist still contains unresolved gates and
-    // effective-date placeholders. Keep previews reachable but out of search
-    // results until that checklist is explicitly cleared.
-    robots: { index: false, follow: true },
     openGraph: {
       title,
       description,

--- a/lib/calibaby-public-content.ts
+++ b/lib/calibaby-public-content.ts
@@ -172,12 +172,17 @@ export function caliBabyPageMetadata(
 ): Metadata {
   const content = getCaliBabyPublicContent(locale, kind)
   const unlocalizedPath = kind === 'support' ? '/calibaby/help' : `/calibaby/${kind}`
-  return caliBabyMetadata(
-    locale,
-    unlocalizedPath,
-    content.metadataTitle,
-    content.metadataDescription,
-  )
+  return {
+    ...caliBabyMetadata(
+      locale,
+      unlocalizedPath,
+      content.metadataTitle,
+      content.metadataDescription,
+    ),
+    // The product has launched, but this source copy remains subject to the
+    // publication gates in docs/calibaby-public-copy.md.
+    robots: { index: false, follow: true },
+  }
 }
 
 export function caliBabyLandingMetadata(locale: Locale): Metadata {

--- a/lib/calibaby-public-content.ts
+++ b/lib/calibaby-public-content.ts
@@ -18,14 +18,14 @@ const LANDING_METADATA: Record<
   { title: string; description: string }
 > = {
   zh: {
-    title: 'Cali 宝宝｜喂奶、睡眠、尿布与胎动记录',
+    title: 'Cali 宝宝｜宝宝的事很多，不必都靠脑子记',
     description:
-      '从孕期到宝宝出生后，记录胎动、宫缩、喂奶、睡眠、尿布、成长等日常，并通过家庭同步与授权照顾者共享近况。现已上线 App Store。',
+      '胎动、喂奶、睡眠、尿布，发生了就顺手记一下。家里人都能看到刚刚发生了什么，换谁来照顾，都不用再从头问一遍。',
   },
   en: {
-    title: 'Cali Baby: Baby Tracker for Feeding, Sleep & Diapers',
+    title: 'Cali Baby | You don’t have to remember every feed.',
     description:
-      'Track kicks, contractions, feeding, sleep, diapers, growth, and more. Keep authorized caregivers in sync with Cali Baby for iPhone and Apple Watch.',
+      'Log kicks, feeds, sleep, and diapers as they happen. Everyone caring for the baby can see what happened and when, so whoever takes over doesn’t have to start with a round of questions.',
   },
 }
 
@@ -187,10 +187,7 @@ export function caliBabyPageMetadata(
 
 export function caliBabyLandingMetadata(locale: Locale): Metadata {
   const copy = LANDING_METADATA[locale]
-  return {
-    ...caliBabyMetadata(locale, '/calibaby', copy.title, copy.description),
-    category: 'Health & Fitness',
-  }
+  return caliBabyMetadata(locale, '/calibaby', copy.title, copy.description)
 }
 
 export function caliBabyLandingStructuredData(locale: Locale) {

--- a/lib/next-config.test.ts
+++ b/lib/next-config.test.ts
@@ -60,4 +60,13 @@ describe('route security headers', () => {
       "form-action 'self' https://accounts.google.com",
     )
   })
+
+  it('advertises the root llms.txt from every response', async () => {
+    const rules = await nextConfig.headers!()
+    const llmsLink = rules
+      .find(({ source }) => source === '/:path*')
+      ?.headers.find(({ key }) => key === 'Link')?.value
+
+    expect(llmsLink).toBe('</llms.txt>; rel="describedby"')
+  })
 })

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -15,7 +15,7 @@ export const projects: Project[] = [
     nameEn: 'Cali Baby',
     description: '宝宝的事很多，不必都靠脑子记。',
     descriptionEn: 'You don’t have to remember every feed.',
-    url: 'https://cali.so/calibaby',
+    url: '/calibaby',
     icon: '/images/calibaby-app-icon.png',
     domain: 'cali.so',
   },

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -11,6 +11,15 @@ export interface Project {
 
 export const projects: Project[] = [
   {
+    name: 'Cali 宝宝',
+    nameEn: 'Cali Baby',
+    description: '宝宝的事很多，不必都靠脑子记。',
+    descriptionEn: 'You don’t have to remember every feed.',
+    url: 'https://cali.so/calibaby',
+    icon: '/images/calibaby-app-icon.png',
+    domain: 'cali.so',
+  },
+  {
     name: '佐玩官网',
     nameEn: 'Zolplay Website',
     description: '为自己的公司佐玩设计开发的官网，简约的设计结合噪点材质感。',

--- a/next.config.ts
+++ b/next.config.ts
@@ -82,7 +82,13 @@ const nextConfig: NextConfig = {
   headers: async () => [
     {
       source: '/:path*',
-      headers: [...securityHeaders],
+      headers: [
+        ...securityHeaders,
+        {
+          key: 'Link',
+          value: '</llms.txt>; rel="describedby"',
+        },
+      ],
     },
     {
       // The global policy is intentionally useful for public navigation, but

--- a/scripts/verify-public-discovery.mjs
+++ b/scripts/verify-public-discovery.mjs
@@ -235,6 +235,19 @@ function requiredElement(document, selector, description) {
   return element
 }
 
+function markdownLinkTargets(markdown) {
+  const targets = new Set()
+  for (const line of markdown.split('\n')) {
+    if (!line.startsWith('- [')) continue
+    const targetStart = line.indexOf('](')
+    const targetEnd = line.indexOf('): ', targetStart + 2)
+    if (targetStart >= 0 && targetEnd > targetStart) {
+      targets.add(line.slice(targetStart + 2, targetEnd))
+    }
+  }
+  return targets
+}
+
 async function verifyMetadata(baseUrl, page) {
   const response = await fetch(new URL(page.path, baseUrl))
   assert.equal(response.status, 200, `${page.path} status`)
@@ -409,13 +422,14 @@ async function verifyDiscoveryFiles(baseUrl) {
   assert.match(llms.headers.get('content-type') ?? '', /^text\/markdown/)
   const llmsText = await llms.text()
   assert.match(llmsText, /^# Cali Castle and Cali Baby\n\n>/)
+  const llmsTargets = markdownLinkTargets(llmsText)
   assert.ok(
-    llmsText.includes('https://apps.apple.com/app/id6769728441'),
+    llmsTargets.has('https://apps.apple.com/app/id6769728441'),
     'llms.txt App Store listing',
   )
   for (const path of new Set(publicPages.map((page) => page.path))) {
     assert.ok(
-      llmsText.includes(new URL(path, productionOrigin).href),
+      llmsTargets.has(new URL(path, productionOrigin).href),
       `llms.txt ${path}`,
     )
   }

--- a/scripts/verify-public-discovery.mjs
+++ b/scripts/verify-public-discovery.mjs
@@ -32,7 +32,7 @@ function localizedPages(pathname, zh, en, imageAlt) {
   ]
 }
 
-function localizedCaliBabyPages(pathname, zh, en) {
+function localizedCaliBabyPages(pathname, zh, en, indexable) {
   const enPath = `/en${pathname}`
   return [
     {
@@ -43,6 +43,7 @@ function localizedCaliBabyPages(pathname, zh, en) {
       description: zh.description,
       imageAlt: 'Cali 宝宝应用图标与名称',
       smartAppBanner: true,
+      indexable,
     },
     {
       path: enPath,
@@ -52,6 +53,7 @@ function localizedCaliBabyPages(pathname, zh, en) {
       description: en.description,
       imageAlt: 'Cali Baby app icon and wordmark',
       smartAppBanner: true,
+      indexable,
     },
   ]
 }
@@ -146,6 +148,7 @@ const publicPages = [
       description:
         'Track kicks, contractions, feeding, sleep, diapers, growth, and more. Keep authorized caregivers in sync with Cali Baby for iPhone and Apple Watch.',
     },
+    true,
   ),
   ...localizedCaliBabyPages(
     '/calibaby/help',
@@ -158,6 +161,7 @@ const publicPages = [
       description:
         'Get help with Family Sync, backups, voice records, and deletion, learn about Cali Baby, or contact support.',
     },
+    false,
   ),
   ...localizedCaliBabyPages(
     '/calibaby/privacy',
@@ -170,6 +174,7 @@ const publicPages = [
       description:
         'Learn how Cali Baby handles device records, Family Sync, voice processing, analytics, diagnostics, and deletion requests.',
     },
+    false,
   ),
   ...localizedCaliBabyPages(
     '/calibaby/terms',
@@ -182,6 +187,7 @@ const publicPages = [
       description:
         "Read Cali Baby's terms for accounts, Family sharing, Cali Baby Pro, health boundaries, and service regions.",
     },
+    false,
   ),
 ]
 
@@ -236,11 +242,14 @@ async function verifyMetadata(baseUrl, page) {
   const { document } = dom.window
 
   assert.equal(document.documentElement.lang, page.locale, `${page.path} lang`)
-  assert.doesNotMatch(
-    document.querySelector('meta[name="robots"]')?.getAttribute('content') ?? '',
-    /noindex|nofollow/,
-    `${page.path} indexing`,
-  )
+  const robots =
+    document.querySelector('meta[name="robots"]')?.getAttribute('content') ?? ''
+  if (page.indexable === false) {
+    assert.match(robots, /noindex/, `${page.path} indexing`)
+    assert.doesNotMatch(robots, /nofollow/, `${page.path} links`)
+  } else {
+    assert.doesNotMatch(robots, /noindex|nofollow/, `${page.path} indexing`)
+  }
   assert.equal(document.title, page.documentTitle, `${page.path} title`)
   assert.equal(
     requiredElement(
@@ -361,10 +370,19 @@ async function verifyDiscoveryFiles(baseUrl) {
     /(?:application|text)\/xml/,
   )
   const sitemapXml = await sitemap.text()
-  for (const path of new Set(publicPages.map((page) => page.path))) {
+  const sitemapPaths = publicPages
+    .filter((page) => page.indexable !== false)
+    .map((page) => page.path)
+  for (const path of new Set(sitemapPaths)) {
     assert.ok(
       sitemapXml.includes(new URL(path, productionOrigin).href),
       `sitemap ${path}`,
+    )
+  }
+  for (const page of publicPages.filter((candidate) => candidate.indexable === false)) {
+    assert.ok(
+      !sitemapXml.includes(new URL(page.path, productionOrigin).href),
+      `sitemap excludes ${page.path}`,
     )
   }
 

--- a/scripts/verify-public-discovery.mjs
+++ b/scripts/verify-public-discovery.mjs
@@ -32,6 +32,30 @@ function localizedPages(pathname, zh, en, imageAlt) {
   ]
 }
 
+function localizedCaliBabyPages(pathname, zh, en) {
+  const enPath = `/en${pathname}`
+  return [
+    {
+      path: pathname,
+      locale: 'zh-CN',
+      title: zh.title,
+      documentTitle: zh.title,
+      description: zh.description,
+      imageAlt: 'Cali 宝宝应用图标与名称',
+      smartAppBanner: true,
+    },
+    {
+      path: enPath,
+      locale: 'en',
+      title: en.title,
+      documentTitle: en.title,
+      description: en.description,
+      imageAlt: 'Cali Baby app icon and wordmark',
+      smartAppBanner: true,
+    },
+  ]
+}
+
 const publicPages = [
   ...localizedPages(
     '/',
@@ -108,6 +132,55 @@ const publicPages = [
     {
       zh: '一对一 · Cali Castle。从产品设计、工程、职业到独立开发、创业、出海、英语学习与 AI 工作流，用一小时聊清楚怎么判断、怎么取舍、下一步做什么。',
       en: 'AMA · Cali Castle. A one-to-one conversation about AI-native work, product strategy, engineering, startups, career moves, and building products.',
+    },
+  ),
+  ...localizedCaliBabyPages(
+    '/calibaby',
+    {
+      title: 'Cali 宝宝｜喂奶、睡眠、尿布与胎动记录',
+      description:
+        '从孕期到宝宝出生后，记录胎动、宫缩、喂奶、睡眠、尿布、成长等日常，并通过家庭同步与授权照顾者共享近况。现已上线 App Store。',
+    },
+    {
+      title: 'Cali Baby: Baby Tracker for Feeding, Sleep & Diapers',
+      description:
+        'Track kicks, contractions, feeding, sleep, diapers, growth, and more. Keep authorized caregivers in sync with Cali Baby for iPhone and Apple Watch.',
+    },
+  ),
+  ...localizedCaliBabyPages(
+    '/calibaby/help',
+    {
+      title: 'Cali 宝宝｜帮助与支持',
+      description: '查找家庭同步、备份、语音记录和账号删除帮助，了解 Cali 宝宝，或联系我们。',
+    },
+    {
+      title: 'Cali Baby | Help and Support',
+      description:
+        'Get help with Family Sync, backups, voice records, and deletion, learn about Cali Baby, or contact support.',
+    },
+  ),
+  ...localizedCaliBabyPages(
+    '/calibaby/privacy',
+    {
+      title: 'Cali 宝宝隐私政策',
+      description: '了解 Cali 宝宝如何处理设备记录、家庭同步、语音、分析、诊断和删除请求。',
+    },
+    {
+      title: 'Cali Baby Privacy Policy',
+      description:
+        'Learn how Cali Baby handles device records, Family Sync, voice processing, analytics, diagnostics, and deletion requests.',
+    },
+  ),
+  ...localizedCaliBabyPages(
+    '/calibaby/terms',
+    {
+      title: 'Cali 宝宝使用条款',
+      description: '阅读 Cali 宝宝关于账号、家庭共享、Cali Baby Pro、医疗边界和服务区域的使用条款。',
+    },
+    {
+      title: 'Cali Baby Terms of Use',
+      description:
+        "Read Cali Baby's terms for accounts, Family sharing, Cali Baby Pro, health boundaries, and service regions.",
     },
   ),
 ]
@@ -249,6 +322,16 @@ async function verifyMetadata(baseUrl, page) {
     ).getAttribute('content'),
     '630',
   )
+  if (page.smartAppBanner) {
+    assert.equal(
+      requiredElement(
+        document,
+        'meta[name="apple-itunes-app"]',
+        `${page.path} App Store smart banner`,
+      ).getAttribute('content'),
+      'app-id=6769728441',
+    )
+  }
   const ogImage = requiredElement(
     document,
     'meta[property="og:image"]',
@@ -302,6 +385,54 @@ async function verifyDiscoveryFiles(baseUrl) {
   assert.match(icon.headers.get('content-type') ?? '', /^image\/png/)
   const iconBytes = new Uint8Array(await icon.arrayBuffer())
   assert.deepEqual([...iconBytes.slice(1, 4)], [0x50, 0x4e, 0x47])
+
+  const llms = await fetch(new URL('/llms.txt', baseUrl))
+  assert.equal(llms.status, 200)
+  assert.match(llms.headers.get('content-type') ?? '', /^text\/markdown/)
+  const llmsText = await llms.text()
+  assert.match(llmsText, /^# Cali Castle and Cali Baby\n\n>/)
+  assert.match(llmsText, /https:\/\/apps\.apple\.com\/app\/id6769728441/)
+  for (const path of new Set(publicPages.map((page) => page.path))) {
+    assert.ok(
+      llmsText.includes(new URL(path, productionOrigin).href),
+      `llms.txt ${path}`,
+    )
+  }
+}
+
+async function verifyCaliBabyProductData(baseUrl) {
+  for (const [path, name, heading] of [
+    ['/calibaby', 'Cali 宝宝', '从孕期到宝宝出生后的每一天'],
+    ['/en/calibaby', 'Cali Baby: Baby Tracker', 'From pregnancy through everyday care'],
+  ]) {
+    const response = await fetch(new URL(path, baseUrl))
+    assert.equal(response.status, 200, `${path} status`)
+    assert.match(
+      response.headers.get('link') ?? '',
+      /<\/llms\.txt>; rel="describedby"/,
+      `${path} llms.txt discovery header`,
+    )
+    const document = new JSDOM(await response.text()).window.document
+    assert.match(document.body.textContent ?? '', new RegExp(heading))
+    assert.match(document.body.textContent ?? '', /iOS 18/)
+
+    const data = JSON.parse(
+      requiredElement(
+        document,
+        'script[type="application/ld+json"]',
+        `${path} structured data`,
+      ).textContent ?? '{}',
+    )
+    assert.equal(data['@context'], 'https://schema.org')
+    assert.equal(data['@type'], 'MobileApplication')
+    assert.equal(data.name, name)
+    assert.equal(data.url, new URL(path, productionOrigin).href)
+    assert.equal(data.downloadUrl, 'https://apps.apple.com/app/id6769728441')
+    assert.equal(data.applicationCategory, 'HealthApplication')
+    assert.equal(data.offers?.price, 0)
+    assert.equal(data.publisher?.name, 'Zolplay')
+    assert.equal(data.featureList?.length, 4)
+  }
 }
 
 async function verifyNotFound(baseUrl) {
@@ -384,6 +515,7 @@ try {
   for (const page of publicPages) {
     await verifyMetadata(server.baseUrl, page)
   }
+  await verifyCaliBabyProductData(server.baseUrl)
   await verifyNoIndexUtilities(server.baseUrl)
   await verifyNotFound(server.baseUrl)
   console.log(

--- a/scripts/verify-public-discovery.mjs
+++ b/scripts/verify-public-discovery.mjs
@@ -139,14 +139,14 @@ const publicPages = [
   ...localizedCaliBabyPages(
     '/calibaby',
     {
-      title: 'Cali 宝宝｜喂奶、睡眠、尿布与胎动记录',
+      title: 'Cali 宝宝｜宝宝的事很多，不必都靠脑子记',
       description:
-        '从孕期到宝宝出生后，记录胎动、宫缩、喂奶、睡眠、尿布、成长等日常，并通过家庭同步与授权照顾者共享近况。现已上线 App Store。',
+        '胎动、喂奶、睡眠、尿布，发生了就顺手记一下。家里人都能看到刚刚发生了什么，换谁来照顾，都不用再从头问一遍。',
     },
     {
-      title: 'Cali Baby: Baby Tracker for Feeding, Sleep & Diapers',
+      title: 'Cali Baby | You don’t have to remember every feed.',
       description:
-        'Track kicks, contractions, feeding, sleep, diapers, growth, and more. Keep authorized caregivers in sync with Cali Baby for iPhone and Apple Watch.',
+        'Log kicks, feeds, sleep, and diapers as they happen. Everyone caring for the baby can see what happened and when, so whoever takes over doesn’t have to start with a round of questions.',
     },
     true,
   ),

--- a/scripts/verify-public-discovery.mjs
+++ b/scripts/verify-public-discovery.mjs
@@ -391,7 +391,10 @@ async function verifyDiscoveryFiles(baseUrl) {
   assert.match(llms.headers.get('content-type') ?? '', /^text\/markdown/)
   const llmsText = await llms.text()
   assert.match(llmsText, /^# Cali Castle and Cali Baby\n\n>/)
-  assert.match(llmsText, /https:\/\/apps\.apple\.com\/app\/id6769728441/)
+  assert.ok(
+    llmsText.includes('https://apps.apple.com/app/id6769728441'),
+    'llms.txt App Store listing',
+  )
   for (const path of new Set(publicPages.map((page) => page.path))) {
     assert.ok(
       llmsText.includes(new URL(path, productionOrigin).href),

--- a/tests/browser/interactions.spec.ts
+++ b/tests/browser/interactions.spec.ts
@@ -55,6 +55,7 @@ test('keyboard lightbox opens and closes immediately with focus restoration', as
   const dialog = page.getByRole('dialog')
   await expect(dialog).toBeVisible()
   await expect(dialog).toHaveAttribute('data-state', 'open')
+  await expect(dialog).toHaveAttribute('data-motion', 'instant')
   expect(
     await dialog.evaluate(
       (element) =>

--- a/tests/browser/navigation.spec.ts
+++ b/tests/browser/navigation.spec.ts
@@ -55,6 +55,22 @@ test('@hosted prefetched dock navigation renders instantly and preserves history
   expect(browserErrors).toEqual([])
 })
 
+test('Cali Baby project navigates internally in the current locale', async ({ page }) => {
+  await prepareBrowserPage(page)
+  const browserErrors = watchBrowserErrors(page)
+  await page.goto('/en/projects')
+
+  const project = page.locator('[data-list-stage-id="Cali 宝宝"]')
+  await expect(project).toHaveAttribute('href', '/en/calibaby')
+  await expect(project).not.toHaveAttribute('target', '_blank')
+  await expect(project.locator('.external-mark')).toHaveCount(0)
+
+  await project.click()
+  await expect(page).toHaveURL(/\/en\/calibaby$/)
+  await expect(page.locator('h1')).toContainText('You don’t have to')
+  expect(browserErrors).toEqual([])
+})
+
 test('Preferences applies theme from the keyboard and restores trigger focus', async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

- harden AMA reschedule completion and recovery behavior
- launch Cali Baby project navigation, metadata, sitemap, and AI discovery content
- include the validated keyboard lightbox reliability fix

## Verification

- `dev` Security workflow passed typecheck, unit and integration tests, migration validation, deployment-contract tests, localization, dependency audit, production build, browser release gate, link checks, legacy URL checks, public discovery checks, and security-boundary verification
- `dev` CodeQL passed
- `dev` Staging deployment and hosted browser verification passed
- PRs #292 and #293 passed their required checks before merge

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR strengthens AMA rescheduling recovery, publishes Cali Baby landing-page discovery, and makes keyboard-opened image lightboxes settle reliably.
- Refreshes finalizing admin bookings and suppresses stale meeting artifacts across confirmation, management, and admin views.
- Adds bounded same-run draining of newly enqueued confirmation emails.
- Adds localized Cali Baby project navigation, product details, structured data, sitemap coverage, smart-app metadata, and `/llms.txt`.
- Makes keyboard and reduced-motion lightbox transitions instantaneous while ignoring no-op scroll events.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

The changed AMA queue behavior preserves durable leasing and covers the only immediately due downstream operation, stale meeting links are consistently hidden during finalization, JSON-LD is safely serialized from fixed content, and the discovery and lightbox changes maintain their routing and lifecycle contracts.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/ama/operations/runner.ts | Adds bounded follow-up claims for immediately due confirmation emails while preserving the batch and execution-time limits. |
| lib/ama/operations/repository.ts | Adds optional operation-kind filtering without weakening lease compare-and-set behavior. |
| app/admin/(protected)/ama/bookings/[bookingId]/BookingDetail.tsx | Synchronizes refreshed booking state, polls briefly during finalization, and hides stale meeting artifacts. |
| components/ama/manage-booking.tsx | Prevents guests from using stale meeting links while a rescheduled booking is being finalized. |
| components/zoom-image.tsx | Distinguishes animated and instant lightbox motion and ignores scroll events that do not change viewport position. |
| lib/calibaby-public-content.ts | Centralizes App Store details, localized product facts, metadata, and MobileApplication structured data. |
| app/llms.txt/route.ts | Introduces a cached Markdown discovery map covering localized site content and Cali Baby resources. |
| app/_views/projects-page.tsx | Supports locale-aware internal project links while retaining external-link behavior for other projects. |
| next.config.ts | Advertises the new root discovery document through a global Link response header. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Worker as AMA Worker
  participant Queue as Durable Operations
  participant Finalize as Finalize Handler
  participant Booking as Booking Store
  participant Email as Email Handler
  Worker->>Queue: Claim initial due batch
  Queue-->>Worker: finalize_booking
  Worker->>Finalize: Execute operation
  Finalize->>Booking: Create/update artifacts and confirm booking
  Finalize->>Queue: Enqueue send_booking_email
  Worker->>Queue: Claim one due email with budget headroom
  Queue-->>Worker: send_booking_email
  Worker->>Email: Deliver confirmation
  Worker->>Queue: Complete operation
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Launch Cali Baby SEO and AI discovery (#..."](https://github.com/calicastle/cali.so/commit/c9f24ebfa4e1d8689a6f16f0bfa82c3e4df82b3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53618256)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Public site: content routing, localization, and rendering](https://app.greptile.com/zolplay/-/custom-context/knowledge-base/calicastle/cali.so/-/docs/public-site-content-routing.md)
- Knowledge Base — [Cali Baby public surface](https://app.greptile.com/zolplay/-/custom-context/knowledge-base/calicastle/cali.so/-/docs/calibaby-public-surface.md)
- Knowledge Base — [AMA Admin Operations](https://app.greptile.com/zolplay/-/custom-context/knowledge-base/calicastle/cali.so/-/docs/ama-admin-operations.md)
</details>

<!-- /greptile_comment -->