### PR TITLE
fix(ama): enforce inline drain deadline

### DIFF
--- a/docs/ama-booking-operations.md
+++ b/docs/ama-booking-operations.md
@@ -67,10 +67,17 @@ unconfigured returns 503 before touching provider code.
 
 ## Scheduled work
 
-`vercel.json` runs `/api/internal/ama/work` every five minutes with
+`vercel.json` runs `/api/internal/ama/work` every thirty minutes with
 `CRON_SECRET` bearer auth. Each run releases expired Slot Holds and drains due
 durable operations under leases; an interrupted worker's lease expires and the
 next run reclaims the work, so no step depends on a healthy previous run.
+
+Successful booking mutations also start a background drain of due operations.
+Its shared 240-second deadline cancels in-flight provider requests and prevents
+new claims or handlers from starting after expiry; interrupted operations use
+the normal durable retry path. Reminders, retry backoff, and expired Slot Hold
+release still rely on the scheduled sweep, so due work may wait up to thirty
+minutes for its next scheduled run. Media reconciliation runs hourly.
 
 ## Local confirmation previews
 

--- a/lib/ama/booking/server.ts
+++ b/lib/ama/booking/server.ts
@@ -19,6 +19,10 @@ import type { BookingCalendar } from '../meeting/calendar'
 import { createTencentMeetingAdapter } from '../meeting/tencent'
 import type { MeetingProviderAdapter } from '../meeting/types'
 import { createOperationHandlers } from '../operations/handlers'
+import {
+  fetchWithOperationsTimeout,
+  withOperationsDeadline,
+} from '../operations/deadline'
 import { durableOperationsRepository } from '../operations/repository'
 import { createOperationsRunner } from '../operations/runner'
 import { createSecretBox } from '../secrets'
@@ -31,21 +35,13 @@ import { createBookingAdminService } from './admin'
 import { bookingRepository } from './repository'
 import { createBookingService } from './service'
 
-const PROVIDER_REQUEST_TIMEOUT_MS = 8_000
 const OPERATIONS_BATCH_SIZE = 10
-// Budget for starting drain passes. The mutating routes set maxDuration to
-// 300s; 240s here plus one worst-case 45s pass still finishes inside that
-// ceiling, and covers enough passes that a backlog cannot starve the
-// operation the triggering mutation enqueued.
+// Cancel provider IO at 240s, leaving time within the 300s routes for the
+// triggering mutation and lease bookkeeping. The runner's per-pass budget
+// is advisory and cannot bound a handler with sequential provider calls.
 const INLINE_DRAIN_BUDGET_MS = 240_000
 
 let services: ReturnType<typeof createServices> | undefined
