### PR TITLE
perf(ama): drain durable operations inline, relax cron cadence

### DIFF
--- a/app/api/admin/ama/bookings/[bookingId]/route.ts
+++ b/app/api/admin/ama/bookings/[bookingId]/route.ts
@@ -5,7 +5,7 @@ import {
 } from '~/lib/ama/admin/server'
 import { kickAmaOperations } from '~/lib/ama/booking/server'
 
-export const maxDuration = 60
+export const maxDuration = 300
 
 export async function POST(
   request: Request,

--- a/app/api/admin/ama/bookings/[bookingId]/route.ts
+++ b/app/api/admin/ama/bookings/[bookingId]/route.ts
@@ -3,6 +3,9 @@ import {
   getAmaAdminServices,
   ownerRequestAuthenticator,
 } from '~/lib/ama/admin/server'
+import { kickAmaOperations } from '~/lib/ama/booking/server'
+
+export const maxDuration = 60
 
 export async function POST(
   request: Request,
@@ -10,10 +13,12 @@ export async function POST(
 ) {
   const { bookingId } = await params
   const { bookingAdmin, security, baseUrl } = getAmaAdminServices()
-  return createAdminBookingActionHandler({
+  const response = await createAdminBookingActionHandler({
     authenticator: ownerRequestAuthenticator,
     service: bookingAdmin,
     security,
     baseUrl,
   })(request, bookingId)
+  if (response.ok) kickAmaOperations()
+  return response
 }

--- a/app/api/admin/ama/operations/[operationId]/route.ts
+++ b/app/api/admin/ama/operations/[operationId]/route.ts
@@ -5,7 +5,7 @@ import {
 } from '~/lib/ama/admin/server'
 import { kickAmaOperations } from '~/lib/ama/booking/server'
 
-export const maxDuration = 60
+export const maxDuration = 300
 
 export async function POST(
   request: Request,

--- a/app/api/admin/ama/operations/[operationId]/route.ts
+++ b/app/api/admin/ama/operations/[operationId]/route.ts
@@ -3,6 +3,9 @@ import {
   getAmaAdminServices,
   ownerRequestAuthenticator,
 } from '~/lib/ama/admin/server'
+import { kickAmaOperations } from '~/lib/ama/booking/server'
+
+export const maxDuration = 60
 
 export async function POST(
   request: Request,
@@ -10,10 +13,12 @@ export async function POST(
 ) {
   const { operationId } = await params
   const { bookingAdmin, security, baseUrl } = getAmaAdminServices()
-  return createAdminOperationActionHandler({
+  const response = await createAdminOperationActionHandler({
     authenticator: ownerRequestAuthenticator,
     service: bookingAdmin,
     security,
     baseUrl,
   })(request, operationId)
+  if (response.ok) kickAmaOperations()
+  return response
 }

--- a/app/api/ama/manage/[token]/cancel/route.ts
+++ b/app/api/ama/manage/[token]/cancel/route.ts
@@ -5,7 +5,7 @@ import {
 } from '~/lib/ama/booking/server'
 import { protectAmaLaunchBoundary } from '~/lib/ama/security/launch-boundary-server'
 
-export const maxDuration = 60
+export const maxDuration = 300
 
 export async function POST(
   request: Request,

--- a/app/api/ama/manage/[token]/cancel/route.ts
+++ b/app/api/ama/manage/[token]/cancel/route.ts
@@ -1,6 +1,11 @@
 import { createManageCancelHandler } from '~/lib/ama/booking/http'
-import { getAmaBookingServices } from '~/lib/ama/booking/server'
+import {
+  getAmaBookingServices,
+  kickAmaOperations,
+} from '~/lib/ama/booking/server'
 import { protectAmaLaunchBoundary } from '~/lib/ama/security/launch-boundary-server'
+
+export const maxDuration = 60
 
 export async function POST(
   request: Request,
@@ -13,5 +18,10 @@ export async function POST(
   if (blocked) return blocked
   const { token } = await params
   const { manage, guard } = getAmaBookingServices()
-  return createManageCancelHandler({ manage, guard })(request, token)
+  const response = await createManageCancelHandler({ manage, guard })(
+    request,
+    token,
+  )
+  if (response.ok) kickAmaOperations()
+  return response
 }

--- a/app/api/ama/manage/[token]/reschedule/route.ts
+++ b/app/api/ama/manage/[token]/reschedule/route.ts
@@ -1,6 +1,11 @@
 import { createManageRescheduleHandler } from '~/lib/ama/booking/http'
-import { getAmaBookingServices } from '~/lib/ama/booking/server'
+import {
+  getAmaBookingServices,
+  kickAmaOperations,
+} from '~/lib/ama/booking/server'
 import { protectAmaLaunchBoundary } from '~/lib/ama/security/launch-boundary-server'
+
+export const maxDuration = 60
 
 export async function POST(
   request: Request,
@@ -13,5 +18,10 @@ export async function POST(
   if (blocked) return blocked
   const { token } = await params
   const { manage, guard } = getAmaBookingServices()
-  return createManageRescheduleHandler({ manage, guard })(request, token)
+  const response = await createManageRescheduleHandler({ manage, guard })(
+    request,
+    token,
+  )
+  if (response.ok) kickAmaOperations()
+  return response
 }

--- a/app/api/ama/manage/[token]/reschedule/route.ts
+++ b/app/api/ama/manage/[token]/reschedule/route.ts
@@ -5,7 +5,7 @@ import {
 } from '~/lib/ama/booking/server'
 import { protectAmaLaunchBoundary } from '~/lib/ama/security/launch-boundary-server'
 
-export const maxDuration = 60
+export const maxDuration = 300
 
 export async function POST(
   request: Request,

--- a/app/api/ama/stripe/webhook/route.ts
+++ b/app/api/ama/stripe/webhook/route.ts
@@ -5,7 +5,7 @@ import {
 } from '~/lib/ama/booking/server'
 import { protectAmaLaunchBoundary } from '~/lib/ama/security/launch-boundary-server'
 
-export const maxDuration = 60
+export const maxDuration = 300
 
 export async function POST(request: Request) {
   const blocked = protectAmaLaunchBoundary(request, ['payments'])

--- a/app/api/ama/stripe/webhook/route.ts
+++ b/app/api/ama/stripe/webhook/route.ts
@@ -1,14 +1,21 @@
 import { createStripeWebhookHandler, json } from '~/lib/ama/booking/http'
-import { getAmaBookingServices } from '~/lib/ama/booking/server'
+import {
+  getAmaBookingServices,
+  kickAmaOperations,
+} from '~/lib/ama/booking/server'
 import { protectAmaLaunchBoundary } from '~/lib/ama/security/launch-boundary-server'
+
+export const maxDuration = 60
 
 export async function POST(request: Request) {
   const blocked = protectAmaLaunchBoundary(request, ['payments'])
   if (blocked) return blocked
   const { booking, stripeWebhookSecret } = getAmaBookingServices()
   if (!stripeWebhookSecret) return json(503, { error: 'feature_disabled' })
-  return createStripeWebhookHandler({
+  const response = await createStripeWebhookHandler({
     service: booking,
     signingSecret: stripeWebhookSecret,
   })(request)
+  if (response.ok) kickAmaOperations()
+  return response
 }

--- a/app/api/ama/stripe/webhook/route.ts
+++ b/app/api/ama/stripe/webhook/route.ts
@@ -12,10 +12,13 @@ export async function POST(request: Request) {
   if (blocked) return blocked
   const { booking, stripeWebhookSecret } = getAmaBookingServices()
   if (!stripeWebhookSecret) return json(503, { error: 'feature_disabled' })
-  const response = await createStripeWebhookHandler({
+  return createStripeWebhookHandler({
     service: booking,
     signingSecret: stripeWebhookSecret,
+    // Only booking creation enqueues durable work; duplicate, ignored,
+    // orphaned, and hold-release deliveries return 200 without any.
+    onOutcome: (outcome) => {
+      if (outcome === 'booking_created') kickAmaOperations()
+    },
   })(request)
-  if (response.ok) kickAmaOperations()
-  return response
 }

--- a/lib/ama/booking/http.ts
+++ b/lib/ama/booking/http.ts
@@ -9,7 +9,7 @@ import {
 import type { SecurityRateLimiter } from '../security/service'
 import { verifyStripeWebhook } from '../stripe/webhook'
 import type { ManageService } from './manage'
-import type { BookingService } from './service'
+import type { BookingService, WebhookOutcome } from './service'
 
 const MAX_JSON_BODY_BYTES = 32 * 1024
 
@@ -253,12 +253,18 @@ type WebhookDependencies = {
   service: Pick<BookingService, 'processWebhookEvent'>
   signingSecret: string
   clock?: { now(): Date }
+  /**
+   * Observes the processed outcome so callers can react to the ones that
+   * enqueued durable work without re-parsing the response body.
+   */
+  onOutcome?: (outcome: WebhookOutcome) => void
 }
 
 export function createStripeWebhookHandler({
   service,
   signingSecret,
   clock = { now: () => new Date() },
+  onOutcome,
 }: WebhookDependencies) {
   return async function POST(request: Request) {
     let payload: string
@@ -276,6 +282,7 @@ export function createStripeWebhookHandler({
     if (!event) return json(400, { error: 'invalid_signature' })
     try {
       const outcome = await service.processWebhookEvent(event)
+      onOutcome?.(outcome)
       return json(200, { received: true, outcome })
     } catch {
       // Signal Stripe to redeliver; the persisted provider event makes the

--- a/lib/ama/booking/server.ts
+++ b/lib/ama/booking/server.ts
@@ -32,6 +32,10 @@ import { bookingRepository } from './repository'
 import { createBookingService } from './service'
 
 const PROVIDER_REQUEST_TIMEOUT_MS = 8_000
+const OPERATIONS_BATCH_SIZE = 10
+// Leaves headroom under the mutating routes' maxDuration for the drain pass
+// already in flight when the budget runs out.
+const INLINE_DRAIN_BUDGET_MS = 30_000
 
 let services: ReturnType<typeof createServices> | undefined
 
@@ -188,6 +192,7 @@ function createServices() {
     clock,
   })
   const runner = createOperationsRunner({
+    batchSize: OPERATIONS_BATCH_SIZE,
     operations: durableOperationsRepository,
     handler: createOperationHandlers({
       repository: bookingRepository,
@@ -240,7 +245,20 @@ export function getAmaBookingServices() {
 export function kickAmaOperations() {
   const { runner } = getAmaBookingServices()
   waitUntil(
-    runner.run().catch((error) => {
+    (async () => {
+      // A full batch means older due work may have crowded out the operation
+      // this mutation enqueued, so keep draining until a partial batch shows
+      // the due queue is empty or the inline budget is spent. Anything left
+      // over stays with the scheduled sweep.
+      const startedAtMs = Date.now()
+      let result = await runner.run()
+      while (
+        result.claimed >= OPERATIONS_BATCH_SIZE &&
+        Date.now() - startedAtMs < INLINE_DRAIN_BUDGET_MS
+      ) {
+        result = await runner.run()
+      }
+    })().catch((error) => {
       console.error('ama: inline operations drain failed', error)
     }),
   )

--- a/lib/ama/booking/server.ts
+++ b/lib/ama/booking/server.ts
@@ -1,5 +1,7 @@
 import 'server-only'
 
+import { waitUntil } from '@vercel/functions'
+
 import { createRateLimiter } from '~/lib/rate-limit/server'
 
 import { availabilityRepository } from '../availability/repository'
@@ -226,4 +228,20 @@ function createServices() {
 export function getAmaBookingServices() {
   services ??= createServices()
   return services
+}
+
+/**
+ * Starts a background drain of due durable operations inside the current
+ * invocation, so work enqueued by a mutation (booking emails, Finalizing
+ * Booking recovery, refunds) begins immediately instead of waiting for the
+ * next scheduled sweep. The scheduled endpoint remains the sole driver for
+ * reminders, retry backoff, and expired Slot Hold release.
+ */
+export function kickAmaOperations() {
+  const { runner } = getAmaBookingServices()
+  waitUntil(
+    runner.run().catch((error) => {
+      console.error('ama: inline operations drain failed', error)
+    }),
+  )
 }

--- a/lib/ama/booking/server.ts
+++ b/lib/ama/booking/server.ts
@@ -33,9 +33,11 @@ import { createBookingService } from './service'
 
 const PROVIDER_REQUEST_TIMEOUT_MS = 8_000
 const OPERATIONS_BATCH_SIZE = 10
-// Leaves headroom under the mutating routes' maxDuration for the drain pass
-// already in flight when the budget runs out.
-const INLINE_DRAIN_BUDGET_MS = 30_000
+// Budget for starting drain passes. The mutating routes set maxDuration to
+// 300s; 240s here plus one worst-case 45s pass still finishes inside that
+// ceiling, and covers enough passes that a backlog cannot starve the
+// operation the triggering mutation enqueued.
+const INLINE_DRAIN_BUDGET_MS = 240_000
 
 let services: ReturnType<typeof createServices> | undefined
 

--- a/vercel.json
+++ b/vercel.json
@@ -6,11 +6,11 @@
   "crons": [
     {
       "path": "/api/internal/media/reconcile",
-      "schedule": "*/15 * * * *"
+      "schedule": "0 * * * *"
     },
     {
       "path": "/api/internal/ama/work",
-      "schedule": "*/5 * * * *"
+      "schedule": "*/30 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Why

Neon compute usage has been ~183 CU-hrs/month — the endpoint never autosuspends. The `*/5 * * * *` AMA work cron issues an unconditional hold-release `UPDATE` plus a `claimDue` query on every run, resetting Neon's 5-minute autosuspend timer exactly at the threshold, 288 times a day. Page visits are not a factor (public routes are fully static under Cache Components and never touch the database).

## What changed

**Inline drain on mutation.** New `kickAmaOperations()` in `lib/ama/booking/server.ts` runs `runner.run()` via `waitUntil` in the background of the current invocation. It is called after a successful response in the five routes that enqueue durable work:

- Stripe webhook — confirmation email and Finalizing Booking recovery start the moment payment lands (previously up to 5 minutes later)
- Guest cancel / reschedule — refunds, artifact updates, and emails go out immediately
- Admin booking action / operation retry — admin "retry" executes instantly

Each of these routes now sets `maxDuration = 60` so the runner's 45-second time budget always fits.

**Sparser crons.** AMA work drops from `*/5` to `*/30`; media reconcile drops from `*/15` to hourly on the hour, aligned so wakeups consolidate. The cron is now purely the clock fallback for reminders, retry backoff, and expired Slot Hold bookkeeping.

## Reviewer notes

- **No double-execution risk**: the operations runner claims work under leases (`claimDue` + lease token), so a concurrent inline drain and scheduled sweep cannot run the same operation twice. An interrupted drain's lease expires and the next run reclaims it.
- **Correctness never depended on sweep cadence**: availability filters expired-but-unreleased holds by their own expiry, and hold→booking conversion transactionally requires `expiresAt > now`. `releaseExpiredHolds` is bookkeeping only.
- **Accepted trade-off**: the 24h/1h session reminders and failed-operation retry backoff can now land up to 30 minutes later than scheduled. Everything guest-facing gets faster.
- Expected Neon impact: 48 short wakeups/day instead of always-on — roughly ~30 CU-hrs/month (~85% reduction).
- Cron schedule changes take effect on the next production deploy.

## Verification

- `npx tsc --noEmit` clean
- `pnpm test:ama` — 668 tests + 9 migration tests pass
- `pnpm test:unit` — 1245 tests pass





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR starts AMA durable-operation drains from successful enqueueing mutations and reduces cron frequency to allow the database to autosuspend.
- Adds background, lease-safe draining after booking creation, guest management mutations, and relevant admin actions.
- Repeats full operation batches within a bounded inline budget.
- Avoids draining for Stripe webhook outcomes that enqueue no work.
- Changes AMA work cadence to every 30 minutes and media reconciliation to hourly.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/ama/booking/server.ts | Adds a bounded inline drain that repeatedly runs full operation batches under the existing lease-based runner. |
| lib/ama/booking/http.ts | Exposes processed webhook outcomes to route wiring without changing signature verification or durable booking semantics. |
| app/api/ama/stripe/webhook/route.ts | Starts the inline drain only when webhook processing creates a booking and enqueues durable work. |
| app/api/ama/manage/[token]/cancel/route.ts | Starts durable-operation processing after successful guest cancellation responses. |
| app/api/ama/manage/[token]/reschedule/route.ts | Starts durable-operation processing after successful guest rescheduling responses. |
| app/api/admin/ama/bookings/[bookingId]/route.ts | Starts durable-operation processing after successful owner booking actions. |
| app/api/admin/ama/operations/[operationId]/route.ts | Starts durable-operation processing after successful operation actions such as retry. |
| vercel.json | Reduces AMA and media cron frequency to consolidate database wakeups. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Mutation as AMA mutation/webhook
  participant Queue as Durable operations
  participant Drain as Inline runner
  participant Provider as Email/Calendar/Stripe
  participant Cron as 30-minute cron
  Mutation->>Queue: Enqueue durable work
  Mutation->>Drain: kickAmaOperations via waitUntil
  loop While batch is full and budget remains
    Drain->>Queue: Claim due work under leases
    Drain->>Provider: Execute side effects
    Drain->>Queue: Complete or schedule retry
  end
  Cron->>Queue: Fallback sweep
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ama): give the inline drain room to ..."](https://github.com/calicastle/cali.so/commit/26ce34035770fe44620c686cb21eda7c33ee9700) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55972826)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [AMA booking flow](https://app.greptile.com/zolplay/-/custom-context/knowledge-base/calicastle/cali.so/-/docs/ama-booking-flow.md)
- Knowledge Base — [AMA Admin Operations](https://app.greptile.com/zolplay/-/custom-context/knowledge-base/calicastle/cali.so/-/docs/ama-admin-operations.md)
- Knowledge Base — [AMA Stripe Payments](https://app.greptile.com/zolplay/-/custom-context/knowledge-base/calicastle/cali.so/-/docs/ama-stripe-payments.md)
</details>


<!-- /greptile_comment -->