### PR TITLE
Promote dev to main: inline AMA operations drain, sparser crons

### DIFF
--- a/app/api/admin/ama/bookings/[bookingId]/route.ts
+++ b/app/api/admin/ama/bookings/[bookingId]/route.ts
@@ -5,7 +5,7 @@ import {
 } from '~/lib/ama/admin/server'
 import { kickAmaOperations } from '~/lib/ama/booking/server'
 
-export const maxDuration = 60
+export const maxDuration = 300
 
 export async function POST(
   request: Request,

--- a/app/api/admin/ama/bookings/[bookingId]/route.ts
+++ b/app/api/admin/ama/bookings/[bookingId]/route.ts
@@ -3,6 +3,9 @@ import {
   getAmaAdminServices,
   ownerRequestAuthenticator,
 } from '~/lib/ama/admin/server'
+import { kickAmaOperations } from '~/lib/ama/booking/server'
+
+export const maxDuration = 60
 
 export async function POST(
   request: Request,
@@ -10,10 +13,12 @@ export async function POST(
 ) {
   const { bookingId } = await params
   const { bookingAdmin, security, baseUrl } = getAmaAdminServices()
-  return createAdminBookingActionHandler({
+  const response = await createAdminBookingActionHandler({
     authenticator: ownerRequestAuthenticator,
     service: bookingAdmin,
     security,
     baseUrl,
   })(request, bookingId)
+  if (response.ok) kickAmaOperations()
+  return response
 }

--- a/app/api/admin/ama/operations/[operationId]/route.ts
+++ b/app/api/admin/ama/operations/[operationId]/route.ts
@@ -5,7 +5,7 @@ import {
 } from '~/lib/ama/admin/server'
 import { kickAmaOperations } from '~/lib/ama/booking/server'
 
-export const maxDuration = 60
+export const maxDuration = 300
 
 export async function POST(
   request: Request,

--- a/app/api/admin/ama/operations/[operationId]/route.ts
+++ b/app/api/admin/ama/operations/[operationId]/route.ts
@@ -3,6 +3,9 @@ import {
   getAmaAdminServices,
   ownerRequestAuthenticator,
 } from '~/lib/ama/admin/server'
+import { kickAmaOperations } from '~/lib/ama/booking/server'
+
+export const maxDuration = 60
 
 export async function POST(
   request: Request,
@@ -10,10 +13,12 @@ export async function POST(
 ) {
   const { operationId } = await params
   const { bookingAdmin, security, baseUrl } = getAmaAdminServices()
-  return createAdminOperationActionHandler({
+  const response = await createAdminOperationActionHandler({
     authenticator: ownerRequestAuthenticator,
     service: bookingAdmin,
     security,
     baseUrl,
   })(request, operationId)
+  if (response.ok) kickAmaOperations()
+  return response
 }

--- a/app/api/ama/manage/[token]/cancel/route.ts
+++ b/app/api/ama/manage/[token]/cancel/route.ts
@@ -5,7 +5,7 @@ import {
 } from '~/lib/ama/booking/server'
 import { protectAmaLaunchBoundary } from '~/lib/ama/security/launch-boundary-server'
 
-export const maxDuration = 60
+export const maxDuration = 300
 
 export async function POST(
   request: Request,

--- a/app/api/ama/manage/[token]/cancel/route.ts
+++ b/app/api/ama/manage/[token]/cancel/route.ts
@@ -1,6 +1,11 @@
 import { createManageCancelHandler } from '~/lib/ama/booking/http'
-import { getAmaBookingServices } from '~/lib/ama/booking/server'
+import {
+  getAmaBookingServices,
+  kickAmaOperations,
+} from '~/lib/ama/booking/server'
 import { protectAmaLaunchBoundary } from '~/lib/ama/security/launch-boundary-server'
+
+export const maxDuration = 60
 
 export async function POST(
   request: Request,
@@ -13,5 +18,10 @@ export async function POST(
   if (blocked) return blocked
   const { token } = await params
   const { manage, guard } = getAmaBookingServices()
-  return createManageCancelHandler({ manage, guard })(request, token)
+  const response = await createManageCancelHandler({ manage, guard })(
+    request,
+    token,
+  )
+  if (response.ok) kickAmaOperations()
+  return response
 }

--- a/app/api/ama/manage/[token]/reschedule/route.ts
+++ b/app/api/ama/manage/[token]/reschedule/route.ts
@@ -1,6 +1,11 @@
 import { createManageRescheduleHandler } from '~/lib/ama/booking/http'
-import { getAmaBookingServices } from '~/lib/ama/booking/server'
+import {
+  getAmaBookingServices,
+  kickAmaOperations,
+} from '~/lib/ama/booking/server'
 import { protectAmaLaunchBoundary } from '~/lib/ama/security/launch-boundary-server'
+
+export const maxDuration = 60
 
 export async function POST(
   request: Request,
@@ -13,5 +18,10 @@ export async function POST(
   if (blocked) return blocked
   const { token } = await params
   const { manage, guard } = getAmaBookingServices()
-  return createManageRescheduleHandler({ manage, guard })(request, token)
+  const response = await createManageRescheduleHandler({ manage, guard })(
+    request,
+    token,
+  )
+  if (response.ok) kickAmaOperations()
+  return response
 }

--- a/app/api/ama/manage/[token]/reschedule/route.ts
+++ b/app/api/ama/manage/[token]/reschedule/route.ts
@@ -5,7 +5,7 @@ import {
 } from '~/lib/ama/booking/server'
 import { protectAmaLaunchBoundary } from '~/lib/ama/security/launch-boundary-server'
 
-export const maxDuration = 60
+export const maxDuration = 300
 
 export async function POST(
   request: Request,

--- a/app/api/ama/stripe/webhook/route.ts
+++ b/app/api/ama/stripe/webhook/route.ts
@@ -5,7 +5,7 @@ import {
 } from '~/lib/ama/booking/server'
 import { protectAmaLaunchBoundary } from '~/lib/ama/security/launch-boundary-server'
 
-export const maxDuration = 60
+export const maxDuration = 300
 
 export async function POST(request: Request) {
   const blocked = protectAmaLaunchBoundary(request, ['payments'])

--- a/app/api/ama/stripe/webhook/route.ts
+++ b/app/api/ama/stripe/webhook/route.ts
@@ -1,14 +1,21 @@
 import { createStripeWebhookHandler, json } from '~/lib/ama/booking/http'
-import { getAmaBookingServices } from '~/lib/ama/booking/server'
+import {
+  getAmaBookingServices,
+  kickAmaOperations,
+} from '~/lib/ama/booking/server'
 import { protectAmaLaunchBoundary } from '~/lib/ama/security/launch-boundary-server'
+
+export const maxDuration = 60
 
 export async function POST(request: Request) {
   const blocked = protectAmaLaunchBoundary(request, ['payments'])
   if (blocked) return blocked
   const { booking, stripeWebhookSecret } = getAmaBookingServices()
   if (!stripeWebhookSecret) return json(503, { error: 'feature_disabled' })
-  return createStripeWebhookHandler({
+  const response = await createStripeWebhookHandler({
     service: booking,
     signingSecret: stripeWebhookSecret,
   })(request)
+  if (response.ok) kickAmaOperations()
+  return response
 }

--- a/app/api/ama/stripe/webhook/route.ts
+++ b/app/api/ama/stripe/webhook/route.ts
@@ -12,10 +12,13 @@ export async function POST(request: Request) {
   if (blocked) return blocked
   const { booking, stripeWebhookSecret } = getAmaBookingServices()
   if (!stripeWebhookSecret) return json(503, { error: 'feature_disabled' })
-  const response = await createStripeWebhookHandler({
+  return createStripeWebhookHandler({
     service: booking,
     signingSecret: stripeWebhookSecret,
+    // Only booking creation enqueues durable work; duplicate, ignored,
+    // orphaned, and hold-release deliveries return 200 without any.
+    onOutcome: (outcome) => {
+      if (outcome === 'booking_created') kickAmaOperations()
+    },
   })(request)
-  if (response.ok) kickAmaOperations()
-  return response
 }

--- a/lib/ama/booking/http.ts
+++ b/lib/ama/booking/http.ts
@@ -9,7 +9,7 @@ import {
 import type { SecurityRateLimiter } from '../security/service'
 import { verifyStripeWebhook } from '../stripe/webhook'
 import type { ManageService } from './manage'
-import type { BookingService } from './service'
+import type { BookingService, WebhookOutcome } from './service'
 
 const MAX_JSON_BODY_BYTES = 32 * 1024
 
@@ -253,12 +253,18 @@ type WebhookDependencies = {
   service: Pick<BookingService, 'processWebhookEvent'>
   signingSecret: string
   clock?: { now(): Date }
+  /**
+   * Observes the processed outcome so callers can react to the ones that
+   * enqueued durable work without re-parsing the response body.
+   */
+  onOutcome?: (outcome: WebhookOutcome) => void
 }
 
 export function createStripeWebhookHandler({
   service,
   signingSecret,
   clock = { now: () => new Date() },
+  onOutcome,
 }: WebhookDependencies) {
   return async function POST(request: Request) {
     let payload: string
@@ -276,6 +282,7 @@ export function createStripeWebhookHandler({
     if (!event) return json(400, { error: 'invalid_signature' })
     try {
       const outcome = await service.processWebhookEvent(event)
+      onOutcome?.(outcome)
       return json(200, { received: true, outcome })
     } catch {
       // Signal Stripe to redeliver; the persisted provider event makes the

--- a/lib/ama/booking/server.ts
+++ b/lib/ama/booking/server.ts
@@ -32,6 +32,10 @@ import { bookingRepository } from './repository'
 import { createBookingService } from './service'
 
 const PROVIDER_REQUEST_TIMEOUT_MS = 8_000
+const OPERATIONS_BATCH_SIZE = 10
+// Leaves headroom under the mutating routes' maxDuration for the drain pass
+// already in flight when the budget runs out.
+const INLINE_DRAIN_BUDGET_MS = 30_000
 
 let services: ReturnType<typeof createServices> | undefined
 
@@ -188,6 +192,7 @@ function createServices() {
     clock,
   })
   const runner = createOperationsRunner({
+    batchSize: OPERATIONS_BATCH_SIZE,
     operations: durableOperationsRepository,
     handler: createOperationHandlers({
       repository: bookingRepository,
@@ -240,7 +245,20 @@ export function getAmaBookingServices() {
 export function kickAmaOperations() {
   const { runner } = getAmaBookingServices()
   waitUntil(
-    runner.run().catch((error) => {
+    (async () => {
+      // A full batch means older due work may have crowded out the operation
+      // this mutation enqueued, so keep draining until a partial batch shows
+      // the due queue is empty or the inline budget is spent. Anything left
+      // over stays with the scheduled sweep.
+      const startedAtMs = Date.now()
+      let result = await runner.run()
+      while (
+        result.claimed >= OPERATIONS_BATCH_SIZE &&
+        Date.now() - startedAtMs < INLINE_DRAIN_BUDGET_MS
+      ) {
+        result = await runner.run()
+      }
+    })().catch((error) => {
       console.error('ama: inline operations drain failed', error)
     }),
   )

--- a/lib/ama/booking/server.ts
+++ b/lib/ama/booking/server.ts
@@ -1,5 +1,7 @@
 import 'server-only'
 
+import { waitUntil } from '@vercel/functions'
+
 import { createRateLimiter } from '~/lib/rate-limit/server'
 
 import { availabilityRepository } from '../availability/repository'
@@ -226,4 +228,20 @@ function createServices() {
 export function getAmaBookingServices() {
   services ??= createServices()
   return services
+}
+
+/**
+ * Starts a background drain of due durable operations inside the current
+ * invocation, so work enqueued by a mutation (booking emails, Finalizing
+ * Booking recovery, refunds) begins immediately instead of waiting for the
+ * next scheduled sweep. The scheduled endpoint remains the sole driver for
+ * reminders, retry backoff, and expired Slot Hold release.
+ */
+export function kickAmaOperations() {
+  const { runner } = getAmaBookingServices()
+  waitUntil(
+    runner.run().catch((error) => {
+      console.error('ama: inline operations drain failed', error)
+    }),
+  )
 }

--- a/lib/ama/booking/server.ts
+++ b/lib/ama/booking/server.ts
@@ -33,9 +33,11 @@ import { createBookingService } from './service'
 
 const PROVIDER_REQUEST_TIMEOUT_MS = 8_000
 const OPERATIONS_BATCH_SIZE = 10
-// Leaves headroom under the mutating routes' maxDuration for the drain pass
-// already in flight when the budget runs out.
-const INLINE_DRAIN_BUDGET_MS = 30_000
+// Budget for starting drain passes. The mutating routes set maxDuration to
+// 300s; 240s here plus one worst-case 45s pass still finishes inside that
+// ceiling, and covers enough passes that a backlog cannot starve the
+// operation the triggering mutation enqueued.
+const INLINE_DRAIN_BUDGET_MS = 240_000
 
 let services: ReturnType<typeof createServices> | undefined
 

--- a/vercel.json
+++ b/vercel.json
@@ -6,11 +6,11 @@
   "crons": [
     {
       "path": "/api/internal/media/reconcile",
-      "schedule": "*/15 * * * *"
+      "schedule": "0 * * * *"
     },
     {
       "path": "/api/internal/ama/work",
-      "schedule": "*/5 * * * *"
+      "schedule": "*/30 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Release

Promotes #299 to production.

**Neon compute fix**: the `*/5` AMA work cron kept the database endpoint awake 24/7 (~183 CU-hrs/month). Durable operations (booking emails, Finalizing Booking recovery, refunds, artifact updates) now drain inline via `waitUntil` in the same invocation that enqueues them, so guest-facing work starts immediately. The cron drops to `*/30` (media reconcile to hourly) as a pure clock fallback for reminders, retry backoff, and expired Slot Hold bookkeeping — letting Neon autosuspend between wakeups (~85% compute reduction expected).

Review hardening included: webhook kick gated on `booking_created`, drain loops past full batches under a 240s budget, mutating routes at the platform-default 300s maxDuration.

**Note**: the new cron schedules take effect with this production deployment.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR starts due AMA durable operations within the mutation invocation that enqueues them, while retaining less-frequent cron sweeps for time-based and recovery work.
- Adds `waitUntil`-backed, multi-batch operation draining with a 240-second start budget.
- Triggers draining after successful booking-management actions and newly created Stripe bookings.
- Raises affected mutation routes to the platform’s 300-second duration limit.
- Changes the AMA worker cadence from five to thirty minutes and media reconciliation from fifteen minutes to hourly.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with inline processing covering mutation-triggered AMA work and existing cron paths retaining scheduled recovery duties.

Durable-operation leasing protects concurrent drains, all changed enqueueing mutation paths trigger the runner, and the reduced schedules do not establish a broken correctness contract.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/ama/booking/server.ts | Adds a bounded `waitUntil` drain that repeatedly runs full operation batches while relying on existing lease-based concurrency controls. |
| lib/ama/booking/http.ts | Adds a typed webhook-outcome callback after successful event processing without changing signature verification or retry responses. |
| app/api/ama/stripe/webhook/route.ts | Starts inline processing only when webhook handling creates a booking and therefore enqueues finalization work. |
| app/api/ama/manage/[token]/cancel/route.ts | Starts operation draining after a successful guest cancellation and raises the route duration limit. |
| app/api/ama/manage/[token]/reschedule/route.ts | Starts operation draining after a successful guest reschedule and raises the route duration limit. |
| app/api/admin/ama/bookings/[bookingId]/route.ts | Starts operation draining after successful owner booking actions. |
| app/api/admin/ama/operations/[operationId]/route.ts | Starts the runner after successful retry or resolution actions, including a harmless empty pass for resolution-only actions. |
| vercel.json | Reduces AMA and media maintenance frequency, intentionally increasing clock-driven latency while allowing database autosuspension. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  M[AMA mutation] --> E[Enqueue durable operation]
  E --> K[kickAmaOperations]
  K --> W[waitUntil inline drain]
  W --> R[Runner: batches of 10]
  R --> P[Calendar / Meeting / Email / Stripe]
  C[30-minute AMA cron] --> R
  C --> H[Expired hold cleanup]
  C --> T[Reminders and retry backoff]
  MC[Hourly media cron] --> MR[Media reconciliation]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["perf(ama): drain durable operations inli..."](https://github.com/calicastle/cali.so/commit/9837a2567c85cc9f95bd6290c70871146bb032ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55977765)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [AMA booking flow](https://app.greptile.com/zolplay/-/custom-context/knowledge-base/calicastle/cali.so/-/docs/ama-booking-flow.md)
- Knowledge Base — [AMA Admin Operations](https://app.greptile.com/zolplay/-/custom-context/knowledge-base/calicastle/cali.so/-/docs/ama-admin-operations.md)
- Knowledge Base — [AMA Stripe Payments](https://app.greptile.com/zolplay/-/custom-context/knowledge-base/calicastle/cali.so/-/docs/ama-stripe-payments.md)
- Knowledge Base — [Media reconciliation, purge, geocoding, and privacy](https://app.greptile.com/zolplay/-/custom-context/knowledge-base/calicastle/cali.so/-/docs/media-reconciliation-purge.md)
</details>


<!-- /greptile_comment -->