-
-function fetchWithTimeout(input: string | URL | Request, init: RequestInit = {}) {
-  const timeout = AbortSignal.timeout(PROVIDER_REQUEST_TIMEOUT_MS)
-  const signal = init.signal ? AbortSignal.any([init.signal, timeout]) : timeout
-  return fetch(input, { ...init, signal })
-}
 
 function disabledGoogleService(): GoogleCalendarService {
   return {
@@ -112,7 +108,7 @@ function createServices() {
     ? createGoogleCalendarClient({
         clientId: environment.GOOGLE_CLIENT_ID!,
         clientSecret: environment.GOOGLE_CLIENT_SECRET!,
-        fetch: fetchWithTimeout,
+        fetch: fetchWithOperationsTimeout,
         clock,
       })
     : null
@@ -144,7 +140,7 @@ function createServices() {
     environment.features.payments && environment.STRIPE_SECRET_KEY
       ? createStripeClient({
           secretKey: environment.STRIPE_SECRET_KEY,
-          fetch: fetchWithTimeout,
+          fetch: fetchWithOperationsTimeout,
         })
       : disabledStripeClient()
 
@@ -155,7 +151,7 @@ function createServices() {
       ? createResendEmailSender({
           apiKey: environment.RESEND_API_KEY,
           from: environment.AMA_EMAIL_FROM,
-          fetch: fetchWithTimeout,
+          fetch: fetchWithOperationsTimeout,
         })
       : disabledEmailSender()
 
@@ -166,7 +162,7 @@ function createServices() {
       ? createTencentMeetingAdapter({
           url: environment.TENCENT_MEETING_MCP_URL,
           token: environment.TENCENT_MEETING_MCP_TOKEN,
-          fetch: fetchWithTimeout,
+          fetch: fetchWithOperationsTimeout,
         })
       : null
 
@@ -247,20 +243,19 @@ export function getAmaBookingServices() {
 export function kickAmaOperations() {
   const { runner } = getAmaBookingServices()
   waitUntil(
-    (async () => {
+    withOperationsDeadline(INLINE_DRAIN_BUDGET_MS, async (signal) => {
       // A full batch means older due work may have crowded out the operation
       // this mutation enqueued, so keep draining until a partial batch shows
       // the due queue is empty or the inline budget is spent. Anything left
       // over stays with the scheduled sweep.
-      const startedAtMs = Date.now()
-      let result = await runner.run()
+      let result = await runner.run({ signal })
       while (
         result.claimed >= OPERATIONS_BATCH_SIZE &&
-        Date.now() - startedAtMs < INLINE_DRAIN_BUDGET_MS
+        !signal.aborted
       ) {
-        result = await runner.run()
+        result = await runner.run({ signal })
       }
-    })().catch((error) => {
+    }).catch((error) => {
       console.error('ama: inline operations drain failed', error)
     }),
   )

--- a/lib/ama/operations/deadline.test.ts
+++ b/lib/ama/operations/deadline.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import { fetchWithOperationsTimeout, withOperationsDeadline } from './deadline'
+import type { DurableOperationsRepository } from './repository'
+import { createOperationsRunner } from './runner'
+
+function abortableFetch() {
+  return vi.fn((_input: unknown, init?: RequestInit) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init!.signal!
+      signal.throwIfAborted()
+      signal.addEventListener('abort', () => reject(signal.reason), { once: true })
+    }),
+  )
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+describe('operation deadline', () => {
+  it('aborts a late multi-call handler, records its retry, and defers remaining work', async () => {
+    vi.useFakeTimers()
+    const fetch = abortableFetch()
+    fetch.mockResolvedValueOnce(new Response('{}'))
+    vi.stubGlobal('fetch', fetch)
+    const claimDue = vi.fn().mockResolvedValue([
+      { id: 'slow', leaseToken: 'lease-1', attemptCount: 1 },
+      { id: 'later', leaseToken: 'lease-2', attemptCount: 1 },
+    ])
+    const complete = vi.fn()
+    const fail = vi.fn().mockResolvedValue({ status: 'pending' })
+    const handler = vi.fn(async () => {
+      await fetchWithOperationsTimeout('https://provider.test/first')
+      try {
+        await fetchWithOperationsTimeout('https://provider.test/second')
+      } catch {
+        // A provider retry must inherit the expired deadline too.
+        await fetchWithOperationsTimeout('https://provider.test/retry')
+      }
+    })
+    const runner = createOperationsRunner({
+      operations: { claimDue, complete, fail } as unknown as DurableOperationsRepository,
+      handler,
+    })
+    const drain = withOperationsDeadline(240_000, async (signal) => {
+      // Earlier passes consume almost the entire shared drain budget.
+      await new Promise((resolve) => setTimeout(resolve, 239_000))
+      return runner.run({ signal })
+    })
+
+    await vi.advanceTimersByTimeAsync(240_000)
+    expect(await drain).toEqual({
+      claimed: 2, succeeded: 0, retried: 1, failed: 0, deferred: 1,
+    })
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(claimDue).toHaveBeenCalledTimes(1)
+    expect(complete).not.toHaveBeenCalled()
+    expect(fail).toHaveBeenCalledWith(expect.objectContaining({
+      operationId: 'slow', leaseToken: 'lease-1', terminal: false,
+    }))
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('does not claim work when the shared deadline has already expired', async () => {
+    const claimDue = vi.fn()
+    const runner = createOperationsRunner({
+      operations: { claimDue } as unknown as DurableOperationsRepository,
+      handler: vi.fn(),
+    })
+    const result = await runner.run({ signal: AbortSignal.abort() })
+    expect(result.claimed).toBe(0)
+    expect(claimDue).not.toHaveBeenCalled()
+  })
+
+  it('isolates concurrent drains and leaves ordinary provider requests unaffected', async () => {
+    vi.useFakeTimers()
+    const signals: AbortSignal[] = []
+    vi.stubGlobal('fetch', vi.fn(async (_input, init) => {
+      signals.push(init.signal)
+      return new Response('{}')
+    }))
+    const short = withOperationsDeadline(100, async () => {
+      await fetchWithOperationsTimeout('https://provider.test/short')
+      await new Promise((resolve) => setTimeout(resolve, 150))
+    })
+    const long = withOperationsDeadline(300, async () => {
+      await fetchWithOperationsTimeout('https://provider.test/long')
+      await new Promise((resolve) => setTimeout(resolve, 200))
+    })
+    await fetchWithOperationsTimeout('https://provider.test/outside')
+    await vi.advanceTimersByTimeAsync(100)
+    expect(signals.map((signal) => signal.aborted)).toEqual([true, false, false])
+    await vi.advanceTimersByTimeAsync(100)
+    await Promise.all([short, long])
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('preserves caller cancellation and the per-request timeout', async () => {
+    const fetch = abortableFetch()
+    vi.stubGlobal('fetch', fetch)
+    const caller = new AbortController()
+    const request = fetchWithOperationsTimeout('https://provider.test', { signal: caller.signal })
+    caller.abort()
+    await expect(request).rejects.toMatchObject({ name: 'AbortError' })
+
+    const timeout = new AbortController()
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeout.signal)
+    try {
+      const pending = fetchWithOperationsTimeout('https://provider.test')
+      timeout.abort(new DOMException('Timed out', 'TimeoutError'))
+      await expect(pending).rejects.toMatchObject({ name: 'TimeoutError' })
+      expect(timeoutSpy).toHaveBeenCalledWith(8_000)
+    } finally {
+      timeoutSpy.mockRestore()
+    }
+  })
+})

--- a/lib/ama/operations/deadline.ts
+++ b/lib/ama/operations/deadline.ts
@@ -1,0 +1,35 @@
+import 'server-only'
+
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+const operationSignal = new AsyncLocalStorage<AbortSignal>()
+const PROVIDER_REQUEST_TIMEOUT_MS = 8_000
+
+/** Share one deadline across every provider call in a drain, including retries. */
+export async function withOperationsDeadline<T>(
+  budgetMs: number,
+  work: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), budgetMs)
+  try {
+    return await operationSignal.run(controller.signal, () => work(controller.signal))
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/** The shared clients read the current drain's signal without affecting other requests. */
+export function fetchWithOperationsTimeout(
+  input: string | URL | Request,
+  init: RequestInit = {},
+) {
+  const signals = [AbortSignal.timeout(PROVIDER_REQUEST_TIMEOUT_MS)]
+  const callerSignal = init.signal ?? (input instanceof Request ? input.signal : null)
+  if (callerSignal) signals.push(callerSignal)
+  const deadlineSignal = operationSignal.getStore()
+  if (deadlineSignal) signals.push(deadlineSignal)
+  const signal = AbortSignal.any(signals)
+  signal.throwIfAborted()
+  return fetch(input, { ...init, signal })
+}

--- a/lib/ama/operations/runner.ts
+++ b/lib/ama/operations/runner.ts
@@ -62,7 +62,7 @@ export function createOperationsRunner(dependencies: OperationsRunnerDependencie
   } = dependencies
 
   return {
-    async run(): Promise<OperationsRunResult> {
+    async run({ signal }: { signal?: AbortSignal } = {}): Promise<OperationsRunResult> {
       const startedAtMs = clock.now().getTime()
       const result: OperationsRunResult = {
         claimed: 0,
@@ -76,6 +76,7 @@ export function createOperationsRunner(dependencies: OperationsRunnerDependencie
         const isFollowUp = result.claimed > 0
         const startHeadroomMs = isFollowUp ? FOLLOW_UP_START_HEADROOM_MS : 0
         if (
+          signal?.aborted ||
           clock.now().getTime() - startedAtMs >=
           timeBudgetMs - startHeadroomMs
         ) {
@@ -95,6 +96,7 @@ export function createOperationsRunner(dependencies: OperationsRunnerDependencie
         for (const operation of claimed) {
           if (!operation.leaseToken) continue
           if (
+            signal?.aborted ||
             clock.now().getTime() - startedAtMs >=
             timeBudgetMs - startHeadroomMs
           ) {


### PR DESCRIPTION
The inline AMA drain could start a late pass whose sequential provider calls outlasted the routes' 300-second limit. Give all calls in a drain one shared 240-second cancellation signal, retain the individual eight-second provider timeout, and stop claiming or starting operations after cancellation. Provider failures keep the existing durable retry bookkeeping, and concurrent drains remain isolated.

Update the operations guide to reflect the thirty-minute AMA sweep and hourly media reconciliation.

Addresses the two Greptile findings on #310. This follow-up targets `dev` because its branch protection requires changes through a PR; merging it updates the existing promotion.

Validation: TypeScript, all 672 AMA tests, nine migration checks, and `git diff --check` pass. Added regression coverage for a late multi-call handler, its cancelled retry and deferred sibling, expired claims, concurrent drain isolation, and caller/per-request cancellation.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bounds inline AMA durable-operation drains with one shared 240-second cancellation signal while retaining the existing eight-second timeout for each provider request.

- Propagates drain cancellation to Google Calendar, Stripe, Resend, and Tencent provider calls.
- Prevents the runner from claiming or starting further work after cancellation.
- Preserves durable retry handling for interrupted operations and isolates concurrent drains through async-local context.
- Adds regression coverage for cancellation, retries, deferred work, expired deadlines, and concurrent drains.
- Updates the operations guide to match the deployed AMA and media schedules.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no actionable correctness, security, or repository-rule violations remain.

Provider calls consistently inherit the shared deadline, cancellation stops additional work, interrupted handlers retain durable retry bookkeeping, and concurrent drains remain isolated.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/ama/operations/deadline.ts | Introduces an async-context-scoped drain deadline and combines it with caller cancellation and per-request provider timeouts. |
| lib/ama/operations/runner.ts | Adds cancellation checks before claims and handler starts while preserving existing completion, retry, and lease-recovery behavior. |
| lib/ama/booking/server.ts | Wires deadline-aware fetch into every durable provider client and applies the shared deadline to inline drains. |
| lib/ama/operations/deadline.test.ts | Covers late cancellation, retry persistence, deferred siblings, expired signals, concurrent isolation, and caller/request timeouts. |
| docs/ama-booking-operations.md | Documents inline cancellation behavior and the deployed thirty-minute AMA and hourly media schedules. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Mutation as AMA mutation
  participant Drain as Inline drain
  participant Runner as Operations runner
  participant Provider as External provider
  participant DB as Durable operations store
  Mutation->>Drain: Start background work
  Drain->>Drain: Create shared 240s signal
  Drain->>Runner: run(signal)
  Runner->>DB: Claim due operations
  Runner->>Provider: Request with 8s timeout and shared signal
  alt Provider succeeds
    Provider-->>Runner: Success
    Runner->>DB: Complete operation
  else Provider fails or deadline expires
    Provider-->>Runner: Retryable failure
    Runner->>DB: Persist retry
  end
  Drain->>Runner: Continue while batch is full and signal active
  Note over Runner,DB: Unstarted claimed work remains leased for later recovery
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ama): enforce inline drain deadline"](https://github.com/calicastle/cali.so/commit/2c7c56d0b8ba13836c9c8a6978a13152c72a96ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61106888)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [AMA booking platform](https://app.greptile.com/zolplay/-/custom-context/knowledge-base/calicastle/cali.so/-/docs/ama-booking-platform.md)
- Knowledge Base — [AMA booking lifecycle](https://app.greptile.com/zolplay/-/custom-context/knowledge-base/calicastle/cali.so/-/docs/ama-booking-lifecycle.md)
- Knowledge Base — [AMA payment and calendar integrations](https://app.greptile.com/zolplay/-/custom-context/knowledge-base/calicastle/cali.so/-/docs/ama-external-integrations.md)
</details>


<!-- /greptile_comment -->